### PR TITLE
Add freezeModel runtime config for mutation detection in dev

### DIFF
--- a/.changeset/freeze-model-in-dev.md
+++ b/.changeset/freeze-model-in-dev.md
@@ -1,0 +1,20 @@
+---
+'foldkit': minor
+---
+
+Add `freezeModel` runtime config — Foldkit now deep-freezes the Model in development by default, so accidental mutations (e.g. `model.items.push(...)`) throw a `TypeError` at the exact write site with a clear stack trace, instead of silently corrupting state or breaking reference-equality change detection.
+
+Freezing is scoped to plain objects and arrays. Effect-tagged values (`Option`, `Either`, `DateTime`, `HashSet`, `HashMap`, etc.), `Date`, `Map`, `Set`, and class instances are left untouched because they rely on lazy instance writes for hash memoization. Nested payloads inside an `Option.some` are still frozen.
+
+Config shape mirrors `devtools` and `slowView`:
+
+```ts
+makeProgram({
+  // ...
+  freezeModel: { show: 'Development' }, // default
+  // freezeModel: { show: 'Always' },   // enforce in production too
+  // freezeModel: false,                // disable entirely
+})
+```
+
+Production builds pay nothing for this feature unless `show: 'Always'` is set.

--- a/packages/foldkit/src/runtime/deepFreeze.test.ts
+++ b/packages/foldkit/src/runtime/deepFreeze.test.ts
@@ -1,0 +1,131 @@
+import { describe, it } from '@effect/vitest'
+import { Equal, Hash, Option } from 'effect'
+import { expect } from 'vitest'
+
+import { deepFreeze } from './deepFreeze'
+
+describe('deepFreeze', () => {
+  it('returns primitives unchanged', () => {
+    expect(deepFreeze(null)).toBe(null)
+    expect(deepFreeze(undefined)).toBe(undefined)
+    expect(deepFreeze(0)).toBe(0)
+    expect(deepFreeze('')).toBe('')
+    expect(deepFreeze(false)).toBe(false)
+    expect(deepFreeze(Number.NaN)).toBeNaN()
+  })
+
+  it('freezes arrays so push throws', () => {
+    const array = [1, 2, 3]
+    deepFreeze(array)
+    expect(Object.isFrozen(array)).toBe(true)
+    expect(() => array.push(4)).toThrow(TypeError)
+  })
+
+  it('freezes nested arrays recursively', () => {
+    const array = [
+      [1, 2],
+      [3, 4],
+    ]
+    deepFreeze(array)
+    expect(Object.isFrozen(array)).toBe(true)
+    expect(Object.isFrozen(array[0])).toBe(true)
+    expect(Object.isFrozen(array[1])).toBe(true)
+  })
+
+  it('freezes nested plain objects recursively', () => {
+    const model = {
+      user: { name: 'test', address: { city: 'NY' } },
+      items: [{ id: 1 }, { id: 2 }],
+    }
+    deepFreeze(model)
+    expect(Object.isFrozen(model)).toBe(true)
+    expect(Object.isFrozen(model.user)).toBe(true)
+    expect(Object.isFrozen(model.user.address)).toBe(true)
+    expect(Object.isFrozen(model.items)).toBe(true)
+    expect(Object.isFrozen(model.items[0])).toBe(true)
+  })
+
+  it('is idempotent by reference', () => {
+    const model = { count: 0 }
+    const first = deepFreeze(model)
+    const second = deepFreeze(first)
+    expect(second).toBe(first)
+    expect(second).toBe(model)
+  })
+
+  it('handles cycles without infinite recursion', () => {
+    type Node = { label: string; self?: Node }
+    const node: Node = { label: 'root' }
+    node.self = node
+    expect(() => deepFreeze(node)).not.toThrow()
+    expect(Object.isFrozen(node)).toBe(true)
+  })
+
+  it('returns already-frozen input unchanged', () => {
+    const frozen = Object.freeze({ a: 1 })
+    expect(deepFreeze(frozen)).toBe(frozen)
+  })
+
+  it('leaves Date instances untouched', () => {
+    const model = { createdAt: new Date(0) }
+    deepFreeze(model)
+    expect(Object.isFrozen(model.createdAt)).toBe(false)
+  })
+
+  it('leaves Map instances untouched', () => {
+    const map = new Map<string, number>([['a', 1]])
+    const model = { map }
+    deepFreeze(model)
+    expect(Object.isFrozen(map)).toBe(false)
+    expect(() => map.set('b', 2)).not.toThrow()
+  })
+
+  it('leaves Set instances untouched', () => {
+    const set = new Set([1, 2])
+    const model = { set }
+    deepFreeze(model)
+    expect(Object.isFrozen(set)).toBe(false)
+    expect(() => set.add(3)).not.toThrow()
+  })
+
+  it('leaves class instances untouched', () => {
+    class Counter {
+      constructor(public count = 0) {}
+    }
+    const counter = new Counter()
+    const model = { counter }
+    deepFreeze(model)
+    expect(Object.isFrozen(counter)).toBe(false)
+    expect(() => {
+      counter.count = 1
+    }).not.toThrow()
+  })
+
+  it('walks into Option.some payload but leaves the Some wrapper intact', () => {
+    const payload = { value: 1 }
+    const option = Option.some(payload)
+    deepFreeze(option)
+    expect(Object.isFrozen(option)).toBe(false)
+    expect(Object.isFrozen(payload)).toBe(true)
+    expect(() => {
+      payload.value = 2
+    }).toThrow(TypeError)
+  })
+
+  it('leaves Option.none untouched', () => {
+    const option = Option.none()
+    deepFreeze(option)
+    expect(Object.isFrozen(option)).toBe(false)
+  })
+
+  it('preserves Hash.hash and Equal.equals on Options after freezing', () => {
+    const payload = { id: 42 }
+    const a = Option.some(payload)
+    const b = Option.some(payload)
+    deepFreeze(a)
+    deepFreeze(b)
+    expect(() => Hash.hash(a)).not.toThrow()
+    expect(() => Equal.equals(a, b)).not.toThrow()
+    expect(Equal.equals(a, b)).toBe(true)
+  })
+})

