### PR TITLE
Handle hash-only URL changes without full route updates

### DIFF
--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -5,6 +5,7 @@ import {
   Array,
   DateTime,
   Effect,
+  Equal,
   HashSet,
   Layer,
   Match as M,
@@ -482,6 +483,20 @@ const update = (
         ),
 
       ChangedUrl: ({ url }) => {
+        const isHashOnlyChange =
+          url.pathname === model.url.pathname &&
+          Equal.equals(url.search, model.url.search)
+
+        if (isHashOnlyChange) {
+          return [
+            evo(model, { url: () => url }),
+            Option.match(url.hash, {
+              onNone: () => [scrollToTop],
+              onSome: hash => [scrollToHashAfterRender(hash)],
+            }),
+          ]
+        }
+
         const nextRoute = urlToAppRoute(url)
         const [closedMobileMenu, closeMobileMenuCommands] = Ui.Dialog.update(
           model.mobileMenuDialog,


### PR DESCRIPTION
## Summary
Optimize URL change handling to detect and process hash-only changes separately, avoiding unnecessary full route updates when only the URL fragment changes.

## Key Changes
- Added `Equal` import from Effect library for value comparison
- Implemented hash-only change detection in the `ChangedUrl` update handler
  - Compares pathname and search parameters to identify when only the hash has changed
  - When a hash-only change is detected, updates the URL and scrolls to the target hash (or top if no hash)
  - Skips the full route resolution logic for these cases, improving performance

## Implementation Details
- Uses `Equal.equals()` for reliable search parameter comparison
- Leverages existing `scrollToTop` and `scrollToHashAfterRender()` commands for scroll behavior
- Early returns from the update handler when hash-only change is detected, preventing unnecessary route recalculation

https://claude.ai/code/session_01Jued3HWgs5MjwdbTtTmFuS