### PR TITLE
Add terminal view layer with ANSI rendering and raw input

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,6 +22,7 @@
     "counter-example",
     "websocket-chat-example",
     "snake-example",
+    "snake-terminal-example",
     "crash-view-example",
     "query-sync-example",
     "ui-showcase",

--- a/.changeset/terminal-view-layer.md
+++ b/.changeset/terminal-view-layer.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add terminal view layer (`foldkit/terminal`). Same Elm Architecture with a terminal-native view — box/text elements, ANSI rendering, cell grid diffing, and raw stdin input handling. Includes `makeTerminalProgram` and `runTerminal` entry points.

--- a/examples/snake-terminal/package.json
+++ b/examples/snake-terminal/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "snake-terminal-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/main.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@effect/platform-node": "^0.74.0",
+    "effect": "^3.19.19",
+    "foldkit": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/snake-terminal/src/constants.ts
+++ b/examples/snake-terminal/src/constants.ts
@@ -1,0 +1,24 @@
+export const GAME = {
+  GRID_SIZE: 20,
+  INITIAL_POSITION: { x: 10, y: 10 },
+  INITIAL_DIRECTION: 'Right',
+  POINTS_PER_APPLE: 10,
+} as const
+
+export const GAME_SPEED = {
+  MIN_INTERVAL: 80,
+  BASE_INTERVAL: 150,
+} as const
+
+export const CONTROLS = {
+  SPACE: ' ',
+  RESTART: 'r',
+  ARROW_UP: 'ArrowUp',
+  ARROW_DOWN: 'ArrowDown',
+  ARROW_LEFT: 'ArrowLeft',
+  ARROW_RIGHT: 'ArrowRight',
+  W: 'w',
+  A: 'a',
+  S: 's',
+  D: 'd',
+} as const

--- a/examples/snake-terminal/src/domain/apple.ts
+++ b/examples/snake-terminal/src/domain/apple.ts
@@ -1,0 +1,18 @@
+import { Effect, Random, Schedule } from 'effect'
+
+import { GAME } from '../constants'
+import { Position } from './position'
+import * as Snake from './snake'
+
+export const generatePosition = (snake: Snake.Snake) =>
+  Effect.gen(function* () {
+    const x = yield* Random.nextIntBetween(0, GAME.GRID_SIZE)
+    const y = yield* Random.nextIntBetween(0, GAME.GRID_SIZE)
+    const pos: Position = { x, y }
+
+    if (Snake.contains(snake, pos)) {
+      return yield* Effect.fail('PositionCollision' as const)
+    } else {
+      return pos
+    }
+  }).pipe(Effect.retry(Schedule.forever), Effect.orDie)

--- a/examples/snake-terminal/src/domain/direction.ts
+++ b/examples/snake-terminal/src/domain/direction.ts
@@ -1,0 +1,17 @@
+import { Match, Schema } from 'effect'
+
+export const Direction = Schema.Literal('Up', 'Down', 'Left', 'Right')
+export type Direction = typeof Direction.Type
+
+export const opposite = (direction: Direction): Direction =>
+  Match.value(direction).pipe(
+    Match.withReturnType<Direction>(),
+    Match.when('Up', () => 'Down'),
+    Match.when('Down', () => 'Up'),
+    Match.when('Left', () => 'Right'),
+    Match.when('Right', () => 'Left'),
+    Match.exhaustive,
+  )
+
+export const isOpposite = (a: Direction, b: Direction): boolean =>
+  opposite(a) === b

--- a/examples/snake-terminal/src/domain/index.ts
+++ b/examples/snake-terminal/src/domain/index.ts
@@ -1,0 +1,4 @@
+export * as Position from './position'
+export * as Direction from './direction'
+export * as Snake from './snake'
+export * as Apple from './apple'

--- a/examples/snake-terminal/src/domain/position.ts
+++ b/examples/snake-terminal/src/domain/position.ts
@@ -1,0 +1,32 @@
+import { Match, Schema } from 'effect'
+
+import { GAME } from '../constants'
+import * as Direction from './direction'
+
+export const Position = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+})
+
+export const equivalence = Schema.equivalence(Position)
+
+export type Position = typeof Position.Type
+
+export const wrap = ({ x, y }: Position): Position => ({
+  x: x < 0 ? GAME.GRID_SIZE - 1 : x >= GAME.GRID_SIZE ? 0 : x,
+  y: y < 0 ? GAME.GRID_SIZE - 1 : y >= GAME.GRID_SIZE ? 0 : y,
+})
+
+export const move = (
+  pos: Position,
+  direction: Direction.Direction,
+): Position => {
+  const next = Match.value(direction).pipe(
+    Match.when('Up', () => ({ x: pos.x, y: pos.y - 1 })),
+    Match.when('Down', () => ({ x: pos.x, y: pos.y + 1 })),
+    Match.when('Left', () => ({ x: pos.x - 1, y: pos.y })),
+    Match.when('Right', () => ({ x: pos.x + 1, y: pos.y })),
+    Match.exhaustive,
+  )
+  return wrap(next)
+}

--- a/examples/snake-terminal/src/domain/snake.ts
+++ b/examples/snake-terminal/src/domain/snake.ts
@@ -1,0 +1,43 @@
+import { Array, Schema as S } from 'effect'
+
+import type { Direction } from './direction'
+import * as Position from './position'
+
+export const INITIAL_LENGTH = 3
+
+export const Snake = S.NonEmptyArray(Position.Position)
+export type Snake = typeof Snake.Type
+
+export const create = (startPos: Position.Position): Snake =>
+  Array.makeBy(INITIAL_LENGTH, i => ({
+    x: startPos.x - i,
+    y: startPos.y,
+  }))
+
+export const move = (snake: Snake, direction: Direction): Snake =>
+  Array.matchLeft(snake, {
+    onEmpty: () => snake,
+    onNonEmpty: (head, tail) => {
+      const newHead = Position.move(head, direction)
+      return [newHead, head, ...Array.dropRight(tail, 1)]
+    },
+  })
+
+export const grow = (snake: Snake, direction: Direction): Snake =>
+  Array.matchLeft(snake, {
+    onEmpty: () => snake,
+    onNonEmpty: (head, tail) => {
+      const newHead = Position.move(head, direction)
+      return [newHead, head, ...tail]
+    },
+  })
+
+export const hasCollision = (snake: Snake): boolean =>
+  Array.matchLeft(snake, {
+    onEmpty: () => false,
+    onNonEmpty: (head, tail) =>
+      Array.some(tail, segment => Position.equivalence(head, segment)),
+  })
+
+export const contains = (snake: Snake, pos: Position.Position): boolean =>
+  Array.some(snake, segment => Position.equivalence(segment, pos))

--- a/examples/snake-terminal/src/main.ts
+++ b/examples/snake-terminal/src/main.ts
@@ -8,9 +8,9 @@ import {
   pipe,
 } from 'effect'
 import * as Command from 'foldkit/command'
