### PR TITLE
docs(website): split Guides sidebar into For React Developers + Guides

### DIFF
--- a/packages/website/src/docsNav.ts
+++ b/packages/website/src/docsNav.ts
@@ -235,7 +235,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
-    label: 'Guides',
+    label: 'For React Developers',
     pageGroups: [
       [
         {
@@ -253,6 +253,13 @@ export const docsSections: ReadonlyArray<DocsSection> = [
           href: whyNoJsxRouter(),
           label: 'Why no JSX?',
         },
+      ],
+    ],
+  },
+  {
+    label: 'Guides',
+    pageGroups: [
+      [
         {
           _tag: 'RoutingAndNavigation',
           href: routingAndNavigationRouter(),

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -51,6 +51,7 @@ import {
   GotExampleDetailMessage,
   GotExamplesGroupMessage,
   GotFoldkitUiGroupMessage,
+  GotForReactDevelopersGroupMessage,
   GotGetStartedGroupMessage,
   GotGuidesGroupMessage,
   GotMobileMenuDialogMessage,
@@ -200,6 +201,7 @@ export const Model = S.Struct({
   playgroundError: S.OptionFromSelf(S.String),
   getStartedGroup: Ui.Disclosure.Model,
   coreConceptsGroup: Ui.Disclosure.Model,
+  forReactDevelopersGroup: Ui.Disclosure.Model,
   guidesGroup: Ui.Disclosure.Model,
   testingGroup: Ui.Disclosure.Model,
   bestPracticesGroup: Ui.Disclosure.Model,
@@ -353,6 +355,10 @@ const init: Runtime.RoutingProgramInit<Model, Message, Flags, AppResources> = (
       },
       coreConceptsGroup: {
         ...Ui.Disclosure.init({ id: 'core-concepts-group' }),
+        isOpen: true,
+      },
+      forReactDevelopersGroup: {
+        ...Ui.Disclosure.init({ id: 'for-react-developers-group' }),
         isOpen: true,
       },
       guidesGroup: {
@@ -870,6 +876,24 @@ const update = (
           coreConceptsGroupCommands.map(
             Command.mapEffect(
               Effect.map(message => GotCoreConceptsGroupMessage({ message })),
+            ),
+          ),
+        ]
+      },
+
+      GotForReactDevelopersGroupMessage: ({ message }) => {
+        const [nextForReactDevelopersGroup, forReactDevelopersGroupCommands] =
+          Ui.Disclosure.update(model.forReactDevelopersGroup, message)
+
+        return [
+          evo(model, {
+            forReactDevelopersGroup: () => nextForReactDevelopersGroup,
+          }),
+          forReactDevelopersGroupCommands.map(
+            Command.mapEffect(
+              Effect.map(message =>
+                GotForReactDevelopersGroupMessage({ message }),
+              ),
             ),
           ),
         ]

--- a/packages/website/src/message.ts
+++ b/packages/website/src/message.ts
@@ -107,6 +107,12 @@ export const GotGetStartedGroupMessage = m('GotGetStartedGroupMessage', {
 export const GotCoreConceptsGroupMessage = m('GotCoreConceptsGroupMessage', {
   message: Ui.Disclosure.Message,
 })
+export const GotForReactDevelopersGroupMessage = m(
+  'GotForReactDevelopersGroupMessage',
+  {
+    message: Ui.Disclosure.Message,
+  },
+)
 export const GotGuidesGroupMessage = m('GotGuidesGroupMessage', {
   message: Ui.Disclosure.Message,
 })
@@ -179,6 +185,7 @@ export const Message = S.Union(
   GotApiReferenceMessage,
   GotGetStartedGroupMessage,
   GotCoreConceptsGroupMessage,
+  GotForReactDevelopersGroupMessage,
   GotGuidesGroupMessage,
   GotTestingGroupMessage,
   GotBestPracticesGroupMessage,

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -37,6 +37,7 @@ import {
   GotCoreConceptsGroupMessage,
   GotExamplesGroupMessage,
   GotFoldkitUiGroupMessage,
+  GotForReactDevelopersGroupMessage,
   GotGetStartedGroupMessage,
   GotGuidesGroupMessage,
   GotMobileMenuDialogMessage,
@@ -98,6 +99,7 @@ const sidebarViewInner = (
   route: Model['route'],
   getStartedGroup: Ui.Disclosure.Model,
   coreConceptsGroup: Ui.Disclosure.Model,
+  forReactDevelopersGroup: Ui.Disclosure.Model,
   guidesGroup: Ui.Disclosure.Model,
   testingGroup: Ui.Disclosure.Model,
   bestPracticesGroup: Ui.Disclosure.Model,
@@ -157,6 +159,11 @@ const sidebarViewInner = (
     {
       model: coreConceptsGroup,
       toParentMessage: message => GotCoreConceptsGroupMessage({ message }),
+    },
+    {
+      model: forReactDevelopersGroup,
+      toParentMessage: message =>
+        GotForReactDevelopersGroupMessage({ message }),
     },
     {
       model: guidesGroup,
@@ -341,6 +348,7 @@ export const sidebarView = (model: Model): Html =>
     model.route,
     model.getStartedGroup,
     model.coreConceptsGroup,
+    model.forReactDevelopersGroup,
     model.guidesGroup,
     model.testingGroup,
     model.bestPracticesGroup,


### PR DESCRIPTION
The Guides section had grown to mix two distinct audiences. The
React-comparison pages (Coming from React, Foldkit vs React, Why no JSX?)
serve newcomers orienting from another framework, while the practical
guides (Routing & Navigation, Field Validation, Project Organization)
apply to anyone building a Foldkit app.

Splits them into a new For React Developers section placed right after
Get Started, leaving Guides focused on practical how-tos.