### PR TITLE
feat(vite-plugin): explain port conflicts on DevTools MCP relay

### DIFF
--- a/.changeset/devtools-port-in-use-message.md
+++ b/.changeset/devtools-port-in-use-message.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/vite-plugin': patch
+---
+
+Show a helpful error when the DevTools MCP port is already in use. Previously the relay logged a generic "failed to start" line with the raw `EADDRINUSE` error, which made it hard to tell why an agent could not connect to Foldkit DevTools via MCP. The plugin now explains that another Foldkit project is likely bound to the port, and suggests either stopping that project or setting a different `devToolsMcpPort` in vite config.
+
+The success log was also moved into the WebSocket server's `listening` event, so "MCP relay listening on ..." no longer prints when the bind ultimately fails.

--- a/packages/vite-plugin-foldkit/src/index.ts
+++ b/packages/vite-plugin-foldkit/src/index.ts
@@ -104,10 +104,19 @@ const startMcpWebSocketServer = (port: number): void => {
   const wss = new WebSocketServer({ port })
   mcpWebSocketServer = wss
   wss.on('error', error => {
-    console.error(
-      `[foldkit:devTools] MCP relay failed to start on port ${port}; continuing without the relay`,
-      error,
-    )
+    if ('code' in error && error.code === 'EADDRINUSE') {
+      console.error(
+        `\n[foldkit:devTools] Port ${port} is already in use, so the DevTools MCP relay could not start.\n` +
+          `[foldkit:devTools] This usually means another Foldkit project is already running and bound to this port.\n` +
+          `[foldkit:devTools] Until the port is freed, agents will not be able to connect to this app via the Foldkit DevTools MCP server.\n` +
+          `[foldkit:devTools] Stop the other project, or set a different \`devToolsMcpPort\` in this project's vite config.\n`,
+      )
+    } else {
+      console.error(
+        `[foldkit:devTools] MCP relay failed to start on port ${port}; continuing without the relay`,
+        error,
+      )
+    }
     mcpWebSocketServer = null
   })
   wss.on('connection', client => {
@@ -128,9 +137,11 @@ const startMcpWebSocketServer = (port: number): void => {
       console.error('[foldkit:devTools] MCP client error', error)
     })
   })
-  console.log(
-    `[foldkit:devTools] MCP relay listening on ws://localhost:${port}`,
-  )
+  wss.on('listening', () => {
+    console.log(
+      `[foldkit:devTools] MCP relay listening on ws://localhost:${port}`,
+    )
+  })
 }
 
 const stopMcpWebSocketServer = (): void => {


### PR DESCRIPTION
When the DevTools MCP port is already in use, the plugin now logs a
specific message naming the port, explaining that another Foldkit
project is likely bound to it, and suggesting either stopping that
project or setting a different `devToolsMcpPort` in vite config.

Also move the 'MCP relay listening on ...' log into the WebSocket
server's 'listening' event so it does not print when the bind fails.