--- a/packages/foldkit/src/runtime/deepFreeze.ts
+++ b/packages/foldkit/src/runtime/deepFreeze.ts
@@ -1,0 +1,63 @@
+import { Array, Option, Predicate, Record } from 'effect'
+
+/**
+ * Recursively `Object.freeze`s a Model so accidental mutations throw a
+ * `TypeError` at the write site with a clear stack trace, instead of silently
+ * corrupting state or breaking reference-equality change detection.
+ *
+ * Scope — plain objects and arrays only. `Date`, `Map`, `Set`, `File`, class
+ * instances, and Effect-tagged values (`Option`, `Either`, `DateTime`,
+ * `HashSet`, `HashMap`, `Chunk`, etc.) are returned untouched. Effect values
+ * rely on `Hash.cached(this, ...)` — which lazily writes to the instance via
+ * `Object.defineProperty` on the first `Equal.equals` or `Hash.hash` call —
+ * so freezing them would transform a latent silent mutation into a new
+ * `TypeError` class from legitimate Effect-structural operations.
+ *
+ * `Option` is special-cased so nested plain payloads still get frozen:
+ * `Option.some({ items: [...] })` walks into `.value` and freezes the inner
+ * record, but returns the `Some` wrapper untouched.
+ *
+ * Idempotent: already-frozen values are returned as-is. This also serves as
+ * the cycle-safety bailout and ensures amortized cost is O(diff) per update
+ * when combined with `evo()` which preserves unchanged branches by reference.
+ */
+export const deepFreeze = <T>(value: T): T => {
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+
+  if (Object.isFrozen(value)) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    Object.freeze(value)
+    value.forEach(deepFreeze)
+    return value
+  }
+
+  if (Option.isOption(value)) {
+    if (Option.isSome(value)) {
+      deepFreeze(value.value)
+    }
+    return value
+  }
+
+  if (!isPlainObject(value)) {
+    return value
+  }
+
+  Object.freeze(value)
+  Record.keys(value).forEach(key => {
+    deepFreeze(value[key])
+  })
+  return value
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (!Predicate.isRecord(value)) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}

--- a/packages/foldkit/src/runtime/public.ts
+++ b/packages/foldkit/src/runtime/public.ts
@@ -14,6 +14,7 @@ export type {
   Visibility,
   SlowViewContext,
   SlowViewConfig,
+  FreezeModelConfig,
   DevtoolsConfig,
 } from './runtime'
 

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -33,6 +33,7 @@ import {
   addNavigationEventListeners,
 } from './browserListeners'
 import { defaultCrashView, noOpDispatch } from './crashUI'
+import { deepFreeze } from './deepFreeze'
 import type { ManagedResourceConfig, ManagedResources } from './managedResource'
 import type { Subscriptions } from './subscription'
 import { UrlRequest } from './urlRequest'
@@ -109,6 +110,33 @@ export type SlowViewConfig<Model, Message> =
 
 const DEFAULT_SLOW_VIEW_SHOW: Visibility = 'Development'
 const DEFAULT_SLOW_VIEW_THRESHOLD_MS = 16
