### PR TITLE
fix(website): disable overscroll bounce on comparison tables

### DIFF
--- a/packages/website/src/view/table.ts
+++ b/packages/website/src/view/table.ts
@@ -44,7 +44,7 @@ export const comparisonTable = (
   div(
     [
       Class(
-        'overflow-x-auto mb-6 border border-gray-300 dark:border-gray-700 rounded-lg overflow-hidden',
+        'overflow-x-auto overscroll-x-none mb-6 border border-gray-300 dark:border-gray-700 rounded-lg overflow-hidden',
       ),
     ],
     [


### PR DESCRIPTION
Add overscroll-x-none to the comparison table wrapper so horizontal
swipes past the edge no longer trigger the rubber-band effect or
chain to the page.