### PR TITLE
claude/lint-rule-ban-date-U1PPJ

### DIFF
--- a/.changeset/ban-impure-date-random.md
+++ b/.changeset/ban-impure-date-random.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Add ESLint `no-restricted-syntax` rules banning `new Date()`, `Date.now()`, and `Math.random()` — impure APIs that bypass Effect. Legitimate bridge sites in `calendar/` and `task/random.ts` use inline `eslint-disable-next-line`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,26 @@ export default [
       'no-redeclare': 'off',
       'no-undef': 'off',
       'no-unused-vars': 'off',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "NewExpression[callee.name='Date']",
+          message:
+            'Impure — use Calendar.today.local for current time (Effect-based), or Calendar.make(year, month, day) for fixed dates.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='Date'][callee.property.name='now']",
+          message:
+            'Impure — use Clock.currentTimeMillis from Effect instead of Date.now().',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='Math'][callee.property.name='random']",
+          message:
+            'Impure — use Task.randomInt from Foldkit (Effect-based) instead of Math.random().',
+        },
+      ],
       '@typescript-eslint/consistent-type-assertions': [
         'error',
         { assertionStyle: 'never' },
@@ -55,6 +75,26 @@ export default [
       'no-redeclare': 'off',
       'no-undef': 'off',
       'no-unused-vars': 'off',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "NewExpression[callee.name='Date']",
+          message:
+            'Impure — use Calendar.today.local for current time (Effect-based), or Calendar.make(year, month, day) for fixed dates.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='Date'][callee.property.name='now']",
+          message:
+            'Impure — use Clock.currentTimeMillis from Effect instead of Date.now().',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='Math'][callee.property.name='random']",
+          message:
+            'Impure — use Task.randomInt from Foldkit (Effect-based) instead of Math.random().',
+        },
+      ],
       '@typescript-eslint/consistent-type-assertions': [
         'error',
         { assertionStyle: 'never' },

--- a/packages/foldkit/src/calendar/calendarDate.test.ts
+++ b/packages/foldkit/src/calendar/calendarDate.test.ts
@@ -150,11 +150,13 @@ describe('fromDateLocal', () => {
   it('reads year, month, and day from a JS Date in local time', () => {
     // new Date(year, monthIndex, day) constructs in local time; reading back
     // with the same local-time getters round-trips cleanly.
+    // eslint-disable-next-line no-restricted-syntax
     const jsDate = new Date(2026, 3, 13)
     expect(fromDateLocal(jsDate)).toStrictEqual(make(2026, 4, 13))
   })
 
   it('handles month boundaries', () => {
+    // eslint-disable-next-line no-restricted-syntax
     const jsDate = new Date(2026, 11, 31)
     expect(fromDateLocal(jsDate)).toStrictEqual(make(2026, 12, 31))
   })
@@ -163,6 +165,7 @@ describe('fromDateLocal', () => {
 describe('fromDateInZone', () => {
   it('reads year, month, and day in a specified IANA timezone', () => {
     // 2026-04-13T12:00:00Z is April 13 in UTC and in America/New_York (08:00 local).
+    // eslint-disable-next-line no-restricted-syntax
     const jsDate = new Date(Date.UTC(2026, 3, 13, 12, 0, 0))
     expect(fromDateInZone(jsDate, 'America/New_York')).toStrictEqual(
       make(2026, 4, 13),
@@ -173,6 +176,7 @@ describe('fromDateInZone', () => {
   it('handles timezone-dependent date transitions', () => {
     // 2026-04-13T01:00:00Z is still April 12 in New York (21:00 on the 12th)
     // but April 13 in UTC.
+    // eslint-disable-next-line no-restricted-syntax
     const jsDate = new Date(Date.UTC(2026, 3, 13, 1, 0, 0))
     expect(fromDateInZone(jsDate, 'UTC')).toStrictEqual(make(2026, 4, 13))
     expect(fromDateInZone(jsDate, 'America/New_York')).toStrictEqual(

--- a/packages/foldkit/src/calendar/calendarDate.ts
+++ b/packages/foldkit/src/calendar/calendarDate.ts
@@ -180,6 +180,7 @@ export const fromDateInZone = (date: Date, timeZone: string): CalendarDate => {
  * ```
  */
 export const toDateLocal = (calendarDate: CalendarDate): Date =>
+  // eslint-disable-next-line no-restricted-syntax
   new Date(calendarDate.year, calendarDate.month - 1, calendarDate.day)
 
 const isoPattern = /^(\d{4})-(\d{2})-(\d{2})$/

--- a/packages/foldkit/src/calendar/today.ts
+++ b/packages/foldkit/src/calendar/today.ts
@@ -32,6 +32,7 @@ export const today = {
    */
   local: Effect.map(
     Clock.currentTimeMillis,
+    // eslint-disable-next-line no-restricted-syntax
     (millis): CalendarDate => fromDateLocal(new Date(millis)),
   ),
 
@@ -42,6 +43,7 @@ export const today = {
   inZone: (timeZone: string) =>
     Effect.map(
       Clock.currentTimeMillis,
+      // eslint-disable-next-line no-restricted-syntax
       (millis): CalendarDate => fromDateInZone(new Date(millis), timeZone),
     ),
 }

--- a/packages/foldkit/src/task/random.ts
+++ b/packages/foldkit/src/task/random.ts
@@ -9,4 +9,5 @@ import { Effect } from 'effect'
  * ```
  */
 export const randomInt = (min: number, max: number): Effect.Effect<number> =>
+  // eslint-disable-next-line no-restricted-syntax
   Effect.sync(() => Math.floor(Math.random() * (max - min)) + min)

--- a/packages/website/eslint.config.mjs
+++ b/packages/website/eslint.config.mjs
@@ -20,6 +20,26 @@ export default [
       'no-redeclare': 'off',
       'no-undef': 'off',
       'no-unused-vars': 'off',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "NewExpression[callee.name='Date']",
+          message:
+            'Impure — use Calendar.today.local for current time (Effect-based), or Calendar.make(year, month, day) for fixed dates.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='Date'][callee.property.name='now']",
+          message:
+            'Impure — use Clock.currentTimeMillis from Effect instead of Date.now().',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='Math'][callee.property.name='random']",
+          message:
+            'Impure — use Task.randomInt from Foldkit (Effect-based) instead of Math.random().',
+        },
+      ],
       '@typescript-eslint/consistent-type-assertions': [
         'error',
         { assertionStyle: 'never' },

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -1258,7 +1258,7 @@ const devTracerLayer: Layer.Layer<never> = import.meta.hot
           return {
             _tag: 'Span' as const,
             name,
-            spanId: `${name}-${Date.now()}`,
+            spanId: `${name}-${startTime}`,
             traceId: 'dev',
             sampled: true,
             parent: Option.none(),


### PR DESCRIPTION
Add no-restricted-syntax rules to root and website ESLint configs banning
impure APIs that bypass Effect:
- new Date() — use Calendar.today.local or Calendar.make() instead
- Date.now() — use Clock.currentTimeMillis from Effect instead
- Math.random() — use Task.randomInt from Foldkit instead

Allowlisted paths (where the Effect bridge legitimately wraps impurity):
- packages/foldkit/src/calendar/** (Clock → CalendarDate bridge)
- packages/foldkit/src/task/random.ts (Effect.sync → Math.random bridge)

Investigated alternatives before choosing no-restricted-syntax:
- no-restricted-globals: too broad, bans all Date references
- no-restricted-properties: only covers Date.now, not new Date()
- @typescript-eslint and eslint-plugin-unicorn: no built-in rule for this
- no-restricted-syntax with AST selectors: covers all three patterns with
  granular messages pointing to the idiomatic Effect-based alternative

Audit found one violation: Date.now() in the website dev tracer span ID
(packages/website/src/main.ts). Replaced with startTime parameter already
available in scope — it's a nanosecond bigint, unique per span.

https://claude.ai/code/session_01W9ymiiAMX4C77cvXGwUiUJ