### PR TITLE
feat(foldkit): path/expand on RequestGetModel + RequestGetModelAt

### DIFF
--- a/.changeset/agent-friendly-state-inspection.md
+++ b/.changeset/agent-friendly-state-inspection.md
@@ -1,0 +1,10 @@
+---
+'foldkit': minor
+'@foldkit/devtools-mcp': minor
+---
+
+Make DevTools state inspection agent-friendly. `foldkit_get_model` now accepts an optional `path` to narrow the response to a subtree (dot-string anchored at `root`, matching `SerializedEntry.changedPaths`) and `expand` to control summarization. By default the response is summarized: arrays collapse to `{ _summary, length, sample: [head, last] }`, deeply nested records collapse to `{ _summary, keys }`, and long strings collapse to `{ _summary, length, head }` so a full Model snapshot fits inside an agent's context window. A path miss returns an error listing the keys available at the deepest segment that resolved, so an agent can refine in one follow-up call.
+
+A new `foldkit_get_model_at` tool snapshots historical Model state at an absolute history index. Pass `index: N - 1` to read the Model just before message `N`. For the initial Model, use `foldkit_get_init` (which also returns the names of Commands returned from `init`).
+
+`foldkit_get_message` no longer carries `modelBefore` / `modelAfter` snapshots. Each entry's `changedPaths` already answers the common "what did this message change?" question. To inspect the literal Model values around an entry, call `foldkit_get_model_at` with `index - 1` and `index`. This is a wire-format change to `ResponseMessage`; bumping `@foldkit/devtools-mcp` in lockstep.

