### PR TITLE
Expand Task documentation with detailed explanations and API reference

### DIFF
--- a/packages/website/src/docsNav.ts
+++ b/packages/website/src/docsNav.ts
@@ -184,6 +184,8 @@ export const docsSections: ReadonlyArray<DocsSection> = [
           href: coreInitAndFlagsRouter(),
           label: 'Init & Flags',
         },
+      ],
+      [
         {
           _tag: 'CoreTask',
           href: coreTaskRouter(),

--- a/packages/website/src/page/core/task.ts
+++ b/packages/website/src/page/core/task.ts
@@ -4,10 +4,12 @@ import { Class, InnerHTML, div } from '../../html'
 import type { TableOfContentsEntry } from '../../main'
 import {
   inlineCode,
+  link,
   pageTitle,
   para,
   tableOfContentsEntryToHeader,
 } from '../../prose'
+import { apiModuleRouter, coreCommandsRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
@@ -17,9 +19,32 @@ const overviewHeader: TableOfContentsEntry = {
   text: 'Overview',
 }
 
+const whatTasksAreHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'what-tasks-are-and-are-not',
+  text: 'What Tasks are (and are not)',
+}
+
+const usingTasksHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'using-tasks',
+  text: 'Using Tasks',
+}
+
+const fullApiSurfaceHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'full-api-surface',
+  text: 'Full API surface',
+}
+
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
+  whatTasksAreHeader,
+  usingTasksHeader,
+  fullApiSurfaceHeader,
 ]
+
+const taskApiHref = apiModuleRouter({ moduleSlug: 'task' })
 
 export const view = (copiedSnippets: CopiedSnippets): Html =>
   div(
@@ -28,15 +53,51 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       pageTitle('core/task', 'Task'),
       tableOfContentsEntryToHeader(overviewHeader),
       para(
-        'Foldkit provides utility functions for common side effects that return Commands you can use in your update function.',
+        'The ',
+        inlineCode('Task'),
+        ' module is a small set of utility functions that wrap the most common browser side effects as Effects: getting the current time, generating a random integer, focusing an element, locking page scroll, waiting for an animation to settle. You use them inside your own ',
+        link(coreCommandsRouter(), 'Commands'),
+        '.',
       ),
       para(
+        'Tasks exist so every Foldkit app reaches for the same wrapper when it needs the time or a UUID. That consistency keeps DevTools traces, scene tests, and example code reading the same way across projects.',
+      ),
+      tableOfContentsEntryToHeader(whatTasksAreHeader),
+      para(
+        'A Task is just an Effect. ',
         inlineCode('Task.getTime'),
-        ' gets the current UTC time. ',
-        inlineCode('Task.getZonedTime'),
-        ' gets time with the system timezone. ',
-        inlineCode('Task.getZonedTimeIn'),
-        ' gets time in a specific timezone.',
+        ' is an ',
+        inlineCode('Effect.Effect<DateTime.Utc>'),
+        '. ',
+        inlineCode('Task.focus'),
+        ' returns an ',
+        inlineCode('Effect.Effect<void, ElementNotFound>'),
+        '. There is no special Task type, no separate runtime hook, no registration step. The runtime sees only Commands. Tasks are the Effects you choose to put inside them.',
+      ),
+      para(
+        'Tasks are not the only way to write a Command. Any Effect works. If you have your own ',
+        inlineCode('HttpClient'),
+        ' call, your own ',
+        inlineCode('localStorage'),
+        ' wrapper, or a third-party Effect, drop it straight into ',
+        inlineCode('Command.define'),
+        '. Reach for a Task when one exists for what you need. Write your own Effect when one does not.',
+      ),
+      para(
+        'Tasks are not a runtime feature. They cannot do anything that a plain Effect cannot. The runtime has no opinion about whether the Effect inside your Command came from ',
+        inlineCode('Task'),
+        ' or from somewhere else.',
+      ),
+      para(
+        'Tasks are not a parallel concept to Messages, Models, or Subscriptions. Those are architectural roles. Task is a utility namespace.',
+      ),
+      tableOfContentsEntryToHeader(usingTasksHeader),
+      para(
+        'Wrap a Task in a Command at the call site. The Task produces a value (a ',
+        inlineCode('DateTime'),
+        ', a ',
+        inlineCode('number'),
+        ', a UUID), and you map that value into one of your Messages.',
       ),
       highlightedCodeBlock(
         div([Class('text-sm'), InnerHTML(Snippets.taskGetTimeHighlighted)], []),
@@ -46,10 +107,21 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         'mb-8',
       ),
       para(
+        'Tasks that touch the DOM can fail. ',
         inlineCode('Task.focus'),
-        ' focuses an element by CSS selector (useful after form submission). ',
-        inlineCode('Task.randomInt'),
-        ' generates random integers.',
+        ' and ',
+        inlineCode('Task.scrollIntoView'),
+        ' fail with ',
+        inlineCode('ElementNotFound'),
+        ' when the selector does not match. ',
+        inlineCode('Task.getZonedTimeIn'),
+        ' fails with ',
+        inlineCode('TimeZoneError'),
+        ' on an invalid zone ID. Catch the failure with ',
+        inlineCode('Effect.catch'),
+        ' and turn it into a Message, or ignore it with ',
+        inlineCode('Effect.ignore'),
+        ' when the failure is not interesting (a stale focus call after the user has navigated away).',
       ),
       highlightedCodeBlock(
         div([Class('text-sm'), InnerHTML(Snippets.taskFocusHighlighted)], []),
@@ -58,8 +130,14 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         copiedSnippets,
         'mb-8',
       ),
+      tableOfContentsEntryToHeader(fullApiSurfaceHeader),
       para(
-        'Now that you know how to write Commands and use built-in tasks, the next step is wiring everything together into a running application.',
+        'The Task module covers time and timezones, DOM focus and scrolling, animation timing, randomness, and scroll lock. The ',
+        link(taskApiHref, 'Task API reference'),
+        ' lists every function with its signature and an inline example, generated directly from the source.',
+      ),
+      para(
+        'When you need a side effect that Task does not cover, write the Effect yourself and wrap it in a Command. Tasks are shared shortcuts, not a fence around what is allowed.',
       ),
     ],
   )