+
+/**
+ * Model-freeze configuration for catching accidental mutations in development.
+ *
+ * When active, Foldkit deep-freezes the Model after `init` and after every
+ * `update`. Accidental mutations (e.g. `model.items.push(...)`) then throw a
+ * `TypeError` at the exact write site with a stack trace, rather than
+ * silently corrupting state or breaking reference-equality change detection.
+ *
+ * Pass `false` to disable entirely.
+ *
+ * - `show`: `'Development'` (default) enables when Vite HMR is active,
+ *   `'Always'` enables in all environments including production.
+ *
+ * Scope — only the Model is frozen. Messages are short-lived and are not
+ * frozen; they often carry `OptionFromSelf` / `DateTimeFromSelf` fields that
+ * rely on `Hash.cached` which lazily writes to the instance. Production
+ * builds (`'Development'` + no HMR) leave change detection at reference
+ * equality and pay nothing for this feature.
+ */
+export type FreezeModelConfig =
+  | false
+  | Readonly<{
+      show?: Visibility
+    }>
+
+const DEFAULT_FREEZE_MODEL_SHOW: Visibility = 'Development'
 
 const defaultSlowViewCallback = (
   context: SlowViewContext<unknown, unknown>,
@@ -197,6 +225,7 @@ type RuntimeConfig<
   routing?: RoutingConfig<Message>
   crash?: CrashConfig<Model, Message>
   slowView?: SlowViewConfig<Model, Message>
+  freezeModel?: FreezeModelConfig
   /**
    * An Effect Layer providing long-lived resources that persist across command
    * invocations. Use this for browser resources with lifecycle (AudioContext,
@@ -244,6 +273,7 @@ type BaseProgramConfig<
   container: HTMLElement
   crash?: CrashConfig<Model, Message>
   slowView?: SlowViewConfig<Model, Message>
+  freezeModel?: FreezeModelConfig
   resources?: Layer.Layer<Resources>
   managedResources?: ManagedResources<Model, Message, ManagedResourceServices>
   /** Derives the document title from the current model. Called after every render. */
@@ -428,6 +458,7 @@ const makeRuntime = <
   routing: routingConfig,
   crash,
   slowView,
+  freezeModel,
   resources,
   managedResources,
   title,
@@ -455,6 +486,22 @@ const makeRuntime = <
       onSlowView: config.onSlowView ?? defaultSlowViewCallback,
     })),
   )
+
+  const isFreezeModelActive = pipe(
+    freezeModel ?? {},
+    Option.liftPredicate(config => config !== false),
+    Option.filter(config =>
+      Match.value(config.show ?? DEFAULT_FREEZE_MODEL_SHOW).pipe(
+        Match.when('Always', () => true),
+        Match.when('Development', () => !!import.meta.hot),
+        Match.exhaustive,
+      ),
+    ),
+    Option.isSome,
+  )
+
+  const maybeFreezeModel = (model: Model): Model =>
+    isFreezeModelActive ? deepFreeze(model) : model
 
   return (hmrModel?: unknown): Effect.Effect<void> =>
     Effect.scoped(
@@ -535,7 +582,7 @@ const makeRuntime = <
           routingConfig,
         ).pipe(Option.flatMap(() => urlFromString(window.location.href)))
 
-        const [initModel, initCommands] = Predicate.isNotUndefined(hmrModel)
+        const [initModelRaw, initCommands] = Predicate.isNotUndefined(hmrModel)
           ? pipe(
               hmrModel,
               Schema.decodeUnknownEither(Model),
@@ -545,6 +592,8 @@ const makeRuntime = <
               }),
             )
           : init(flags, Option.getOrUndefined(currentUrl))
+
+        const initModel = maybeFreezeModel(initModelRaw)
 
         const modelSubscriptionRef = yield* SubscriptionRef.make(initModel)
 
