### PR TITLE
Add links to DevTools and tests in architecture documentation

### DIFF
--- a/packages/website/src/page/core/architecture.ts
+++ b/packages/website/src/page/core/architecture.ts
@@ -11,6 +11,7 @@ import {
   para,
   tableOfContentsEntryToHeader,
 } from '../../prose'
+import { coreDevToolsRouter, testingRouter } from '../../route'
 import { comparisonTable } from '../../view/table'
 
 const overviewHeader: TableOfContentsEntry = {
@@ -75,7 +76,11 @@ export const view = (): Html =>
       para(
         'Commands are descriptions of one-shot side effects \u2014 HTTP requests, focus operations, ',
         inlineCode('localStorage'),
-        ' writes, navigation calls. The Foldkit runtime executes them and sends their results back as new Messages, feeding them into the same loop. Each Command carries a name, which surfaces in tracing and tests.',
+        ' writes, navigation calls. The Foldkit runtime executes them and sends their results back as new Messages, feeding them into the same loop. Each Command carries a name, which surfaces in ',
+        link(coreDevToolsRouter(), 'DevTools'),
+        ', ',
+        link(testingRouter(), 'tests'),
+        ', and tracing.',
       ),
       para(
         'Subscriptions are continuous streams of Messages from external sources \u2014 keypresses, recurring timers, ',


### PR DESCRIPTION
## Summary
Updated the architecture documentation to include hyperlinks to DevTools and testing resources when describing Commands in the Foldkit framework.

## Changes
- Added imports for `coreDevToolsRouter` and `testingRouter` route functions
- Enhanced the Commands description paragraph to include:
  - A link to DevTools documentation where Command names surface
  - A link to testing documentation where Command names surface
  - Improved text flow by restructuring the sentence to better integrate the new links

## Details
The change makes the architecture documentation more discoverable by linking readers directly to relevant resources (DevTools and testing guides) when they encounter information about how Command names are used in those contexts. This improves navigation and helps users find related documentation more easily.

https://claude.ai/code/session_016MBWzokR4ZsCsbkMLHrUbg