### PR TITLE
Remove "Make it cool" from manifesto closing statement

### DIFF
--- a/packages/website/src/page/manifesto.ts
+++ b/packages/website/src/page/manifesto.ts
@@ -88,7 +88,7 @@ export const view = (): Html =>
         'So here\u2019s the big claim: Foldkit models the frontend so you can model everything else. State, events, transitions, effects, streams, resource management. All accounted for. All connected. All typed. All in one place.',
       ),
       para(
-        'Frontend architecture is solved. The only question left is, what are you going to create? Make it cool.',
+        'Frontend architecture is solved. The only question left is, what are you going to create?',
       ),
       div([Class('mb-4')], [p([], ['See you on GitHub,']), p([], ['Devin'])]),
     ],


### PR DESCRIPTION
## Summary
Updated the closing statement in the manifesto page to remove the phrase "Make it cool" from the final paragraph.

## Changes
- Removed "Make it cool." from the end of the closing statement in the manifesto
- The paragraph now ends with "what are you going to create?" instead of "what are you going to create? Make it cool."

## Details
This is a minor content update to the manifesto messaging, making the closing statement more concise and focused on the core question posed to users.

https://claude.ai/code/session_019pUZxWUck2KLcoshf2Z1Da