### PR TITLE
feat(foldkit): add session scrubber slider to DevTools

### DIFF
--- a/.changeset/devtools-scrubber-slider.md
+++ b/.changeset/devtools-scrubber-slider.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+Add a session scrubber to the DevTools panel. In TimeTravel mode, a horizontal slider sits at the bottom of the panel and lets you drag through the message history. Each step replays the host app to that point, so you can watch the UI evolve over the session instead of clicking message rows one at a time. Keyboard navigation works the same as any Foldkit slider (arrows, Page Up/Down, Home, End). The scrubber is hidden in Inspect mode and when the history is empty.
+
+The Slider component now accepts an optional `getTrackRoot: () => Document | ShadowRoot` in `ViewConfig`, plus a `subscriptionsForRoot(getTrackRoot)` factory next to the existing `subscriptions` value. Both default to `document`. Pass a `ShadowRoot` when rendering the slider inside a shadow tree so pointer events on the track can find their bounding rect. Existing slider consumers need no changes.

--- a/packages/foldkit/src/devTools/overlay.css
+++ b/packages/foldkit/src/devTools/overlay.css
@@ -577,6 +577,52 @@ ul {
   cursor: not-allowed;
 }
 
+/* Scrubber */
+.dt-scrubber-row {
+  background-color: var(--dt-bg);
+}
+.dt-scrubber-control {
+  position: relative;
+  height: 16px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+.dt-scrubber-track {
+  width: 100%;
+  height: 4px;
+  background-color: var(--dt-border);
+  border-radius: 9999px;
+  cursor: pointer;
+}
+.dt-scrubber-track[data-disabled] {
+  cursor: not-allowed;
+}
+.dt-scrubber-fill {
+  height: 100%;
+  background-color: var(--dt-accent);
+  border-radius: 9999px;
+}
+.dt-scrubber-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 9999px;
+  background-color: var(--dt-accent);
+  border: 2px solid var(--dt-bg);
+  cursor: grab;
+  outline: none;
+  top: 50%;
+  margin-top: -7px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+.dt-scrubber-thumb:focus-visible {
+  outline: 2px solid var(--dt-text);
+  outline-offset: 2px;
+}
+.dt-scrubber-thumb[data-dragging] {
+  cursor: grabbing;
+}
+
 /* Mobile */
 @media (max-width: 767px) {
   .dt-panel {

--- a/packages/foldkit/src/devTools/overlay.ts
+++ b/packages/foldkit/src/devTools/overlay.ts
@@ -34,6 +34,7 @@ import { makeSubscriptions } from '../runtime/subscription.js'
 import { evo } from '../struct/index.js'
 import { lockScroll, unlockScroll } from '../task/scrollLock.js'
 import * as Listbox from '../ui/listbox/public.js'
+import * as Slider from '../ui/slider/public.js'
 import * as Tabs from '../ui/tabs/public.js'
 import { overlayStyles } from './overlay-styles.js'
 import { toInspectableValue } from './serialize.js'
@@ -57,6 +58,7 @@ const DisplayEntry = S.Struct({
 
 const INSPECTOR_TABS_ID = 'dt-inspector'
 const SUBMODEL_FILTER_ID = 'dt-submodel-filter'
+const SCRUBBER_SLIDER_ID = 'dt-scrubber'
 
 const InspectorTabsModel = S.Struct({
   id: S.String,
@@ -84,6 +86,7 @@ const Model = S.Struct({
   changedPaths: S.HashSet(S.String),
   affectedPaths: S.HashSet(S.String),
   inspectorTabs: InspectorTabsModel,
+  scrubberSlider: S.suspend((): typeof Slider.Model => Slider.Model),
 })
 type Model = typeof Model.Type
 
@@ -135,6 +138,9 @@ const GotSubmodelFilterMessage = m('GotSubmodelFilterMessage', {
 const SelectedSubmodelFilter = m('SelectedSubmodelFilter', {
   tag: S.String,
 })
+const GotScrubberSliderMessage = m('GotScrubberSliderMessage', {
+  message: S.suspend((): typeof Slider.Message => Slider.Message),
+})
 
 const Message = S.Union([
   ClickedToggle,
@@ -155,6 +161,7 @@ const Message = S.Union([
   ReceivedStoreUpdate,
   GotSubmodelFilterMessage,
   SelectedSubmodelFilter,
+  GotScrubberSliderMessage,
 ])
 type Message = typeof Message.Type
 
@@ -483,6 +490,15 @@ const makeUpdate = (
                   : current,
               selectedIndex: current =>
                 shouldFollowLatest ? latestIndex : current,
+              scrubberSlider: current => {
+                const isScrubbing = current.dragState._tag === 'Dragging'
+                const targetValue = isPaused ? pausedAtIndex : latestIndex
+                return evo(current, {
+                  max: () => latestIndex,
+                  value: previousValue =>
+                    isScrubbing ? previousValue : targetValue,
+                })
+              },
             }),
             shouldFollowLatest ? [scrollToTop, inspectLatest] : [],
           ]
@@ -527,6 +543,30 @@ const makeUpdate = (
             ),
           ]
         },
+        GotScrubberSliderMessage: ({ message: sliderMessage }) => {
+          const [nextSlider, sliderCommands, maybeOutMessage] = Slider.update(
+            model.scrubberSlider,
+            sliderMessage,
+          )
+
+          const mappedSliderCommands = sliderCommands.map(
+            Command.mapEffect(
+              Effect.map(innerMessage =>
+                GotScrubberSliderMessage({ message: innerMessage }),
+              ),
+            ),
+          )
+
+          const additionalCommands = Option.match(maybeOutMessage, {
+            onNone: () => [],
+            onSome: ({ value }) => [jumpTo(value), inspectState(value)],
+          })
+
+          return [
+            evo(model, { scrubberSlider: () => nextSlider }),
+            [...mappedSliderCommands, ...additionalCommands],
+          ]
+        },
       }),
       M.tag(
         'CompletedJump',
@@ -543,13 +583,26 @@ const makeUpdate = (
 
 // SUBSCRIPTION
 
+const ScrubberDragActivity = S.Literals(['Idle', 'Active'])
+
 const SubscriptionDeps = S.Struct({
   storeUpdates: S.Boolean,
   mobileBreakpoint: S.Null,
+  scrubberPointer: S.Struct({
+    dragActivity: ScrubberDragActivity,
+    id: S.String,
+    min: S.Number,
+    max: S.Number,
+  }),
+  scrubberEscape: S.Struct({
+    dragActivity: ScrubberDragActivity,
+  }),
 })
 
-const makeOverlaySubscriptions = (store: DevToolsStore) =>
-  makeSubscriptions(SubscriptionDeps)<Model, Message>({
+const makeOverlaySubscriptions = (store: DevToolsStore, shadow: ShadowRoot) => {
+  const sliderSubscriptions = Slider.subscriptionsForRoot(() => shadow)
+
+  return makeSubscriptions(SubscriptionDeps)<Model, Message>({
     storeUpdates: {
       modelToDependencies: () => true,
       dependenciesToStream: () =>
@@ -587,7 +640,36 @@ const makeOverlaySubscriptions = (store: DevToolsStore) =>
           ).pipe(Effect.flatMap(() => Effect.never)),
         ),
     },
+    scrubberPointer: {
+      modelToDependencies: model =>
+        sliderSubscriptions.documentPointer.modelToDependencies(
+          model.scrubberSlider,
+        ),
+      dependenciesToStream: (deps, readDeps) =>
+        Stream.map(
+          sliderSubscriptions.documentPointer.dependenciesToStream(
+            deps,
+            readDeps,
+          ),
+          message => GotScrubberSliderMessage({ message }),
+        ),
+    },
+    scrubberEscape: {
+      modelToDependencies: model =>
+        sliderSubscriptions.documentEscape.modelToDependencies(
+          model.scrubberSlider,
+        ),
+      dependenciesToStream: (deps, readDeps) =>
+        Stream.map(
+          sliderSubscriptions.documentEscape.dependenciesToStream(
+            deps,
+            readDeps,
+          ),
+          message => GotScrubberSliderMessage({ message }),
+        ),
+    },
   })
+}
 
 // VIEW
 
@@ -616,6 +698,7 @@ const PANEL_POSITION_CLASS: Record<DevToolsPosition, string> = {
 const makeView = (
   position: DevToolsPosition,
   mode: DevToolsMode,
+  shadow: ShadowRoot,
   maybeBanner: Option.Option<string>,
 ): ((model: Model) => Document) => {
   const {
@@ -1502,7 +1585,66 @@ const makeView = (
     )
   }
 
+  // SCRUBBER
+
+  const scrubberPositionLabel = (model: Model): string => {
+    const lastIndex = Array_.match(model.entries, {
+      onEmpty: () => INIT_INDEX,
+      onNonEmpty: () => model.startIndex + model.entries.length - 1,
+    })
+    const currentValue = model.scrubberSlider.value
+    if (currentValue === INIT_INDEX) {
+      return `init / ${lastIndex + 1}`
+    }
+    return `${currentValue + 1} / ${lastIndex + 1}`
+  }
+
+  const scrubberView = (model: Model): Html =>
+    Slider.view<Message>({
+      model: model.scrubberSlider,
+      toParentMessage: message => GotScrubberSliderMessage({ message }),
+      ariaLabel: 'Session scrubber',
+      getTrackRoot: () => shadow,
+      formatValue: value =>
+        value === INIT_INDEX ? 'init' : `Message ${String(value + 1)}`,
+      toView: attributes =>
+        div(
+          [
+            Class(
+              'dt-scrubber-row flex items-center gap-3 px-3 py-2 border-t shrink-0',
+            ),
+          ],
+          [
+            div(
+              [
+                ...attributes.root,
+                Class('dt-scrubber-control flex-1 flex items-center'),
+              ],
+              [
+                div(
+                  [...attributes.track, Class('dt-scrubber-track')],
+                  [
+                    div(
+                      [...attributes.filledTrack, Class('dt-scrubber-fill')],
+                      [],
+                    ),
+                  ],
+                ),
+                div([...attributes.thumb, Class('dt-scrubber-thumb')], []),
+              ],
+            ),
+            span(
+              [Class('text-2xs text-dt-muted font-mono shrink-0 tabular-nums')],
+              [scrubberPositionLabel(model)],
+            ),
+          ],
+        ),
+    })
+
   // PANEL
+
+  const isScrubberVisible = (model: Model): boolean =>
+    mode === 'TimeTravel' && !Array_.isReadonlyArrayEmpty(model.entries)
 
   const panelView = (model: Model): Html =>
     keyed('div')(
@@ -1542,6 +1684,9 @@ const makeView = (
             ),
             inspectorPaneView(model),
           ],
+        ),
+        ...OptionExt.when(isScrubberVisible(model), scrubberView(model)).pipe(
+          Option.toArray,
         ),
       ],
     )
@@ -1613,27 +1758,44 @@ export const createOverlay = (
 
     const init = (
       flags: typeof Flags.Type,
-    ): readonly [Model, ReadonlyArray<Command.Command<Message>>] => [
-      {
-        isOpen: false,
-        ...flags,
-        selectedIndex: INIT_INDEX,
-        isFollowingLatest: true,
-        submodelTags: computeSubmodelTags(flags.entries),
-        maybeSubmodelFilter: Option.none(),
-        submodelFilterListbox: Listbox.init({
-          id: SUBMODEL_FILTER_ID,
-          selectedItem: ALL_MESSAGES_VALUE,
-        }),
-        maybeInspectedModel: Option.none(),
-        maybeInspectedMessage: Option.none(),
-        expandedPaths: HashSet.empty(),
-        changedPaths: HashSet.empty(),
-        affectedPaths: HashSet.empty(),
-        inspectorTabs: Tabs.init({ id: INSPECTOR_TABS_ID }),
-      },
-      [],
-    ]
+    ): readonly [Model, ReadonlyArray<Command.Command<Message>>] => {
+      const latestIndex = Array_.match(flags.entries, {
+        onEmpty: () => INIT_INDEX,
+        onNonEmpty: () => flags.startIndex + flags.entries.length - 1,
+      })
+      const initialScrubberValue = flags.isPaused
+        ? flags.pausedAtIndex
+        : latestIndex
+
+      return [
+        {
+          isOpen: false,
+          ...flags,
+          selectedIndex: INIT_INDEX,
+          isFollowingLatest: true,
+          submodelTags: computeSubmodelTags(flags.entries),
+          maybeSubmodelFilter: Option.none(),
+          submodelFilterListbox: Listbox.init({
+            id: SUBMODEL_FILTER_ID,
+            selectedItem: ALL_MESSAGES_VALUE,
+          }),
+          maybeInspectedModel: Option.none(),
+          maybeInspectedMessage: Option.none(),
+          expandedPaths: HashSet.empty(),
+          changedPaths: HashSet.empty(),
+          affectedPaths: HashSet.empty(),
+          inspectorTabs: Tabs.init({ id: INSPECTOR_TABS_ID }),
+          scrubberSlider: Slider.init({
+            id: SCRUBBER_SLIDER_ID,
+            min: INIT_INDEX,
+            max: latestIndex,
+            step: 1,
+            initialValue: initialScrubberValue,
+          }),
+        },
+        [],
+      ]
+    }
 
     const overlayRuntime = makeProgram({
       Model,
@@ -1641,9 +1803,9 @@ export const createOverlay = (
       flags,
       init,
       update: makeUpdate(store, shadow, mode),
-      view: makeView(position, mode, maybeBanner),
+      view: makeView(position, mode, shadow, maybeBanner),
       container,
-      subscriptions: makeOverlaySubscriptions(store),
+      subscriptions: makeOverlaySubscriptions(store, shadow),
       devTools: false,
     })
 

--- a/packages/foldkit/src/ui/slider/index.ts
+++ b/packages/foldkit/src/ui/slider/index.ts
@@ -334,9 +334,12 @@ const dragActivityFromModel = (model: Model): typeof DragActivity.Type =>
     M.orElse(() => 'Idle'),
   )
 
-const trackElement = (id: string): Option.Option<HTMLElement> =>
+const trackElement = (
+  id: string,
+  root: Document | ShadowRoot,
+): Option.Option<HTMLElement> =>
   Option.fromNullishOr(
-    document.querySelector<HTMLElement>(`[data-slider-track-id="${id}"]`),
+    root.querySelector<HTMLElement>(`[data-slider-track-id="${id}"]`),
   )
 
 const valueFromClientX = (
@@ -368,86 +371,92 @@ export const SubscriptionDeps = S.Struct({
   }),
 })
 
-/** Document-level subscriptions for pointer and keyboard events during slider
- *  drag. */
-export const subscriptions = makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
-  documentPointer: {
-    modelToDependencies: model => ({
-      dragActivity: dragActivityFromModel(model),
-      id: model.id,
-      min: model.min,
-      max: model.max,
-    }),
-    dependenciesToStream: ({ dragActivity, id, min, max }) => {
-      const pointerEvents = Stream.merge(
-        Stream.fromEventListener<PointerEvent>(document, 'pointermove').pipe(
-          Stream.mapEffect(event =>
-            Effect.sync(() =>
-              Option.map(trackElement(id), element =>
-                MovedDragPointer({
-                  value: valueFromClientX(event.clientX, element, min, max),
-                }),
+/** Builds document-level subscriptions for slider drag, looking up the track
+ *  element through the supplied root resolver. Use this when the slider is
+ *  rendered inside a Shadow DOM. The root is read lazily so consumers can
+ *  resolve it at subscription time. */
+export const subscriptionsForRoot = (
+  getTrackRoot: () => Document | ShadowRoot,
+) =>
+  makeSubscriptions(SubscriptionDeps)<Model, Message>({
+    documentPointer: {
+      modelToDependencies: model => ({
+        dragActivity: dragActivityFromModel(model),
+        id: model.id,
+        min: model.min,
+        max: model.max,
+      }),
+      dependenciesToStream: ({ dragActivity, id, min, max }) => {
+        const pointerEvents = Stream.merge(
+          Stream.fromEventListener<PointerEvent>(document, 'pointermove').pipe(
+            Stream.mapEffect(event =>
+              Effect.sync(() =>
+                Option.map(trackElement(id, getTrackRoot()), element =>
+                  MovedDragPointer({
+                    value: valueFromClientX(event.clientX, element, min, max),
+                  }),
+                ),
               ),
             ),
+            Stream.filter(Option.isSome),
+            Stream.map(option => option.value),
           ),
-          Stream.filter(Option.isSome),
-          Stream.map(option => option.value),
-        ),
-        Stream.fromEventListener<PointerEvent>(document, 'pointerup').pipe(
-          Stream.map(() => ReleasedDragPointer()),
-        ),
-      )
+          Stream.fromEventListener<PointerEvent>(document, 'pointerup').pipe(
+            Stream.map(() => ReleasedDragPointer()),
+          ),
+        )
 
-      // NOTE: prevents text selection and locks cursor to grabbing while the
-      // user drags the thumb. Matches the approach used in drag-and-drop.
-      const documentDragStyles = Stream.callback<never>(() =>
-        Effect.acquireRelease(
-          Effect.sync(() => {
-            document.documentElement.style.setProperty('user-select', 'none')
-            document.documentElement.style.setProperty(
-              '-webkit-user-select',
-              'none',
-            )
-            const cursorStyle = document.createElement('style')
-            cursorStyle.textContent = '* { cursor: grabbing !important; }'
-            document.head.appendChild(cursorStyle)
-            return cursorStyle
-          }),
-          cursorStyle =>
+        // NOTE: prevents text selection and locks cursor to grabbing while the
+        // user drags the thumb. Matches the approach used in drag-and-drop.
+        const documentDragStyles = Stream.callback<never>(() =>
+          Effect.acquireRelease(
             Effect.sync(() => {
-              document.documentElement.style.removeProperty('user-select')
-              document.documentElement.style.removeProperty(
+              document.documentElement.style.setProperty('user-select', 'none')
+              document.documentElement.style.setProperty(
                 '-webkit-user-select',
+                'none',
               )
-              cursorStyle.remove()
+              const cursorStyle = document.createElement('style')
+              cursorStyle.textContent = '* { cursor: grabbing !important; }'
+              document.head.appendChild(cursorStyle)
+              return cursorStyle
             }),
-        ).pipe(Effect.flatMap(() => Effect.never)),
-      )
+            cursorStyle =>
+              Effect.sync(() => {
+                document.documentElement.style.removeProperty('user-select')
+                document.documentElement.style.removeProperty(
+                  '-webkit-user-select',
+                )
+                cursorStyle.remove()
+              }),
+          ).pipe(Effect.flatMap(() => Effect.never)),
+        )
 
-      return Stream.when(
-        Stream.merge(pointerEvents, documentDragStyles),
-        Effect.sync(() => dragActivity === 'Active'),
-      )
+        return Stream.when(
+          Stream.merge(pointerEvents, documentDragStyles),
+          Effect.sync(() => dragActivity === 'Active'),
+        )
+      },
     },
-  },
 
-  documentEscape: {
-    modelToDependencies: model => ({
-      dragActivity: dragActivityFromModel(model),
-    }),
-    dependenciesToStream: ({ dragActivity }) =>
-      Stream.when(
-        Stream.fromEventListener<KeyboardEvent>(document, 'keydown').pipe(
-          Stream.filter(({ key }) => key === 'Escape'),
-          Stream.map(() => CancelledDrag()),
+    documentEscape: {
+      modelToDependencies: model => ({
+        dragActivity: dragActivityFromModel(model),
+      }),
+      dependenciesToStream: ({ dragActivity }) =>
+        Stream.when(
+          Stream.fromEventListener<KeyboardEvent>(document, 'keydown').pipe(
+            Stream.filter(({ key }) => key === 'Escape'),
+            Stream.map(() => CancelledDrag()),
+          ),
+          Effect.sync(() => dragActivity === 'Active'),
         ),
-        Effect.sync(() => dragActivity === 'Active'),
-      ),
-  },
-})
+    },
+  })
+
+/** Document-level subscriptions for pointer and keyboard events during slider
+ *  drag. */
+export const subscriptions = subscriptionsForRoot(() => document)
 
 // VIEW
 
@@ -501,6 +510,11 @@ export type ViewConfig<Message> = Readonly<{
   formatValue?: (value: number) => string
   isDisabled?: boolean
   name?: string
+  /** Resolves the root that holds the slider track when looking it up by its
+   *  `data-slider-track-id` attribute. Defaults to `document`. Provide a
+   *  ShadowRoot when rendering the slider inside a shadow tree so pointer
+   *  events on the track can map clientX into a value. */
+  getTrackRoot?: () => Document | ShadowRoot
 }>
 
 /** Renders an accessible slider by building ARIA attribute groups and
@@ -537,6 +551,7 @@ export const view = <Message>(config: ViewConfig<Message>): Html => {
     formatValue,
     isDisabled = false,
     name,
+    getTrackRoot = () => document,
   } = config
   const { id, value, min, max } = model
   const isDragging = model.dragState._tag === 'Dragging'
@@ -548,7 +563,7 @@ export const view = <Message>(config: ViewConfig<Message>): Html => {
     )
 
   const pointerAtClientX = (clientX: number): Option.Option<Message> =>
-    Option.map(trackElement(id), element =>
+    Option.map(trackElement(id, getTrackRoot()), element =>
       toParentMessage(
         PressedPointer({
           value: valueFromClientX(clientX, element, min, max),

--- a/packages/foldkit/src/ui/slider/public.ts
+++ b/packages/foldkit/src/ui/slider/public.ts
@@ -4,6 +4,7 @@ export {
   view,
   lazy,
   subscriptions,
+  subscriptionsForRoot,
   fractionOfValue,
   Model,
   Message,


### PR DESCRIPTION
In TimeTravel mode, a horizontal slider sits at the bottom of the panel
and lets you drag through the message history. Dragging replays the host
app live, so you can watch the UI evolve across the session instead of
clicking message rows one at a time. The scrubber is hidden in Inspect
mode and when the history is empty.

The Slider component gains an optional `getTrackRoot` in `ViewConfig`
and a `subscriptionsForRoot(getTrackRoot)` factory. Both default to
`document`; the DevTools overlay passes its `ShadowRoot` so pointer
events on the track can resolve their bounding rect. Existing slider
consumers need no changes.