### PR TITLE
Add regex capture group to embedded query parameter rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,13 @@
   "rewrites": [
     {
       "source": "/",
-      "has": [{ "type": "query", "key": "embedded" }],
+      "has": [
+        {
+          "type": "query",
+          "key": "embedded",
+          "value": "(?<embedded>[^&]+)"
+        }
+      ],
       "destination": "/example-apps-embed/:embedded/index.html"
     },
     {


### PR DESCRIPTION
## Summary
Updated the Vercel rewrite rule for the embedded query parameter to include a regex capture group, enabling proper extraction and routing of the embedded parameter value.

## Key Changes
- Modified the `/` rewrite rule's `has` condition to include a regex pattern `(?<embedded>[^&]+)` that captures the embedded parameter value
- This allows the rewrite destination `/example-apps-embed/:embedded/index.html` to properly receive the captured parameter value instead of just checking for the parameter's existence

## Implementation Details
The change converts the query parameter check from a simple existence check to a named capture group pattern that:
- Captures one or more non-ampersand characters (`[^&]+`)
- Uses a named group `(?<embedded>...)` to make the captured value available as `:embedded` in the destination path
- Maintains backward compatibility with the existing rewrite destination path

https://claude.ai/code/session_01VEzMRTZVMGSap8XuK3eDoa