### PR TITLE
Clarify DevTools MCP port configuration error message

### DIFF
--- a/.changeset/devtools-mcp-port-env-hint.md
+++ b/.changeset/devtools-mcp-port-env-hint.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/vite-plugin': patch
+---
+
+Clarify the DevTools MCP port-in-use error by reminding users that changing `devToolsMcpPort` requires setting `FOLDKIT_DEVTOOLS_MCP_PORT` to the same value for the MCP server.

--- a/packages/vite-plugin-foldkit/src/index.ts
+++ b/packages/vite-plugin-foldkit/src/index.ts
@@ -109,7 +109,8 @@ const startMcpWebSocketServer = (port: number): void => {
         `\n[foldkit:devTools] Port ${port} is already in use, so the DevTools MCP relay could not start.\n` +
           `[foldkit:devTools] This usually means another Foldkit project is already running and bound to this port.\n` +
           `[foldkit:devTools] Until the port is freed, agents will not be able to connect to this app via the Foldkit DevTools MCP server.\n` +
-          `[foldkit:devTools] Stop the other project, or set a different \`devToolsMcpPort\` in this project's vite config.\n`,
+          `[foldkit:devTools] Stop the other project, or set a different \`devToolsMcpPort\` in this project's vite config.\n` +
+          `[foldkit:devTools] If you change \`devToolsMcpPort\`, also set \`FOLDKIT_DEVTOOLS_MCP_PORT\` to the same value for your MCP server.\n`,
       )
     } else {
       console.error(


### PR DESCRIPTION
## Summary
Improved the error message displayed when the DevTools MCP port is already in use to provide clearer guidance to users about environment variable configuration.

## Changes
- Enhanced the port-in-use error message in the MCP WebSocket server startup to remind users that changing `devToolsMcpPort` in the Vite config also requires setting the `FOLDKIT_DEVTOOLS_MCP_PORT` environment variable to the same value for the MCP server
- This prevents confusion when users change the port configuration but forget to update the corresponding environment variable, which would cause the MCP server to fail to connect

## Details
The error message now explicitly states that both the Vite config setting and the environment variable must be synchronized when changing the DevTools MCP port, reducing troubleshooting time for users encountering port conflicts.

https://claude.ai/code/session_014TbpepjJCdxzZXdPGHgKsm