### PR TITLE
chore(ci): reorder pre-push and CI to fail-fast on cheap checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,32 @@ jobs:
       - name: Check formatting
         run: pnpm format:check
 
+      - name: Verify skill version bump
+        if: github.event_name == 'pull_request'
+        run: pnpm check:skill-version
+
+      - name: Block major changesets (pre-1.0)
+        if: github.event_name == 'pull_request'
+        run: pnpm check:no-major-changesets
+
+      - name: Verify changeset ignore list
+        run: pnpm check:changeset-ignore
+
+      - name: Check changeset status
+        if: github.event_name == 'pull_request'
+        run: pnpm changeset status --since=origin/main
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Check circular dependencies
+        run: pnpm check:circular-deps
+
       - name: Build packages
         run: pnpm -r --filter './packages/**' build
 
       - name: Typecheck
         run: pnpm -r typecheck
-
-      - name: Lint
-        run: pnpm lint
 
       - name: Test
         run: pnpm test
@@ -59,21 +77,3 @@ jobs:
 
       - name: E2E smoke test
         run: pnpm --filter website test:e2e
-
-      - name: Check circular dependencies
-        run: pnpm check:circular-deps
-
-      - name: Verify changeset ignore list
-        run: pnpm check:changeset-ignore
-
-      - name: Verify skill version bump
-        if: github.event_name == 'pull_request'
-        run: pnpm check:skill-version
-
-      - name: Block major changesets (pre-1.0)
-        if: github.event_name == 'pull_request'
-        run: pnpm check:no-major-changesets
-
-      - name: Check changeset status
-        if: github.event_name == 'pull_request'
-        run: pnpm changeset status --since=origin/main

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check:no-major-changesets": "bash scripts/check-no-major-changesets.sh",
     "check:no-claude-comments": "bash scripts/check-no-claude-comments.sh",
     "check:circular-deps": "bash scripts/check-circular-deps.sh",
-    "pre-push": "pnpm check:no-claude-comments && pnpm build && pnpm format:check && pnpm check && pnpm test && pnpm --filter website test:e2e && pnpm check:circular-deps && pnpm check:changeset-ignore && pnpm check:skill-version && pnpm check:no-major-changesets && pnpm changeset status --since=origin/main",
+    "pre-push": "pnpm check:no-claude-comments && pnpm format:check && pnpm check:skill-version && pnpm check:no-major-changesets && pnpm check:changeset-ignore && pnpm changeset status --since=origin/main && pnpm lint && pnpm check:effect-prebundle && pnpm check:circular-deps && pnpm build && pnpm -r typecheck && pnpm test && pnpm --filter website test:e2e",
     "test": "pnpm -r --filter './examples/*' --filter './packages/*' run --if-present test",
     "test:e2e": "pnpm --filter website test:e2e",
     "format": "prettier -w .",


### PR DESCRIPTION
Run cheap deterministic checks (format, plugin.json version bump, changeset
gates) before expensive ones (build, typecheck, tests) so a failed cheap
check does not waste 30+ seconds of test time.