### PR TITLE
feat(website): add UI doc page template and convert Button page

### DIFF
--- a/packages/website/src/page/ui/button.ts
+++ b/packages/website/src/page/ui/button.ts
@@ -3,7 +3,6 @@ import { Ui } from 'foldkit'
 import { Class, button, div, span } from '../../html'
 import type { Message as ParentMessage } from '../../main'
 import type { TableOfContentsEntry } from '../../main'
-import { heading } from '../../prose'
 import { ClickedButtonDemo, type Message } from './message'
 import type { Model } from './model'
 
@@ -32,7 +31,6 @@ export const basicDemo = (
   model: Model,
   toParentMessage: (message: Message) => ParentMessage,
 ) => [
-  heading('h3', basicHeader.id, basicHeader.text),
   div(
     [Class('flex flex-col items-start gap-2')],
     [
@@ -55,7 +53,6 @@ export const disabledDemo = (
   _model: Model,
   _toParentMessage: (message: Message) => ParentMessage,
 ) => [
-  heading('h3', disabledHeader.id, disabledHeader.text),
   Ui.Button.view<ParentMessage>({
     isDisabled: true,
     toView: attributes =>

--- a/packages/website/src/page/ui/buttonPage.ts
+++ b/packages/website/src/page/ui/buttonPage.ts
@@ -9,7 +9,6 @@ import {
   link,
   pageTitle,
   para,
-  subPara,
   tableOfContentsEntryToHeader,
 } from '../../prose'
 import { uiCheckboxRouter } from '../../route'
@@ -173,7 +172,7 @@ export const view = (
         Button.basicHeader.id,
         Button.basicHeader.text,
       ),
-      subPara(
+      para(
         'Pass an ',
         inlineCode('onClick'),
         ' Message and a ',
@@ -199,7 +198,7 @@ export const view = (
         Button.disabledHeader.id,
         Button.disabledHeader.text,
       ),
-      subPara(
+      para(
         'Set ',
         inlineCode('isDisabled: true'),
         ' to disable the button. Foldkit uses ',
@@ -269,11 +268,7 @@ export const view = (
         viewConfigHeader.id,
         viewConfigHeader.text,
       ),
-      subPara(
-        'Configuration object passed to ',
-        inlineCode('Button.view()'),
-        '.',
-      ),
+      para('Configuration object passed to ', inlineCode('Button.view()'), '.'),
       propTable(viewConfigProps),
 
       heading(
@@ -281,7 +276,7 @@ export const view = (
         buttonAttributesHeader.id,
         buttonAttributesHeader.text,
       ),
-      subPara(
+      para(
         'Attribute groups provided to the ',
         inlineCode('toView'),
         ' callback.',

--- a/packages/website/src/page/ui/buttonPage.ts
+++ b/packages/website/src/page/ui/buttonPage.ts
@@ -1,12 +1,33 @@
 import type { Html } from 'foldkit/html'
 
-import { div } from '../../html'
+import { Class, InnerHTML, div } from '../../html'
 import type { Message as ParentMessage } from '../../main'
 import type { TableOfContentsEntry } from '../../main'
-import { pageTitle, para, tableOfContentsEntryToHeader } from '../../prose'
+import {
+  heading,
+  inlineCode,
+  link,
+  pageTitle,
+  para,
+  subPara,
+  tableOfContentsEntryToHeader,
+} from '../../prose'
+import { uiCheckboxRouter } from '../../route'
+import * as Snippets from '../../snippet'
+import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
+import {
+  type DataAttributeEntry,
+  type KeyboardEntry,
+  type PropEntry,
+  dataAttributeTable,
+  keyboardTable,
+  propTable,
+} from '../../view/docTable'
 import * as Button from './button'
 import type { Message } from './message'
 import type { Model } from './model'
+
+// TABLE OF CONTENTS
 
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
@@ -14,25 +35,277 @@ const overviewHeader: TableOfContentsEntry = {
   text: 'Overview',
 }
 
+const examplesHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'examples',
+  text: 'Examples',
+}
+
+const stylingHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'styling',
+  text: 'Styling',
+}
+
+const keyboardInteractionHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'keyboard-interaction',
+  text: 'Keyboard Interaction',
+}
+
+const accessibilityHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'accessibility',
+  text: 'Accessibility',
+}
+
+const apiReferenceHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'api-reference',
+  text: 'API Reference',
+}
+
+const viewConfigHeader: TableOfContentsEntry = {
+  level: 'h3',
+  id: 'view-config',
+  text: 'ViewConfig',
+}
+
+const buttonAttributesHeader: TableOfContentsEntry = {
+  level: 'h3',
+  id: 'button-attributes',
+  text: 'ButtonAttributes',
+}
+
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
+  examplesHeader,
   Button.basicHeader,
   Button.disabledHeader,
+  stylingHeader,
+  keyboardInteractionHeader,
+  accessibilityHeader,
+  apiReferenceHeader,
+  viewConfigHeader,
+  buttonAttributesHeader,
 ]
+
+// SECTION DATA
+
+const viewConfigProps: ReadonlyArray<PropEntry> = [
+  {
+    name: 'toView',
+    type: '(attributes: ButtonAttributes) => Html',
+    description:
+      'Callback that receives attribute groups and returns the button markup.',
+  },
+  {
+    name: 'onClick',
+    type: 'Message',
+    description: 'Message to dispatch when the button is clicked.',
+  },
+  {
+    name: 'isDisabled',
+    type: 'boolean',
+    default: 'false',
+    description:
+      'Whether the button is disabled. Uses aria-disabled instead of the disabled attribute to preserve focusability.',
+  },
+  {
+    name: 'type',
+    type: "'button' | 'submit' | 'reset'",
+    default: "'button'",
+    description: 'The HTML button type attribute.',
+  },
+  {
+    name: 'isAutofocus',
+    type: 'boolean',
+    default: 'false',
+    description: 'Whether the button receives focus when the page loads.',
+  },
+]
+
+const buttonAttributesProps: ReadonlyArray<PropEntry> = [
+  {
+    name: 'button',
+    type: 'ReadonlyArray<Attribute<Message>>',
+    description:
+      'Spread onto the <button> element. Includes type, tabindex, ARIA attributes, and event handlers.',
+  },
+]
+
+const dataAttributes: ReadonlyArray<DataAttributeEntry> = [
+  {
+    attribute: 'data-disabled',
+    condition: 'Present when isDisabled is true.',
+  },
+]
+
+const keyboardEntries: ReadonlyArray<KeyboardEntry> = [
+  {
+    key: 'Enter',
+    description: 'Activates the button.',
+  },
+  {
+    key: 'Space',
+    description: 'Activates the button.',
+  },
+]
+
+// VIEW
 
 export const view = (
   model: Model,
   toParentMessage: (message: Message) => ParentMessage,
+  copiedSnippets: CopiedSnippets,
 ): Html =>
   div(
     [],
     [
       pageTitle('ui/button', 'Button'),
+
+      // OVERVIEW
       tableOfContentsEntryToHeader(overviewHeader),
       para(
-        'A thin wrapper around the native button element that provides consistent accessibility attributes and data-attribute hooks for styling.',
+        'A thin wrapper around the native button element that provides consistent accessibility attributes and data-attribute hooks for styling. Button is a view-only component — it has no Model, Messages, or update function.',
+      ),
+
+      // EXAMPLES
+      heading(examplesHeader.level, examplesHeader.id, examplesHeader.text),
+
+      heading(
+        Button.basicHeader.level,
+        Button.basicHeader.id,
+        Button.basicHeader.text,
+      ),
+      subPara(
+        'Pass an ',
+        inlineCode('onClick'),
+        ' Message and a ',
+        inlineCode('toView'),
+        ' callback that spreads the provided attributes onto a ',
+        inlineCode('<button>'),
+        ' element.',
       ),
       ...Button.basicDemo(model, toParentMessage),
+      highlightedCodeBlock(
+        div(
+          [Class('text-sm'), InnerHTML(Snippets.uiButtonBasicHighlighted)],
+          [],
+        ),
+        Snippets.uiButtonBasicRaw,
+        'Copy basic button example to clipboard',
+        copiedSnippets,
+        'mb-8',
+      ),
+
+      heading(
+        Button.disabledHeader.level,
+        Button.disabledHeader.id,
+        Button.disabledHeader.text,
+      ),
+      subPara(
+        'Set ',
+        inlineCode('isDisabled: true'),
+        ' to disable the button. Foldkit uses ',
+        inlineCode('aria-disabled'),
+        ' instead of the native ',
+        inlineCode('disabled'),
+        ' attribute so the button remains focusable for screen readers.',
+      ),
       ...Button.disabledDemo(model, toParentMessage),
+      highlightedCodeBlock(
+        div(
+          [Class('text-sm'), InnerHTML(Snippets.uiButtonDisabledHighlighted)],
+          [],
+        ),
+        Snippets.uiButtonDisabledRaw,
+        'Copy disabled button example to clipboard',
+        copiedSnippets,
+        'mb-8',
+      ),
+
+      // STYLING
+      heading(stylingHeader.level, stylingHeader.id, stylingHeader.text),
+      para(
+        'Button is headless — it provides no default styles. Your ',
+        inlineCode('toView'),
+        ' callback receives attribute groups to spread onto the element, and you control all markup and styling.',
+      ),
+      para('Use the following data attributes to style different states:'),
+      dataAttributeTable(dataAttributes),
+
+      // KEYBOARD INTERACTION
+      heading(
+        keyboardInteractionHeader.level,
+        keyboardInteractionHeader.id,
+        keyboardInteractionHeader.text,
+      ),
+      para(
+        'Button uses the native ',
+        inlineCode('<button>'),
+        ' element, so keyboard interaction is handled by the browser.',
+      ),
+      keyboardTable(keyboardEntries),
+
+      // ACCESSIBILITY
+      heading(
+        accessibilityHeader.level,
+        accessibilityHeader.id,
+        accessibilityHeader.text,
+      ),
+      para(
+        'Button sets ',
+        inlineCode('aria-disabled="true"'),
+        ' when disabled instead of the native ',
+        inlineCode('disabled'),
+        ' attribute. This ensures the button remains in the tab order and is announced by screen readers, while preventing click handlers from firing.',
+      ),
+      para(
+        inlineCode('tabindex="0"'),
+        ' is always set to ensure focusability. The ',
+        inlineCode('type'),
+        ' attribute defaults to ',
+        inlineCode('"button"'),
+        ' to prevent accidental form submissions.',
+      ),
+
+      // API REFERENCE
+      heading(
+        apiReferenceHeader.level,
+        apiReferenceHeader.id,
+        apiReferenceHeader.text,
+      ),
+
+      heading(
+        viewConfigHeader.level,
+        viewConfigHeader.id,
+        viewConfigHeader.text,
+      ),
+      subPara(
+        'Configuration object passed to ',
+        inlineCode('Button.view()'),
+        '.',
+      ),
+      propTable(viewConfigProps),
+
+      heading(
+        buttonAttributesHeader.level,
+        buttonAttributesHeader.id,
+        buttonAttributesHeader.text,
+      ),
+      subPara(
+        'Attribute groups provided to the ',
+        inlineCode('toView'),
+        ' callback.',
+      ),
+      propTable(buttonAttributesProps),
+
+      // RELATED COMPONENTS
+      para(
+        'For a toggle between two states, see ',
+        link(uiCheckboxRouter(), 'Checkbox'),
+        '.',
+      ),
     ],
   )

--- a/packages/website/src/page/ui/buttonPage.ts
+++ b/packages/website/src/page/ui/buttonPage.ts
@@ -13,7 +13,7 @@ import {
   tableOfContentsEntryToHeader,
 } from '../../prose'
 import { uiCheckboxRouter } from '../../route'
-import * as Snippets from '../../snippet'
+import * as Snippet from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 import {
   type DataAttributeEntry,
@@ -163,16 +163,11 @@ export const view = (
     [],
     [
       pageTitle('ui/button', 'Button'),
-
-      // OVERVIEW
       tableOfContentsEntryToHeader(overviewHeader),
       para(
         'A thin wrapper around the native button element that provides consistent accessibility attributes and data-attribute hooks for styling. Button is a view-only component — it has no Model, Messages, or update function.',
       ),
-
-      // EXAMPLES
       heading(examplesHeader.level, examplesHeader.id, examplesHeader.text),
-
       heading(
         Button.basicHeader.level,
         Button.basicHeader.id,
@@ -190,10 +185,10 @@ export const view = (
       ...Button.basicDemo(model, toParentMessage),
       highlightedCodeBlock(
         div(
-          [Class('text-sm'), InnerHTML(Snippets.uiButtonBasicHighlighted)],
+          [Class('text-sm'), InnerHTML(Snippet.uiButtonBasicHighlighted)],
           [],
         ),
-        Snippets.uiButtonBasicRaw,
+        Snippet.uiButtonBasicRaw,
         'Copy basic button example to clipboard',
         copiedSnippets,
         'mb-8',
@@ -216,16 +211,14 @@ export const view = (
       ...Button.disabledDemo(model, toParentMessage),
       highlightedCodeBlock(
         div(
-          [Class('text-sm'), InnerHTML(Snippets.uiButtonDisabledHighlighted)],
+          [Class('text-sm'), InnerHTML(Snippet.uiButtonDisabledHighlighted)],
           [],
         ),
-        Snippets.uiButtonDisabledRaw,
+        Snippet.uiButtonDisabledRaw,
         'Copy disabled button example to clipboard',
         copiedSnippets,
         'mb-8',
       ),
-
-      // STYLING
       heading(stylingHeader.level, stylingHeader.id, stylingHeader.text),
       para(
         'Button is headless — it provides no default styles. Your ',
@@ -234,8 +227,6 @@ export const view = (
       ),
       para('Use the following data attributes to style different states:'),
       dataAttributeTable(dataAttributes),
-
-      // KEYBOARD INTERACTION
       heading(
         keyboardInteractionHeader.level,
         keyboardInteractionHeader.id,
@@ -247,8 +238,6 @@ export const view = (
         ' element, so keyboard interaction is handled by the browser.',
       ),
       keyboardTable(keyboardEntries),
-
-      // ACCESSIBILITY
       heading(
         accessibilityHeader.level,
         accessibilityHeader.id,
@@ -269,8 +258,6 @@ export const view = (
         inlineCode('"button"'),
         ' to prevent accidental form submissions.',
       ),
-
-      // API REFERENCE
       heading(
         apiReferenceHeader.level,
         apiReferenceHeader.id,
@@ -301,7 +288,6 @@ export const view = (
       ),
       propTable(buttonAttributesProps),
 
-      // RELATED COMPONENTS
       para(
         'For a toggle between two states, see ',
         link(uiCheckboxRouter(), 'Checkbox'),

--- a/packages/website/src/page/ui/buttonPage.ts
+++ b/packages/website/src/page/ui/buttonPage.ts
@@ -6,12 +6,10 @@ import type { TableOfContentsEntry } from '../../main'
 import {
   heading,
   inlineCode,
-  link,
   pageTitle,
   para,
   tableOfContentsEntryToHeader,
 } from '../../prose'
-import { uiCheckboxRouter } from '../../route'
 import * as Snippet from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 import {
@@ -282,11 +280,5 @@ export const view = (
         ' callback.',
       ),
       propTable(buttonAttributesProps),
-
-      para(
-        'For a toggle between two states, see ',
-        link(uiCheckboxRouter(), 'Checkbox'),
-        '.',
-      ),
     ],
   )

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -71,7 +71,7 @@ const sectionHeadingConfig = {
   },
   h3: {
     textClassName:
-      'text-lg font-normal text-gray-900 dark:text-white scroll-mt-6',
+      'text-xl font-normal text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
       'group flex items-center gap-1 md:hover-capable:gap-0 mt-6 mb-2 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },

--- a/packages/website/src/snippet/index.ts
+++ b/packages/website/src/snippet/index.ts
@@ -232,3 +232,7 @@ export { default as comparisonFoldkitSceneTestRaw } from './comparisonFoldkitSce
 export { default as comparisonFoldkitSceneTestHighlighted } from './comparisonFoldkitSceneTest.ts?highlighted'
 export { default as comparisonReactSceneTestRaw } from './comparisonReactSceneTest.tsx?raw'
 export { default as comparisonReactSceneTestHighlighted } from './comparisonReactSceneTest.tsx?highlighted'
+export { default as uiButtonBasicRaw } from './uiButtonBasic.ts?raw'
+export { default as uiButtonBasicHighlighted } from './uiButtonBasic.ts?highlighted'
+export { default as uiButtonDisabledRaw } from './uiButtonDisabled.ts?raw'
+export { default as uiButtonDisabledHighlighted } from './uiButtonDisabled.ts?highlighted'

--- a/packages/website/src/snippet/uiButtonBasic.ts
+++ b/packages/website/src/snippet/uiButtonBasic.ts
@@ -1,0 +1,15 @@
+import { Ui } from 'foldkit'
+
+import { Class, button } from './html'
+
+Ui.Button.view({
+  onClick: ClickedSave(),
+  toView: attributes =>
+    button(
+      [
+        ...attributes.button,
+        Class('px-4 py-2 rounded-lg bg-blue-600 text-white'),
+      ],
+      ['Save'],
+    ),
+})

--- a/packages/website/src/snippet/uiButtonDisabled.ts
+++ b/packages/website/src/snippet/uiButtonDisabled.ts
@@ -1,0 +1,15 @@
+import { Ui } from 'foldkit'
+
+import { Class, button } from './html'
+
+Ui.Button.view({
+  isDisabled: true,
+  toView: attributes =>
+    button(
+      [
+        ...attributes.button,
+        Class('px-4 py-2 rounded-lg bg-gray-300 text-gray-500'),
+      ],
+      ['Disabled'],
+    ),
+})

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -90,7 +90,7 @@
   }
 
   body {
-    @apply text-base leading-relaxed font-light tracking-[0.01em] text-gray-800 dark:text-gray-300 bg-cream dark:bg-gray-900;
+    @apply text-base leading-relaxed font-light tracking-[0.01em] text-gray-800 dark:text-gray-200 bg-cream dark:bg-gray-900;
   }
 
   strong {
@@ -114,7 +114,7 @@
   }
 
   pre {
-    @apply pr-14 pl-[11px] py-4 rounded-lg overflow-x-auto border border-gray-200 dark:border-gray-700/50 font-code text-sm;
+    @apply pr-14 pl-2.75 py-4 rounded-lg overflow-x-auto border border-gray-200 dark:border-gray-700/50 font-code text-sm;
   }
 
   .dark .shiki {
@@ -169,7 +169,7 @@
     @apply flex-1 min-w-0 relative flex flex-col;
 
     .code-embed-copy {
-      @apply !right-6;
+      @apply right-6!;
     }
   }
 

--- a/packages/website/src/view/docTable.ts
+++ b/packages/website/src/view/docTable.ts
@@ -1,0 +1,173 @@
+import { Array } from 'effect'
+import type { Html } from 'foldkit/html'
+
+import {
+  Class,
+  code,
+  div,
+  span,
+  table,
+  tbody,
+  td,
+  th,
+  thead,
+  tr,
+} from '../html'
+
+// SHARED STYLES
+
+const headerCellClassName =
+  'py-2 pr-4 text-left font-medium text-gray-900 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700/50'
+
+const rowClassName = 'border-b border-gray-200 dark:border-gray-700/50'
+
+const cellClassName = 'py-2.5 pr-4 align-top'
+
+const descriptionCellClassName =
+  'py-2.5 text-gray-600 dark:text-gray-400 align-top'
+
+const codeClassName =
+  'bg-gray-200/70 dark:bg-gray-800 px-1 py-px rounded text-sm border border-gray-300/50 dark:border-gray-700/50 whitespace-nowrap'
+
+const inlineCode = (text: string): Html => code([Class(codeClassName)], [text])
+
+// PROP TABLE
+
+export type PropEntry = Readonly<{
+  name: string
+  type: string
+  default?: string
+  description: string | Html
+}>
+
+const propRow = (entry: PropEntry): Html =>
+  tr(
+    [Class(rowClassName)],
+    [
+      td([Class(cellClassName)], [inlineCode(entry.name)]),
+      td([Class(cellClassName)], [inlineCode(entry.type)]),
+      td(
+        [Class(cellClassName)],
+        [
+          entry.default !== undefined
+            ? inlineCode(entry.default)
+            : span([Class('text-gray-400 dark:text-gray-500 text-sm')], ['-']),
+        ],
+      ),
+      td([Class(descriptionCellClassName)], [entry.description]),
+    ],
+  )
+
+export const propTable = (entries: ReadonlyArray<PropEntry>): Html =>
+  div(
+    [Class('mb-8 overflow-x-auto')],
+    [
+      table(
+        [Class('w-full text-sm')],
+        [
+          thead(
+            [],
+            [
+              tr(
+                [],
+                [
+                  th([Class(headerCellClassName)], ['Name']),
+                  th([Class(headerCellClassName)], ['Type']),
+                  th([Class(headerCellClassName)], ['Default']),
+                  th([Class(headerCellClassName)], ['Description']),
+                ],
+              ),
+            ],
+          ),
+          tbody([], Array.map(entries, propRow)),
+        ],
+      ),
+    ],
+  )
+
+// KEYBOARD TABLE
+
+export type KeyboardEntry = Readonly<{
+  key: string
+  description: string
+}>
+
+const kbdClassName =
+  'inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 text-xs font-mono text-gray-700 dark:text-gray-300'
+
+const keyboardRow = (entry: KeyboardEntry): Html =>
+  tr(
+    [Class(rowClassName)],
+    [
+      td([Class(cellClassName)], [span([Class(kbdClassName)], [entry.key])]),
+      td([Class(descriptionCellClassName)], [entry.description]),
+    ],
+  )
+
+export const keyboardTable = (entries: ReadonlyArray<KeyboardEntry>): Html =>
+  div(
+    [Class('mb-8 overflow-x-auto')],
+    [
+      table(
+        [Class('w-full text-sm')],
+        [
+          thead(
+            [],
+            [
+              tr(
+                [],
+                [
+                  th([Class(headerCellClassName)], ['Key']),
+                  th([Class(headerCellClassName)], ['Description']),
+                ],
+              ),
+            ],
+          ),
+          tbody([], Array.map(entries, keyboardRow)),
+        ],
+      ),
+    ],
+  )
+
+// DATA ATTRIBUTE TABLE
+
+export type DataAttributeEntry = Readonly<{
+  attribute: string
+  condition: string
+}>
+
+const dataAttributeRow = (entry: DataAttributeEntry): Html =>
+  tr(
+    [Class(rowClassName)],
+    [
+      td([Class(cellClassName)], [inlineCode(entry.attribute)]),
+      td([Class(descriptionCellClassName)], [entry.condition]),
+    ],
+  )
+
+export const dataAttributeTable = (
+  entries: ReadonlyArray<DataAttributeEntry>,
+): Html =>
+  div(
+    [Class('mb-8 overflow-x-auto')],
+    [
+      table(
+        [Class('w-full text-sm')],
+        [
+          thead(
+            [],
+            [
+              tr(
+                [],
+                [
+                  th([Class(headerCellClassName)], ['Attribute']),
+                  th([Class(headerCellClassName)], ['Condition']),
+                ],
+              ),
+            ],
+          ),
+          tbody([], Array.map(entries, dataAttributeRow)),
+        ],
+      ),
+    ],
+  )

--- a/packages/website/src/view/docTable.ts
+++ b/packages/website/src/view/docTable.ts
@@ -92,14 +92,17 @@ export type KeyboardEntry = Readonly<{
   description: string
 }>
 
-const kbdClassName =
+const keyboardKeyClassName =
   'inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 text-xs font-mono text-gray-700 dark:text-gray-300'
 
 const keyboardRow = (entry: KeyboardEntry): Html =>
   tr(
     [Class(rowClassName)],
     [
-      td([Class(cellClassName)], [span([Class(kbdClassName)], [entry.key])]),
+      td(
+        [Class(cellClassName)],
+        [span([Class(keyboardKeyClassName)], [entry.key])],
+      ),
       td([Class(descriptionCellClassName)], [entry.description]),
     ],
   )

--- a/packages/website/src/view/docTable.ts
+++ b/packages/website/src/view/docTable.ts
@@ -23,8 +23,7 @@ const rowClassName = 'border-b border-gray-200 dark:border-gray-700/50'
 
 const cellClassName = 'py-2.5 pr-4 align-top'
 
-const descriptionCellClassName =
-  'py-2.5 text-gray-600 dark:text-gray-400 align-top'
+const descriptionCellClassName = 'py-2.5 align-top'
 
 const codeClassName =
   'bg-gray-200/70 dark:bg-gray-800 px-1 py-px rounded text-sm border border-gray-300/50 dark:border-gray-700/50 whitespace-nowrap'

--- a/packages/website/src/view/docTable.ts
+++ b/packages/website/src/view/docTable.ts
@@ -92,7 +92,7 @@ export type KeyboardEntry = Readonly<{
 }>
 
 const keyboardKeyClassName =
-  'inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 text-xs font-mono text-gray-700 dark:text-gray-300'
+  'inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 text-sm font-mono text-gray-700 dark:text-gray-300'
 
 const keyboardRow = (entry: KeyboardEntry): Html =>
   tr(

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -632,7 +632,11 @@ export const docsView = (model: Model, docsRoute: DocsRoute) => {
         ),
       UiButton: () =>
         withTableOfContents(
-          Page.UiPages.ButtonPage.view(model.uiPages, toUiPageMessage),
+          Page.UiPages.ButtonPage.view(
+            model.uiPages,
+            toUiPageMessage,
+            model.copiedSnippets,
+          ),
           Page.UiPages.ButtonPage.tableOfContents,
         ),
       UiTabs: () =>


### PR DESCRIPTION
## Summary

- Add reusable `docTable.ts` view components (`propTable`, `keyboardTable`, `dataAttributeTable`) for UI component documentation pages
- Thread `copiedSnippets` through the Button page view for code block copy functionality
- Convert the Button page to the full 7-section template: overview, examples (with live demos + syntax-highlighted code), styling, keyboard interaction, accessibility, and API reference
- Add Button code snippets (`uiButtonBasic.ts`, `uiButtonDisabled.ts`)

This establishes the page infrastructure from FOL-111 that all subsequent UI component doc pages will follow.

## Test plan

- [x] Type check passes
- [x] Full pre-push suite passes (build, format, lint, tests, circular deps)
- [x] Button page renders all 7 sections at `/ui/button`
- [x] Live demos remain interactive
- [x] Code blocks have syntax highlighting and copy buttons
- [x] Table of contents shows all section anchors
- [ ] Verify deep links to each section work
- [ ] Verify responsive layout on narrow viewports