### PR TITLE
Update 404 page link text from "Go to Introduction" to "Go Home"

### DIFF
--- a/packages/website/src/page/notFound.ts
+++ b/packages/website/src/page/notFound.ts
@@ -12,6 +12,6 @@ export const view = (path: string, introductionRoute: string): Html =>
         ['404 - Page Not Found'],
       ),
       para(`The path "${path}" was not found.`),
-      link(introductionRoute, '← Go to Introduction'),
+      link(introductionRoute, '← Go Home'),
     ],
   )


### PR DESCRIPTION
## Summary
Updated the call-to-action link text on the 404 error page to use more intuitive language.

## Changes
- Changed the 404 page link text from "← Go to Introduction" to "← Go Home" for better user experience and clarity

## Details
This change simplifies the navigation label on the not found page, making it clearer to users that clicking the link will take them back to the home/introduction page. The updated text is more concise and user-friendly.

https://claude.ai/code/session_014AYTzJGuj1StcoTwzwZefL