### PR TITLE
fix(foldkit): skip replay for latest model in DevTools store

### DIFF
--- a/.changeset/devtools-skip-replay-on-latest.md
+++ b/.changeset/devtools-skip-replay-on-latest.md
@@ -1,0 +1,11 @@
+---
+'foldkit': patch
+---
+
+Fix per-keystroke input latency in apps using `devTools: { Message }` once history accumulates.
+
+The DevTools store stamps the post-update model into `StoreState.maybeLatestModel` on every `recordMessage`, and `getModelAtIndex` returns it directly when the requested index is the latest entry. The inspector's follow-latest path (the default while the user types) used to recover that same model by replaying up to `KEYFRAME_INTERVAL` user updates against the most recent keyframe, calling the consumer's update function plus `deepFreeze` on every step. With a large user model that walk dominated each dispatch and grew with history depth.
+
+Time-travel still goes through `replayToIndex`. Only the latest entry takes the new fast path, and only when `maybeLatestModel` is populated.
+
+Adds a `Deep history` scenario to `internal/performance-harness` that fills the store with 500 small Messages so the regression is reproducible in one click.

--- a/internal/performance-harness/README.md
+++ b/internal/performance-harness/README.md
@@ -18,5 +18,6 @@ Scenarios currently covered:
 
 - **Large Message payload**: walks captured Message bodies in the DevTools store. Reproduced the Effect 4 `Equal.equals` regression on `S.Unknown`.
 - **Large Model array**: walks the Model array via Schema-derived equivalence on every dispatch.
+- **Deep history**: replays user updates from the latest keyframe to recover the inspector's follow-latest model. Reproduced per-dispatch latency that grew with history depth.
 
 Future candidates: deep Submodel nesting, high-frequency dispatch loops, large view trees.

--- a/internal/performance-harness/src/main.ts
+++ b/internal/performance-harness/src/main.ts
@@ -27,26 +27,31 @@ const ClickedTick = m('ClickedTick')
 const ClickedDispatchLargeMessage = m('ClickedDispatchLargeMessage')
 const ClickedFillLargeModel = m('ClickedFillLargeModel')
 const ClickedClearLargeModel = m('ClickedClearLargeModel')
+const ClickedFillHistory = m('ClickedFillHistory')
 const ReceivedLargePayload = m('ReceivedLargePayload', {
   payload: S.Array(HeavyItem),
 })
 const FilledLargeModel = m('FilledLargeModel', {
   items: S.Array(HeavyItem),
 })
+const FilledHistoryStep = m('FilledHistoryStep', { remaining: S.Number })
 
 const Message = S.Union([
   ClickedTick,
   ClickedDispatchLargeMessage,
   ClickedFillLargeModel,
   ClickedClearLargeModel,
+  ClickedFillHistory,
   ReceivedLargePayload,
   FilledLargeModel,
+  FilledHistoryStep,
 ])
 type Message = typeof Message.Type
 
 // CONSTANTS
 
 const HEAVY_ITEM_COUNT = 10_000
