### PR TITLE
Improve clarity and flow of core documentation pages

### DIFF
--- a/packages/website/src/page/core/commands.ts
+++ b/packages/website/src/page/core/commands.ts
@@ -52,7 +52,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       pageTitle('core/commands', 'Commands'),
       tableOfContentsEntryToHeader(overviewHeader),
       para(
-        'So far, update has been returning an empty Commands array. It\u2019s time to put it to use. But before we write our first Command, there\u2019s a fundamental idea to understand: the update function doesn\u2019t actually do anything.',
+        'A Command is a description of a side effect \u2014 an HTTP request, a timer, a DOM focus call. The update function doesn\u2019t actually do anything on its own: it returns data, and the Foldkit runtime reads the Commands and carries them out.',
       ),
       para(
         'In the ',
@@ -63,7 +63,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         ', Commands are the slips the waiter hands to the kitchen. The waiter doesn\u2019t cook \u2014 they describe what\u2019s needed and hand it off. The kitchen does the work and reports back when it\u2019s done.',
       ),
       para(
-        'When update runs, no HTTP request fires, no timer starts, no DOM changes. It returns data \u2014 a new Model and a list of Commands that describe what should happen. The Foldkit runtime reads those descriptions and executes them.',
+        'When update runs, no HTTP request fires, no timer starts, no DOM changes. It returns a new Model and a list of Commands that describe what should happen, and the runtime executes them.',
       ),
       infoCallout(
         'A different model for side effects',
@@ -74,7 +74,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         '. In Foldkit, update is pure. It describes what should happen and the runtime does it.',
       ),
       para(
-        'Let\u2019s see what that looks like. Say we want a delayed reset: when the user clicks reset, the count resets after one second:',
+        'So far, update has been returning an empty Commands array. Let\u2019s put it to use. Say we want a delayed reset: when the user clicks reset, the count resets after one second:',
       ),
       highlightedCodeBlock(
         div(

--- a/packages/website/src/page/core/subscriptions.ts
+++ b/packages/website/src/page/core/subscriptions.ts
@@ -56,24 +56,24 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       pageTitle('core/subscriptions', 'Subscriptions'),
       tableOfContentsEntryToHeader(overviewHeader),
       para(
-        'Commands handle one-off side effects \u2014 a slip to the kitchen that comes back with a result. But what about ongoing streams? In the ',
+        'A Subscription is a reactive binding between your Model and a long-running stream \u2014 timers, ',
+        inlineCode('WebSocket'),
+        ' connections, keyboard input, resize observers, anything that produces a continuous stream of events. You declare which part of the Model the Subscription depends on, and Foldkit manages the stream lifecycle automatically, starting it when dependencies are met and stopping it when they change.',
+      ),
+      para(
+        'In the ',
         link(
           `${coreArchitectureRouter()}#the-restaurant-analogy`,
           'restaurant analogy',
         ),
-        ', a Subscription is a standing order: \u201Ckeep the coffee coming for table 5.\u201D The waiter doesn\u2019t keep walking back to repeat the order \u2014 the kitchen knows to keep pouring until the table says stop. Anything that produces a continuous stream of events \u2014 timers, ',
-        inlineCode('WebSocket'),
-        ' connections, keyboard input, resize observers \u2014 is a Subscription.',
+        ', a Subscription is a standing order: \u201Ckeep the coffee coming for table 5.\u201D The waiter doesn\u2019t keep walking back to repeat the order \u2014 the kitchen knows to keep pouring until the table says stop.',
       ),
       para(
-        'A Subscription is a reactive binding between your Model and a long-running stream. You declare which part of the Model the Subscription depends on, and Foldkit manages the stream lifecycle automatically \u2014 starting it when dependencies are met, stopping it when they change.',
-      ),
-      para(
-        'Here\u2019s how we add auto-counting to the counter. When ',
+        'Commands handle one-off side effects \u2014 a slip to the kitchen that comes back with a single result. Subscriptions handle the ongoing kind. Here\u2019s how we add auto-counting to the counter: when ',
         inlineCode('isAutoCounting'),
         ' is ',
         inlineCode('true'),
-        ', a stream ticks every second. When it flips to ',
+        ', a stream ticks every second, and when it flips to ',
         inlineCode('false'),
         ', the stream stops.',
       ),

--- a/packages/website/src/page/core/view.ts
+++ b/packages/website/src/page/core/view.ts
@@ -45,7 +45,10 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       pageTitle('core/view', 'View'),
       tableOfContentsEntryToHeader(overviewHeader),
       para(
-        'The update function produces a new Model. But the user doesn\u2019t see the Model \u2014 they see what the view function renders from it. In the ',
+        'The view function turns your Model into HTML. The user doesn\u2019t see the Model directly \u2014 they see what view renders from it.',
+      ),
+      para(
+        'In the ',
         link(
           `${coreArchitectureRouter()}#the-restaurant-analogy`,
           'restaurant analogy',


### PR DESCRIPTION
## Summary
Reorganized and refined the introductory explanations on the Commands, Subscriptions, and View documentation pages to improve clarity and better establish foundational concepts before diving into implementation details.

## Key Changes
- **Commands page**: Moved the core definition of Commands to the opening paragraph, establishing upfront that Commands are descriptions of side effects executed by the runtime. Reordered content to flow from concept → analogy → implementation details.

- **Subscriptions page**: Restructured the introduction to lead with a clear definition of Subscriptions as reactive bindings to long-running streams, followed by the restaurant analogy, then practical examples. Added explicit contrast between Commands (one-off effects) and Subscriptions (ongoing streams).

- **View page**: Split the opening paragraph into two for better readability, leading with the core concept that the view function renders the Model into HTML, then introducing the restaurant analogy in a separate paragraph.

## Notable Details
- Improved pedagogical flow by presenting definitions before analogies
- Enhanced clarity around the distinction between Commands and Subscriptions
- Maintained all existing code examples and technical accuracy
- Refined wording for conciseness while preserving meaning

https://claude.ai/code/session_01MxQ3Ya1xCVqn7inpD4E79d