-import * as Subscription from 'foldkit/subscription'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
+import * as Subscription from 'foldkit/subscription'
 import {
   type KeyPress,
   type TerminalView,
@@ -293,8 +293,7 @@ const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
 
 // VIEW
 
-const { box, text, Fg, Bg, Bold, Direction: Dir, Border } =
-  terminal<Message>()
+const { box, text, Fg, Bg, Bold, Direction: Dir, Border } = terminal<Message>()
 
 const CELL_CHAR = '  '
 

--- a/examples/snake-terminal/src/main.ts
+++ b/examples/snake-terminal/src/main.ts
@@ -1,0 +1,375 @@
+import {
+  Array,
+  Duration,
+  Effect,
+  Match as M,
+  Schema as S,
+  Stream,
+  pipe,
+} from 'effect'
+import * as Command from 'foldkit/command'
+import * as Subscription from 'foldkit/subscription'
+import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
+import {
+  type KeyPress,
+  type TerminalView,
+  keyPressStream,
+  makeTerminalProgram,
+  runTerminal,
+  terminal,
+} from 'foldkit/terminal'
+
+import { GAME, GAME_SPEED } from './constants'
+import { Apple, Direction, Position, Snake } from './domain'
+
+// MODEL
+
+export const GameState = S.Literal(
+  'NotStarted',
+  'Playing',
+  'Paused',
+  'GameOver',
+)
+export type GameState = typeof GameState.Type
+
+const Model = S.Struct({
+  snake: Snake.Snake,
+  apple: Position.Position,
+  direction: Direction.Direction,
+  nextDirection: Direction.Direction,
+  gameState: GameState,
+  points: S.Number,
+  highScore: S.Number,
+})
+type Model = typeof Model.Type
+
+// MESSAGE
+
+const TickedClock = m('TickedClock')
+const PressedKey = m('PressedKey', { key: S.String })
+const PausedGame = m('PausedGame')
+const RestartedGame = m('RestartedGame')
+const GeneratedApplePosition = m('GeneratedApplePosition', {
+  position: Position.Position,
+})
+
+export const Message = S.Union(
+  TickedClock,
+  PressedKey,
+  PausedGame,
+  RestartedGame,
+  GeneratedApplePosition,
+)
+export type Message = typeof Message.Type
+
+// INIT
+
+const init = (): readonly [Model, ReadonlyArray<Command.Command<Message>>] => {
+  const snake = Snake.create(GAME.INITIAL_POSITION)
+
+  return [
+    {
+      snake,
+      apple: { x: 15, y: 15 },
+      direction: GAME.INITIAL_DIRECTION,
+      nextDirection: GAME.INITIAL_DIRECTION,
+      gameState: 'NotStarted',
+      points: 0,
+      highScore: 0,
+    },
+    [generateApplePosition(snake)],
+  ]
+}
+
+// UPDATE
+
+const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    M.tagsExhaustive({
+      PressedKey: ({ key }) =>
+        M.value(key).pipe(
+          M.withReturnType<
+            readonly [Model, ReadonlyArray<Command.Command<Message>>]
+          >(),
+          M.whenOr(
+            'ArrowUp',
+            'ArrowDown',
+            'ArrowLeft',
+            'ArrowRight',
+            'w',
+            'a',
+            's',
+            'd',
+            moveKey => {
+              const nextDirection = M.value(moveKey).pipe(
+                M.withReturnType<Direction.Direction>(),
+                M.whenOr('ArrowUp', 'w', () => 'Up'),
+                M.whenOr('ArrowDown', 's', () => 'Down'),
+                M.whenOr('ArrowLeft', 'a', () => 'Left'),
+                M.whenOr('ArrowRight', 'd', () => 'Right'),
+                M.exhaustive,
+              )
+
+              if (model.gameState === 'Playing') {
+                return [
+                  evo(model, {
+                    nextDirection: () => nextDirection,
+                  }),
+                  [],
+                ]
+              } else {
+                return [model, []]
+              }
+            },
+          ),
+          M.when(' ', () => {
+            const nextGameState = M.value(model.gameState).pipe(
+              M.withReturnType<GameState>(),
+              M.when('NotStarted', () => 'Playing'),
+              M.when('Playing', () => 'Paused'),
+              M.when('Paused', () => 'Playing'),
+              M.when('GameOver', () => 'GameOver'),
+              M.exhaustive,
+            )
+            return [
+              evo(model, {
+                gameState: () => nextGameState,
+              }),
+              [],
+            ]
+          }),
+          M.when('r', () => {
+            const nextSnake = Snake.create(GAME.INITIAL_POSITION)
+
+            return [
+              evo(model, {
+                snake: () => nextSnake,
+                direction: () => GAME.INITIAL_DIRECTION,
+                nextDirection: () => GAME.INITIAL_DIRECTION,
+                gameState: () => 'NotStarted',
+                points: () => 0,
+              }),
+              [generateApplePosition(nextSnake)],
+            ]
+          }),
+          M.orElse(() => [model, []]),
+        ),
+
+      TickedClock: () => {
+        if (model.gameState !== 'Playing') {
+          return [model, []]
+        }
+
+        const currentDirection = Direction.isOpposite(
+          model.direction,
+          model.nextDirection,
+        )
+          ? model.direction
+          : model.nextDirection
+
+        const newHead = Position.move(model.snake[0], currentDirection)
+        const willEatApple = Position.equivalence(newHead, model.apple)
+
+        const nextSnake = willEatApple
+          ? Snake.grow(model.snake, currentDirection)
+          : Snake.move(model.snake, currentDirection)
+
+        if (Snake.hasCollision(nextSnake)) {
+          return [
+            evo(model, {
+              gameState: () => 'GameOver',
+              highScore: highScore => Math.max(model.points, highScore),
+            }),
+            [],
+          ]
+        }
+
+        const commands = willEatApple ? [generateApplePosition(nextSnake)] : []
+
+        return [
+          evo(model, {
+            snake: () => nextSnake,
+            direction: () => currentDirection,
+            points: points =>
+              willEatApple ? points + GAME.POINTS_PER_APPLE : points,
+          }),
+          commands,
+        ]
+      },
+
+      PausedGame: () => [
+        evo(model, {
+          gameState: gameState =>
+            gameState === 'Playing' ? 'Paused' : 'Playing',
+        }),
+        [],
+      ],
+
+      RestartedGame: () => {
+        const startPos: Position.Position = { x: 10, y: 10 }
+        const nextSnake = Snake.create(startPos)
+
+        return [
+          evo(model, {
+            snake: () => nextSnake,
+            direction: () => 'Right',
+            nextDirection: () => 'Right',
+            gameState: () => 'NotStarted',
+            points: () => 0,
+          }),
+          [generateApplePosition(nextSnake)],
+        ]
+      },
+
+      GeneratedApplePosition: ({ position }) => [
+        evo(model, {
+          apple: () => position,
+        }),
+        [],
+      ],
+    }),
+  )
+
+// COMMAND
+
+const GenerateApplePosition = Command.define(
+  'GenerateApplePosition',
+  GeneratedApplePosition,
+)
+
+const generateApplePosition = (snake: Snake.Snake) =>
+  GenerateApplePosition(
+    Apple.generatePosition(snake).pipe(
+      Effect.map(position => GeneratedApplePosition({ position })),
+    ),
+  )
+
+// SUBSCRIPTION
+
+const SubscriptionDeps = S.Struct({
+  gameClock: S.Struct({
+    isPlaying: S.Boolean,
+    interval: S.Number,
+  }),
+  keyboard: S.Null,
+})
+
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+  Model,
+  Message
+>({
+  gameClock: {
+    modelToDependencies: (model: Model) => ({
+      isPlaying: model.gameState === 'Playing',
+      interval: Math.max(
+        GAME_SPEED.MIN_INTERVAL,
+        GAME_SPEED.BASE_INTERVAL - model.points,
+      ),
+    }),
+    dependenciesToStream: (deps: { isPlaying: boolean; interval: number }) =>
+      Stream.when(
+        Stream.tick(Duration.millis(deps.interval)).pipe(
+          Stream.map(TickedClock),
+        ),
+        () => deps.isPlaying,
+      ),
+  },
+
+  keyboard: {
+    modelToDependencies: () => null,
+    dependenciesToStream: () =>
+      keyPressStream().pipe(
+        Stream.map((keyPress: KeyPress) => PressedKey({ key: keyPress.key })),
+      ),
+  },
+})
+
+// VIEW
+
+const { box, text, Fg, Bg, Bold, Direction: Dir, Border } =
+  terminal<Message>()
+
+const CELL_CHAR = '  '
+
+const cellView = (x: number, y: number, model: Model): TerminalView => {
+  const isSnakeHead = Position.equivalence({ x, y }, model.snake[0])
+  const isSnakeTail = pipe(
+    model.snake,
+    Array.tailNonEmpty,
+    Array.some(segment => Position.equivalence({ x, y }, segment)),
+  )
+  const isApple = Position.equivalence({ x, y }, model.apple)
+
+  const cellColor = M.value({ isSnakeHead, isSnakeTail, isApple }).pipe(
+    M.when({ isSnakeHead: true }, () => Bg('Green')),
+    M.when({ isSnakeTail: true }, () => Bg('BrightGreen')),
+    M.when({ isApple: true }, () => Bg('Red')),
+    M.orElse(() => Bg('BrightBlack')),
+  )
+
+  return text([cellColor], CELL_CHAR)
+}
+
+const gridView = (model: Model): TerminalView =>
+  box(
+    [Border('Round')],
+    Array.makeBy(GAME.GRID_SIZE, y =>
+      box(
+        [Dir('Row')],
+        Array.makeBy(GAME.GRID_SIZE, x => cellView(x, y, model)),
+      ),
+    ),
+  )
+
+const gameStateView = (gameState: GameState): string =>
+  M.value(gameState).pipe(
+    M.when('NotStarted', () => 'Press SPACE to start'),
+    M.when('Playing', () => 'Playing - SPACE to pause'),
+    M.when('Paused', () => 'Paused - SPACE to continue'),
+    M.when('GameOver', () => 'Game Over - Press R to restart'),
+    M.exhaustive,
+  )
+
+const view = (model: Model): TerminalView =>
+  box(
+    [Fg('White')],
+    [
+      text([Bold, Fg('Green')], ' Snake Game'),
+      text([], ''),
+      box(
+        [Dir('Row')],
+        [
+          text([Fg('Yellow')], ` Score: ${model.points}`),
+          text([], '   '),
+          text([Fg('Cyan')], `High Score: ${model.highScore}`),
+        ],
+      ),
+      text([Fg('BrightBlack')], ` ${gameStateView(model.gameState)}`),
+      text([], ''),
+      gridView(model),
+      text([], ''),
+      text([Fg('BrightBlack')], ' Arrow keys or WASD to move'),
+      text([Fg('BrightBlack')], ' SPACE to pause/start'),
+      text([Fg('BrightBlack')], ' R to restart | Ctrl+C to quit'),
+    ],
+  )
+
+// RUN
+
+const program = makeTerminalProgram({
+  Model,
+  init,
+  update,
+  view,
+  subscriptions,
+  title: model => `Snake - Score: ${model.points}`,
+})
+
+runTerminal(program)

--- a/examples/snake-terminal/tsconfig.json
+++ b/examples/snake-terminal/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "../../packages/foldkit/src"]
+}

--- a/packages/foldkit/package.json
+++ b/packages/foldkit/package.json
@@ -130,6 +130,10 @@
     "./url": {
       "types": "./dist/url/public.d.ts",
       "import": "./dist/url/public.js"
+    },
+    "./terminal": {
+      "types": "./dist/terminal/public.d.ts",
+      "import": "./dist/terminal/public.js"
     }
   },
   "files": [
@@ -146,10 +150,20 @@
   },
   "peerDependencies": {
     "@effect/platform-browser": "^0.74.0",
+    "@effect/platform-node": "^0.74.0",
     "effect": "^3.18.2"
+  },
+  "peerDependenciesMeta": {
+    "@effect/platform-browser": {
+      "optional": true
+    },
+    "@effect/platform-node": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@effect/platform-browser": "^0.74.0",
+    "@effect/platform-node": "^0.74.0",
     "@effect/vitest": "^0.27.0",
     "effect": "^3.19.19",
     "happy-dom": "^18.0.1",

--- a/packages/foldkit/src/runtime/dispatch.ts
+++ b/packages/foldkit/src/runtime/dispatch.ts
@@ -1,0 +1,10 @@
+import { Context, Effect } from 'effect'
+
+/** Effect service tag that provides message dispatching to the view layer. */
+export class Dispatch extends Context.Tag('@foldkit/Dispatch')<
+  Dispatch,
+  {
+    readonly dispatchAsync: (message: unknown) => Effect.Effect<void>
+    readonly dispatchSync: (message: unknown) => void
+  }
+>() {}

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -33,6 +33,7 @@ import {
   addNavigationEventListeners,
 } from './browserListeners'
 import { defaultCrashView, noOpDispatch } from './crashUI'
+import { Dispatch } from './dispatch'
 import type { ManagedResourceConfig, ManagedResources } from './managedResource'
 import type { Subscriptions } from './subscription'
 import { UrlRequest } from './urlRequest'
@@ -130,7 +131,6 @@ const defaultSlowViewCallback = (
   )
 }
 
-import { Dispatch } from './dispatch'
 export { Dispatch }
 
 export type { Command } from '../command'

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -130,14 +130,8 @@ const defaultSlowViewCallback = (
   )
 }
 
-/** Effect service tag that provides message dispatching to the view layer. */
-export class Dispatch extends Context.Tag('@foldkit/Dispatch')<
-  Dispatch,
-  {
-    readonly dispatchAsync: (message: unknown) => Effect.Effect<void>
-    readonly dispatchSync: (message: unknown) => void
-  }
->() {}
+import { Dispatch } from './dispatch'
+export { Dispatch }
 
 export type { Command } from '../command'
 

