### PR TITLE
refactor(kanban): replace sequential card IDs with UUIDs

### DIFF
--- a/examples/kanban/src/command.ts
+++ b/examples/kanban/src/command.ts
@@ -5,10 +5,16 @@ import { Command, Task } from 'foldkit'
 
 import { ADD_CARD_INPUT_ID, STORAGE_KEY } from './constant'
 import { Column } from './domain'
-import { CompletedFocusAddCardInput, CompletedSaveBoard } from './message'
+import {
+  CompletedFocusAddCardInput,
+  CompletedSaveBoard,
+  GeneratedCardId,
+} from './message'
 import { SavedBoard } from './model'
 
 const ADD_CARD_INPUT_SELECTOR = `#${ADD_CARD_INPUT_ID}`
+
+export const GenerateCardId = Command.define('GenerateCardId', GeneratedCardId)
 
 export const SaveBoard = Command.define('SaveBoard', CompletedSaveBoard)
 
@@ -16,6 +22,13 @@ export const FocusAddCardInput = Command.define(
   'FocusAddCardInput',
   CompletedFocusAddCardInput,
 )
+
+export const generateCardId = (columnId: string, title: string) =>
+  GenerateCardId(
+    Effect.sync(() =>
+      GeneratedCardId({ cardId: crypto.randomUUID(), columnId, title }),
+    ),
+  )
 
 export const focusAddCardInput = FocusAddCardInput(
   Task.focus(ADD_CARD_INPUT_SELECTOR).pipe(

--- a/examples/kanban/src/main.scene.test.ts
+++ b/examples/kanban/src/main.scene.test.ts
@@ -2,10 +2,14 @@ import { Option } from 'effect'
 import { Scene, Ui } from 'foldkit'
 import { describe, test } from 'vitest'
 
-import { FocusAddCardInput, SaveBoard } from './command'
+import { FocusAddCardInput, GenerateCardId, SaveBoard } from './command'
 import type { Card } from './domain/card'
 import type { Column } from './domain/column'
-import { CompletedFocusAddCardInput, CompletedSaveBoard } from './message'
+import {
+  CompletedFocusAddCardInput,
+  CompletedSaveBoard,
+  GeneratedCardId,
+} from './message'
 import type { Model } from './model'
 import { update } from './update'
 import { view } from './view/index'
@@ -36,7 +40,6 @@ const testModel: Model = {
   dragAndDrop: Ui.DragAndDrop.init({ id: 'kanban' }),
   maybeNewCardColumnId: Option.none(),
   newCardTitle: '',
-  nextCardId: 100,
   announcement: '',
 }
 
@@ -118,6 +121,15 @@ describe('scene', () => {
         Scene.resolve(FocusAddCardInput, CompletedFocusAddCardInput()),
         Scene.type(Scene.label('New card title'), 'Buy groceries'),
         Scene.submit(Scene.role('form')),
+        Scene.expectExactCommands(GenerateCardId),
+        Scene.resolve(
+          GenerateCardId,
+          GeneratedCardId({
+            cardId: 'test-uuid',
+            columnId: 'todo',
+            title: 'Buy groceries',
+          }),
+        ),
         Scene.expectExactCommands(SaveBoard),
         Scene.resolve(SaveBoard, CompletedSaveBoard()),
         Scene.expect(Scene.text('Buy groceries')).toExist(),

--- a/examples/kanban/src/main.story.test.ts
+++ b/examples/kanban/src/main.story.test.ts
@@ -3,7 +3,7 @@ import { Story, Ui } from 'foldkit'
 import { generateKeyBetween } from 'fractional-indexing'
 import { describe, expect, test } from 'vitest'
 
-import { FocusAddCardInput, SaveBoard } from './command'
+import { FocusAddCardInput, GenerateCardId, SaveBoard } from './command'
 import { Column } from './domain'
 import type { Card } from './domain/card'
 import {
@@ -12,6 +12,7 @@ import {
   ClickedAddCard,
   CompletedFocusAddCardInput,
   CompletedSaveBoard,
+  GeneratedCardId,
   GotDragAndDropMessage,
   SubmittedNewCard,
 } from './message'
@@ -61,7 +62,6 @@ const emptyModel: Model = {
   dragAndDrop: Ui.DragAndDrop.init({ id: 'kanban' }),
   maybeNewCardColumnId: Option.none(),
   newCardTitle: '',
-  nextCardId: 100,
   announcement: '',
 }
 
@@ -102,13 +102,21 @@ describe('kanban update', () => {
         Story.resolve(FocusAddCardInput, CompletedFocusAddCardInput()),
         Story.message(ChangedNewCardTitle({ value: 'Ship it' })),
         Story.message(SubmittedNewCard()),
+        Story.resolve(
+          GenerateCardId,
+          GeneratedCardId({
+            cardId: 'test-uuid',
+            columnId: 'done',
+            title: 'Ship it',
+          }),
+        ),
         Story.resolve(SaveBoard, CompletedSaveBoard()),
         Story.model(model => {
           const doneColumn = model.columns.find(column => column.id === 'done')
           const lastCard = doneColumn?.cards[doneColumn.cards.length - 1]
           expect(lastCard?.title).toBe('Ship it')
+          expect(lastCard?.id).toBe('test-uuid')
           expect(model.maybeNewCardColumnId).toStrictEqual(Option.none())
-          expect(model.nextCardId).toBe(101)
         }),
       )
     })

--- a/examples/kanban/src/main.ts
+++ b/examples/kanban/src/main.ts
@@ -1,6 +1,6 @@
 import { KeyValueStore } from '@effect/platform'
 import { BrowserKeyValueStore } from '@effect/platform-browser'
-import { Array, Effect, Option, Schema as S, pipe } from 'effect'
+import { Effect, Option, Schema as S } from 'effect'
 import { Runtime, Ui } from 'foldkit'
 
 import { DEFAULT_COLUMNS, STORAGE_KEY } from './constant'
@@ -30,36 +30,6 @@ const flags: Effect.Effect<Flags> = Effect.gen(function* () {
 
 // INIT
 
-const INITIAL_NEXT_CARD_ID = 100
-
-const CARD_ID_PREFIX = 'card-'
-
-const deriveNextCardId = (
-  columns: ReadonlyArray<{
-    readonly cards: ReadonlyArray<{ readonly id: string }>
-  }>,
-): number =>
-  pipe(
-    columns,
-    Array.flatMap(({ cards }) => cards),
-    Array.filterMap(({ id }) =>
-      Option.flatMap(
-        id.startsWith(CARD_ID_PREFIX)
-          ? Option.some(id.slice(CARD_ID_PREFIX.length))
-          : Option.none(),
-        suffix => {
-          const parsed = Number(suffix)
-          return Number.isNaN(parsed) ? Option.none() : Option.some(parsed)
-        },
-      ),
-    ),
-    Array.match({
-      onEmpty: () => INITIAL_NEXT_CARD_ID,
-      onNonEmpty: ids => Math.max(...ids) + 1,
-    }),
-    nextId => Math.max(nextId, INITIAL_NEXT_CARD_ID),
-  )
-
 const init: Runtime.ProgramInit<Model, Message, Flags> = flags => {
   const columns = Option.match(flags.maybeSavedBoard, {
     onNone: () => DEFAULT_COLUMNS,
@@ -72,7 +42,6 @@ const init: Runtime.ProgramInit<Model, Message, Flags> = flags => {
       dragAndDrop: Ui.DragAndDrop.init({ id: 'kanban' }),
       maybeNewCardColumnId: Option.none(),
       newCardTitle: '',
-      nextCardId: deriveNextCardId(columns),
       announcement: '',
     },
     [],

--- a/examples/kanban/src/message.ts
+++ b/examples/kanban/src/message.ts
@@ -11,6 +11,11 @@ export const ChangedNewCardTitle = m('ChangedNewCardTitle', {
 })
 export const SubmittedNewCard = m('SubmittedNewCard')
 export const CancelledNewCard = m('CancelledNewCard')
+export const GeneratedCardId = m('GeneratedCardId', {
+  cardId: S.String,
+  columnId: S.String,
+  title: S.String,
+})
 export const CompletedSaveBoard = m('CompletedSaveBoard')
 export const CompletedFocusAddCardInput = m('CompletedFocusAddCardInput')
 
@@ -20,6 +25,7 @@ export const Message = S.Union(
   ChangedNewCardTitle,
   SubmittedNewCard,
   CancelledNewCard,
+  GeneratedCardId,
   CompletedSaveBoard,
   CompletedFocusAddCardInput,
 )

--- a/examples/kanban/src/model.ts
+++ b/examples/kanban/src/model.ts
@@ -14,7 +14,6 @@ export const Model = S.Struct({
   dragAndDrop: Ui.DragAndDrop.Model,
   maybeNewCardColumnId: S.OptionFromSelf(S.String),
   newCardTitle: S.String,
-  nextCardId: S.Number,
   announcement: S.String,
 })
 

--- a/examples/kanban/src/update.ts
+++ b/examples/kanban/src/update.ts
@@ -2,7 +2,7 @@ import { Array, Effect, Match as M, Option, String, pipe } from 'effect'
 import { Command, Ui } from 'foldkit'
 import { evo } from 'foldkit/struct'
 
-import { focusAddCardInput, saveBoard } from './command'
+import { focusAddCardInput, generateCardId, saveBoard } from './command'
 import { Column } from './domain'
 import { GotDragAndDropMessage, type Message } from './message'
 import type { Model } from './model'
@@ -180,34 +180,37 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         Option.match(model.maybeNewCardColumnId, {
           onNone: () => [model, []],
           onSome: columnId => {
-            if (String.isEmpty(String.trim(model.newCardTitle))) {
+            const title = String.trim(model.newCardTitle)
+            if (String.isEmpty(title)) {
               return [model, []]
             }
 
-            const cardId = `card-${model.nextCardId}`
-            const nextColumns = Array.map(model.columns, column => {
-              if (column.id !== columnId) {
-                return column
-              }
-              return Column.appendCard(column, {
-                id: cardId,
-                title: String.trim(model.newCardTitle),
-                description: '',
-                sortKey: '',
-              })
-            })
-
-            return [
-              evo(model, {
-                columns: () => nextColumns,
-                maybeNewCardColumnId: () => Option.none(),
-                newCardTitle: () => '',
-                nextCardId: nextCardId => nextCardId + 1,
-              }),
-              [saveBoard(nextColumns)],
-            ]
+            return [model, [generateCardId(columnId, title)]]
           },
         }),
+
+      GeneratedCardId: ({ cardId, columnId, title }) => {
+        const nextColumns = Array.map(model.columns, column => {
+          if (column.id !== columnId) {
+            return column
+          }
+          return Column.appendCard(column, {
+            id: cardId,
+            title,
+            description: '',
+            sortKey: '',
+          })
+        })
+
+        return [
+          evo(model, {
+            columns: () => nextColumns,
+            maybeNewCardColumnId: () => Option.none(),
+            newCardTitle: () => '',
+          }),
+          [saveBoard(nextColumns)],
+        ]
+      },
 
       CancelledNewCard: () => [
         evo(model, {


### PR DESCRIPTION
## Summary

- Replace sequential numeric card IDs (`card-1`, `card-2`) with `crypto.randomUUID()` via a `GenerateCardId` Command
- Delete `deriveNextCardId`, `CARD_ID_PREFIX`, `INITIAL_NEXT_CARD_ID`, and the `nextCardId` Model field
- `SubmittedNewCard` now fires a Command; `GeneratedCardId` Message threads back the UUID, column ID, and title to create the card

## Test plan

- [x] All 22 kanban tests pass (story + scene)
- [ ] Verify new cards get unique UUIDs in the browser
- [ ] Verify cards persist and reload correctly from localStorage

https://claude.ai/code/session_01Fd6VqzPav7s8vC3XTq41s3