### PR TITLE
fix(website): improve dark mode contrast on demo hint text

### DIFF
--- a/packages/website/src/page/demoView.ts
+++ b/packages/website/src/page/demoView.ts
@@ -127,7 +127,7 @@ export const demoViewShell = (codePanel: Html, appPanel: Html): Html =>
       p(
         [
           Class(
-            'text-sm text-gray-500 dark:text-gray-500 text-center text-balance lg:hidden',
+            'text-sm text-gray-500 dark:text-gray-400 text-center text-balance lg:hidden',
           ),
           AriaHidden(true),
         ],


### PR DESCRIPTION
The demo section's mobile hint paragraph used dark:text-gray-500 on a dark:bg-gray-900 background, producing only a 3.4:1 contrast ratio. Lighthouse flags this as insufficient (WCAG AA requires 4.5:1 for normal text). Bump to dark:text-gray-400 to meet the threshold.