### PR TITLE
Simplify Model construction in snippets and add HttpClient documentation

### DIFF
--- a/packages/website/src/page/core/commands.ts
+++ b/packages/website/src/page/core/commands.ts
@@ -10,7 +10,11 @@ import {
   para,
   tableOfContentsEntryToHeader,
 } from '../../prose'
-import { coreArchitectureRouter, testingRouter } from '../../route'
+import {
+  coreArchitectureRouter,
+  exampleDetailRouter,
+  testingRouter,
+} from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
@@ -173,6 +177,33 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         'Copy HTTP command example to clipboard',
         copiedSnippets,
         'mb-8',
+      ),
+      infoCallout(
+        'Using fetch for simplicity',
+        'This example wraps ',
+        inlineCode('fetch'),
+        ' in ',
+        inlineCode('Effect.tryPromise'),
+        ' to keep the focus on Commands. For real applications, we recommend Effect\u2019s ',
+        inlineCode('HttpClient'),
+        ' module \u2014 it gives you typed errors, request and response schemas, retries, and ',
+        inlineCode('Layer'),
+        '-based configuration. See the ',
+        link(
+          exampleDetailRouter({ exampleSlug: 'weather' }),
+          'Weather example',
+        ),
+        ' for a real ',
+        inlineCode('HttpClient'),
+        ' usage \u2014 ',
+        inlineCode('fetchWeather'),
+        ' builds requests with ',
+        inlineCode('HttpClientRequest.get'),
+        ', runs them through ',
+        inlineCode('client.execute'),
+        ', and decodes the response with ',
+        inlineCode('S.decodeUnknown'),
+        '. Whatever Effect produces the value, the Command shape stays the same.',
       ),
       para(
         'Let\u2019s zoom in on ',

--- a/packages/website/src/snippet/counterCommands.ts
+++ b/packages/website/src/snippet/counterCommands.ts
@@ -20,6 +20,6 @@ const update = (
     >(),
     M.tagsExhaustive({
       ClickedResetAfterDelay: () => [model, [delayReset]],
-      CompletedDelayReset: () => [Model({ count: 0 }), []],
+      CompletedDelayReset: () => [{ count: 0 }, []],
     }),
   )

--- a/packages/website/src/snippet/counterHttpCommand.ts
+++ b/packages/website/src/snippet/counterHttpCommand.ts
@@ -26,7 +26,7 @@ const update = (
     >(),
     M.tagsExhaustive({
       ClickedFetchCount: () => [model, [fetchCount]],
-      SucceededFetchCount: ({ count }) => [Model({ count }), []],
+      SucceededFetchCount: ({ count }) => [{ count }, []],
       FailedFetchCount: () => [model, []],
     }),
   )

--- a/packages/website/src/snippet/counterUpdate.ts
+++ b/packages/website/src/snippet/counterUpdate.ts
@@ -14,8 +14,8 @@ const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedDecrement: () => [Model({ count: model.count - 1 }), []],
-      ClickedIncrement: () => [Model({ count: model.count + 1 }), []],
-      ClickedReset: () => [Model({ count: 0 }), []],
+      ClickedDecrement: () => [{ count: model.count - 1 }, []],
+      ClickedIncrement: () => [{ count: model.count + 1 }, []],
+      ClickedReset: () => [{ count: 0 }, []],
     }),
   )

--- a/packages/website/src/snippet/initSimple.ts
+++ b/packages/website/src/snippet/initSimple.ts
@@ -13,7 +13,4 @@ const ClickedDecrement = m('ClickedDecrement')
 const Message = S.Union(ClickedIncrement, ClickedDecrement)
 type Message = typeof Message.Type
 
-const init: Runtime.ProgramInit<Model, Message> = () => [
-  Model({ count: 0 }),
-  [],
-]
+const init: Runtime.ProgramInit<Model, Message> = () => [{ count: 0 }, []]


### PR DESCRIPTION
## Summary
This PR simplifies Model object construction across code snippets by removing unnecessary `Model()` constructor calls, and adds documentation about using Effect's `HttpClient` module for real-world applications.

## Key Changes
- **Simplified Model construction**: Replaced `Model({ count: ... })` with direct object literals `{ count: ... }` in four snippet files (`counterUpdate.ts`, `initSimple.ts`, `counterCommands.ts`, `counterHttpCommand.ts`). This makes the code more concise while maintaining the same functionality.
- **Added HttpClient documentation**: Inserted an info callout in the Commands documentation page that explains the difference between the simplified `fetch` approach used in examples and Effect's recommended `HttpClient` module for production applications.
- **Added example reference**: Linked to the Weather example to demonstrate real-world `HttpClient` usage with typed errors, request/response schemas, retries, and Layer-based configuration.
- **Updated imports**: Added `exampleDetailRouter` import to support the new Weather example link.

## Notable Details
The Model constructor removal is a refactoring that improves code readability in documentation snippets without changing behavior. The new documentation callout helps users understand when to use the simplified patterns shown in examples versus production-ready patterns with `HttpClient`.

https://claude.ai/code/session_01Sq1bDrxe4VDXmjcikr3AS2