--- a/packages/devtools-mcp/README.md
+++ b/packages/devtools-mcp/README.md
@@ -4,7 +4,8 @@ A Model Context Protocol server that exposes a running [Foldkit](https://foldkit
 
 With it attached, agents can:
 
-- Read the current Model
+- Read the current Model, or any historical Model by history index
+- Narrow reads with dot-string paths and summarized payloads to fit token budgets
 - List and inspect the Message history, with diffs and submodel chains
 - Read the recorded init Model and init Command names
 - Inspect runtime state: current index, retained history bounds, pause status
@@ -57,7 +58,7 @@ Runtime.makeProgram({
 })
 ```
 
-Restart your dev server, then restart your AI agent. The MCP server will appear with the ten `foldkit_*` tools attached.
+Restart your dev server, then restart your AI agent. The MCP server will appear with the `foldkit_*` tools attached.
 
 The browser bridge runs inside your app, so the MCP server only sees a runtime while the app is open in a browser tab. Close the tab and the runtime disappears from `foldkit_list_runtimes`.
 
@@ -68,15 +69,23 @@ Each tool accepts an optional `runtime_id`. When omitted, the most recently conn
 | Tool                         | Description                                                                                                                                                                                                                                             |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `foldkit_list_runtimes`      | Returns metadata for every connected browser tab. Agents call this first to discover which runtime to target.                                                                                                                                           |
-| `foldkit_get_model`          | Snapshots the current Model.                                                                                                                                                                                                                            |
+| `foldkit_get_model`          | Snapshots the current Model. Accepts an optional `path` to narrow to a subtree and `expand` to control summarization.                                                                                                                                   |
+| `foldkit_get_model_at`       | Snapshots a historical Model after a given history entry. Pass `index: N - 1` to read the Model just before message `N`. Same `path`/`expand` semantics as `foldkit_get_model`. For the initial Model (and init Command names), use `foldkit_get_init`. |
 | `foldkit_get_init`           | Reads the recorded initial Model and the names of Commands returned from the application's `init` function. Equivalent to selecting the synthetic "init" row in the DevTools panel.                                                                     |
 | `foldkit_get_runtime_state`  | Snapshots the runtime's DevTools state: history bounds, current paused/live status, and whether init is recorded. Useful for understanding what `foldkit_list_messages` and `foldkit_get_message` will see and detecting whether the runtime is paused. |
 | `foldkit_list_messages`      | Lists recent Message history entries with pagination. Each entry carries the Message body, Command names triggered, timestamp, an `isModelChanged` flag, the diff path lists (`changedPaths` / `affectedPaths`), and any extracted Submodel chain.      |
-| `foldkit_get_message`        | Reads one entry at a given index, including the Model before and after the Message was applied. Use `foldkit_get_init` instead for the synthetic init entry at index -1.                                                                                |
+| `foldkit_get_message`        | Reads one entry at a given index. The response carries the SerializedEntry only; to inspect the Model around the entry, call `foldkit_get_model_at` with `index - 1` (before) and `index` (after). Use `foldkit_get_init` for the synthetic init entry. |
 | `foldkit_list_keyframes`     | Returns the indices Foldkit can replay back to. Index `-1` is the initial Model.                                                                                                                                                                        |
 | `foldkit_replay_to_keyframe` | Time-travels the runtime to a previous state. The runtime is paused at that snapshot until `foldkit_resume` is called.                                                                                                                                  |
 | `foldkit_resume`             | Resumes normal execution after a replay.                                                                                                                                                                                                                |
 | `foldkit_dispatch_message`   | Enqueues a Message into the runtime as if your application produced it. The runtime decodes the payload against your Schema and returns a clean error if it does not match.                                                                             |
+
+### Reading the Model efficiently
+
+`foldkit_get_model` and `foldkit_get_model_at` are designed for AI agents reading state into a token-bounded context. Two parameters control the payload size:
+
+- **`path`** is a dot-string anchored at `root` that narrows the response to a subtree. The alphabet matches the `changedPaths` array on each `SerializedEntry`, so a path observed in `foldkit_list_messages` can be passed straight back. Examples: `'root'` (the whole Model), `'root.route'`, `'root.session.user'`, `'root.cards.0'`. When the path doesn't resolve, the response is an error listing the keys available at the deepest segment that did resolve, so the agent can refine in one follow-up call.
+- **`expand`** controls summarization. By default (`false`), large arrays collapse to `{ _summary: 'array', length, sample: [head, last] }`, deeply nested records collapse to `{ _summary: 'record', keys }`, and long strings collapse to `{ _summary: 'string', length, head }`. Tagged-union variants (`{ _tag, ... }`) keep their tag and recursively summarize children. With `expand: true`, the literal value at the path is returned with no summarization. Pair a narrow `path` with `expand: true` to read a specific subtree at full fidelity without paying for the rest of the Model.
 
 ## Architecture
 

--- a/packages/devtools-mcp/src/tools.ts
+++ b/packages/devtools-mcp/src/tools.ts
@@ -5,6 +5,7 @@ import {
   RequestGetInit,
   RequestGetMessage,
   RequestGetModel,
+  RequestGetModelAt,
   RequestGetRuntimeState,
   RequestListKeyframes,
   RequestListMessages,
@@ -56,8 +57,39 @@ const KeyframeIndex = S.Number.pipe(
   }),
 )
 
+const ModelIndex = S.Number.pipe(
+  S.int(),
+  S.annotations({
+    description:
+      'Absolute history index. Returns the Model state right after the entry at this index was applied. To inspect the Model immediately before message N, pass index N - 1. For the initial Model, use foldkit_get_init.',
+  }),
+)
+
+const PathField = S.optional(
+  S.String.annotations({
+    description:
+      "Dot-string path into the Model anchored at 'root'. Examples: 'root', 'root.route', 'root.session.user', 'root.cards.0'. Matches the alphabet used by SerializedEntry.changedPaths so paths copied from one tool's output can be passed straight into the next. Defaults to 'root' (the whole Model).",
+  }),
+)
+
+const ExpandField = S.optional(
+  S.Boolean.annotations({
+    description:
+      "When false (the default), large arrays/records/strings collapse to '_summary' placeholders to keep payloads small. Set true to receive the literal value at the path. Pair with `path` to drill in: a narrow path with `expand: true` is the cheapest way to read a specific subtree at full fidelity.",
+  }),
+)
+
 const GetModelInput = S.Struct({
   runtime_id: RuntimeIdField,
+  path: PathField,
+  expand: ExpandField,
+})
+
+const GetModelAtInput = S.Struct({
+  runtime_id: RuntimeIdField,
+  index: ModelIndex,
+  path: PathField,
+  expand: ExpandField,
 })
 
 const ListMessagesInput = S.Struct({
@@ -240,9 +272,34 @@ export const buildTools = (
 ): ReadonlyArray<ToolDefinition> => [
   {
     name: 'foldkit_get_model',
-    description: 'Snapshot the current Model from a connected Foldkit runtime.',
+    description:
+      "Snapshot the current Model from a connected Foldkit runtime. By default the response is summarized (large arrays/records/strings collapse to `_summary` placeholders) to keep payloads small for AI agents. Pass `path` (e.g. 'root.session.user') to narrow to a subtree, and `expand: true` to receive the literal value at that path. Returns `{ value, atPath, summarized }`.",
     inputSchema: JSONSchema.make(GetModelInput),
-    handle: runRuntimeTool(GetModelInput, () => RequestGetModel(), wsClient),
+    handle: runRuntimeTool(
+      GetModelInput,
+      ({ path, expand }) =>
+        RequestGetModel({
+          maybePath: Option.fromNullable(path),
+          expand: expand ?? false,
+        }),
+      wsClient,
+    ),
+  },
+  {
+    name: 'foldkit_get_model_at',
+    description:
+      "Snapshot a historical Model after a given history entry was applied. Pass `index: N - 1` to read the Model just before message N. Same `path`/`expand` semantics as foldkit_get_model. For the initial Model (and the names of Commands returned from the application's `init`), use foldkit_get_init.",
+    inputSchema: JSONSchema.make(GetModelAtInput),
+    handle: runRuntimeTool(
+      GetModelAtInput,
+      ({ index, path, expand }) =>
+        RequestGetModelAt({
+          index,
+          maybePath: Option.fromNullable(path),
+          expand: expand ?? false,
+        }),
+      wsClient,
+    ),
   },
   {
     name: 'foldkit_list_messages',
@@ -262,7 +319,7 @@ export const buildTools = (
   {
     name: 'foldkit_get_message',
     description:
-      'Read a single Message history entry by absolute index, including before/after Model snapshots. The entry carries the Message body, the Commands the update function returned, an `isModelChanged` flag, and the diff path lists (`changedPaths` for leaf-level mutations and `affectedPaths` adding their ancestor paths) so you can see exactly which Model fields changed. For Submodel-routed entries (those whose tag matches `Got*Message`), the entry also carries `submodelPath` listing the wrapper tags from outer to inner and `maybeLeafTag` naming the innermost child Message.',
+      'Read a single Message history entry by absolute index. The response carries the SerializedEntry (tag, message body, commandNames, timestamp, `isModelChanged`, `changedPaths` for leaf-level mutations, `affectedPaths` adding their ancestor paths). For Submodel-routed entries (tag matches `Got*Message`), the entry also carries `submodelPath` listing wrapper tags from outer to inner and `maybeLeafTag` naming the innermost child Message. Model snapshots are not included; call foldkit_get_model_at with `index - 1` (before) and `index` (after) to inspect Model state around the entry.',
     inputSchema: JSONSchema.make(GetMessageInput),
     handle: runRuntimeTool(
       GetMessageInput,

--- a/packages/foldkit/src/devTools/protocol.ts
+++ b/packages/foldkit/src/devTools/protocol.ts
@@ -38,8 +38,18 @@ export type RuntimeInfo = typeof RuntimeInfo.Type
 
 // REQUEST
 
-/** Request the current Model snapshot. */
-export const RequestGetModel = ts('RequestGetModel')
+/** Request the current Model snapshot, optionally narrowed to a path and/or expanded. */
+export const RequestGetModel = ts('RequestGetModel', {
+  maybePath: S.Option(S.String),
+  expand: S.Boolean,
+})
+
+/** Request a historical Model snapshot at an absolute history index, optionally narrowed to a path and/or expanded. Use `index: -1` for the initial Model. */
+export const RequestGetModelAt = ts('RequestGetModelAt', {
+  index: S.Number,
+  maybePath: S.Option(S.String),
+  expand: S.Boolean,
+})
 
 /** Request recent history entries, optionally starting from a given index. */
 export const RequestListMessages = ts('RequestListMessages', {
@@ -47,7 +57,7 @@ export const RequestListMessages = ts('RequestListMessages', {
   maybeSinceIndex: S.Option(S.Number),
 })
 
-/** Request a single history entry by index, including before/after Model snapshots. */
+/** Request a single history entry by index. To inspect the Model around the entry, call `RequestGetModelAt` with `index - 1` (before) and `index` (after). */
 export const RequestGetMessage = ts('RequestGetMessage', {
   index: S.Number,
 })
@@ -80,6 +90,7 @@ export const RequestListRuntimes = ts('RequestListRuntimes')
 /** A request from the MCP server. RequestListRuntimes is handled at the Vite plugin layer; all other requests are routed to a browser runtime. */
 export const Request = S.Union(
   RequestGetModel,
+  RequestGetModelAt,
   RequestListMessages,
   RequestGetMessage,
   RequestListKeyframes,
@@ -95,9 +106,11 @@ export type Request = typeof Request.Type
 
 // RESPONSE
 
-/** Response carrying the current Model snapshot. */
+/** Response carrying a Model snapshot. The `value` is the resolved subtree at `atPath` (or the whole Model when no path was supplied). When `summarized` is true, large arrays/records/strings have been collapsed to `_summary` placeholders to keep payloads small for AI agents; pass `expand: true` on the Request to receive the literal value. */
 export const ResponseModel = ts('ResponseModel', {
-  model: S.Unknown,
+  value: S.Unknown,
+  atPath: S.String,
+  summarized: S.Boolean,
 })
 
 /** Response carrying a page of history entries. `maybeNextIndex` is `Some` when more entries are available beyond this page (pass it as `RequestListMessages.maybeSinceIndex` to fetch the next page) and `None` when this page reaches the current end of history. */
@@ -106,11 +119,9 @@ export const ResponseMessages = ts('ResponseMessages', {
   maybeNextIndex: S.Option(S.Number),
 })
 
-/** Response carrying a single history entry with surrounding Model snapshots. */
+/** Response carrying a single history entry. Model snapshots are not included; use `RequestGetModelAt` with `index - 1` and `index` to inspect Model state around the entry. */
 export const ResponseMessage = ts('ResponseMessage', {
   entry: SerializedEntry,
-  modelBefore: S.Unknown,
-  modelAfter: S.Unknown,
 })
 
 /** Response carrying the list of available keyframes. */

--- a/packages/foldkit/src/devTools/public.ts
+++ b/packages/foldkit/src/devTools/public.ts
@@ -9,6 +9,7 @@ export {
   RequestGetInit,
   RequestGetMessage,
   RequestGetModel,
+  RequestGetModelAt,
   RequestGetRuntimeState,
   RequestListKeyframes,
   RequestListMessages,

--- a/packages/foldkit/src/devTools/summarize.test.ts
+++ b/packages/foldkit/src/devTools/summarize.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatPathNotFound, resolvePath, summarizeValue } from './summarize.js'
+
+describe('resolvePath', () => {
+  const model = {
+    route: { _tag: 'Home' },
+    session: { user: { id: 'u1', name: 'Alice' } },
+    cards: [
+      { id: 'c1', title: 'A' },
+      { id: 'c2', title: 'B' },
+      { id: 'c3', title: 'C' },
+    ],
+  }
+
+  it('resolves the bare root path to the whole value', () => {
+    const result = resolvePath(model, 'root')
+    expect(result).toEqual({ _tag: 'Found', value: model, atPath: 'root' })
+  })
+
+  it('resolves a top-level field', () => {
+    const result = resolvePath(model, 'root.route')
+    expect(result).toEqual({
+      _tag: 'Found',
+      value: { _tag: 'Home' },
+      atPath: 'root.route',
+    })
+  })
+
+  it('resolves a nested record path', () => {
+    const result = resolvePath(model, 'root.session.user.name')
+    expect(result).toEqual({
+      _tag: 'Found',
+      value: 'Alice',
+      atPath: 'root.session.user.name',
+    })
+  })
+
+  it('resolves an array index segment', () => {
+    const result = resolvePath(model, 'root.cards.1')
+    expect(result).toEqual({
+      _tag: 'Found',
+      value: { id: 'c2', title: 'B' },
+      atPath: 'root.cards.1',
+    })
+  })
+
+  it('rejects paths that do not start with root', () => {
+    const result = resolvePath(model, 'session.user')
+    expect(result._tag).toBe('NotFound')
+    if (result._tag === 'NotFound') {
+      expect(result.reason).toMatch(/must start with 'root'/)
+    }
+  })
+
+  it('reports availableKeys when a key is missing', () => {
+    const result = resolvePath(model, 'root.facility')
+    expect(result._tag).toBe('NotFound')
+    if (result._tag === 'NotFound') {
+      expect(result.failedAt).toBe('root')
+      expect(new Set(result.availableKeys)).toEqual(
+        new Set(['route', 'session', 'cards']),
+      )
+    }
+  })
+
+  it('reports the failure point for nested misses', () => {
+    const result = resolvePath(model, 'root.session.user.email')
+    expect(result._tag).toBe('NotFound')
+    if (result._tag === 'NotFound') {
+      expect(result.failedAt).toBe('root.session.user')
+      expect(new Set(result.availableKeys)).toEqual(new Set(['id', 'name']))
+    }
+  })
+
+  it('reports out-of-bounds array indices as NotFound', () => {
+    const result = resolvePath(model, 'root.cards.99')
+    expect(result._tag).toBe('NotFound')
+    if (result._tag === 'NotFound') {
+      expect(result.failedAt).toBe('root.cards')
+    }
+  })
+
+  it('rejects non-integer segments against an array', () => {
+    const fractional = resolvePath(model, 'root.cards.1.5')
+    expect(fractional._tag).toBe('NotFound')
+
+    const nonNumeric = resolvePath(model, 'root.cards.abc')
+    expect(nonNumeric._tag).toBe('NotFound')
+    if (nonNumeric._tag === 'NotFound') {
+      expect(nonNumeric.failedAt).toBe('root.cards')
+    }
+  })
+
+  it('reports descent into a primitive as NotFound', () => {
+    const result = resolvePath(model, 'root.session.user.name.first')
+    expect(result._tag).toBe('NotFound')
+    if (result._tag === 'NotFound') {
+      expect(result.failedAt).toBe('root.session.user.name')
+      expect(result.reason).toMatch(/Cannot descend into a primitive/)
+    }
+  })
+})
+
+describe('formatPathNotFound', () => {
+  it('appends available keys when present', () => {
+    const formatted = formatPathNotFound({
+      _tag: 'NotFound',
+      failedAt: 'root',
+      reason: "No 'facility' at 'root'.",
+      availableKeys: ['route', 'session'],
+    })
+    expect(formatted).toBe(
+      "No 'facility' at 'root'. Available keys: route, session.",
+    )
+  })
+
+  it('omits the available keys hint when there are none', () => {
+    const formatted = formatPathNotFound({
+      _tag: 'NotFound',
+      failedAt: '',
+      reason: "Path must start with 'root'. Received: 'oops'.",
+      availableKeys: [],
+    })
+    expect(formatted).toBe("Path must start with 'root'. Received: 'oops'.")
+  })
+})
+
+describe('summarizeValue', () => {
+  it('passes primitives through unchanged', () => {
+    expect(summarizeValue(42)).toBe(42)
+    expect(summarizeValue(true)).toBe(true)
+    expect(summarizeValue(null)).toBe(null)
+    expect(summarizeValue(undefined)).toBe(undefined)
+  })
+
+  it('passes short strings through', () => {
+    expect(summarizeValue('hello')).toBe('hello')
+  })
+
+  it('truncates long strings', () => {
+    const long = 'x'.repeat(500)
+    expect(summarizeValue(long)).toEqual({
+      _summary: 'string',
+      length: 500,
+      head: 'x'.repeat(200),
+    })
+  })
+
+  it('collapses arrays to length plus head/last sample', () => {
+    const items = Array.from({ length: 25 }, (_, index) => ({
+      id: `c${index}`,
+    }))
+    expect(summarizeValue(items)).toEqual({
+      _summary: 'array',
+      length: 25,
+      sample: [{ id: 'c0' }, { id: 'c24' }],
+    })
+  })
+
+  it('emits all elements when an array fits within the sample budget', () => {
+    expect(summarizeValue([1, 2])).toEqual({
+      _summary: 'array',
+      length: 2,
+      sample: [1, 2],
+    })
+  })
+
+  it('walks records up to a depth of 3', () => {
+    const value = {
+      a: {
+        b: {
+          c: {
+            d: { deep: 'too far' },
+          },
+        },
+      },
+    }
+    expect(summarizeValue(value)).toEqual({
+      a: {
+        b: {
+          c: { _summary: 'record', keys: ['d'] },
+        },
+      },
+    })
+  })
+
+  it('preserves _tag fields on tagged unions and summarizes large data siblings', () => {
+    const remoteOk = {
+      _tag: 'Ok',
+      data: Array.from({ length: 25 }, (_, index) => ({ id: index })),
+    }
+    expect(summarizeValue(remoteOk)).toEqual({
+      _tag: 'Ok',
+      data: {
+        _summary: 'array',
+        length: 25,
+        sample: [{ id: 0 }, { id: 24 }],
+      },
+    })
+  })
+
+  it('produces JSON-serializable output for a representative model', () => {
+    const model = {
+      route: { _tag: 'FacilityDetail', facilityId: 'f1' },
+      remote: {
+        _tag: 'Ok',
+        data: Array.from({ length: 50 }, (_, index) => ({
+          id: `u${index}`,
+          notes: 'x'.repeat(300),
+        })),
+      },
+    }
+    expect(() => JSON.stringify(summarizeValue(model))).not.toThrow()
+  })
+})

--- a/packages/foldkit/src/devTools/summarize.ts
+++ b/packages/foldkit/src/devTools/summarize.ts
@@ -1,0 +1,209 @@
+import {
+  Array as Array_,
+  Function,
+  Match as M,
+  Option,
+  Predicate,
+  Record,
+  Schema as S,
+} from 'effect'
+
+import { OptionExt } from '../effectExtensions/index.js'
+import { ts } from '../schema/index.js'
+
+const ROOT = 'root'
+const PATH_SEPARATOR = '.'
+const MAX_DEPTH = 3
+const STRING_TRUNCATE = 200
+const ARRAY_SAMPLE = 2
+
+// PATH
+
+const Found = ts('Found', {
+  value: S.Unknown,
+  atPath: S.String,
+})
+
+const NotFound = ts('NotFound', {
+  failedAt: S.String,
+  reason: S.String,
+  availableKeys: S.Array(S.String),
+})
+
+const PathResolution = S.Union(Found, NotFound)
+
+/**
+ * Result of resolving a dot-string path against a Model snapshot.
+ *
+ * The path representation matches `SerializedEntry.changedPaths` exactly:
+ * dot-separated, anchored at the literal segment `root`. `Found.atPath`
+ * echoes the canonicalized path; `NotFound.availableKeys` lists the keys
+ * present at the deepest segment that resolved, so an agent can recover with
+ * one follow-up call.
+ */
+export type PathResolution = typeof PathResolution.Type
+
+const isExpandable = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> | ReadonlyArray<unknown> =>
+  Predicate.isReadonlyRecord(value) || Array.isArray(value)
+
+const keysOf = (value: unknown): ReadonlyArray<string> =>
+  M.value(value).pipe(
+    M.when(Array.isArray, items =>
+      Array_.makeBy(items.length, index => index.toString()),
+    ),
+    M.when(Predicate.isReadonlyRecord, Record.keys),
+    M.orElse(() => []),
+  )
+
+const segmentsOf = (path: string): ReadonlyArray<string> =>
+  path === ROOT ? [] : path.split(PATH_SEPARATOR).slice(1)
+
+const isRootAnchored = (path: string): boolean =>
+  path === ROOT || path.startsWith(`${ROOT}${PATH_SEPARATOR}`)
+
+const descend = (parent: unknown, segment: string): Option.Option<unknown> =>
+  M.value(parent).pipe(
+    M.when(Array.isArray, array =>
+      Option.liftPredicate(Number(segment), Number.isInteger).pipe(
+        Option.flatMap(index => Array_.get(array, index)),
+      ),
+    ),
+    M.when(Predicate.isReadonlyRecord, record => Record.get(record, segment)),
+    M.orElse(() => Option.none()),
+  )
+
+/**
+ * Walk a dot-string path against a Model snapshot. Returns the resolved value
+ * on success, or a structured `NotFound` describing the deepest segment that
+ * resolved plus its available keys so an agent can refine.
+ */
+export const resolvePath = (root: unknown, path: string): PathResolution => {
+  if (!isRootAnchored(path)) {
+    return NotFound({
+      failedAt: '',
+      reason: `Path must start with '${ROOT}'. Received: '${path}'.`,
+      availableKeys: [],
+    })
+  }
+
+  const initial: PathResolution = Found({ value: root, atPath: ROOT })
+
+  return Array_.reduce(
+    segmentsOf(path),
+    initial,
+    (resolution, segment): PathResolution => {
+      if (resolution._tag === 'NotFound') {
+        return resolution
+      }
+      return Option.match(descend(resolution.value, segment), {
+        onNone: () =>
+          NotFound({
+            failedAt: resolution.atPath,
+            reason: isExpandable(resolution.value)
+              ? `No '${segment}' at '${resolution.atPath}'.`
+              : `Cannot descend into a primitive at '${resolution.atPath}' (looking for '${segment}').`,
+            availableKeys: keysOf(resolution.value),
+          }),
+        onSome: descended =>
+          Found({
+            value: descended,
+            atPath: `${resolution.atPath}${PATH_SEPARATOR}${segment}`,
+          }),
+      })
+    },
+  )
+}
+
+// SUMMARIZE
+
+const truncateString = (value: string): unknown =>
+  value.length <= STRING_TRUNCATE
+    ? value
+    : {
+        _summary: 'string',
+        length: value.length,
+        head: value.slice(0, STRING_TRUNCATE),
+      }
+
+const sampleArray = (
+  items: ReadonlyArray<unknown>,
+  depth: number,
+): ReadonlyArray<unknown> => {
+  const sample =
+    items.length <= ARRAY_SAMPLE
+      ? items
+      : [
+          ...Array_.take(items, ARRAY_SAMPLE - 1),
+          ...Option.toArray(Array_.last(items)),
+        ]
+  return Array_.map(sample, item => summarizeAt(item, depth + 1))
+}
+
+const summarizeArray = (
+  items: ReadonlyArray<unknown>,
+  depth: number,
+): unknown => ({
+  _summary: 'array',
+  length: items.length,
+  sample: sampleArray(items, depth),
+})
+
+const summarizeRecord = (
+  value: Readonly<Record<string, unknown>>,
+  depth: number,
+): unknown => {
+  if (depth >= MAX_DEPTH) {
+    return {
+      _summary: 'record',
+      keys: Record.keys(value),
+    }
+  }
+  return Record.map(value, child => summarizeAt(child, depth + 1))
+}
+
+const summarizeAt = (value: unknown, depth: number): unknown =>
+  M.value(value).pipe(
+    M.when(Predicate.isString, truncateString),
+    M.when(Array.isArray, items => summarizeArray(items, depth)),
+    M.when(Predicate.isReadonlyRecord, record =>
+      summarizeRecord(record, depth),
+    ),
+    M.orElse(Function.identity),
+  )
+
+/**
+ * Apply structural summarization rules to a value:
+ * - Arrays collapse to `{ _summary, length, sample: [head, last] }` at every depth.
+ * - Records walk to a depth of 3, then collapse to `{ _summary, keys }`.
+ * - Long strings collapse to `{ _summary, length, head }`.
+ * - Tagged values (`{ _tag, ... }`) keep their `_tag` since it's a record key.
+ *
+ * The result is JSON-serializable and intended for transmission to MCP clients
+ * with `expand: false`. Use raw values directly when `expand: true`.
+ */
+export const summarizeValue = (value: unknown): unknown => summarizeAt(value, 0)
+
+// FORMAT
+
+const formatAvailableKeys = (
+  keys: ReadonlyArray<string>,
+): Option.Option<string> =>
+  OptionExt.when(
+    Array_.isNonEmptyReadonlyArray(keys),
+    `Available keys: ${keys.join(', ')}.`,
+  )
+
+/**
+ * Format a `NotFound` resolution as a single human-readable line for the
+ * `ResponseError.reason` channel. Includes the available keys at the failure
+ * point so an agent can refine the path on the next call.
+ */
+export const formatPathNotFound = (
+  notFound: Extract<PathResolution, { _tag: 'NotFound' }>,
+): string =>
+  Option.match(formatAvailableKeys(notFound.availableKeys), {
+    onNone: () => notFound.reason,
+    onSome: hint => `${notFound.reason} ${hint}`,
+  })

--- a/packages/foldkit/src/devTools/webSocketBridge.ts
+++ b/packages/foldkit/src/devTools/webSocketBridge.ts
@@ -37,6 +37,12 @@ import {
 } from './protocol.js'
 import { toInspectableValue, toSerializedEntry } from './serialize.js'
 import { type DevToolsStore, INIT_INDEX } from './store.js'
+import {
+  type PathResolution,
+  formatPathNotFound,
+  resolvePath,
+  summarizeValue,
+} from './summarize.js'
 
 type Hot = NonNullable<ImportMeta['hot']>
 
@@ -151,6 +157,46 @@ export const startWebSocketBridge = (
     window.addEventListener('beforeunload', emitDisconnect, { once: true })
   })
 
+const presentResolution = (
+  resolution: PathResolution,
+  expand: boolean,
+): Response =>
+  Match.value(resolution).pipe(
+    Match.tag('Found', ({ value, atPath }) =>
+      ResponseModel({
+        value: expand ? value : summarizeValue(value),
+        atPath,
+        summarized: !expand,
+      }),
+    ),
+    Match.orElse(notFound =>
+      ResponseError({ reason: formatPathNotFound(notFound) }),
+    ),
+  )
+
+const readModelResponse = (
+  store: DevToolsStore,
+  index: number,
+  maybePath: Option.Option<string>,
+  expand: boolean,
+): Effect.Effect<Response> =>
+  Effect.gen(function* () {
+    const model = yield* store.getModelAtIndex(index)
+    const path = Option.getOrElse(maybePath, () => 'root')
+    return presentResolution(
+      resolvePath(toInspectableValue(model), path),
+      expand,
+    )
+  }).pipe(
+    Effect.catchAllCause(cause =>
+      Effect.succeed(
+        ResponseError({
+          reason: `Failed to read Model at index ${index}: ${Cause.pretty(cause)}`,
+        }),
+      ),
+    ),
+  )
+
 const dispatchRequest = (
   store: DevToolsStore,
   dispatch: (message: unknown) => Effect.Effect<void>,
@@ -159,28 +205,18 @@ const dispatchRequest = (
 ): Effect.Effect<Response> =>
   Match.value(request).pipe(
     Match.tagsExhaustive({
-      RequestGetModel: () =>
+      RequestGetModel: ({ maybePath, expand }) =>
         Effect.gen(function* () {
           const state = yield* SubscriptionRef.get(store.stateRef)
           const index = currentAbsoluteIndex(
             state.entries.length,
             state.startIndex,
           )
-          return yield* pipe(
-            index,
-            store.getModelAtIndex,
-            Effect.map(model =>
-              ResponseModel({ model: toInspectableValue(model) }),
-            ),
-            Effect.catchAllCause(cause =>
-              Effect.succeed(
-                ResponseError({
-                  reason: `Failed to read current Model: ${Cause.pretty(cause)}`,
-                }),
-              ),
-            ),
-          )
+          return yield* readModelResponse(store, index, maybePath, expand)
         }),
+
+      RequestGetModelAt: ({ index, maybePath, expand }) =>
+        readModelResponse(store, index, maybePath, expand),
 
       RequestListMessages: ({ limit, maybeSinceIndex }) =>
         Effect.gen(function* () {
@@ -227,26 +263,10 @@ const dispatchRequest = (
                 }),
               ),
             onSome: entry =>
-              pipe(
-                {
-                  modelBefore: store.getModelAtIndex(index - 1),
-                  modelAfter: store.getModelAtIndex(index),
-                },
-                Effect.all,
-                Effect.map(({ modelBefore, modelAfter }) =>
-                  ResponseMessage({
-                    entry: toSerializedEntry(entry, index),
-                    modelBefore: toInspectableValue(modelBefore),
-                    modelAfter: toInspectableValue(modelAfter),
-                  }),
-                ),
-                Effect.catchAllCause(cause =>
-                  Effect.succeed(
-                    ResponseError({
-                      reason: `Failed to read Models around index ${index}: ${Cause.pretty(cause)}`,
-                    }),
-                  ),
-                ),
+              Effect.succeed(
+                ResponseMessage({
+                  entry: toSerializedEntry(entry, index),
+                }),
               ),
           })
         }),

--- a/packages/website/src/page/aiMcp.ts
+++ b/packages/website/src/page/aiMcp.ts
@@ -87,7 +87,31 @@ const tools: ReadonlyArray<ToolRowSpec> = [
   },
   {
     name: 'foldkit_get_model',
-    description: ['Snapshots the current Model.'],
+    description: [
+      'Snapshots the current Model. Accepts an optional ',
+      inlineCode('path', 'text-xs'),
+      ' to narrow to a subtree and ',
+      inlineCode('expand', 'text-xs'),
+      ' to control summarization.',
+    ],
+  },
+  {
+    name: 'foldkit_get_model_at',
+    description: [
+      'Snapshots a historical Model after a given history entry. Pass ',
+      inlineCode('index: N - 1', 'text-xs'),
+      ' to read the Model before message ',
+      inlineCode('N', 'text-xs'),
+      '. Same ',
+      inlineCode('path', 'text-xs'),
+      '/',
+      inlineCode('expand', 'text-xs'),
+      ' semantics as ',
+      inlineCode('foldkit_get_model', 'text-xs'),
+      '. For the initial Model, use ',
+      inlineCode('foldkit_get_init', 'text-xs'),
+      '.',
+    ],
   },
   {
     name: 'foldkit_get_init',
@@ -120,7 +144,13 @@ const tools: ReadonlyArray<ToolRowSpec> = [
   {
     name: 'foldkit_get_message',
     description: [
-      'Reads one entry at a given index, including the Model before and after the Message was applied. Use ',
+      'Reads one entry at a given index. To inspect the Model around the entry, call ',
+      inlineCode('foldkit_get_model_at', 'text-xs'),
+      ' with ',
+      inlineCode('index - 1', 'text-xs'),
+      ' (before) and ',
+      inlineCode('index', 'text-xs'),
+      ' (after). Use ',
       inlineCode('foldkit_get_init', 'text-xs'),
       ' for the synthetic init entry at index ',
       inlineCode('-1', 'text-xs'),


### PR DESCRIPTION
Reshape the DevTools protocol so AI agents can read state without dumping
the entire Model into context. RequestGetModel now carries an optional
dot-string `path` (anchored at `root`, matching SerializedEntry.changedPaths)
and an `expand` boolean. By default the response is summarized: arrays
collapse to `{ _summary, length, sample: [head, last] }`, deeply nested
records collapse to `{ _summary, keys }`, long strings collapse to
`{ _summary, length, head }`. Tagged-union variants keep their `_tag` and
recursively summarize children, so `Ok({ data: [...] })` from a RemoteData
type becomes `{ _tag: 'Ok', data: { _summary: 'array', length, sample } }`.

A new RequestGetModelAt tool snapshots historical Model state at an
absolute history index. Use `index: -1` for INIT, or `index: N - 1` to
inspect the Model immediately before message N. ResponseMessage no longer
carries `modelBefore` / `modelAfter` snapshots; per-entry `changedPaths`
already answers the "what changed?" question, and an agent that needs the
literal values calls RequestGetModelAt with the appropriate indices.

Path misses return a structured error listing the keys available at the
deepest segment that resolved, so an agent can refine in one follow-up
call instead of probing.

The summarization rules are generic and structural; no Schema annotations
are required, and no app-level types (RemoteData, Result, etc.) are
hardcoded.