--- a/packages/foldkit/src/terminal/ansi.ts
+++ b/packages/foldkit/src/terminal/ansi.ts
@@ -1,0 +1,166 @@
+import { Match, Option } from 'effect'
+
+import type { Cell, CellGrid } from './cell'
+import { cellEquals } from './cell'
+import type { Color } from './view'
+
+const ESC = '\x1b['
+const RESET = `${ESC}0m`
+
+const colorToFgCode = (color: Color): string =>
+  Match.value(color).pipe(
+    Match.when('Black', () => '30'),
+    Match.when('Red', () => '31'),
+    Match.when('Green', () => '32'),
+    Match.when('Yellow', () => '33'),
+    Match.when('Blue', () => '34'),
+    Match.when('Magenta', () => '35'),
+    Match.when('Cyan', () => '36'),
+    Match.when('White', () => '37'),
+    Match.when('Default', () => '39'),
+    Match.when('BrightBlack', () => '90'),
+    Match.when('BrightRed', () => '91'),
+    Match.when('BrightGreen', () => '92'),
+    Match.when('BrightYellow', () => '93'),
+    Match.when('BrightBlue', () => '94'),
+    Match.when('BrightMagenta', () => '95'),
+    Match.when('BrightCyan', () => '96'),
+    Match.when('BrightWhite', () => '97'),
+    Match.exhaustive,
+  )
+
+const colorToBgCode = (color: Color): string =>
+  Match.value(color).pipe(
+    Match.when('Black', () => '40'),
+    Match.when('Red', () => '41'),
+    Match.when('Green', () => '42'),
+    Match.when('Yellow', () => '43'),
+    Match.when('Blue', () => '44'),
+    Match.when('Magenta', () => '45'),
+    Match.when('Cyan', () => '46'),
+    Match.when('White', () => '47'),
+    Match.when('Default', () => '49'),
+    Match.when('BrightBlack', () => '100'),
+    Match.when('BrightRed', () => '101'),
+    Match.when('BrightGreen', () => '102'),
+    Match.when('BrightYellow', () => '103'),
+    Match.when('BrightBlue', () => '104'),
+    Match.when('BrightMagenta', () => '105'),
+    Match.when('BrightCyan', () => '106'),
+    Match.when('BrightWhite', () => '107'),
+    Match.exhaustive,
+  )
+
+const styleCell = (cell: Cell): string => {
+  const codes: Array<string> = []
+
+  Option.map(cell.foreground, color => {
+    codes.push(colorToFgCode(color))
+  })
+
+  Option.map(cell.background, color => {
+    codes.push(colorToBgCode(color))
+  })
+
+  if (cell.isBold) {
+    codes.push('1')
+  }
+  if (cell.isDim) {
+    codes.push('2')
+  }
+  if (cell.isItalic) {
+    codes.push('3')
+  }
+  if (cell.isUnderline) {
+    codes.push('4')
+  }
+
+  if (codes.length === 0) {
+    return cell.char
+  }
+
+  return `${ESC}${codes.join(';')}m${cell.char}${RESET}`
+}
+
+const moveCursor = (row: number, col: number): string =>
+  `${ESC}${row + 1};${col + 1}H`
+
+const hideCursor = `${ESC}?25l`
+const showCursor = `${ESC}?25h`
+
+const getCell = (
+  grid: CellGrid,
+  row: number,
+  col: number,
+): Cell | undefined => {
+  const gridRow = grid[row]
+  return gridRow ? gridRow[col] : undefined
+}
+
+/** Render the full grid to an ANSI string (for initial render). */
+export const renderFull = (grid: CellGrid): string => {
+  let output = hideCursor + moveCursor(0, 0)
+
+  for (let row = 0; row < grid.length; row++) {
+    output += moveCursor(row, 0)
+    const gridRow = grid[row]
+    if (!gridRow) {
+      continue
+    }
+    for (let col = 0; col < gridRow.length; col++) {
+      const cell = gridRow[col]
+      if (cell) {
+        output += styleCell(cell)
+      }
+    }
+  }
+
+  return output
+}
+
+/** Render only the cells that changed between two grids. */
+export const renderDiff = (previous: CellGrid, next: CellGrid): string => {
+  let output = hideCursor
+  let lastRow = -1
+  let lastCol = -1
+
+  for (let row = 0; row < next.length; row++) {
+    const nextRow = next[row]
+    if (!nextRow) {
+      continue
+    }
+    for (let col = 0; col < nextRow.length; col++) {
+      const nextCell = nextRow[col]
+      if (!nextCell) {
+        continue
+      }
+
+      const previousCell = getCell(previous, row, col)
+
+      if (previousCell && cellEquals(previousCell, nextCell)) {
+        continue
+      }
+
+      if (row !== lastRow || col !== lastCol + 1) {
+        output += moveCursor(row, col)
+      }
+
+      output += styleCell(nextCell)
+      lastRow = row
+      lastCol = col
+    }
+  }
+
+  return output
+}
+
+/** Enter the alternate screen buffer. */
+export const enterAltScreen = `${ESC}?1049h`
+
+/** Leave the alternate screen buffer. */
+export const exitAltScreen = `${ESC}?1049l`
+
+/** Clear the entire screen. */
+export const clearScreen = `${ESC}2J${ESC}H`
+
+export { hideCursor, showCursor }

--- a/packages/foldkit/src/terminal/cell.ts
+++ b/packages/foldkit/src/terminal/cell.ts
@@ -1,0 +1,47 @@
+import { Option } from 'effect'
+
+import type { Color } from './view'
+
+/** A single cell in the terminal grid. */
+export type Cell = Readonly<{
+  char: string
+  foreground: Option.Option<Color>
+  background: Option.Option<Color>
+  isBold: boolean
+  isDim: boolean
+  isUnderline: boolean
+  isItalic: boolean
+}>
+
+export const emptyCell: Cell = {
+  char: ' ',
+  foreground: Option.none(),
+  background: Option.none(),
+  isBold: false,
+  isDim: false,
+  isUnderline: false,
+  isItalic: false,
+}
+
+/** A 2D grid of cells — rows of columns. */
+export type CellGrid = ReadonlyArray<ReadonlyArray<Cell>>
+
+/** Create an empty grid filled with spaces. */
+export const createGrid = (width: number, height: number): CellGrid => {
+  const row = globalThis.Array.from({ length: width }, () => emptyCell)
+  return globalThis.Array.from({ length: height }, () => [...row])
+}
+
+/** Check if two cells are visually identical. */
+export const cellEquals = (a: Cell, b: Cell): boolean =>
+  a.char === b.char &&
+  Option.getEquivalence(
+    (x: Color, y: Color) => x === y,
+  )(a.foreground, b.foreground) &&
+  Option.getEquivalence(
+    (x: Color, y: Color) => x === y,
+  )(a.background, b.background) &&
+  a.isBold === b.isBold &&
+  a.isDim === b.isDim &&
+  a.isUnderline === b.isUnderline &&
+  a.isItalic === b.isItalic

--- a/packages/foldkit/src/terminal/cell.ts
+++ b/packages/foldkit/src/terminal/cell.ts
@@ -35,12 +35,14 @@ export const createGrid = (width: number, height: number): CellGrid => {
 /** Check if two cells are visually identical. */
 export const cellEquals = (a: Cell, b: Cell): boolean =>
   a.char === b.char &&
-  Option.getEquivalence(
-    (x: Color, y: Color) => x === y,
-  )(a.foreground, b.foreground) &&
-  Option.getEquivalence(
-    (x: Color, y: Color) => x === y,
-  )(a.background, b.background) &&
+  Option.getEquivalence((x: Color, y: Color) => x === y)(
+    a.foreground,
+    b.foreground,
+  ) &&
+  Option.getEquivalence((x: Color, y: Color) => x === y)(
+    a.background,
+    b.background,
+  ) &&
   a.isBold === b.isBold &&
   a.isDim === b.isDim &&
   a.isUnderline === b.isUnderline &&

--- a/packages/foldkit/src/terminal/input.ts
+++ b/packages/foldkit/src/terminal/input.ts
@@ -1,0 +1,89 @@
+import { Effect, Stream } from 'effect'
+
+/** A parsed key press from raw terminal input. */
+export type KeyPress = Readonly<{
+  key: string
+  ctrl: boolean
+  shift: boolean
+  alt: boolean
+}>
+
+/** Parse raw stdin bytes into a KeyPress. */
+export const parseKeyPress = (data: Buffer): KeyPress => {
+  const hex = data.toString('hex')
+  const str = data.toString('utf8')
+
+  if (hex === '1b5b41') {
+    return { key: 'ArrowUp', ctrl: false, shift: false, alt: false }
+  }
+  if (hex === '1b5b42') {
+    return { key: 'ArrowDown', ctrl: false, shift: false, alt: false }
+  }
+  if (hex === '1b5b43') {
+    return { key: 'ArrowRight', ctrl: false, shift: false, alt: false }
+  }
+  if (hex === '1b5b44') {
+    return { key: 'ArrowLeft', ctrl: false, shift: false, alt: false }
+  }
+
+  if (hex === '0d' || hex === '0a') {
+    return { key: 'Enter', ctrl: false, shift: false, alt: false }
+  }
+  if (hex === '1b') {
+    return { key: 'Escape', ctrl: false, shift: false, alt: false }
+  }
+  if (hex === '7f' || hex === '08') {
+    return { key: 'Backspace', ctrl: false, shift: false, alt: false }
+  }
+  if (hex === '09') {
+    return { key: 'Tab', ctrl: false, shift: false, alt: false }
+  }
+  if (hex === '20') {
+    return { key: ' ', ctrl: false, shift: false, alt: false }
+  }
+
+  const firstByte = data[0]
+  if (data.length === 1 && firstByte !== undefined && firstByte < 27) {
+    return {
+      key: String.fromCharCode(firstByte + 96),
+      ctrl: true,
+      shift: false,
+      alt: false,
+    }
+  }
+
+  return { key: str, ctrl: false, shift: false, alt: false }
+}
+
+/** Create an Effect Stream of key presses from stdin. Enables raw mode. */
+export const keyPressStream = (): Stream.Stream<KeyPress> =>
+  Stream.asyncScoped<KeyPress>(emit =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        process.stdin.setRawMode(true)
+        process.stdin.resume()
+        process.stdin.setEncoding('utf8')
+
+        const onData = (data: Buffer) => {
+          const keyPress = parseKeyPress(
+            Buffer.isBuffer(data) ? data : Buffer.from(data),
+          )
+
+          if (keyPress.ctrl && keyPress.key === 'c') {
+            process.exit(0)
+          }
+
+          emit.single(keyPress)
+        }
+
+        process.stdin.on('data', onData)
+        return onData
+      }),
+      onData =>
+        Effect.sync(() => {
+          process.stdin.removeListener('data', onData)
+          process.stdin.setRawMode(false)
+          process.stdin.pause()
+        }),
+    ),
+  )