@@ -602,7 +651,8 @@ const makeRuntime = <
           Effect.gen(function* () {
             const currentModel = yield* Ref.get(modelRef)
 
-            const [nextModel, commands] = update(currentModel, message)
+            const [nextModelRaw, commands] = update(currentModel, message)
+            const nextModel = maybeFreezeModel(nextModelRaw)
 
             if (currentModel !== nextModel) {
               yield* Ref.set(modelRef, nextModel)
@@ -792,8 +842,10 @@ const makeRuntime = <
           const { position, mode, maybeBanner } = resolvedDevtools.value
           const devtoolsStore = yield* createDevtoolsStore({
             replay: (model, message) =>
-              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-              Tuple.getFirst(update(model as Model, message as Message)),
+              maybeFreezeModel(
+                /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+                Tuple.getFirst(update(model as Model, message as Message)),
+              ),
             render: model =>
               /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
               render(model as Model, Option.none()),
@@ -1172,6 +1224,9 @@ export function makeProgram<
     ...(config.crash && { crash: config.crash }),
     ...(Predicate.isNotUndefined(config.slowView) && {
       slowView: config.slowView,
+    }),
+    ...(Predicate.isNotUndefined(config.freezeModel) && {
+      freezeModel: config.freezeModel,
     }),
     ...(config.resources && { resources: config.resources }),
     ...(config.managedResources && {

--- a/packages/website/src/page/bestPractices/immutability.ts
+++ b/packages/website/src/page/bestPractices/immutability.ts
@@ -17,8 +17,15 @@ const immutableUpdatesHeader: TableOfContentsEntry = {
   text: 'Immutable Updates with evo',
 }
 
+const runtimeEnforcementHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'runtime-enforcement',
+  text: 'Runtime Enforcement in Development',
+}
+
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   immutableUpdatesHeader,
+  runtimeEnforcementHeader,
 ]
 
 export const view = (copiedSnippets: CopiedSnippets): Html =>
@@ -32,7 +39,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         inlineCode('evo'),
         " for immutable model updates. It wraps Effect's ",
         inlineCode('Struct.evolve'),
-        ' with stricter type checking \u2014 if you remove or rename a key from your Model, you\u2019ll get type errors everywhere you try to update it.',
+        ' with stricter type checking — if you remove or rename a key from your Model, you’ll get type errors everywhere you try to update it.',
       ),
       highlightedCodeBlock(
         div([Class('text-sm'), InnerHTML(Snippets.evoExampleHighlighted)], []),
@@ -43,6 +50,36 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
       para(
         'Each property in the transform object is a function that takes the current value and returns the new value. Properties not included remain unchanged.',
+      ),
+      tableOfContentsEntryToHeader(runtimeEnforcementHeader),
+      para(
+        'In development, Foldkit deep-freezes the Model after ',
+        inlineCode('init'),
+        ' and after every ',
+        inlineCode('update'),
+        '. An accidental mutation like ',
+        inlineCode('model.items.push(...)'),
+        ' throws a ',
+        inlineCode('TypeError'),
+        ' at the exact write site with a clear stack trace, instead of silently corrupting state or breaking reference-equality change detection.',
+      ),
+      para(
+        'Freezing is scoped to plain objects and arrays. Effect-tagged values (',
+        inlineCode('Option'),
+        ', ',
+        inlineCode('DateTime'),
+        ', ',
+        inlineCode('HashSet'),
+        ', class instances) are left alone because they rely on lazy instance writes for hash memoization. Nested payloads inside an ',
+        inlineCode('Option.some'),
+        ' are still frozen.',
+      ),
+      para(
+        'Production builds pay nothing for this feature. To enable freezing in every environment, or to disable it entirely, pass a ',
+        inlineCode('freezeModel'),
+        ' option to ',
+        inlineCode('makeProgram'),
+        '.',
       ),
     ],
   )


### PR DESCRIPTION
## Summary

Adds a new `freezeModel` runtime configuration option that deep-freezes the Model in development by default, catching accidental mutations at the write site with clear `TypeError` stack traces instead of silently corrupting state.

## Key Changes

- **New `deepFreeze` utility** (`packages/foldkit/src/runtime/deepFreeze.ts`):
  - Recursively freezes plain objects and arrays
  - Skips Effect-tagged values (`Option`, `Either`, etc.), `Date`, `Map`, `Set`, and class instances to preserve hash memoization
  - Special-cases `Option.some` to freeze nested payloads while leaving the wrapper untouched
  - Handles cycles and is idempotent for amortized O(diff) cost with reference-preserving updates

- **New `FreezeModelConfig` type** in runtime:
  - Mirrors `devtools` and `slowView` config shape
  - `show: 'Development'` (default) — active when Vite HMR is present
  - `show: 'Always'` — enforces in all environments including production
  - `false` — disables entirely

- **Runtime integration**:
  - Freezes Model after `init` and after every `update`
  - Applied to devtools replay as well
  - Zero cost in production builds unless explicitly enabled

- **Comprehensive test suite** covering:
  - Primitive passthrough
  - Array and nested object freezing
  - Cycle detection
  - Effect value handling (`Option`, `Hash`, `Equal`)
  - Built-in type exclusions (`Date`, `Map`, `Set`, class instances)

- **Documentation updates** in best practices guide explaining the feature, scope, and configuration options

## Implementation Details

The freezing logic is conservative: it only freezes plain objects (prototype chain is `Object.prototype` or `null`) and arrays. This prevents breaking Effect's lazy hash memoization while still catching the most common mutation patterns in user code. The idempotency check (`Object.isFrozen`) also serves as the cycle-safety bailout.

https://claude.ai/code/session_01XyraCiqmAzN5wBWZzRxB4u