### PR TITLE
docs: surface Foldkit DevTools MCP in agent guidance

### DIFF
--- a/.changeset/agents-md-devtools.md
+++ b/.changeset/agents-md-devtools.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Add a "Debugging with Foldkit DevTools" section to the AGENTS.md template. New apps now ship with explicit guidance for AI agents on the `foldkit_*` MCP tools, when to reach for them over `console.log`, and what to check when the relay isn't visible.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ dist
 **/.claude/*
 !/.claude/commands/
 !/.claude/settings.json
-packages/foldkit/src/devtools/overlay-styles.ts
+packages/foldkit/src/devTools/overlay-styles.ts
 packages/website/src/generated/
 .playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,17 @@ Command definitions live where they're produced — colocated with the update fu
 
 - When making multi-file edits or refactors, apply changes to ALL relevant files — not just a subset. After refactoring, verify that spacing, margins, and visual formatting haven't regressed from the original.
 
+## Debugging Example Apps
+
+The apps in `examples/` ship with Foldkit DevTools and the `@foldkit/devtools-mcp` relay wired up. When debugging behavior in a running example, the `foldkit_*` MCP tools are usually faster than reading code or adding logs:
+
+- `foldkit_list_runtimes` to find connected tabs, `foldkit_get_model` for the current Model.
+- `foldkit_list_messages` and `foldkit_get_message` for the Message history with per-path diffs.
+- `foldkit_list_keyframes`, `foldkit_replay_to_keyframe`, and `foldkit_resume` for time-travel.
+- `foldkit_dispatch_message` to enqueue a Message decoded against the app's Schema.
+
+The relay only runs when an example's dev server and a browser tab are open. It is unavailable when working purely on library internals in `packages/foldkit/`. The agent-facing reference for app projects lives in `packages/create-foldkit-app/templates/base/AGENTS.md`. Keep the two in sync when changing the public tool surface.
+
 ## Communication
 
 - When I ask a question or make a comment that sounds rhetorical, opinion-based, or conversational (e.g., 'what do you think about X?', 'im asking you'), respond with discussion — not code edits. Only make code changes when explicitly asked to.

--- a/packages/create-foldkit-app/templates/base/AGENTS.md
+++ b/packages/create-foldkit-app/templates/base/AGENTS.md
@@ -101,6 +101,22 @@ Use `Story.story` to chain steps into a readable narrative: set initial Model â†
 
 If the `repos/foldkit` submodule is available, study the `.test.ts` files in `repos/foldkit/examples/` for patterns â€” they cover simple Command resolution, multi-step interactions, and Submodel OutMessage assertions.
 
+## Debugging with Foldkit DevTools
+
+This project ships with `@foldkit/devtools-mcp` pre-wired. When the dev server is running and the app is open in a browser tab, the following MCP tools are available (prefix `foldkit_`):
+
+- `foldkit_list_runtimes`: connected browser tabs. Call first to discover which runtime to target.
+- `foldkit_get_model`: snapshots the current Model.
+- `foldkit_list_messages` / `foldkit_get_message`: Message history with per-path diffs, plus the Model before and after each Message.
+- `foldkit_list_keyframes` / `foldkit_replay_to_keyframe` / `foldkit_resume`: time-travel to a past state and resume.
+- `foldkit_dispatch_message`: enqueue a Message into the runtime, decoded against the app's Schema.
+
+Reach for these before adding `console.log` whenever the question is about state, Message flow, or reproducing a sequence. To verify a behavior change end-to-end, dispatch the Messages that exercise it rather than clicking through the UI.
+
+If `foldkit_list_runtimes` returns nothing, ask the user to open the app in a browser tab. If the `foldkit_*` tools aren't visible at all, the relay may not be wired. Check `devToolsMcpPort` in `vite.config.ts` and the `Message` field in `Runtime.makeProgram`'s `devTools` config, and ask the user before adding them.
+
+The relay is dev-only. Production builds never include it, so DevTools cannot be used to debug deployed apps.
+
 ## Code Quality Standards
 
 - Every name should eliminate ambiguity. Prefix Option-typed values with `maybe` (e.g. `maybeSession`). Name functions by their precise effect (e.g. `enqueueMessage` not `addMessage`). A reader should never need to check a type signature to understand what a name refers to.


### PR DESCRIPTION
Add a Debugging section to the create-foldkit-app AGENTS.md template that
lists the foldkit_* MCP tools, when to use them over console.log, and
what to check if they aren't visible. Add a matching pointer in the
monorepo CLAUDE.md so agents debugging examples reach for DevTools
before adding logs, and so the two docs stay in sync.