--- a/packages/foldkit/src/terminal/layout.ts
+++ b/packages/foldkit/src/terminal/layout.ts
@@ -1,0 +1,426 @@
+import { Match, Option } from 'effect'
+
+import type { Cell, CellGrid } from './cell'
+import { createGrid, emptyCell } from './cell'
+import type { BorderStyle, TerminalAttributes, TerminalNode } from './view'
+
+type Rect = Readonly<{
+  x: number
+  y: number
+  width: number
+  height: number
+}>
+
+/** Lay out a TerminalNode tree into a flat CellGrid. */
+export const layout = (
+  node: TerminalNode,
+  availableWidth: number,
+  availableHeight: number,
+): CellGrid => {
+  const grid = createGrid(availableWidth, availableHeight)
+  const mutableGrid = grid.map(row => [...row])
+  renderNode(mutableGrid, node, {
+    x: 0,
+    y: 0,
+    width: availableWidth,
+    height: availableHeight,
+  })
+  return mutableGrid
+}
+
+const setGridCell = (
+  grid: Array<Array<Cell>>,
+  row: number,
+  col: number,
+  cell: Cell,
+): void => {
+  const gridRow = grid[row]
+  if (gridRow && col >= 0 && col < gridRow.length) {
+    gridRow[col] = cell
+  }
+}
+
+const getGridWidth = (grid: Array<Array<Cell>>): number => {
+  const firstRow = grid[0]
+  return firstRow ? firstRow.length : 0
+}
+
+const renderNode = (
+  grid: Array<Array<Cell>>,
+  node: TerminalNode,
+  rect: Rect,
+): void => {
+  Match.value(node).pipe(
+    Match.tag('Text', textNode => {
+      renderText(grid, textNode.content, textNode.attributes, rect)
+    }),
+    Match.tag('Box', boxNode => {
+      renderBox(grid, boxNode.attributes, boxNode.children, rect)
+    }),
+    Match.exhaustive,
+  )
+}
+
+const renderText = (
+  grid: Array<Array<Cell>>,
+  content: string,
+  attributes: TerminalAttributes,
+  rect: Rect,
+): void => {
+  let col = rect.x
+  let row = rect.y
+
+  for (const char of content) {
+    if (row >= rect.y + rect.height) {
+      break
+    }
+
+    if (char === '\n') {
+      col = rect.x
+      row++
+      continue
+    }
+
+    if (col >= rect.x + rect.width) {
+      col = rect.x
+      row++
+      if (row >= rect.y + rect.height) {
+        break
+      }
+    }
+
+    if (row >= 0 && row < grid.length && col >= 0 && col < getGridWidth(grid)) {
+      setGridCell(grid, row, col, {
+        char,
+        foreground: attributes.foreground,
+        background: attributes.background,
+        isBold: attributes.isBold,
+        isDim: attributes.isDim,
+        isUnderline: attributes.isUnderline,
+        isItalic: attributes.isItalic,
+      })
+    }
+
+    col++
+  }
+}
+
+const borderChars = (
+  style: BorderStyle,
+): Readonly<{
+  topLeft: string
+  topRight: string
+  bottomLeft: string
+  bottomRight: string
+  horizontal: string
+  vertical: string
+}> =>
+  Match.value(style).pipe(
+    Match.when('None', () => ({
+      topLeft: ' ',
+      topRight: ' ',
+      bottomLeft: ' ',
+      bottomRight: ' ',
+      horizontal: ' ',
+      vertical: ' ',
+    })),
+    Match.when('Single', () => ({
+      topLeft: '┌',
+      topRight: '┐',
+      bottomLeft: '└',
+      bottomRight: '┘',
+      horizontal: '─',
+      vertical: '│',
+    })),
+    Match.when('Double', () => ({
+      topLeft: '╔',
+      topRight: '╗',
+      bottomLeft: '╚',
+      bottomRight: '╝',
+      horizontal: '═',
+      vertical: '║',
+    })),
+    Match.when('Round', () => ({
+      topLeft: '╭',
+      topRight: '╮',
+      bottomLeft: '╰',
+      bottomRight: '╯',
+      horizontal: '─',
+      vertical: '│',
+    })),
+    Match.when('Bold', () => ({
+      topLeft: '┏',
+      topRight: '┓',
+      bottomLeft: '┗',
+      bottomRight: '┛',
+      horizontal: '━',
+      vertical: '┃',
+    })),
+    Match.exhaustive,
+  )
+
+const renderBorder = (
+  grid: Array<Array<Cell>>,
+  style: BorderStyle,
+  attributes: TerminalAttributes,
+  rect: Rect,
+): void => {
+  if (style === 'None') {
+    return
+  }
+
+  const chars = borderChars(style)
+  const cellStyle: Omit<Cell, 'char'> = {
+    foreground: attributes.foreground,
+    background: attributes.background,
+    isBold: attributes.isBold,
+    isDim: attributes.isDim,
+    isUnderline: false,
+    isItalic: false,
+  }
+
+  const setChar = (row: number, col: number, char: string): void => {
+    if (row >= 0 && row < grid.length && col >= 0 && col < getGridWidth(grid)) {
+      setGridCell(grid, row, col, { ...cellStyle, char })
+    }
+  }
+
+  setChar(rect.y, rect.x, chars.topLeft)
+  setChar(rect.y, rect.x + rect.width - 1, chars.topRight)
+  setChar(rect.y + rect.height - 1, rect.x, chars.bottomLeft)
+  setChar(rect.y + rect.height - 1, rect.x + rect.width - 1, chars.bottomRight)
+
+  for (let col = rect.x + 1; col < rect.x + rect.width - 1; col++) {
+    setChar(rect.y, col, chars.horizontal)
+    setChar(rect.y + rect.height - 1, col, chars.horizontal)
+  }
+
+  for (let row = rect.y + 1; row < rect.y + rect.height - 1; row++) {
+    setChar(row, rect.x, chars.vertical)
+    setChar(row, rect.x + rect.width - 1, chars.vertical)
+  }
+}
+
+const fillBackground = (
+  grid: Array<Array<Cell>>,
+  background: Option.Option<string>,
+  rect: Rect,
+): void => {
+  if (Option.isNone(background)) {
+    return
+  }
+
+  for (let row = rect.y; row < rect.y + rect.height; row++) {
+    for (let col = rect.x; col < rect.x + rect.width; col++) {
+      if (
+        row >= 0 &&
+        row < grid.length &&
+        col >= 0 &&
+        col < getGridWidth(grid)
+      ) {
+        setGridCell(grid, row, col, {
+          ...emptyCell,
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+          background: background as Option.Option<any>,
+        })
+      }
+    }
+  }
+}
+
+const renderBox = (
+  grid: Array<Array<Cell>>,
+  attributes: TerminalAttributes,
+  children: ReadonlyArray<TerminalNode>,
+  rect: Rect,
+): void => {
+  const hasBorder = attributes.border !== 'None'
+  const borderOffset = hasBorder ? 1 : 0
+
+  fillBackground(grid, attributes.background, rect)
+
+  if (hasBorder) {
+    renderBorder(grid, attributes.border, attributes, rect)
+  }
+
+  const contentRect: Rect = {
+    x: rect.x + borderOffset + attributes.paddingLeft,
+    y: rect.y + borderOffset + attributes.paddingTop,
+    width:
+      rect.width -
+      borderOffset * 2 -
+      attributes.paddingLeft -
+      attributes.paddingRight,
+    height:
+      rect.height -
+      borderOffset * 2 -
+      attributes.paddingTop -
+      attributes.paddingBottom,
+  }
+
+  if (contentRect.width <= 0 || contentRect.height <= 0) {
+    return
+  }
+
+  layoutChildren(grid, attributes, children, contentRect)
+}
+
+/** Measure the natural size of a node (without constraints). */
+const measureNode = (
+  node: TerminalNode,
+  availableWidth: number,
+): Readonly<{ width: number; height: number }> =>
+  Match.value(node).pipe(
+    Match.tag('Text', textNode => {
+      const lines = wrapText(textNode.content, availableWidth)
+      return {
+        width: lines.reduce((max, line) => Math.max(max, line.length), 0),
+        height: lines.length,
+      }
+    }),
+    Match.tag('Box', boxNode => {
+      const hasBorder = boxNode.attributes.border !== 'None'
+      const borderOffset = hasBorder ? 1 : 0
+      const paddingH =
+        boxNode.attributes.paddingLeft + boxNode.attributes.paddingRight
+      const paddingV =
+        boxNode.attributes.paddingTop + boxNode.attributes.paddingBottom
+      const overhead = borderOffset * 2
+
+      const innerWidth = Option.getOrElse(boxNode.attributes.width, () =>
+        Math.max(0, availableWidth - overhead - paddingH),
+      )
+
+      const childSizes = boxNode.children.map(child =>
+        measureNode(child, innerWidth),
+      )
+
+      const contentSize =
+        boxNode.attributes.flexDirection === 'Column'
+          ? {
+              width: childSizes.reduce(
+                (max, size) => Math.max(max, size.width),
+                0,
+              ),
+              height: childSizes.reduce(
+                (total, size) => total + size.height,
+                0,
+              ),
+            }
+          : {
+              width: childSizes.reduce(
+                (total, size) => total + size.width,
+                0,
+              ),
+              height: childSizes.reduce(
+                (max, size) => Math.max(max, size.height),
+                0,
+              ),
+            }
+
+      return {
+        width: Option.getOrElse(
+          boxNode.attributes.width,
+          () => contentSize.width + overhead + paddingH,
+        ),
+        height: Option.getOrElse(
+          boxNode.attributes.height,
+          () => contentSize.height + overhead + paddingV,
+        ),
+      }
+    }),
+    Match.exhaustive,
+  )
+
+const wrapText = (text: string, maxWidth: number): ReadonlyArray<string> => {
+  if (maxWidth <= 0) {
+    return ['']
+  }
+
+  const result: Array<string> = []
+  const lines = text.split('\n')
+
+  for (const line of lines) {
+    if (line.length <= maxWidth) {
+      result.push(line)
+    } else {
+      for (let i = 0; i < line.length; i += maxWidth) {
+        result.push(line.slice(i, i + maxWidth))
+      }
+    }
+  }
+
+  return result.length === 0 ? [''] : result
+}
+
+const getNodeWidth = (node: TerminalNode): Option.Option<number> =>
+  node._tag === 'Box' ? node.attributes.width : Option.none()
+
+const getNodeHeight = (node: TerminalNode): Option.Option<number> =>
+  node._tag === 'Box' ? node.attributes.height : Option.none()
+
+const layoutChildren = (
+  grid: Array<Array<Cell>>,
+  attributes: TerminalAttributes,
+  children: ReadonlyArray<TerminalNode>,
+  contentRect: Rect,
+): void => {
+  if (attributes.flexDirection === 'Column') {
+    let currentY = contentRect.y
+
+    for (const child of children) {
+      if (currentY >= contentRect.y + contentRect.height) {
+        break
+      }
+
+      const childSize = measureNode(child, contentRect.width)
+      const childWidth = Option.match(getNodeWidth(child), {
+        onNone: () => contentRect.width,
+        onSome: (width: number) => Math.min(width, contentRect.width),
+      })
+      const childHeight = Math.min(
+        Option.getOrElse(getNodeHeight(child), () => childSize.height),
+        contentRect.y + contentRect.height - currentY,
+      )
+
+      renderNode(grid, child, {
+        x: contentRect.x,
+        y: currentY,
+        width: childWidth,
+        height: childHeight,
+      })
+
+      currentY += childHeight
+    }
+  } else {
+    let currentX = contentRect.x
+
+    for (const child of children) {
+      if (currentX >= contentRect.x + contentRect.width) {
+        break
+      }
+
+      const childSize = measureNode(
+        child,
+        contentRect.width - (currentX - contentRect.x),
+      )
+      const childWidth = Math.min(
+        Option.getOrElse(getNodeWidth(child), () => childSize.width),
+        contentRect.x + contentRect.width - currentX,
+      )
+      const childHeight = Option.match(getNodeHeight(child), {
+        onNone: () => contentRect.height,
+        onSome: (height: number) => Math.min(height, contentRect.height),
+      })
+
+      renderNode(grid, child, {
+        x: currentX,
+        y: contentRect.y,
+        width: childWidth,
+        height: childHeight,
+      })
+
+      currentX += childWidth
+    }
+  }
+}