### PR DESCRIPTION
## Summary
This PR significantly expands the Task module documentation page with comprehensive explanations of what Tasks are, how to use them, and their role in the framework. The documentation now includes multiple new sections with clearer guidance and links to the API reference.

## Key Changes
- **Restructured documentation** with four main sections: Overview, What Tasks are (and are not), Using Tasks, and Full API surface
- **Enhanced overview paragraph** to better explain the purpose of Tasks as utility functions wrapping common browser side effects
- **Added "What Tasks are (and are not)" section** clarifying that:
  - Tasks are just Effects with no special runtime behavior
  - Tasks are not the only way to write Commands
  - Tasks are not a runtime feature or architectural role, but a utility namespace
- **Added "Using Tasks" section** with practical guidance on wrapping Tasks in Commands and handling failures with `Effect.catch` and `Effect.ignore`
- **Added "Full API surface" section** with a link to the Task API reference documentation
- **Imported routing utilities** (`apiModuleRouter`, `coreCommandsRouter`) and the `link` function to support cross-references
- **Updated table of contents** to include the three new section headers
- **Fixed navigation structure** in `docsNav.ts` by properly grouping the Core Task navigation item

## Notable Implementation Details
- The documentation now emphasizes that Tasks are optional utilities, not mandatory patterns
- Error handling is explicitly covered with examples of DOM-related failures (`ElementNotFound`) and timezone failures (`TimeZoneError`)
- Links to related documentation (Commands, API reference) are now embedded in the prose for better navigation

https://claude.ai/code/session_014MpcziGEuaC8oiHQP53AgM