### PR TITLE
Rename blur event messages to describe observed behavior

### DIFF
--- a/.changeset/blurred-message-renames.md
+++ b/.changeset/blurred-message-renames.md
@@ -1,0 +1,14 @@
+---
+'foldkit': minor
+---
+
+Rename misleading Messages in `Ui.Combobox`, `Ui.Listbox`, `Ui.Menu`, and `Ui.Popover` so each name describes what its dispatch site actually observes. All four components emitted `ClosedByTab` from an `OnBlur` handler, which fires for any blur cause (Tab key, outside click, programmatic blur, focus shift). The "ByTab" suffix invented a trigger the handler cannot verify.
+
+**Breaking.**
+
+- `Combobox.ClosedByTab` → `Combobox.BlurredInput`
+- `Listbox.ClosedByTab` → `Listbox.BlurredItems`
+- `Menu.ClosedByTab` → `Menu.BlurredItems`
+- `Popover.ClosedByTab` → `Popover.BlurredPanel`
+
+Update any code that constructed or pattern-matched on the old names. Behavior is unchanged.

--- a/examples/auth/src/page/loggedOut/page/login.story.test.ts
+++ b/examples/auth/src/page/loggedOut/page/login.story.test.ts
@@ -5,10 +5,10 @@ import { describe, expect, test } from 'vitest'
 import {
   ChangedEmail,
   ChangedPassword,
-  ClickedSubmit,
   FailedSimulateAuthRequest,
   type Model,
   SimulateAuthRequest,
+  SubmittedForm,
   SucceededLogin,
   SucceededSimulateAuthRequest,
   initModel,
@@ -59,7 +59,7 @@ describe('login', () => {
     Story.story(
       update,
       Story.with(initModel()),
-      Story.message(ClickedSubmit()),
+      Story.message(SubmittedForm()),
       Story.model(model => {
         expect(model.isSubmitting).toBe(false)
       }),
@@ -71,7 +71,7 @@ describe('login', () => {
     Story.story(
       update,
       Story.with(validModel),
-      Story.message(ClickedSubmit()),
+      Story.message(SubmittedForm()),
       Story.model(model => {
         expect(model.isSubmitting).toBe(true)
       }),
@@ -88,7 +88,7 @@ describe('login', () => {
     Story.story(
       update,
       Story.with(validModel),
-      Story.message(ClickedSubmit()),
+      Story.message(SubmittedForm()),
       Story.model(model => {
         expect(model.isSubmitting).toBe(true)
       }),

--- a/examples/auth/src/page/loggedOut/page/login.ts
+++ b/examples/auth/src/page/loggedOut/page/login.ts
@@ -69,7 +69,7 @@ export const initModel = (): Model => ({
 
 export const ChangedEmail = m('ChangedEmail', { value: S.String })
 export const ChangedPassword = m('ChangedPassword', { value: S.String })
-export const ClickedSubmit = m('ClickedSubmit')
+export const SubmittedForm = m('SubmittedForm')
 export const SucceededSimulateAuthRequest = m('SucceededSimulateAuthRequest', {
   session: Session,
 })
@@ -80,7 +80,7 @@ export const FailedSimulateAuthRequest = m('FailedSimulateAuthRequest', {
 export const Message = S.Union(
   ChangedEmail,
   ChangedPassword,
-  ClickedSubmit,
+  SubmittedForm,
   SucceededSimulateAuthRequest,
   FailedSimulateAuthRequest,
 )
@@ -165,7 +165,7 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         Option.none(),
       ],
 
-      ClickedSubmit: () => {
+      SubmittedForm: () => {
         if (!isFormValid(model)) {
           return [model, [], Option.none()]
         }
@@ -293,7 +293,7 @@ export const view = (
             ],
           ),
           form(
-            [Class('space-y-6'), OnSubmit(toParentMessage(ClickedSubmit()))],
+            [Class('space-y-6'), OnSubmit(toParentMessage(SubmittedForm()))],
             [
               fieldView(
                 'email',

--- a/examples/stopwatch/src/main.ts
+++ b/examples/stopwatch/src/main.ts
@@ -27,19 +27,19 @@ type Model = typeof Model.Type
 
 // MESSAGE
 
-const RequestedStart = m('RequestedStart')
+const ClickedStart = m('ClickedStart')
 const RecordedStartTime = m('RecordedStartTime', { startTime: S.Number })
 const ClickedStop = m('ClickedStop')
 const ClickedReset = m('ClickedReset')
-const RequestedTick = m('RequestedTick')
+const Ticked = m('Ticked')
 const RecordedTickTime = m('RecordedTickTime', { elapsedMs: S.Number })
 
 export const Message = S.Union(
-  RequestedStart,
+  ClickedStart,
   RecordedStartTime,
   ClickedStop,
   ClickedReset,
-  RequestedTick,
+  Ticked,
   RecordedTickTime,
 )
 export type Message = typeof Message.Type
@@ -60,7 +60,7 @@ const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      RequestedStart: () => [
+      ClickedStart: () => [
         model,
         [
           RecordStartTime(
@@ -96,7 +96,7 @@ const update = (
         [],
       ],
 
-      RequestedTick: () => [
+      Ticked: () => [
         model,
         [
           RecordTickTime(
@@ -144,9 +144,7 @@ const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
     modelToDependencies: (model: Model) => ({ isRunning: model.isRunning }),
     dependenciesToStream: ({ isRunning }) =>
       Stream.when(
-        Stream.tick(Duration.millis(TICK_INTERVAL_MS)).pipe(
-          Stream.map(RequestedTick),
-        ),
+        Stream.tick(Duration.millis(TICK_INTERVAL_MS)).pipe(Stream.map(Ticked)),
         () => isRunning,
       ),
   },
@@ -219,7 +217,7 @@ const startStopButton = (isRunning: boolean): Html =>
       )
     : button(
         [
-          OnClick(RequestedStart()),
+          OnClick(ClickedStart()),
           Class(buttonStyle + ' bg-green-500 hover:bg-green-600'),
         ],
         ['Start'],

--- a/examples/websocket-chat/src/main.ts
+++ b/examples/websocket-chat/src/main.ts
@@ -54,12 +54,12 @@ type Model = typeof Model.Type
 
 // MESSAGE
 
-const RequestedConnection = m('RequestedConnection')
+const ClickedConnect = m('ClickedConnect')
 const Connected = m('Connected')
 const Disconnected = m('Disconnected')
 const FailedConnect = m('FailedConnect', { error: S.String })
 const UpdatedMessageInput = m('UpdatedMessageInput', { value: S.String })
-const RequestedMessageSend = m('RequestedMessageSend')
+const SubmittedMessage = m('SubmittedMessage')
 const SucceededSendMessage = m('SucceededSendMessage', { text: S.String })
 const ReceivedMessage = m('ReceivedMessage', { text: S.String })
 const TimestampedMessage = m('TimestampedMessage', {
@@ -69,12 +69,12 @@ const TimestampedMessage = m('TimestampedMessage', {
 })
 
 const Message = S.Union(
-  RequestedConnection,
+  ClickedConnect,
   Connected,
   Disconnected,
   FailedConnect,
   UpdatedMessageInput,
-  RequestedMessageSend,
+  SubmittedMessage,
   SucceededSendMessage,
   ReceivedMessage,
   TimestampedMessage,
@@ -95,7 +95,7 @@ const update = (
       [Model, ReadonlyArray<Command.Command<Message, never, ChatSocketService>>]
     >(),
     M.tagsExhaustive({
-      RequestedConnection: () => [
+      ClickedConnect: () => [
         evo(model, {
           connection: () => ConnectionConnecting(),
         }),
@@ -131,7 +131,7 @@ const update = (
         [],
       ],
 
-      RequestedMessageSend: () => {
+      SubmittedMessage: () => {
         const trimmedMessage = model.messageInput.trim()
 
         if (String.isEmpty(trimmedMessage)) {
@@ -536,7 +536,7 @@ const connectButtonView = (): Html =>
     [
       button(
         [
-          OnClick(RequestedConnection()),
+          OnClick(ClickedConnect()),
           Class(
             'bg-blue-500 hover:bg-blue-600 text-white font-semibold px-8 py-3 rounded-lg transition',
           ),
@@ -554,7 +554,7 @@ const connectingView = (): Html =>
 
 const messageInputView = (messageInput: string): Html =>
   form(
-    [Class('p-6 border-t border-gray-200'), OnSubmit(RequestedMessageSend())],
+    [Class('p-6 border-t border-gray-200'), OnSubmit(SubmittedMessage())],
     [
       div(
         [Class('flex gap-3')],
@@ -596,7 +596,7 @@ const errorView = (error: string): Html =>
       ),
       button(
         [
-          OnClick(RequestedConnection()),
+          OnClick(ClickedConnect()),
           Class(
             'w-full bg-blue-500 hover:bg-blue-600 text-white font-semibold px-6 py-3 rounded-lg transition',
           ),

--- a/packages/foldkit/src/ui/combobox/public.ts
+++ b/packages/foldkit/src/ui/combobox/public.ts
@@ -34,7 +34,7 @@ export type {
   ActivationTrigger,
   Opened,
   Closed,
-  ClosedByTab,
+  BlurredInput,
   ActivatedItem,
   DeactivatedItem,
   MovedPointerOverItem,

--- a/packages/foldkit/src/ui/combobox/shared.ts
+++ b/packages/foldkit/src/ui/combobox/shared.ts
@@ -93,8 +93,8 @@ export const Opened = m('Opened', {
 })
 /** Sent when the combobox closes via Escape key or backdrop click. */
 export const Closed = m('Closed')
-/** Sent when focus leaves the input via Tab key or blur. */
-export const ClosedByTab = m('ClosedByTab')
+/** Sent when the combobox input loses focus. */
+export const BlurredInput = m('BlurredInput')
 /** Sent when an item is highlighted via arrow keys or mouse hover. Includes activation trigger and optional immediate selection info. */
 export const ActivatedItem = m('ActivatedItem', {
   index: S.Number,
@@ -150,7 +150,7 @@ export const Message: S.Union<
   [
     typeof Opened,
     typeof Closed,
-    typeof ClosedByTab,
+    typeof BlurredInput,
     typeof ActivatedItem,
     typeof DeactivatedItem,
     typeof SelectedItem,
@@ -170,7 +170,7 @@ export const Message: S.Union<
 > = S.Union(
   Opened,
   Closed,
-  ClosedByTab,
+  BlurredInput,
   ActivatedItem,
   DeactivatedItem,
   SelectedItem,
@@ -190,7 +190,7 @@ export const Message: S.Union<
 
 export type Opened = typeof Opened.Type
 export type Closed = typeof Closed.Type
-export type ClosedByTab = typeof ClosedByTab.Type
+export type BlurredInput = typeof BlurredInput.Type
 export type ActivatedItem = typeof ActivatedItem.Type
 export type DeactivatedItem = typeof DeactivatedItem.Type
 export type SelectedItem = typeof SelectedItem.Type
@@ -429,7 +429,7 @@ export const makeUpdate = <Model extends BaseModel>(
 
         Closed: () => closeCombobox(model, [focusInput]),
 
-        ClosedByTab: () => closeCombobox(model, []),
+        BlurredInput: () => closeCombobox(model, []),
 
         ActivatedItem: ({
           index,
@@ -610,7 +610,7 @@ export type BaseViewConfig<
     message:
       | Opened
       | Closed
-      | ClosedByTab
+      | BlurredInput
       | ActivatedItem
       | DeactivatedItem
       | SelectedItem
@@ -944,7 +944,7 @@ export const makeView =
         : [
             OnInput(value => toParentMessage(UpdatedInputValue({ value }))),
             OnKeyDownPreventDefault(handleInputKeyDown),
-            OnBlur(toParentMessage(ClosedByTab())),
+            OnBlur(toParentMessage(BlurredInput())),
             ...(openOnFocus
               ? [
                   OnFocus(

--- a/packages/foldkit/src/ui/combobox/single.story.test.ts
+++ b/packages/foldkit/src/ui/combobox/single.story.test.ts
@@ -8,9 +8,9 @@ import * as Animation from '../animation/index.js'
 import type { Message } from './shared.js'
 import {
   ActivatedItem,
+  BlurredInput,
   ClickItem,
   Closed,
-  ClosedByTab,
   CompletedClickItem,
   CompletedFocusInput,
   CompletedLockScroll,
@@ -266,12 +266,12 @@ describe('Combobox', () => {
       })
     })
 
-    describe('ClosedByTab', () => {
-      it('closes without focus command', () => {
+    describe('BlurredInput', () => {
+      it('closes without restoring input focus', () => {
         Story.story(
           update,
           withOpen,
-          Story.message(ClosedByTab()),
+          Story.message(BlurredInput()),
           Story.model(model => {
             expect(model.isOpen).toBe(false)
             expect(model.maybeActiveItemIndex).toStrictEqual(Option.none())
@@ -280,7 +280,7 @@ describe('Combobox', () => {
         )
       })
 
-      it('restores input value', () => {
+      it('restores input value to the selected display text', () => {
         Story.story(
           update,
           Story.with({
@@ -289,7 +289,7 @@ describe('Combobox', () => {
             inputValue: 'app',
             maybeSelectedDisplayText: Option.some('Apple'),
           }),
-          Story.message(ClosedByTab()),
+          Story.message(BlurredInput()),
           Story.model(model => {
             expect(model.inputValue).toBe('Apple')
           }),
@@ -728,11 +728,11 @@ describe('Combobox', () => {
           )
         })
 
-        it('sets LeaveStart on ClosedByTab', () => {
+        it('begins the leave animation when the input blurs', () => {
           Story.story(
             update,
             withOpenAnimated,
-            Story.message(ClosedByTab()),
+            Story.message(BlurredInput()),
             Story.model(model => {
               expect(model.isOpen).toBe(false)
               expect(model.animation.transitionState).toBe('LeaveStart')
@@ -949,11 +949,11 @@ describe('Combobox', () => {
       )
     })
 
-    it('emits unlockScroll and restoreInert commands on ClosedByTab when isModal is true', () => {
+    it('emits unlockScroll and restoreInert commands when the input blurs in modal mode', () => {
       Story.story(
         update,
         withOpenModal,
-        Story.message(ClosedByTab()),
+        Story.message(BlurredInput()),
         Story.resolveAll(
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedTeardownInert()],

--- a/packages/foldkit/src/ui/listbox/public.ts
+++ b/packages/foldkit/src/ui/listbox/public.ts
@@ -39,7 +39,7 @@ export type {
   ActivationTrigger,
   Opened,
   Closed,
-  ClosedByTab,
+  BlurredItems,
   ActivatedItem,
   DeactivatedItem,
   MovedPointerOverItem,

--- a/packages/foldkit/src/ui/listbox/shared.ts
+++ b/packages/foldkit/src/ui/listbox/shared.ts
@@ -102,8 +102,8 @@ export const Opened = m('Opened', {
 })
 /** Sent when the listbox closes via Escape key or backdrop click. */
 export const Closed = m('Closed')
-/** Sent when focus leaves the listbox items container via Tab key or blur. */
-export const ClosedByTab = m('ClosedByTab')
+/** Sent when the listbox items container loses focus. */
+export const BlurredItems = m('BlurredItems')
 /** Sent when an item is highlighted via arrow keys or mouse hover. Includes activation trigger. */
 export const ActivatedItem = m('ActivatedItem', {
   index: S.Number,
@@ -165,7 +165,7 @@ export const Message: S.Union<
   [
     typeof Opened,
     typeof Closed,
-    typeof ClosedByTab,
+    typeof BlurredItems,
     typeof ActivatedItem,
     typeof DeactivatedItem,
     typeof SelectedItem,
@@ -189,7 +189,7 @@ export const Message: S.Union<
 > = S.Union(
   Opened,
   Closed,
-  ClosedByTab,
+  BlurredItems,
   ActivatedItem,
   DeactivatedItem,
   SelectedItem,
@@ -213,7 +213,7 @@ export const Message: S.Union<
 
 export type Opened = typeof Opened.Type
 export type Closed = typeof Closed.Type
-export type ClosedByTab = typeof ClosedByTab.Type
+export type BlurredItems = typeof BlurredItems.Type
 export type ActivatedItem = typeof ActivatedItem.Type
 export type DeactivatedItem = typeof DeactivatedItem.Type
 export type SelectedItem = typeof SelectedItem.Type
@@ -475,7 +475,7 @@ export const makeUpdate = <Model extends BaseModel>(
 
         Closed: () => closeListbox(model, closeWithFocusCommands),
 
-        ClosedByTab: () => {
+        BlurredItems: () => {
           if (
             Option.exists(
               model.maybeLastButtonPointerType,
@@ -666,7 +666,7 @@ export type BaseViewConfig<Message, Item, Model extends BaseModel> = Readonly<{
     message:
       | Opened
       | Closed
-      | ClosedByTab
+      | BlurredItems
       | ActivatedItem
       | DeactivatedItem
       | SelectedItem
@@ -1071,7 +1071,7 @@ export const makeView =
         : [
             OnKeyDownPreventDefault(handleItemsKeyDown),
             OnKeyUpPreventDefault(handleSpaceKeyUp),
-            OnBlur(toParentMessage(ClosedByTab())),
+            OnBlur(toParentMessage(BlurredItems())),
           ]),
       ...(itemsClassName ? [Class(itemsClassName)] : []),
       ...itemsAttributes,

--- a/packages/foldkit/src/ui/listbox/single.story.test.ts
+++ b/packages/foldkit/src/ui/listbox/single.story.test.ts
@@ -7,10 +7,10 @@ import * as Story from '../../test/story.js'
 import * as Animation from '../animation/index.js'
 import {
   ActivatedItem,
+  BlurredItems,
   ClearedSearch,
   ClickItem,
   Closed,
-  ClosedByTab,
   CompletedClickItem,
   CompletedFocusButton,
   CompletedFocusItems,
@@ -235,12 +235,12 @@ describe('Listbox', () => {
       })
     })
 
-    describe('ClosedByTab', () => {
-      it('closes the listbox without a focus command', () => {
+    describe('BlurredItems', () => {
+      it('closes the listbox without restoring button focus', () => {
         Story.story(
           update,
           withOpen,
-          Story.message(ClosedByTab()),
+          Story.message(BlurredItems()),
           Story.model(model => {
             expect(model.isOpen).toBe(false)
             expect(model.maybeActiveItemIndex).toStrictEqual(Option.none())
@@ -911,11 +911,11 @@ describe('Listbox', () => {
           )
         })
 
-        it('sets LeaveStart on ClosedByTab', () => {
+        it('begins the leave animation when the items container blurs', () => {
           Story.story(
             update,
             withOpenAnimated,
-            Story.message(ClosedByTab()),
+            Story.message(BlurredItems()),
             Story.model(model => {
               expect(model.isOpen).toBe(false)
               expect(model.animation.transitionState).toBe('LeaveStart')
@@ -1198,11 +1198,11 @@ describe('Listbox', () => {
       )
     })
 
-    it('emits unlockScroll and restoreInert commands on ClosedByTab when isModal is true', () => {
+    it('emits unlockScroll and restoreInert commands when the items container blurs in modal mode', () => {
       Story.story(
         update,
         withOpenModal,
-        Story.message(ClosedByTab()),
+        Story.message(BlurredItems()),
         Story.resolveAll(
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedTeardownInert()],

--- a/packages/foldkit/src/ui/menu/index.story.test.ts
+++ b/packages/foldkit/src/ui/menu/index.story.test.ts
@@ -7,10 +7,10 @@ import * as Story from '../../test/story.js'
 import * as Animation from '../animation/index.js'
 import {
   ActivatedItem,
+  BlurredItems,
   ClearedSearch,
   ClickItem,
   Closed,
-  ClosedByTab,
   CompletedClickItem,
   CompletedFocusButton,
   CompletedFocusItems,
@@ -210,12 +210,12 @@ describe('Menu', () => {
       })
     })
 
-    describe('ClosedByTab', () => {
-      it('closes the menu without a focus command', () => {
+    describe('BlurredItems', () => {
+      it('closes the menu without restoring button focus', () => {
         Story.story(
           update,
           withOpen,
-          Story.message(ClosedByTab()),
+          Story.message(BlurredItems()),
           Story.model(model => {
             expect(model.isOpen).toBe(false)
             expect(model.maybeActiveItemIndex).toStrictEqual(Option.none())
@@ -998,11 +998,11 @@ describe('Menu', () => {
           )
         })
 
-        it('sets LeaveStart on ClosedByTab', () => {
+        it('begins the leave animation when the items container blurs', () => {
           Story.story(
             update,
             withOpenAnimated,
-            Story.message(ClosedByTab()),
+            Story.message(BlurredItems()),
             Story.model(model => {
               expect(model.isOpen).toBe(false)
               expect(model.animation.transitionState).toBe('LeaveStart')
@@ -1282,11 +1282,11 @@ describe('Menu', () => {
       )
     })
 
-    it('emits unlockScroll and restoreInert commands on ClosedByTab when isModal is true', () => {
+    it('emits unlockScroll and restoreInert commands when the items container blurs in modal mode', () => {
       Story.story(
         update,
         withOpenModal,
-        Story.message(ClosedByTab()),
+        Story.message(BlurredItems()),
         Story.resolveAll(
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedTeardownInert()],

--- a/packages/foldkit/src/ui/menu/index.ts
+++ b/packages/foldkit/src/ui/menu/index.ts
@@ -84,8 +84,8 @@ export const Opened = m('Opened', {
 })
 /** Sent when the menu closes via Escape key or backdrop click. */
 export const Closed = m('Closed')
-/** Sent when focus leaves the menu items container via Tab key or blur. */
-export const ClosedByTab = m('ClosedByTab')
+/** Sent when the menu items container loses focus. */
+export const BlurredItems = m('BlurredItems')
 /** Sent when an item is highlighted via arrow keys or mouse hover. Includes activation trigger. */
 export const ActivatedItem = m('ActivatedItem', {
   index: S.Number,
@@ -158,7 +158,7 @@ export const Message: S.Union<
   [
     typeof Opened,
     typeof Closed,
-    typeof ClosedByTab,
+    typeof BlurredItems,
     typeof ActivatedItem,
     typeof DeactivatedItem,
     typeof SelectedItem,
@@ -184,7 +184,7 @@ export const Message: S.Union<
 > = S.Union(
   Opened,
   Closed,
-  ClosedByTab,
+  BlurredItems,
   ActivatedItem,
   DeactivatedItem,
   SelectedItem,
@@ -212,7 +212,7 @@ export type Message = typeof Message.Type
 
 export type Opened = typeof Opened.Type
 export type Closed = typeof Closed.Type
-export type ClosedByTab = typeof ClosedByTab.Type
+export type BlurredItems = typeof BlurredItems.Type
 export type ActivatedItem = typeof ActivatedItem.Type
 export type DeactivatedItem = typeof DeactivatedItem.Type
 export type SelectedItem = typeof SelectedItem.Type
@@ -460,7 +460,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
 
       Closed: () => closeMenu(model, closeWithFocusCommands),
 
-      ClosedByTab: () => {
+      BlurredItems: () => {
         if (
           Option.exists(model.maybeLastButtonPointerType, Equal.equals('mouse'))
         ) {
@@ -702,7 +702,7 @@ export type ViewConfig<Message, Item extends string> = Readonly<{
     message:
       | Opened
       | Closed
-      | ClosedByTab
+      | BlurredItems
       | ActivatedItem
       | DeactivatedItem
       | SelectedItem
@@ -1065,7 +1065,7 @@ export const view = <Message, Item extends string>(
           OnKeyDownPreventDefault(handleItemsKeyDown),
           OnKeyUpPreventDefault(handleSpaceKeyUp),
           OnPointerUp(handleItemsPointerUp),
-          OnBlur(toParentMessage(ClosedByTab())),
+          OnBlur(toParentMessage(BlurredItems())),
         ]),
     ...(itemsClassName ? [Class(itemsClassName)] : []),
     ...itemsAttributes,

--- a/packages/foldkit/src/ui/menu/public.ts
+++ b/packages/foldkit/src/ui/menu/public.ts
@@ -35,7 +35,7 @@ export type {
   ActivationTrigger,
   Opened,
   Closed,
-  ClosedByTab,
+  BlurredItems,
   ActivatedItem,
   DeactivatedItem,
   MovedPointerOverItem,

--- a/packages/foldkit/src/ui/popover/index.story.test.ts
+++ b/packages/foldkit/src/ui/popover/index.story.test.ts
@@ -5,8 +5,8 @@ import { expect } from 'vitest'
 import * as Story from '../../test/story.js'
 import * as Animation from '../animation/index.js'
 import {
+  BlurredPanel,
   Closed,
-  ClosedByTab,
   CompletedFocusButton,
   CompletedFocusPanel,
   CompletedLockScroll,
@@ -153,12 +153,12 @@ describe('Popover', () => {
       })
     })
 
-    describe('ClosedByTab', () => {
-      it('closes the popover without a focus command', () => {
+    describe('BlurredPanel', () => {
+      it('closes the popover without restoring button focus', () => {
         Story.story(
           update,
           withOpen,
-          Story.message(ClosedByTab()),
+          Story.message(BlurredPanel()),
           Story.model(model => {
             expect(model.isOpen).toBe(false)
             expect(model.maybeLastButtonPointerType).toStrictEqual(
@@ -407,11 +407,11 @@ describe('Popover', () => {
           )
         })
 
-        it('sets LeaveStart on ClosedByTab', () => {
+        it('begins the leave animation when the panel blurs', () => {
           Story.story(
             update,
             withOpenAnimated,
-            Story.message(ClosedByTab()),
+            Story.message(BlurredPanel()),
             Story.model(model => {
               expect(model.isOpen).toBe(false)
               expect(model.animation.transitionState).toBe('LeaveStart')
@@ -605,11 +605,11 @@ describe('Popover', () => {
       )
     })
 
-    it('emits unlockScroll and restoreInert commands on ClosedByTab when isModal is true', () => {
+    it('emits unlockScroll and restoreInert commands when the panel blurs in modal mode', () => {
       Story.story(
         update,
         withOpenModal,
-        Story.message(ClosedByTab()),
+        Story.message(BlurredPanel()),
         Story.resolveAll(
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedTeardownInert()],

--- a/packages/foldkit/src/ui/popover/index.ts
+++ b/packages/foldkit/src/ui/popover/index.ts
@@ -48,8 +48,8 @@ export type Model = typeof Model.Type
 export const Opened = m('Opened')
 /** Sent when the popover closes via Escape key or backdrop click. Returns focus to the button. */
 export const Closed = m('Closed')
-/** Sent when focus leaves the popover panel via Tab key. Does NOT return focus to the button. */
-export const ClosedByTab = m('ClosedByTab')
+/** Sent when the popover panel loses focus. Does NOT return focus to the button. */
+export const BlurredPanel = m('BlurredPanel')
 /** Sent when the user presses a pointer device on the popover button. Records pointer type and toggles for mouse. */
 export const PressedPointerOnButton = m('PressedPointerOnButton', {
   pointerType: S.String,
@@ -81,7 +81,7 @@ export const Message: S.Union<
   [
     typeof Opened,
     typeof Closed,
-    typeof ClosedByTab,
+    typeof BlurredPanel,
     typeof PressedPointerOnButton,
     typeof CompletedFocusPanel,
     typeof CompletedFocusButton,
@@ -96,7 +96,7 @@ export const Message: S.Union<
 > = S.Union(
   Opened,
   Closed,
-  ClosedByTab,
+  BlurredPanel,
   PressedPointerOnButton,
   CompletedFocusPanel,
   CompletedFocusButton,
@@ -111,7 +111,7 @@ export const Message: S.Union<
 
 export type Opened = typeof Opened.Type
 export type Closed = typeof Closed.Type
-export type ClosedByTab = typeof ClosedByTab.Type
+export type BlurredPanel = typeof BlurredPanel.Type
 export type PressedPointerOnButton = typeof PressedPointerOnButton.Type
 export type IgnoredMouseClick = typeof IgnoredMouseClick.Type
 export type SuppressedSpaceScroll = typeof SuppressedSpaceScroll.Type
@@ -314,7 +314,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
 
       Closed: () => closePopover(model, closeWithFocusCommands),
 
-      ClosedByTab: () => {
+      BlurredPanel: () => {
         if (
           Option.exists(model.maybeLastButtonPointerType, Equal.equals('mouse'))
         ) {
@@ -390,7 +390,7 @@ export type ViewConfig<Message> = Readonly<{
     message:
       | Opened
       | Closed
-      | ClosedByTab
+      | BlurredPanel
       | PressedPointerOnButton
       | IgnoredMouseClick
       | SuppressedSpaceScroll,
@@ -586,7 +586,7 @@ export const view = <Message>(config: ViewConfig<Message>): Html => {
       ? []
       : [
           OnKeyDownPreventDefault(handlePanelKeyDown),
-          ...(contentFocus ? [] : [OnBlur(toParentMessage(ClosedByTab()))]),
+          ...(contentFocus ? [] : [OnBlur(toParentMessage(BlurredPanel()))]),
         ]),
     ...(panelClassName ? [Class(panelClassName)] : []),
     ...panelAttributes,

--- a/packages/foldkit/src/ui/popover/public.ts
+++ b/packages/foldkit/src/ui/popover/public.ts
@@ -26,7 +26,7 @@ export {
 } from './index.js'
 
 export type {
-  ClosedByTab,
+  BlurredPanel,
   PressedPointerOnButton,
   IgnoredMouseClick,
   SuppressedSpaceScroll,


### PR DESCRIPTION
## Summary

Renames blur event messages across UI components to more accurately describe what triggers them. The previous names (`ClosedByTab`) implied a specific trigger (Tab key), but the messages are dispatched from `OnBlur` handlers that fire for any blur cause. The new names describe only what the dispatch site observes: focus loss.

## Changes

- **Combobox**: `ClosedByTab` → `BlurredInput`
  - Message dispatched when the input element loses focus
  - Updated in `shared.ts`, tests, and public exports

- **Listbox**: `ClosedByTab` → `BlurredItems`
  - Message dispatched when the items container loses focus
  - Updated in `shared.ts`, tests, and public exports

- **Menu**: `ClosedByTab` → `BlurredItems`
  - Message dispatched when the items container loses focus
  - Updated in `index.ts`, tests, and public exports

- **Popover**: `ClosedByTab` → `BlurredPanel`
  - Message dispatched when the panel loses focus
  - Updated in `index.ts`, tests, and public exports

- **Examples**: Updated message names in stopwatch, websocket-chat, and auth examples to use new naming conventions (e.g., `RequestedStart` → `ClickedStart`, `RequestedTick` → `Ticked`, `RequestedConnection` → `ClickedConnect`, `ClickedSubmit` → `SubmittedForm`)

## Implementation Details

- All behavior remains unchanged; only message names and their documentation were updated
- Test descriptions were improved to reflect the actual trigger (blur event) rather than assumed causes
- Changeset entries document the breaking change and migration path for users

https://claude.ai/code/session_019RRxLk4aSqAWWkVAoqtoNc