### PR TITLE
Convert API module slugs to proper module names in metadata

### DIFF
--- a/packages/website/scripts/metadata.ts
+++ b/packages/website/scripts/metadata.ts
@@ -1,5 +1,6 @@
 import { Match as M, Option } from 'effect'
 
+import { slugToModuleName } from '../src/page/apiReference/domain'
 import { findBySlug } from '../src/page/example/meta'
 import { type AppRoute } from '../src/route'
 
@@ -356,13 +357,14 @@ const METADATA_BY_TAG: Record<StaticRouteTag, PageMetadata> = {
 export const routeToMetadata = (route: AppRoute): PageMetadata =>
   M.value(route).pipe(
     M.withReturnType<PageMetadata>(),
-    M.tag('ApiModule', ({ moduleSlug }) =>
-      docs(
-        moduleSlug,
-        `API documentation for the ${moduleSlug} module.`,
+    M.tag('ApiModule', ({ moduleSlug }) => {
+      const moduleName = slugToModuleName(moduleSlug)
+      return docs(
+        moduleName,
+        `API documentation for the ${moduleName} module.`,
         'API Reference',
-      ),
-    ),
+      )
+    }),
     M.tag('ExampleDetail', ({ exampleSlug }) =>
       Option.match(findBySlug(exampleSlug), {
         onNone: () =>

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -1206,7 +1206,7 @@ const LoadExternal = Command.define(
 // VIEW
 
 export const view = (model: Model): Document => ({
-  title: routeTitle(model.route),
+  title: routeTitle(model.route, model.apiReference.apiData),
   body: M.value(model.route).pipe(
     M.tag('Home', () => landingView(model)),
     M.tag('Newsletter', () => newsletterView(model)),
@@ -1225,14 +1225,35 @@ export const view = (model: Model): Document => ({
 
 const SITE_NAME = 'Foldkit'
 
-const routeTitle = (route: AppRoute): string =>
+const resolveApiModuleName = (
+  apiData: typeof Page.ApiReference.ApiDataRemoteData.Union.Type,
+  moduleSlug: string,
+): string =>
+  M.value(apiData).pipe(
+    M.tag('Ok', ({ data }) =>
+      Option.match(
+        Page.ApiReference.resolveModule(data.parsedApi, moduleSlug),
+        {
+          onSome: ({ name }) => name,
+          onNone: () => Page.ApiReference.slugToModuleName(moduleSlug),
+        },
+      ),
+    ),
+    M.orElse(() => Page.ApiReference.slugToModuleName(moduleSlug)),
+  )
+
+const routeTitle = (
+  route: AppRoute,
+  apiData: typeof Page.ApiReference.ApiDataRemoteData.Union.Type,
+): string =>
   M.value(route).pipe(
     M.tag('Home', () => SITE_NAME),
     M.tag('Newsletter', () => `Newsletter — ${SITE_NAME}`),
     M.tag('NotFound', () => `Not Found — ${SITE_NAME}`),
     M.tag(
       'ApiModule',
-      ({ moduleSlug }) => `${moduleSlug} — API — ${SITE_NAME}`,
+      ({ moduleSlug }) =>
+        `${resolveApiModuleName(apiData, moduleSlug)} — API — ${SITE_NAME}`,
     ),
     M.tag('ExampleDetail', ({ exampleSlug }) =>
       pipe(

--- a/packages/website/src/page/apiReference/domain.ts
+++ b/packages/website/src/page/apiReference/domain.ts
@@ -482,3 +482,6 @@ const pascalToKebab = (text: string): string =>
 
 export const moduleNameToSlug = (name: string): string =>
   pipe(name, String.replaceAll('/', '-'), pascalToKebab)
+
+export const slugToModuleName = (slug: string): string =>
+  pipe(slug, String.split('-'), Array.map(String.capitalize), Array.join(''))


### PR DESCRIPTION
## Summary
This PR adds a new utility function to convert URL slugs back to module names and uses it to generate proper metadata titles for API reference pages.

## Key Changes
- Added `slugToModuleName` function in `packages/website/src/page/apiReference/domain.ts` that converts kebab-case slugs (e.g., "effect-core") to PascalCase module names (e.g., "EffectCore")
- Updated the `ApiModule` route handler in `packages/website/scripts/metadata.ts` to use the converted module name for both the page title and description, instead of using the raw slug

## Implementation Details
- The `slugToModuleName` function splits the slug by hyphens, capitalizes each word, and joins them back together
- This ensures API reference pages display user-friendly module names in their metadata while maintaining the slug-based URL structure
- The inverse function `moduleNameToSlug` already existed and is now complemented by this reverse conversion

https://claude.ai/code/session_0134f6jdhUEc35ir8wSJiuvL