### PR TITLE
docs(website): add Mount to the Architecture page

### DIFF
--- a/.changeset/cfa-agents-mount.md
+++ b/.changeset/cfa-agents-mount.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+AGENTS.md template: document Mount with a `Mount.define` + `OnMount` example showing paired cleanup.

--- a/.changeset/foldkit-readme-mount.md
+++ b/.changeset/foldkit-readme-mount.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+README: mention Mount alongside Commands, Subscriptions, and ManagedResources, and link the new Map example.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Source: [examples/counter/src/main.ts](https://github.com/foldkit/foldkit/blob/m
 Foldkit is a complete system, not a collection of libraries you stitch together.
 
 - **Commands**: Side effects are named Effects that return Messages and are executed by the runtime. Define them with `Command.define`, passing the result Message schemas so the Effect's return type stays in lockstep with your Messages. Use any Effect combinator you want: retry, timeout, race, parallel. You write the Effect, the runtime runs it.
+- **Mount**: The seam where view code reaches a real DOM element, like focusing an input or handing the live `Element` to a third-party library that owns its own DOM. The runtime runs your Effect on mount, dispatches its Message back through update, and runs the paired cleanup on unmount.
 - **Routing**: Type-safe bidirectional routing built from parser combinators. URLs parse into typed Routes and Routes build back into URLs. No string matching, no mismatches between parsing and building.
 - **Subscriptions**: Declare which streams your app needs as a function of the Model. The runtime diffs and switches them as the Model changes.
 - **Managed Resources**: Model-driven lifecycle for long-lived browser resources like WebSockets, AudioContext, and RTCPeerConnection. Acquire on state change, release on cleanup.
@@ -157,7 +158,7 @@ Foldkit is a complete system, not a collection of libraries you stitch together.
 
 ## Correctness You (And Your LLM) Can See
 
-Every state change flows through one update function. Every side effect is declared explicitly — in Commands, Subscription streams, and Managed Resource lifecycles. You don't have to hold a mental model of what runs when — you can point at it.
+Every state change flows through one update function. Every side effect is declared explicitly — in Commands, Mount Effects, Subscription streams, and Managed Resource lifecycles. You don't have to hold a mental model of what runs when — you can point at it.
 
 This is what makes Foldkit unusually AI-friendly. The same property that makes the code easy for humans to reason about makes it easy for LLMs to generate and review. The architecture makes correctness visible, whether the reader is a person or an LLM.
 
@@ -173,6 +174,7 @@ This is what makes Foldkit unusually AI-friendly. The same property that makes t
 - **[Routing](https://foldkit.dev/example-apps/routing)** — URL routing with parser combinators
 - **[Query Sync](https://foldkit.dev/example-apps/query-sync)** — URL query parameter sync with filtering and sorting
 - **[Snake](https://foldkit.dev/example-apps/snake)** — Classic game built with Subscriptions
+- **[Map](https://foldkit.dev/example-apps/map)** — Interactive MapLibre GL map demonstrating Mount with a third-party DOM library
 - **[Auth](https://foldkit.dev/example-apps/auth)** — Authentication flow with Submodels and OutMessage
 - **[Shopping Cart](https://foldkit.dev/example-apps/shopping-cart)** — Nested models and complex state
 - **[WebSocket Chat](https://foldkit.dev/example-apps/websocket-chat)** — Managed Resources with WebSocket integration

--- a/packages/create-foldkit-app/templates/base/AGENTS.md
+++ b/packages/create-foldkit-app/templates/base/AGENTS.md
@@ -87,6 +87,33 @@ Commands catch all errors and return Messages — side effects never crash the a
 
 Command definitions live where they're produced — colocated with the update function that returns them. Don't centralize all definitions in one file.
 
+### Mount
+
+For per-element DOM work — focusing an input, handing the live `Element` to a third-party library — define a Mount with `Mount.define` and attach it to a view element with `OnMount`. The runtime runs the Effect when the element mounts, dispatches its result Message back through `update`, and runs the paired cleanup on unmount.
+
+```ts
+const CompletedFocusInput = m('CompletedFocusInput')
+
+const FocusInput = Mount.define('FocusInput', CompletedFocusInput)
+
+const focusInput = FocusInput(element =>
+  Effect.sync(() => {
+    if (element instanceof HTMLInputElement) {
+      element.focus()
+    }
+    return {
+      message: CompletedFocusInput(),
+      cleanup: Function.constVoid,
+    }
+  }),
+)
+
+// In view:
+input([Type('search'), OnMount(focusInput)])
+```
+
+Cleanup is data, paired with setup as a single value. For setup with no cleanup, pass `Function.constVoid`. The `Completed*` Message marks the lifecycle without forcing a meaningful response in update.
+
 ### File Organization
 
 Use uppercase section headers (`// MODEL`, `// MESSAGE`, `// INIT`, `// UPDATE`, `// COMMAND`, `// VIEW`) to make files easier to skim. These are for wayfinding — they make it clear where things live and where new code should go. Use domain-specific headers too when it helps (e.g. `// PHYSICS`, `// ROUTING`).

--- a/packages/foldkit/README.md
+++ b/packages/foldkit/README.md
@@ -141,6 +141,7 @@ Source: [examples/counter/src/main.ts](https://github.com/foldkit/foldkit/blob/m
 Foldkit is a complete system, not a collection of libraries you stitch together.
 
 - **Commands**: Side effects are named Effects that return Messages and are executed by the runtime. Define them with `Command.define`, passing the result Message schemas so the Effect's return type stays in lockstep with your Messages. Use any Effect combinator you want: retry, timeout, race, parallel. You write the Effect, the runtime runs it.
+- **Mount**: The seam where view code reaches a real DOM element, like focusing an input or handing the live `Element` to a third-party library that owns its own DOM. The runtime runs your Effect on mount, dispatches its Message back through update, and runs the paired cleanup on unmount.
 - **Routing**: Type-safe bidirectional routing built from parser combinators. URLs parse into typed Routes and Routes build back into URLs. No string matching, no mismatches between parsing and building.
 - **Subscriptions**: Declare which streams your app needs as a function of the Model. The runtime diffs and switches them as the Model changes.
 - **Managed Resources**: Model-driven lifecycle for long-lived browser resources like WebSockets, AudioContext, and RTCPeerConnection. Acquire on state change, release on cleanup.
@@ -159,7 +160,7 @@ Foldkit is a complete system, not a collection of libraries you stitch together.
 
 ## Correctness You (And Your LLM) Can See
 
-Every state change flows through one update function. Every side effect is declared explicitly — in Commands, Subscription streams, and Managed Resource lifecycles. You don't have to hold a mental model of what runs when — you can point at it.
+Every state change flows through one update function. Every side effect is declared explicitly — in Commands, Mount Effects, Subscription streams, and Managed Resource lifecycles. You don't have to hold a mental model of what runs when — you can point at it.
 
 This is what makes Foldkit unusually AI-friendly. The same property that makes the code easy for humans to reason about makes it easy for LLMs to generate and review. The architecture makes correctness visible, whether the reader is a person or an LLM.
 
@@ -175,6 +176,7 @@ This is what makes Foldkit unusually AI-friendly. The same property that makes t
 - **[Routing](https://foldkit.dev/example-apps/routing)** — URL routing with parser combinators
 - **[Query Sync](https://foldkit.dev/example-apps/query-sync)** — URL query parameter sync with filtering and sorting
 - **[Snake](https://foldkit.dev/example-apps/snake)** — Classic game built with Subscriptions
+- **[Map](https://foldkit.dev/example-apps/map)** — Interactive MapLibre GL map demonstrating Mount with a third-party DOM library
 - **[Auth](https://foldkit.dev/example-apps/auth)** — Authentication flow with Submodels and OutMessage
 - **[Shopping Cart](https://foldkit.dev/example-apps/shopping-cart)** — Nested models and complex state
 - **[WebSocket Chat](https://foldkit.dev/example-apps/websocket-chat)** — Managed Resources with WebSocket integration

--- a/packages/website/src/page/aiOverview.ts
+++ b/packages/website/src/page/aiOverview.ts
@@ -63,7 +63,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         'Most frameworks give AI tools too much freedom. State can live anywhere, effects can happen anywhere, and there\u2019s no canonical structure to follow. The result is generated code that works but doesn\u2019t hold up.',
       ),
       para(
-        'Foldkit\u2019s architecture changes this. The Elm Architecture enforces a rigid, yet expressive structure (Message \u2192 update \u2192 Model \u2192 view \u2192 Command) where every piece has a canonical shape and a canonical place. The same constraints that make your code correct make it machine-legible.',
+        'Foldkit\u2019s architecture changes this. The Elm Architecture enforces a rigid, yet expressive structure (Message \u2192 update \u2192 Model \u2192 view \u2192 Command) where every piece has a canonical shape and place. Side effects are encapsulated in exactly six places: Commands, Mount Effects, flags, Subscription streams, Resources, and ManagedResources. Every Message routes back through update. The same constraints that make your code correct make it machine-legible.',
       ),
       para(
         'An AI that understands this loop can reason about the entire program as a state machine. It can generate structurally valid code, not just syntactically valid code. It can scaffold Messages and know exactly where they wire through. It can extract ',

--- a/packages/website/src/page/bestPractices/sideEffectsAndPurity.ts
+++ b/packages/website/src/page/bestPractices/sideEffectsAndPurity.ts
@@ -14,6 +14,7 @@ import {
   apiModuleRouter,
   coreCommandsRouter,
   coreInitAndFlagsRouter,
+  coreLifecycleHooksRouter,
   coreManagedResourcesRouter,
   coreResourcesRouter,
   coreSubscriptionsRouter,
@@ -113,7 +114,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         inlineCode('update'),
         ' are pure functions. They take inputs and return outputs without touching the outside world.',
       ),
-      para('You encapsulate side effects in exactly five places:'),
+      para('You encapsulate side effects in exactly six places:'),
       ul(
         [Class('list-disc mb-6 space-y-2')],
         [
@@ -122,6 +123,15 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
             [
               link(coreCommandsRouter(), 'Commands'),
               ': an Effect that performs a side effect and returns a Message. HTTP requests, DOM operations, reading from storage. This is where most of your side effects live.',
+            ],
+          ),
+          li(
+            [],
+            [
+              link(coreLifecycleHooksRouter(), 'Mount'),
+              ': an Effect run with the live ',
+              inlineCode('Element'),
+              ' when a view element enters the DOM, paired with cleanup that fires when it unmounts. The seam where view code reaches a real DOM node, like focusing an input or handing it to a third-party library that owns its own DOM.',
             ],
           ),
           li(

--- a/packages/website/src/page/comingFromReact/view.ts
+++ b/packages/website/src/page/comingFromReact/view.ts
@@ -90,6 +90,10 @@ const patternMappingTable = (): Html =>
         ['Commands (returned from ', inlineCode('update'), ')'],
       ],
       [
+        [inlineCode('useRef'), ' + ', inlineCode('useEffect'), ' (DOM access)'],
+        ['Mount (', inlineCode('OnMount'), ' with paired cleanup)'],
+      ],
+      [
         [inlineCode('useContext'), ' / Redux / Zustand'],
         ['Single Model (no prop drilling)'],
       ],

--- a/packages/website/src/page/core/architecture.ts
+++ b/packages/website/src/page/core/architecture.ts
@@ -1,6 +1,6 @@
 import type { Html } from 'foldkit/html'
 
-import { Class, div, pre } from '../../html'
+import { Class, div, li, pre, strong, ul } from '../../html'
 import { Link } from '../../link'
 import type { TableOfContentsEntry } from '../../main'
 import {
@@ -73,24 +73,54 @@ export const view = (): Html =>
         inlineCode('view'),
         ' function renders the new Model as HTML. When the user interacts with the view, it produces another Message, and the loop continues.',
       ),
-      para(
-        'Commands are descriptions of one-shot side effects: HTTP requests, focus operations, ',
-        inlineCode('localStorage'),
-        ' writes, navigation calls. The Foldkit runtime executes them and sends their results back as new Messages, feeding them into the same loop. Each Command carries a name, which surfaces in ',
-        link(coreDevToolsRouter(), 'DevTools'),
-        ', ',
-        link(testingRouter(), 'tests'),
-        ', and tracing.',
-      ),
-      para(
-        'Subscriptions are continuous streams of Messages from external sources: keypresses, recurring timers, ',
-        inlineCode('WebSocket'),
-        ' frames, window resize events. Where a Command runs once and reports back, a Subscription stays active for as long as the Model says it should, and the stream decides which source events become Messages.',
-      ),
-      para(
-        'ManagedResources have an acquire/release lifecycle tied to Model state: a camera stream during a video call, a ',
-        inlineCode('WebSocket'),
-        ' connection while the user is on a chat page. The runtime acquires them when the Model enters the relevant state, releases them when it leaves, and dispatches Messages for each transition.',
+      ul(
+        [Class('list-disc mb-4 space-y-3 ml-6')],
+        [
+          li(
+            [],
+            [
+              strong([], ['Commands:']),
+              ' descriptions of one-shot side effects: HTTP requests, focus operations, ',
+              inlineCode('localStorage'),
+              ' writes, navigation calls. The Foldkit runtime executes them and sends their results back as new Messages, feeding them into the same loop. Each Command carries a name, which surfaces in ',
+              link(coreDevToolsRouter(), 'DevTools'),
+              ', ',
+              link(testingRouter(), 'tests'),
+              ', and tracing.',
+            ],
+          ),
+          li(
+            [],
+            [
+              strong([], ['Mount:']),
+              ' the moment an element from the view enters the live DOM. ',
+              inlineCode('OnMount'),
+              ' is the seam where view code can drop down to imperative work at that moment, like focusing an input or handing a real ',
+              inlineCode('Element'),
+              ' to a third-party library that owns its own DOM. The runtime runs an Effect with the live element, dispatches its Message back through ',
+              inlineCode('update'),
+              ', and runs the paired cleanup when the element unmounts.',
+            ],
+          ),
+          li(
+            [],
+            [
+              strong([], ['Subscriptions:']),
+              ' continuous streams of Messages from external sources: keypresses, recurring timers, ',
+              inlineCode('WebSocket'),
+              ' frames, window resize events. Where a Command runs once and reports back, a Subscription stays active for as long as the Model says it should, and the stream decides which source events become Messages.',
+            ],
+          ),
+          li(
+            [],
+            [
+              strong([], ['ManagedResources:']),
+              ' acquire/release lifecycles tied to Model state: a camera stream during a video call, a ',
+              inlineCode('WebSocket'),
+              ' connection while the user is on a chat page. The runtime acquires them when the Model enters the relevant state, releases them when it leaves, and dispatches Messages for each transition.',
+            ],
+          ),
+        ],
       ),
       para(
         'That\u2019s it. Every state transition in your app flows through a single loop. There\u2019s no action-at-a-distance, no hidden state mutation, no effect that runs outside the cycle. If you want to know how the app got into its current state, you follow the Messages.',
@@ -103,31 +133,33 @@ export const view = (): Html =>
           ),
         ],
         [
-          '          +------------------------------------------+\n' +
-            '          |                                          |\n' +
-            '          \u2193                                          |\n' +
-            '       Message                                       |\n' +
-            '          |                                          |\n' +
-            '          \u2193                                          |\n' +
-            '  +---------------+                                  |\n' +
-            '  |    update     |                                  |\n' +
-            '  +-------+-------+                                  |\n' +
-            '  \u2193               \u2193                                  |\n' +
-            'Model    Command<Message>[]                          |\n' +
-            '  |               |                                  |\n' +
-            '  |               +-> Runtime -----------------------+\n' +
-            '  |                                                  |\n' +
-            '  +-> view -> Browser -> user events ----------------+\n' +
-            '  |                                                  |\n' +
-            '  +-> Subscriptions -> Stream<Message> -> Runtime ---+\n' +
-            '  |                                                  |\n' +
-            '  +-> ManagedResources -> lifecycle -----------------+',
+          '          +------------------------------------------------------+\n' +
+            '          |                                                      |\n' +
+            '          \u2193                                                      |\n' +
+            '       Message                                                   |\n' +
+            '          |                                                      |\n' +
+            '          \u2193                                                      |\n' +
+            '  +---------------+                                              |\n' +
+            '  |    update     |                                              |\n' +
+            '  +-------+-------+                                              |\n' +
+            '  \u2193               \u2193                                              |\n' +
+            'Model    Command<Message>[]                                      |\n' +
+            '  |               |                                              |\n' +
+            '  |               +-> Runtime -----------------------------------+\n' +
+            '  |                                                              |\n' +
+            '  +-> view -> Browser -> user events ----------------------------+\n' +
+            '  |                                                              |\n' +
+            '  +-> view -> Mount(Element) -> Effect<Message> -> Runtime ------+\n' +
+            '  |                                                              |\n' +
+            '  +-> Subscriptions -> Stream<Message> -> Runtime ---------------+\n' +
+            '  |                                                              |\n' +
+            '  +-> ManagedResources -> acquire/release Messages -> Runtime ---+',
         ],
       ),
       para(
         'Every path on the right side produces a Message that feeds back into ',
         inlineCode('update'),
-        '. Four sources: Commands, Subscriptions, ManagedResources, and the Browser. One loop.',
+        '. Five sources: Commands, the Browser, Mount, Subscriptions, and ManagedResources. One loop.',
       ),
       para(
         'Sitting beneath the loop are Resources: app-lifetime singletons like ',
@@ -174,6 +206,12 @@ export const view = (): Html =>
             ],
           ],
           [
+            ['Mount'],
+            [
+              'The seam where view code reaches a live DOM element. The runtime runs an Effect with the Element, dispatches its Message, and runs the paired cleanup on unmount.',
+            ],
+          ],
+          [
             ['Subscription'],
             [
               'A continuous stream of Messages from an external source, active for as long as the Model says it should be.',
@@ -194,7 +232,7 @@ export const view = (): Html =>
           [
             ['Runtime'],
             [
-              'The Foldkit engine that executes Commands, runs Subscriptions, manages resource lifecycles, and routes Messages back into update.',
+              'The Foldkit engine that executes Commands, runs Subscriptions, manages resource and mount lifecycles, and routes Messages back into update.',
             ],
           ],
         ],
@@ -236,6 +274,12 @@ export const view = (): Html =>
           [
             ['Command'],
             ['A slip for the kitchen: \u201Cprepare the salmon\u201D'],
+          ],
+          [
+            ['Mount'],
+            [
+              'Tableside flamb\u00E9: rolled out to a specific table the moment its dish arrives, rolled away when the plate is cleared',
+            ],
           ],
           [
             ['Subscription'],

--- a/packages/website/src/page/core/commands.ts
+++ b/packages/website/src/page/core/commands.ts
@@ -12,6 +12,7 @@ import {
 } from '../../prose'
 import {
   coreArchitectureRouter,
+  coreLifecycleHooksRouter,
   exampleDetailRouter,
   testingRouter,
 } from '../../route'
@@ -232,9 +233,11 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         ', and once all errors are handled, the type confirms it. The update function handles errors the same way it handles success: as facts about what happened.',
       ),
       para(
-        'Commands fire once and produce a single Message when they finish. But what about effects that run continuously, like a timer that ticks every second, a ',
+        'Commands fire once and produce a single Message when they finish. For one-shot work tied to a specific DOM element instead of a Message, Foldkit has ',
+        link(coreLifecycleHooksRouter(), 'Mount'),
+        '. For effects that run continuously (a timer that ticks every second, a ',
         inlineCode('WebSocket'),
-        ' that stays open, keyboard input? For ongoing streams, Foldkit has Subscriptions.',
+        ' that stays open, keyboard input), Foldkit has Subscriptions.',
       ),
     ],
   )

--- a/packages/website/src/page/core/subscriptions.ts
+++ b/packages/website/src/page/core/subscriptions.ts
@@ -229,7 +229,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         '.',
       ),
       para(
-        'You\u2019ve now seen how state changes flow through update, how one-off side effects work as Commands, and how ongoing streams are managed with Subscriptions. But where do the first Model and Commands come from? That\u2019s ',
+        'You\u2019ve now seen how state changes flow through update, how one-off side effects work as Commands, how view code reaches the live DOM with Mount, and how ongoing streams are managed with Subscriptions. But where do the first Model and Commands come from? That\u2019s ',
         inlineCode('init'),
         '.',
       ),

--- a/packages/website/src/page/landing.ts
+++ b/packages/website/src/page/landing.ts
@@ -37,6 +37,7 @@ import {
   comingFromReactRouter,
   coreArchitectureRouter,
   coreDevToolsRouter,
+  coreLifecycleHooksRouter,
   coreSubscriptionsRouter,
   examplesRouter,
   fieldValidationRouter,
@@ -536,6 +537,17 @@ const includedSection = (): Html =>
                 {
                   href: coreSubscriptionsRouter(),
                   label: 'Explore Subscriptions',
+                },
+              ),
+              includedFeature(
+                Icon.link('w-6 h-6'),
+                'Mount',
+                [
+                  'The seam where view code reaches a real DOM element. Run an Effect with the live element on mount, paired with cleanup that fires on unmount.',
+                ],
+                {
+                  href: coreLifecycleHooksRouter(),
+                  label: 'Explore Mount',
                 },
               ),
               includedFeature(

--- a/packages/website/src/page/manifesto.ts
+++ b/packages/website/src/page/manifesto.ts
@@ -62,7 +62,7 @@ export const view = (): Html =>
         'Every Foldkit app has the same architecture. Not by convention. By design.',
       ),
       para(
-        'State lives in the Model. Events are Messages. Every state change flows through update. Side effects are managed by Commands. Ongoing streams are Subscriptions. These aren\u2019t conventions. This is the only path. You can\u2019t scatter state across components because there are no component-local state hooks. You can\u2019t hide side effects in the view because the view is a pure function.',
+        'State lives in the Model. Events are Messages. Every state change flows through update. Side effects are managed by Commands. View code reaches the DOM through Mount. Ongoing streams are Subscriptions. These aren\u2019t conventions. This is the only path. You can\u2019t scatter state across components because there are no component-local state hooks. You can\u2019t hide side effects in the view because the view is a pure function.',
       ),
       para(
         'This might sound limiting. It\u2019s the opposite. When architectural decisions are off the table, development gets more interesting. The questions shift from implementation to behavior. Not \u201cHow should we manage side effects in this component?\u201d but \u201cHow should this feature behave?\u201d Not \u201cWhat tool should we use for streams and how should we wire them up to our components?\u201d but \u201cWhat Model state does this Subscription depend on?\u201d',

--- a/packages/website/src/page/reactComparison.ts
+++ b/packages/website/src/page/reactComparison.ts
@@ -714,6 +714,8 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         inlineCode('ExportPng'),
         '. That\u2019s the complete list of effects your update function can emit. (External event streams like keyboard and mouse release are handled separately through Subscriptions in ',
         inlineCode('subscription.ts'),
+        '. Per-element DOM work like focus or third-party library setup is declared inline in the view via ',
+        inlineCode('OnMount'),
         '.)',
       ),
       tableOfContentsEntryToHeader(reactUseEffectHeader),


### PR DESCRIPTION
Adds Mount alongside the other Message-producing parts of the loop:
introductory paragraph after ManagedResources, a new line in the
ASCII cycle diagram (`view -> Mount -> Element -> Message`), an
entry in the Definitions table, and a tableside-flambé entry in
the Restaurant analogy. Runtime's definition now mentions mount
lifecycles too, and the source-count line goes from four to five.