+const HISTORY_FILL_COUNT = 500
 
 const makeHeavyArray = (count: number): ReadonlyArray<HeavyItem> =>
   Array.makeBy(count, index => ({
@@ -78,6 +83,10 @@ const buildLargeModelArray = BuildLargeModelArray(
   ),
 )
 
+const FillHistoryStep = Command.define('FillHistoryStep', FilledHistoryStep)
+const fillHistoryStep = (remaining: number) =>
+  FillHistoryStep(Effect.sync(() => FilledHistoryStep({ remaining })))
+
 // UPDATE
 
 const update = (
@@ -96,6 +105,7 @@ const update = (
       ClickedDispatchLargeMessage: () => [model, [buildLargePayload]],
       ClickedFillLargeModel: () => [model, [buildLargeModelArray]],
       ClickedClearLargeModel: () => [evo(model, { largeArray: () => [] }), []],
+      ClickedFillHistory: () => [model, [fillHistoryStep(HISTORY_FILL_COUNT)]],
       ReceivedLargePayload: ({ payload }) => [
         evo(model, { lastReceivedPayloadSize: () => payload.length }),
         [],
@@ -103,6 +113,10 @@ const update = (
       FilledLargeModel: ({ items }) => [
         evo(model, { largeArray: () => items }),
         [],
+      ],
+      FilledHistoryStep: ({ remaining }) => [
+        evo(model, { tickCount: tickCount => tickCount + 1 }),
+        remaining > 1 ? [fillHistoryStep(remaining - 1)] : [],
       ],
     }),
   )
@@ -200,6 +214,28 @@ const view = (model: Model): Document => ({
           div(
             [Class(stateStyle)],
             [`largeArray.length: ${model.largeArray.length}`],
+          ),
+        ],
+      ),
+
+      h2([Class(headingStyle)], ['Scenario: deep history']),
+      p(
+        [Class(blurbStyle)],
+        [
+          'Dispatch 500 small Messages so the DevTools store fills its history. ',
+          'The follow-latest path used to replay up to KEYFRAME_INTERVAL user updates ',
+          'on every dispatch to recover the model the inspector pane shows. After ',
+          'filling, click ',
+          code([], ['Tick']),
+          ' rapidly. If the regression returns, every Tick will hang on the replay walk.',
+        ],
+      ),
+      div(
+        [Class(rowStyle)],
+        [
+          button(
+            [OnClick(ClickedFillHistory()), Class(buttonStyle)],
+            [`Fill history (${HISTORY_FILL_COUNT} Messages)`],
           ),
         ],
       ),

--- a/packages/foldkit/src/devTools/store.test.ts
+++ b/packages/foldkit/src/devTools/store.test.ts
@@ -281,6 +281,33 @@ describe('DevToolsStore', () => {
       expect(model).toEqual({ count: 6 })
       expect(replaySpy).toHaveBeenCalledTimes(6)
     })
+
+    it('skips replay entirely when reading the latest recorded model', () => {
+      const { bridge, store } = makeStore()
+      const replaySpy = vi.spyOn(bridge, 'replay')
+
+      recordIncrements(store, 35)
+      replaySpy.mockClear()
+
+      const latestIndex = 34
+      const model = run(store.getModelAtIndex(latestIndex))
+      expect(model).toEqual({ count: 35 })
+      expect(replaySpy).not.toHaveBeenCalled()
+    })
+
+    it('preserves the latest-model fast path across eviction', () => {
+      const { bridge, store } = makeStore(undefined, 50)
+      const replaySpy = vi.spyOn(bridge, 'replay')
+
+      recordIncrements(store, 55)
+      replaySpy.mockClear()
+
+      const state = getState(store)
+      const latestIndex = state.startIndex + state.entries.length - 1
+      const model = run(store.getModelAtIndex(latestIndex))
+      expect(model).toEqual({ count: 55 })
+      expect(replaySpy).not.toHaveBeenCalled()
+    })
   })
 
   describe('eviction', () => {

--- a/packages/foldkit/src/devTools/store.ts
+++ b/packages/foldkit/src/devTools/store.ts
@@ -3,6 +3,7 @@ import {
   Effect,
   HashMap,
   HashSet,
+  Match,
   Option,
   Predicate,
   Record,
@@ -130,6 +131,7 @@ export type StoreState = Readonly<{
   startIndex: number
   isPaused: boolean
   pausedAtIndex: number
+  maybeLatestModel: Option.Option<unknown>
 }>
 
 export type Bridge = Readonly<{
@@ -146,6 +148,7 @@ const emptyState: StoreState = {
   startIndex: 0,
   isPaused: false,
   pausedAtIndex: 0,
+  maybeLatestModel: Option.none(),
 }
 
 export const createDevToolsStore = (
@@ -210,6 +213,7 @@ export const createDevToolsStore = (
         maybeInitModel: Option.some(model),
         initCommandNames: commandNames,
         keyframes: HashMap.set(state.keyframes, 0, model),
+        maybeLatestModel: Option.some(model),
       }))
 
     const recordMessage = (
@@ -243,6 +247,7 @@ export const createDevToolsStore = (
             absoluteIndex + 1,
             modelAfterUpdate,
           ),
+          maybeLatestModel: Option.some(modelAfterUpdate),
         }
 
         return nextState.entries.length > maxEntries
@@ -250,10 +255,23 @@ export const createDevToolsStore = (
           : nextState
       })
 
+    const latestEntryIndex = (state: StoreState): number =>
+      Array.match(state.entries, {
+        onEmpty: () => INIT_INDEX,
+        onNonEmpty: entries => state.startIndex + entries.length - 1,
+      })
+
+    // NOTE: maybeLatestModel must be stamped atomically with the entries
+    // append in recordMessage. The follow-latest fast-path below depends on
+    // that invariant.
     const resolveModel = (state: StoreState, index: number): unknown =>
-      index === INIT_INDEX
-        ? Option.getOrThrow(state.maybeInitModel)
-        : replayToIndex(state, index)
+      Match.value(index).pipe(
+        Match.when(INIT_INDEX, () => Option.getOrThrow(state.maybeInitModel)),
+        Match.when(latestEntryIndex(state), () =>
+          Option.getOrThrow(state.maybeLatestModel),
+        ),
+        Match.orElse(() => replayToIndex(state, index)),
+      )
 
     const getModelAtIndex = (index: number) =>
       pipe(
@@ -306,6 +324,7 @@ export const createDevToolsStore = (
         onSome: model =>
           HashMap.set(HashMap.empty<number, unknown>(), 0, model),
       }),
+      maybeLatestModel: state.maybeInitModel,
     }))
 
     const getDiffAtIndex = (index: number) =>


### PR DESCRIPTION
The inspector's follow-latest path runs on every user dispatch when
devTools is enabled. It used to recover the post-update model by
replaying up to KEYFRAME_INTERVAL user updates against the most recent
keyframe, calling the consumer's update function plus deepFreeze on
every step. With a large user model that walk dominated each dispatch
and grew with history depth — visible as per-keystroke input latency in
search inputs once history accumulated.

recordMessage now stamps the post-update model into
StoreState.maybeLatestModel atomically with the entries append, and
resolveModel returns it directly when the requested index is the latest
entry. Time-travel still goes through replayToIndex; only the latest
entry takes the new fast path.

Adds a Deep history scenario to internal/performance-harness that
fills the store with 500 small Messages so the regression is
reproducible in one click.