### PR TITLE
Fix install command not spawning on Windows

### DIFF
--- a/packages/create-foldkit-app/src/commands/create.ts
+++ b/packages/create-foldkit-app/src/commands/create.ts
@@ -26,6 +26,9 @@ type CreateOptions = {
   packageManager: PackageManager
 }
 
+const packageManagerLookupCommand =
+  process.platform === 'win32' ? 'where' : 'which'
+
 const validateProject = (
   name: string,
   projectPath: string,
@@ -39,10 +42,10 @@ const validateProject = (
       return yield* Effect.fail(`Directory ${name} already exists!`)
     }
 
-    const checkCommand = Command.make('which', packageManager).pipe(
-      Command.stdout('pipe'),
-      Command.stderr('pipe'),
-    )
+    const checkCommand = Command.make(
+      packageManagerLookupCommand,
+      packageManager,
+    ).pipe(Command.stdout('pipe'), Command.stderr('pipe'))
 
     return yield* Command.exitCode(checkCommand).pipe(
       Effect.filterOrFail(

--- a/packages/create-foldkit-app/src/utils/packages.ts
+++ b/packages/create-foldkit-app/src/utils/packages.ts
@@ -6,6 +6,8 @@ type PackageManager = 'pnpm' | 'npm' | 'yarn'
 const GITHUB_RAW_BASE_URL =
   'https://raw.githubusercontent.com/foldkit/foldkit/main/examples'
 
+const shouldRunCommandInShell = process.platform === 'win32'
+
 const getInstallArgs = (
   packageManager: PackageManager,
   isDev = false,
@@ -63,6 +65,7 @@ export const installDependencies = (
       'foldkit',
       ...exampleDeps.dependencies,
     ).pipe(
+      Command.runInShell(shouldRunCommandInShell),
       Command.workingDirectory(projectPath),
       Command.stdout('inherit'),
       Command.stderr('inherit'),
@@ -78,6 +81,7 @@ export const installDependencies = (
       'happy-dom',
       ...exampleDeps.devDependencies,
     ).pipe(
+      Command.runInShell(shouldRunCommandInShell),
       Command.workingDirectory(projectPath),
       Command.stdout('inherit'),
       Command.stderr('inherit'),


### PR DESCRIPTION
# Issue
`create-foldkit-app` command fails to detect installs & spawn the package manager install command on windows
```cmd
COMMAND: create -n site-fold -e routing -p pnpm

Wizard Mode Complete!

You may now execute your command directly with the following options and arguments:

    create -n site-fold -e routing -p pnpm

√ Would you like to run the command? ... yes / no

[16:58:05.560] ERROR (#17):
  SystemError: NotFound: Command.spawn (which pnpm): spawn which ENOENT
```
# Fix
- Use the correct package manager lookup command per platform: `where` on Windows and `which` on Unix-like systems.
- Run dependency installation commands through the shell on Windows with `Command.runInShell(true)` so `pnpm`, `npm`, and `yarn` resolve and execute correctly.
- Preserve existing behavior on non-Windows platforms.