--- a/packages/foldkit/src/terminal/layout.ts
+++ b/packages/foldkit/src/terminal/layout.ts
@@ -308,10 +308,7 @@ const measureNode = (
               ),
             }
           : {
-              width: childSizes.reduce(
-                (total, size) => total + size.width,
-                0,
-              ),
+              width: childSizes.reduce((total, size) => total + size.width, 0),
               height: childSizes.reduce(
                 (max, size) => Math.max(max, size.height),
                 0,

--- a/packages/foldkit/src/terminal/platform.ts
+++ b/packages/foldkit/src/terminal/platform.ts
@@ -48,8 +48,7 @@ const render = (
 
   const output = Option.match(previous, {
     onNone: () => Ansi.renderFull(nextGrid),
-    onSome: ({ grid: previousGrid }) =>
-      Ansi.renderDiff(previousGrid, nextGrid),
+    onSome: ({ grid: previousGrid }) => Ansi.renderDiff(previousGrid, nextGrid),
   })
 
   target.write(output)

--- a/packages/foldkit/src/terminal/platform.ts
+++ b/packages/foldkit/src/terminal/platform.ts
@@ -1,0 +1,100 @@
+import { NodeRuntime } from '@effect/platform-node'
+import { Effect, Option } from 'effect'
+
+import { Dispatch } from '../runtime/dispatch'
+import * as Ansi from './ansi'
+import type { CellGrid } from './cell'
+import { layout } from './layout'
+import type { TerminalNode } from './view'
+import { emptyAttributes } from './view'
+
+/** The render state maintained between frames. */
+export type TerminalRenderState = Readonly<{
+  grid: CellGrid
+  width: number
+  height: number
+}>
+
+/** Target for terminal rendering — uses stdout dimensions. */
+export type TerminalTarget = Readonly<{
+  write: (data: string) => void
+  columns: number
+  rows: number
+}>
+
+const createTarget = (): TerminalTarget => ({
+  write: (data: string) => {
+    process.stdout.write(data)
+  },
+  columns: process.stdout.columns,
+  rows: process.stdout.rows,
+})
+
+const emptyBox: TerminalNode = {
+  _tag: 'Box',
+  attributes: emptyAttributes,
+  children: [],
+}
+
+/** Render a TerminalNode to the terminal, diffing against the previous state. */
+const render = (
+  previous: Option.Option<TerminalRenderState>,
+  next: TerminalNode | null,
+  target: TerminalTarget,
+): TerminalRenderState => {
+  const nextNode = next ?? emptyBox
+
+  const nextGrid = layout(nextNode, target.columns, target.rows)
+
+  const output = Option.match(previous, {
+    onNone: () => Ansi.renderFull(nextGrid),
+    onSome: ({ grid: previousGrid }) =>
+      Ansi.renderDiff(previousGrid, nextGrid),
+  })
+
+  target.write(output)
+
+  return {
+    grid: nextGrid,
+    width: target.columns,
+    height: target.rows,
+  }
+}
+
+const setTitle = (title: string): void => {
+  process.stdout.write(`\x1b]2;${title}\x07`)
+}
+
+const provideDispatch = <A>(
+  effect: Effect.Effect<A, never, Dispatch>,
+  dispatch: {
+    readonly dispatchAsync: (message: unknown) => Effect.Effect<void>
+    readonly dispatchSync: (message: unknown) => void
+  },
+): Effect.Effect<A> => Effect.provideService(effect, Dispatch, dispatch)
+
+const runMain = (effect: Effect.Effect<void>): void => {
+  process.stdout.write(Ansi.enterAltScreen + Ansi.clearScreen)
+
+  const cleanup = () => {
+    process.stdout.write(Ansi.showCursor + Ansi.exitAltScreen)
+    process.exit(0)
+  }
+
+  process.on('SIGINT', cleanup)
+  process.on('SIGTERM', cleanup)
+  process.on('exit', () => {
+    process.stdout.write(Ansi.showCursor + Ansi.exitAltScreen)
+  })
+
+  NodeRuntime.runMain(effect)
+}
+
+export const Terminal = {
+  render,
+  setTitle,
+  provideDispatch,
+  runMain,
+} as const
+
+export { createTarget }

--- a/packages/foldkit/src/terminal/public.ts
+++ b/packages/foldkit/src/terminal/public.ts
@@ -1,0 +1,24 @@
+export { terminal } from './view'
+
+export type {
+  Attribute,
+  BorderStyle,
+  Color,
+  FlexDirection,
+  TerminalNode,
+  TerminalView,
+} from './view'
+
+export { makeTerminalProgram, runTerminal } from './runtime'
+
+export type {
+  MakeTerminalRuntimeReturn,
+  TerminalCrashConfig,
+  TerminalProgramConfig,
+  TerminalProgramConfigWithFlags,
+  TerminalProgramInit,
+} from './runtime'
+
+export { keyPressStream } from './input'
+
+export type { KeyPress } from './input'

--- a/packages/foldkit/src/terminal/runtime.ts
+++ b/packages/foldkit/src/terminal/runtime.ts
@@ -1,0 +1,753 @@
+import {
+  Array,
+  Cause,
+  Context,
+  Effect,
+  Function,
+  Layer,
+  Option,
+  Predicate,
+  Queue,
+  Record,
+  Ref,
+  Runtime,
+  Schema,
+  Stream,
+  SubscriptionRef,
+  pipe,
+} from 'effect'
+
+import type { Command } from '../command'
+import { Dispatch } from '../runtime/dispatch'
+import type { SlowViewConfig } from '../runtime/runtime'
+import type { ManagedResourceConfig, ManagedResources } from '../runtime/managedResource'
+import type { Subscriptions } from '../runtime/subscription'
+import type { TerminalRenderState } from './platform'
+import { Terminal, createTarget } from './platform'
+import type { TerminalView } from './view'
+
+type AnyCommand<T, E = never, R = never> = {
+  readonly name: string
+  readonly effect: Effect.Effect<T, E, R>
+}
+
+const DEFAULT_SLOW_VIEW_THRESHOLD_MS = 16
+
+const defaultSlowViewCallback = (context: {
+  durationMs: number
+  thresholdMs: number
+  message: Option.Option<unknown>
+}): void => {
+  const trigger = Option.match(context.message, {
+    onNone: () => 'init',
+    onSome: message => {
+      const tag =
+        Predicate.isRecord(message) && '_tag' in message
+          ? String(message['_tag'])
+          : 'unknown'
+      return tag
+    },
+  })
+
+  console.warn(
+    `[foldkit] Slow view: ${context.durationMs.toFixed(1)}ms (budget: ${context.thresholdMs}ms), triggered by ${trigger}.`,
+  )
+}
+
+/** Terminal crash config — report only, no custom view. */
+export type TerminalCrashConfig<Model, Message> = Readonly<{
+  report?: (context: Readonly<{ error: Error; model: Model; message: Message }>) => void
+}>
+
+/** Configuration for terminal programs without flags. */
+export type TerminalProgramConfig<
+  Model,
+  Message,
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Resources = never,
+  ManagedResourceServices = never,
+> = Readonly<{
+  Model: Schema.Schema<Model, any, never>
+  init: () => readonly [
+    Model,
+    ReadonlyArray<Command<Message, never, Resources | ManagedResourceServices>>,
+  ]
+  update: (
+    model: Model,
+    message: Message,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command<Message, never, Resources | ManagedResourceServices>>,
+  ]
+  view: (model: Model) => TerminalView
+  subscriptions?: Subscriptions<
+    Model,
+    Message,
+    StreamDepsMap,
+    Resources | ManagedResourceServices
+  >
+  crash?: TerminalCrashConfig<Model, Message>
+  slowView?: SlowViewConfig<Model, Message>
+  resources?: Layer.Layer<Resources>
+  managedResources?: ManagedResources<Model, Message, ManagedResourceServices>
+  title?: (model: Model) => string
+}>
+
+/** Configuration for terminal programs with flags. */
+export type TerminalProgramConfigWithFlags<
+  Model,
+  Message,
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources = never,
+  ManagedResourceServices = never,
+> = TerminalProgramConfig<
+  Model,
+  Message,
+  StreamDepsMap,
+  Resources,
+  ManagedResourceServices
+> &
+  Readonly<{
+    Flags: Schema.Schema<Flags, any, never>
+    flags: Effect.Effect<Flags>
+    init: (
+      flags: Flags,
+    ) => readonly [
+      Model,
+      ReadonlyArray<
+        Command<Message, never, Resources | ManagedResourceServices>
+      >,
+    ]
+  }>
+
+/** The init function type for terminal programs. */
+export type TerminalProgramInit<
+  Model,
+  Message,
+  Flags = void,
+  Resources = never,
+  ManagedResourceServices = never,
+> = Flags extends void
+  ? () => readonly [
+      Model,
+      ReadonlyArray<
+        Command<Message, never, Resources | ManagedResourceServices>
+      >,
+    ]
+  : (
+      flags: Flags,
+    ) => readonly [
+      Model,
+      ReadonlyArray<
+        Command<Message, never, Resources | ManagedResourceServices>
+      >,
+    ]
+
+type TerminalRuntimeConfig<
+  Model,
+  Message,
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources = never,
+  ManagedResourceServices = never,
+> = Readonly<{
+  Model: Schema.Schema<Model, any, never>
+  Flags: Schema.Schema<Flags, any, never>
+  flags: Effect.Effect<Flags>
+  init: (
+    flags: Flags,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command<Message, never, Resources | ManagedResourceServices>>,
+  ]
+  update: (
+    model: Model,
+    message: Message,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command<Message, never, Resources | ManagedResourceServices>>,
+  ]
+  view: (model: Model) => TerminalView
+  subscriptions?: Subscriptions<
+    Model,
+    Message,
+    StreamDepsMap,
+    Resources | ManagedResourceServices
+  >
+  crash?: TerminalCrashConfig<Model, Message>
+  slowView?: SlowViewConfig<Model, Message>
+  resources?: Layer.Layer<Resources>
+  managedResources?: ManagedResources<Model, Message, ManagedResourceServices>
+  title?: (model: Model) => string
+}>
+
+/** A configured terminal runtime, passed to `runTerminal` to start the application. */
+export type MakeTerminalRuntimeReturn = () => Effect.Effect<void>
+
+const makeTerminalRuntime = <
+  Model,
+  Message,
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources,
+  ManagedResourceServices,
+>({
+  Model,
+  flags: resolveFlags,
+  init,
+  update,
+  view,
+  subscriptions,
+  crash,
+  slowView,
+  resources,
+  managedResources,
+  title,
+}: TerminalRuntimeConfig<
+  Model,
+  Message,
+  StreamDepsMap,
+  Flags,
+  Resources,
+  ManagedResourceServices
+>): MakeTerminalRuntimeReturn => {
+  const resolvedSlowView = pipe(
+    slowView ?? {},
+    Option.liftPredicate(config => config !== false),
+    Option.map(config => ({
+      thresholdMs:
+        typeof config === 'object' && 'thresholdMs' in config
+          ? config.thresholdMs ?? DEFAULT_SLOW_VIEW_THRESHOLD_MS
+          : DEFAULT_SLOW_VIEW_THRESHOLD_MS,
+      onSlowView:
+        typeof config === 'object' && 'onSlowView' in config
+          ? config.onSlowView ?? defaultSlowViewCallback
+          : defaultSlowViewCallback,
+    })),
+  )
+
+  return (): Effect.Effect<void> =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const target = createTarget()
+
+        const maybeResourceLayer = resources
+          ? Option.some(yield* Layer.memoize(resources))
+          : Option.none()
+
+        const managedResourceEntries: ReadonlyArray<
+          [string, ManagedResourceConfig<Model, Message>]
+        > = managedResources
+          ? /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+            (Record.toEntries(managedResources) as ReadonlyArray<
+              [string, ManagedResourceConfig<Model, Message>]
+            >)
+          : []
+
+        const managedResourceRefs = yield* Effect.forEach(
+          managedResourceEntries,
+          ([_key, config]) =>
+            Ref.make<Option.Option<unknown>>(Option.none()).pipe(
+              Effect.map(ref => ({ config, ref })),
+            ),
+        )
+
+        const mergeResourceIntoLayer = (
+          layer: Layer.Layer<any>,
+          { config, ref }: ManagedResourceRef,
+        ) =>
+          Layer.merge(
+            layer,
+            Layer.succeed(
+              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+              config.resource._tag as Context.Tag<any, any>,
+              ref,
+            ),
+          )
+
+        const maybeManagedResourceLayer = Array.match(managedResourceRefs, {
+          onEmpty: () => Option.none(),
+          onNonEmpty: refs =>
+            Option.some(
+              Array.reduce(
+                refs,
+                /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+                Layer.empty as Layer.Layer<any>,
+                mergeResourceIntoLayer,
+              ),
+            ),
+        })
+
+        const provideAllResources = <A>(
+          effect: Effect.Effect<A, never, Resources | ManagedResourceServices>,
+        ): Effect.Effect<A> => {
+          const withResources = Option.match(maybeResourceLayer, {
+            onNone: () => effect,
+            onSome: resourceLayer => Effect.provide(effect, resourceLayer),
+          })
+
+          return Option.match(maybeManagedResourceLayer, {
+            /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+            onNone: () => withResources as Effect.Effect<A>,
+            onSome: managedLayer =>
+              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+              Effect.provide(withResources, managedLayer) as Effect.Effect<A>,
+          })
+        }
+
+        const flags = yield* resolveFlags
+
+        const modelEquivalence = Schema.equivalence(Model)
+
+        const messageQueue = yield* Queue.unbounded<Message>()
+        const enqueueMessage = (message: Message) =>
+          Queue.offer(messageQueue, message)
+
+        const [initModel, initCommands] = init(flags)
+
+        const modelSubscriptionRef = yield* SubscriptionRef.make(initModel)
+
+        yield* Effect.forEach(
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+          initCommands as ReadonlyArray<
+            AnyCommand<Message, never, Resources | ManagedResourceServices>
+          >,
+          command =>
+            Effect.forkDaemon(
+              command.effect.pipe(
+                Effect.withSpan(command.name),
+                provideAllResources,
+                Effect.flatMap(enqueueMessage),
+              ),
+            ),
+        )
+
+        const modelRef = yield* Ref.make<Model>(initModel)
+
+        const maybeCurrentRenderStateRef = yield* Ref.make<
+          Option.Option<TerminalRenderState>
+        >(Option.none())
+
+        const currentMessageRef = yield* Ref.make<Option.Option<Message>>(
+          Option.none(),
+        )
+
+        const maybeRuntimeRef = yield* Ref.make<
+          Option.Option<Runtime.Runtime<never>>
+        >(Option.none())
+
+        const processMessage = (message: Message): Effect.Effect<void> =>
+          Effect.gen(function* () {
+            const currentModel = yield* Ref.get(modelRef)
+
+            const [nextModel, commands] = update(currentModel, message)
+
+            if (currentModel !== nextModel) {
+              yield* Ref.set(modelRef, nextModel)
+              yield* render(nextModel, Option.some(message))
+
+              if (!modelEquivalence(currentModel, nextModel)) {
+                yield* SubscriptionRef.set(modelSubscriptionRef, nextModel)
+              }
+            }
+
+            yield* Effect.forEach(
+              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+              commands as ReadonlyArray<
+                AnyCommand<Message, never, Resources | ManagedResourceServices>
+              >,
+              command =>
+                Effect.forkDaemon(
+                  command.effect.pipe(
+                    Effect.withSpan(command.name),
+                    provideAllResources,
+                    Effect.flatMap(enqueueMessage),
+                  ),
+                ),
+            )
+          })
+
+        const runProcessMessage =
+          (message: Message, messageEffect: Effect.Effect<void>) =>
+          (runtime: Runtime.Runtime<never>): void => {
+            try {
+              Runtime.runSync(runtime, messageEffect)
+            } catch (error) {
+              const squashed = Runtime.isFiberFailure(error)
+                ? Cause.squash(error[Runtime.FiberFailureCauseId])
+                : error
+
+              const appError =
+                squashed instanceof Error
+                  ? squashed
+                  : new Error(String(squashed))
+              const model = Ref.get(modelRef).pipe(Effect.runSync)
+
+              console.error('[foldkit] Application crash:', appError)
+
+              if (crash?.report) {
+                try {
+                  crash.report({ error: appError, model, message })
+                } catch (reportError) {
+                  console.error('[foldkit] crash.report failed:', reportError)
+                }
+              }
+            }
+          }
+
+        const dispatchSync = (message: unknown): void => {
+          const maybeRuntime = Ref.get(maybeRuntimeRef).pipe(Effect.runSync)
+
+          Option.match(maybeRuntime, {
+            onNone: Function.constVoid,
+            onSome: runProcessMessage(
+              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+              message as Message,
+              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+              processMessage(message as Message),
+            ),
+          })
+        }
+
+        const dispatchAsync = (message: unknown): Effect.Effect<void> =>
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+          enqueueMessage(message as Message)
+
+        const render = (model: Model, message: Option.Option<Message>) =>
+          Effect.gen(function* () {
+            const viewStart = performance.now()
+            const nextNode = yield* view(model)
+            const viewDuration = performance.now() - viewStart
+
+            Option.match(resolvedSlowView, {
+              onNone: Function.constVoid,
+              onSome: ({ thresholdMs, onSlowView }) => {
+                if (viewDuration > thresholdMs) {
+                  onSlowView({
+                    model,
+                    message,
+                    durationMs: viewDuration,
+                    thresholdMs,
+                  })
+                }
+              },
+            })
+
+            const maybePreviousRenderState = yield* Ref.get(
+              maybeCurrentRenderStateRef,
+            )
+            const nextRenderState = Terminal.render(
+              maybePreviousRenderState,
+              nextNode,
+              target,
+            )
+            yield* Ref.set(
+              maybeCurrentRenderStateRef,
+              Option.some(nextRenderState),
+            )
+
+            if (title) {
+              Terminal.setTitle(title(model))
+            }
+          }).pipe(
+            Effect.provideService(Dispatch, {
+              dispatchAsync,
+              dispatchSync,
+            }),
+          )
+
+        const runtime = yield* Effect.runtime()
+        yield* Ref.set(maybeRuntimeRef, Option.some(runtime))
+
+        yield* render(initModel, Option.none())
+
+        if (subscriptions) {
+          yield* pipe(
+            subscriptions,
+            Record.toEntries,
+            Effect.forEach(
+              ([
+                _key,
+                {
+                  schema,
+                  modelToDependencies,
+                  equivalence: customEquivalence,
+                  dependenciesToStream,
+                },
+              ]) => {
+                let latestDependencies = modelToDependencies(initModel)
+                const equivalence =
+                  customEquivalence ?? Schema.equivalence(schema)
+
+                const modelStream = Stream.concat(
+                  Stream.make(initModel),
+                  modelSubscriptionRef.changes,
+                )
+
+                return Effect.forkDaemon(
+                  modelStream.pipe(
+                    Stream.map(model => {
+                      const dependencies = modelToDependencies(model)
+                      latestDependencies = dependencies
+                      return dependencies
+                    }),
+                    Stream.changesWith(equivalence),
+                    Stream.flatMap(
+                      dependencies =>
+                        dependenciesToStream(
+                          dependencies,
+                          () => latestDependencies,
+                        ),
+                      { switch: true },
+                    ),
+                    Stream.runForEach(enqueueMessage),
+                    provideAllResources,
+                  ),
+                )
+              },
+              {
+                concurrency: 'unbounded',
+                discard: true,
+              },
+            ),
+          )
+        }
+
+        type ManagedResourceRef = (typeof managedResourceRefs)[number]
+
+        const maybeRequirementsToLifecycle =
+          (
+            config: ManagedResourceConfig<Model, Message>,
+            resourceRef: Ref.Ref<Option.Option<unknown>>,
+          ) =>
+          (
+            maybeRequirements: unknown,
+          ): Stream.Stream<Effect.Effect<Message, unknown>> => {
+            if (
+              Option.isOption(maybeRequirements) &&
+              Option.isNone(maybeRequirements)
+            ) {
+              return Stream.empty
+            }
+
+            const requirements = Option.isOption(maybeRequirements)
+              ? Option.getOrThrow(maybeRequirements)
+              : maybeRequirements
+
+            const acquire = Effect.gen(function* () {
+              const value = yield* config.acquire(requirements)
+              yield* Ref.set(resourceRef, Option.some(value))
+              return value
+            })
+
+            const release = (value: unknown) =>
+              Effect.gen(function* () {
+                yield* config.release(value)
+                yield* Ref.set(resourceRef, Option.none())
+                yield* enqueueMessage(config.onReleased())
+              }).pipe(Effect.catchAllCause(() => Effect.void))
+
+            return pipe(
+              Stream.scoped(Effect.acquireRelease(acquire, release)),
+              Stream.flatMap(value =>
+                Stream.concat(
+                  Stream.make(config.onAcquired(value)),
+                  Stream.never,
+                ),
+              ),
+              Stream.map(Effect.succeed),
+              Stream.catchAll(error =>
+                Stream.make(Effect.succeed(config.onAcquireError(error))),
+              ),
+            )
+          }
+
+        const forkManagedResourceLifecycle = ({
+          config,
+          ref: resourceRef,
+        }: ManagedResourceRef) =>
+          Effect.gen(function* () {
+            const modelStream = Stream.concat(
+              Stream.make(initModel),
+              modelSubscriptionRef.changes,
+            )
+
+            const equivalence = Schema.equivalence(config.schema)
+
+            yield* Effect.forkDaemon(
+              modelStream.pipe(
+                Stream.map(config.modelToMaybeRequirements),
+                Stream.changesWith(equivalence),
+                Stream.flatMap(
+                  maybeRequirementsToLifecycle(config, resourceRef),
+                  { switch: true },
+                ),
+                Stream.runForEach(Effect.flatMap(enqueueMessage)),
+              ),
+            )
+          })
+
+        yield* Effect.forEach(
+          managedResourceRefs,
+          forkManagedResourceLifecycle,
+          {
+            concurrency: 'unbounded',
+            discard: true,
+          },
+        )
+
+        yield* pipe(
+          Effect.forever(
+            Effect.gen(function* () {
+              const message = yield* Queue.take(messageQueue)
+              yield* Ref.set(currentMessageRef, Option.some(message))
+              yield* processMessage(message)
+            }),
+          ),
+          Effect.catchAllCause(cause =>
+            Effect.sync(() => {
+              const squashed = Cause.squash(cause)
+              const appError =
+                squashed instanceof Error
+                  ? squashed
+                  : new Error(String(squashed))
+
+              const model = Ref.get(modelRef).pipe(Effect.runSync)
+              const message = Ref.get(currentMessageRef).pipe(
+                Effect.runSync,
+                Option.getOrThrow,
+              )
+
+              console.error('[foldkit] Application crash:', appError)
+
+              if (crash?.report) {
+                try {
+                  crash.report({ error: appError, model, message })
+                } catch (reportError) {
+                  console.error('[foldkit] crash.report failed:', reportError)
+                }
+              }
+            }),
+          ),
+        )
+      }),
+    )
+}
+
+/** Creates a Foldkit terminal program. */
+export function makeTerminalProgram<
+  Model,
+  Message extends { _tag: string },
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources = never,
+  ManagedResourceServices = never,
+>(
+  config: TerminalProgramConfigWithFlags<
+    Model,
+    Message,
+    StreamDepsMap,
+    Flags,
+    Resources,
+    ManagedResourceServices
+  >,
+): MakeTerminalRuntimeReturn
+
+export function makeTerminalProgram<
+  Model,
+  Message extends { _tag: string },
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Resources = never,
+  ManagedResourceServices = never,
+>(
+  config: TerminalProgramConfig<
+    Model,
+    Message,
+    StreamDepsMap,
+    Resources,
+    ManagedResourceServices
+  >,
+): MakeTerminalRuntimeReturn
+
+export function makeTerminalProgram<
+  Model,
+  Message extends { _tag: string },
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources = never,
+  ManagedResourceServices = never,
+>(
+  config:
+    | TerminalProgramConfigWithFlags<
+        Model,
+        Message,
+        StreamDepsMap,
+        Flags,
+        Resources,
+        ManagedResourceServices
+      >
+    | TerminalProgramConfig<
+        Model,
+        Message,
+        StreamDepsMap,
+        Resources,
+        ManagedResourceServices
+      >,
+): MakeTerminalRuntimeReturn {
+  const hasFlags = 'Flags' in config
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  if (hasFlags) {
+    const flagsConfig = config as TerminalProgramConfigWithFlags<
+      Model,
+      Message,
+      StreamDepsMap,
+      Flags,
+      Resources,
+      ManagedResourceServices
+    >
+    return makeTerminalRuntime({
+      ...config,
+      Flags: flagsConfig.Flags,
+      flags: flagsConfig.flags,
+      init: flagsConfig.init,
+    } as TerminalRuntimeConfig<
+      Model,
+      Message,
+      StreamDepsMap,
+      Flags,
+      Resources,
+      ManagedResourceServices
+    >)
+  }
+
+  return makeTerminalRuntime({
+    ...config,
+    Flags: Schema.Void,
+    flags: Effect.succeed(undefined),
+    init: () =>
+      (
+        config as TerminalProgramConfig<
+          Model,
+          Message,
+          StreamDepsMap,
+          Resources,
+          ManagedResourceServices
+        >
+      ).init(),
+  } as TerminalRuntimeConfig<
+    Model,
+    Message,
+    StreamDepsMap,
+    void,
+    Resources,
+    ManagedResourceServices
+  >)
+  /* eslint-enable @typescript-eslint/consistent-type-assertions */
+}
+
+/** Starts a Foldkit terminal runtime. */
+export const runTerminal = (terminalRuntime: MakeTerminalRuntimeReturn): void => {
+  Terminal.runMain(terminalRuntime())
+}

--- a/packages/foldkit/src/terminal/runtime.ts
+++ b/packages/foldkit/src/terminal/runtime.ts
@@ -19,8 +19,11 @@ import {
 
 import type { Command } from '../command'
 import { Dispatch } from '../runtime/dispatch'
+import type {
+  ManagedResourceConfig,
+  ManagedResources,
+} from '../runtime/managedResource'
 import type { SlowViewConfig } from '../runtime/runtime'
-import type { ManagedResourceConfig, ManagedResources } from '../runtime/managedResource'
 import type { Subscriptions } from '../runtime/subscription'
 import type { TerminalRenderState } from './platform'
 import { Terminal, createTarget } from './platform'
@@ -56,7 +59,9 @@ const defaultSlowViewCallback = (context: {
 
 /** Terminal crash config — report only, no custom view. */
 export type TerminalCrashConfig<Model, Message> = Readonly<{
-  report?: (context: Readonly<{ error: Error; model: Model; message: Message }>) => void
+  report?: (
+    context: Readonly<{ error: Error; model: Model; message: Message }>,
+  ) => void
 }>
 
 /** Configuration for terminal programs without flags. */
@@ -218,11 +223,11 @@ const makeTerminalRuntime = <
     Option.map(config => ({
       thresholdMs:
         typeof config === 'object' && 'thresholdMs' in config
-          ? config.thresholdMs ?? DEFAULT_SLOW_VIEW_THRESHOLD_MS
+          ? (config.thresholdMs ?? DEFAULT_SLOW_VIEW_THRESHOLD_MS)
           : DEFAULT_SLOW_VIEW_THRESHOLD_MS,
       onSlowView:
         typeof config === 'object' && 'onSlowView' in config
-          ? config.onSlowView ?? defaultSlowViewCallback
+          ? (config.onSlowView ?? defaultSlowViewCallback)
           : defaultSlowViewCallback,
     })),
   )
@@ -748,6 +753,8 @@ export function makeTerminalProgram<
 }
 
 /** Starts a Foldkit terminal runtime. */
-export const runTerminal = (terminalRuntime: MakeTerminalRuntimeReturn): void => {
+export const runTerminal = (
+  terminalRuntime: MakeTerminalRuntimeReturn,
+): void => {
   Terminal.runMain(terminalRuntime())
 }

--- a/packages/foldkit/src/terminal/runtime.ts
+++ b/packages/foldkit/src/terminal/runtime.ts
@@ -702,7 +702,7 @@ export function makeTerminalProgram<
 ): MakeTerminalRuntimeReturn {
   const hasFlags = 'Flags' in config
 
-  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  /* eslint-disable @typescript-eslint/consistent-type-assertions */
   if (hasFlags) {
     const flagsConfig = config as TerminalProgramConfigWithFlags<
       Model,

--- a/packages/foldkit/src/terminal/view.ts
+++ b/packages/foldkit/src/terminal/view.ts
@@ -1,0 +1,255 @@
+import { Effect, Match, Option } from 'effect'
+
+import { Dispatch } from '../runtime/dispatch'
+
+// TERMINAL VIEW TYPE
+
+/** A terminal view element represented as an Effect that produces a TerminalNode. */
+export type TerminalView = Effect.Effect<TerminalNode | null, never, Dispatch>
+type Child = TerminalView | string
+
+// TERMINAL NODE
+
+export type TerminalNode = BoxNode | TextNode
+
+export type BoxNode = Readonly<{
+  _tag: 'Box'
+  attributes: TerminalAttributes
+  children: ReadonlyArray<TerminalNode>
+}>
+
+export type TextNode = Readonly<{
+  _tag: 'Text'
+  attributes: TerminalAttributes
+  content: string
+}>
+
+// ATTRIBUTES
+
+export type Color =
+  | 'Black'
+  | 'Red'
+  | 'Green'
+  | 'Yellow'
+  | 'Blue'
+  | 'Magenta'
+  | 'Cyan'
+  | 'White'
+  | 'Default'
+  | 'BrightBlack'
+  | 'BrightRed'
+  | 'BrightGreen'
+  | 'BrightYellow'
+  | 'BrightBlue'
+  | 'BrightMagenta'
+  | 'BrightCyan'
+  | 'BrightWhite'
+
+export type FlexDirection = 'Row' | 'Column'
+
+export type BorderStyle = 'None' | 'Single' | 'Double' | 'Round' | 'Bold'
+
+export type TerminalAttributes = Readonly<{
+  foreground: Option.Option<Color>
+  background: Option.Option<Color>
+  isBold: boolean
+  isDim: boolean
+  isUnderline: boolean
+  isItalic: boolean
+  flexDirection: FlexDirection
+  width: Option.Option<number>
+  height: Option.Option<number>
+  paddingTop: number
+  paddingRight: number
+  paddingBottom: number
+  paddingLeft: number
+  border: BorderStyle
+}>
+
+export const emptyAttributes: TerminalAttributes = {
+  foreground: Option.none(),
+  background: Option.none(),
+  isBold: false,
+  isDim: false,
+  isUnderline: false,
+  isItalic: false,
+  flexDirection: 'Column',
+  width: Option.none(),
+  height: Option.none(),
+  paddingTop: 0,
+  paddingRight: 0,
+  paddingBottom: 0,
+  paddingLeft: 0,
+  border: 'None',
+}
+
+// ATTRIBUTE CONSTRUCTORS
+
+export type Attribute =
+  | Readonly<{ _tag: 'Fg'; color: Color }>
+  | Readonly<{ _tag: 'Bg'; color: Color }>
+  | Readonly<{ _tag: 'Bold' }>
+  | Readonly<{ _tag: 'Dim' }>
+  | Readonly<{ _tag: 'Underline' }>
+  | Readonly<{ _tag: 'Italic' }>
+  | Readonly<{ _tag: 'Direction'; direction: FlexDirection }>
+  | Readonly<{ _tag: 'Width'; value: number }>
+  | Readonly<{ _tag: 'Height'; value: number }>
+  | Readonly<{
+      _tag: 'Padding'
+      top: number
+      right: number
+      bottom: number
+      left: number
+    }>
+  | Readonly<{ _tag: 'Border'; style: BorderStyle }>
+
+const resolveAttributes = (
+  attributes: ReadonlyArray<Attribute>,
+): TerminalAttributes => {
+  let result = emptyAttributes
+
+  for (const attribute of attributes) {
+    result = Match.value(attribute).pipe(
+      Match.tag('Fg', ({ color }) => ({
+        ...result,
+        foreground: Option.some(color),
+      })),
+      Match.tag('Bg', ({ color }) => ({
+        ...result,
+        background: Option.some(color),
+      })),
+      Match.tag('Bold', () => ({ ...result, isBold: true as const })),
+      Match.tag('Dim', () => ({ ...result, isDim: true as const })),
+      Match.tag('Underline', () => ({
+        ...result,
+        isUnderline: true as const,
+      })),
+      Match.tag('Italic', () => ({ ...result, isItalic: true as const })),
+      Match.tag('Direction', ({ direction }) => ({
+        ...result,
+        flexDirection: direction,
+      })),
+      Match.tag('Width', ({ value }) => ({
+        ...result,
+        width: Option.some(value),
+      })),
+      Match.tag('Height', ({ value }) => ({
+        ...result,
+        height: Option.some(value),
+      })),
+      Match.tag('Padding', ({ top, right, bottom, left }) => ({
+        ...result,
+        paddingTop: top,
+        paddingRight: right,
+        paddingBottom: bottom,
+        paddingLeft: left,
+      })),
+      Match.tag('Border', ({ style }) => ({ ...result, border: style })),
+      Match.exhaustive,
+    )
+  }
+
+  return result
+}
+
+// ELEMENT CONSTRUCTORS
+
+const resolveChild = (child: Child): TerminalView =>
+  typeof child === 'string'
+    ? Effect.succeed({
+        _tag: 'Text' as const,
+        attributes: emptyAttributes,
+        content: child,
+      })
+    : child
+
+const createBox = (
+  attributes: ReadonlyArray<Attribute>,
+  children: ReadonlyArray<Child>,
+): TerminalView =>
+  Effect.map(
+    Effect.all(children.map(resolveChild)),
+    (resolvedChildren): TerminalNode => ({
+      _tag: 'Box',
+      attributes: resolveAttributes(attributes),
+      children: resolvedChildren.filter(
+        (child): child is TerminalNode => child !== null,
+      ),
+    }),
+  )
+
+const createText = (
+  attributes: ReadonlyArray<Attribute>,
+  content: string,
+): TerminalView =>
+  Effect.succeed({
+    _tag: 'Text',
+    attributes: resolveAttributes(attributes),
+    content,
+  })
+
+// PUBLIC API
+
+type BoxFunction = (
+  attributes: ReadonlyArray<Attribute>,
+  children: ReadonlyArray<Child>,
+) => TerminalView
+
+type TextFunction = (
+  attributes: ReadonlyArray<Attribute>,
+  content: string,
+) => TerminalView
+
+type TerminalElements = Readonly<{
+  box: BoxFunction
+  text: TextFunction
+  empty: TerminalView
+}>
+
+type TerminalAttributeConstructors = Readonly<{
+  Fg: (color: Color) => Attribute
+  Bg: (color: Color) => Attribute
+  Bold: Attribute
+  Dim: Attribute
+  Underline: Attribute
+  Italic: Attribute
+  Direction: (direction: FlexDirection) => Attribute
+  Width: (value: number) => Attribute
+  Height: (value: number) => Attribute
+  Padding: (
+    top: number,
+    right: number,
+    bottom: number,
+    left: number,
+  ) => Attribute
+  Border: (style: BorderStyle) => Attribute
+}>
+
+/**
+ * Factory that returns all terminal element constructors, attribute
+ * constructors, and `empty` for rendering nothing.
+ */
+export const terminal = <_Message = never>(): TerminalElements &
+  TerminalAttributeConstructors => ({
+  box: createBox,
+  text: createText,
+  empty: Effect.succeed(null),
+  Fg: (color): Attribute => ({ _tag: 'Fg', color }),
+  Bg: (color): Attribute => ({ _tag: 'Bg', color }),
+  Bold: { _tag: 'Bold' },
+  Dim: { _tag: 'Dim' },
+  Underline: { _tag: 'Underline' },
+  Italic: { _tag: 'Italic' },
+  Direction: (direction): Attribute => ({ _tag: 'Direction', direction }),
+  Width: (value): Attribute => ({ _tag: 'Width', value }),
+  Height: (value): Attribute => ({ _tag: 'Height', value }),
+  Padding: (top, right, bottom, left): Attribute => ({
+    _tag: 'Padding',
+    top,
+    right,
+    bottom,
+    left,
+  }),
+  Border: (style): Attribute => ({ _tag: 'Border', style }),
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,25 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  examples/snake-terminal:
+    dependencies:
+      '@effect/platform-node':
+        specifier: ^0.104.1
+        version: 0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
+      effect:
+        specifier: ^3.19.19
+        version: 3.19.19
+      foldkit:
+        specifier: workspace:*
+        version: link:../../packages/foldkit
+    devDependencies:
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/stopwatch:
     dependencies:
       '@tailwindcss/vite':
@@ -880,6 +899,9 @@ importers:
       '@effect/platform-browser':
         specifier: ^0.74.0
         version: 0.74.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
+      '@effect/platform-node':
+        specifier: ^0.104.1
+        version: 0.104.1(@effect/cluster@0.56.1(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(@effect/rpc@0.73.2(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
       '@effect/vitest':
         specifier: ^0.27.0
         version: 0.27.0(effect@3.19.19)(vitest@3.2.4(@types/node@25.1.0)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
@@ -1969,36 +1991,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2094,24 +2122,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -2172,66 +2204,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -2333,24 +2378,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -3302,24 +3351,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3927,10 +3980,6 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.19.2:
-    resolution: {integrity: sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.6:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
@@ -4527,7 +4576,7 @@ snapshots:
       '@effect/sql': 0.49.0(@effect/experimental@0.58.0(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.94.5(effect@3.19.19))(effect@3.19.19)
       effect: 3.19.19
       mime: 3.0.0
-      undici: 7.19.2
+      undici: 7.24.6
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -6811,8 +6860,6 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
-
-  undici@7.19.2: {}
 
   undici@7.24.6: {}
 


### PR DESCRIPTION
## Summary

This PR adds a complete terminal view layer to foldkit, enabling Elm Architecture applications to run in the terminal with native box/text elements, ANSI color/styling support, and raw stdin input handling. The implementation includes cell grid-based rendering with diffing, layout engine, and a snake game example.

## Key Changes

- **Terminal View System** (`packages/foldkit/src/terminal/view.ts`): New `TerminalView` effect type and DSL for building terminal UIs with `terminal()` function, supporting box and text elements with attributes (colors, bold, borders, padding, flex layout)

- **Layout Engine** (`packages/foldkit/src/terminal/layout.ts`): Converts TerminalNode tree into a flat CellGrid with support for borders (single/double/round/bold styles), padding, background fills, and text wrapping

- **ANSI Rendering** (`packages/foldkit/src/terminal/ansi.ts`): Generates ANSI escape sequences for colors and styles, with `renderFull()` for initial render and `renderDiff()` for incremental updates to minimize output

- **Terminal Runtime** (`packages/foldkit/src/terminal/runtime.ts`): Full Elm Architecture runtime for terminal apps with `makeTerminalProgram()` and `runTerminal()`, supporting:
  - Model/Message/Update/View pattern
  - Optional flags support
  - Commands and subscriptions
  - Resource layers and managed resources
  - Crash reporting and slow view detection
  - Message queue and async/sync dispatch

- **Input Handling** (`packages/foldkit/src/terminal/input.ts`): Raw terminal mode setup and `keyPressStream()` for parsing stdin into structured KeyPress events (arrow keys, modifiers, etc.)

- **Platform Integration** (`packages/foldkit/src/terminal/platform.ts`): Terminal target abstraction, render state management, and cursor control

- **Cell Grid** (`packages/foldkit/src/terminal/cell.ts`): Core data structure representing terminal cells with character, colors, and text attributes

- **Snake Game Example** (`examples/snake-terminal/`): Complete playable snake game demonstrating the terminal view layer with game state, subscriptions for game clock and keyboard input, and dynamic difficulty scaling

- **Dispatch Service** (`packages/foldkit/src/runtime/dispatch.ts`): New Effect service tag for message dispatching from view layer to runtime

## Notable Implementation Details

- Terminal rendering uses a cell grid diffing strategy to minimize ANSI output and flicker
- Layout engine supports flexible box model with padding, borders, and directional layout (row/column)
- Subscriptions can depend on model state with automatic re-subscription on equivalence changes
- Raw stdin mode is properly managed with cleanup on application exit
- Snake example includes wrapping grid boundaries, collision detection, and score tracking

https://claude.ai/code/session_015d4dn7sgJ9MTc2AtCvyJp1