### PR TITLE
Add cloud session setup script and SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "test -x node_modules/.bin/simple-git-hooks && node_modules/.bin/simple-git-hooks || pnpm install"
+            "command": "bash scripts/cloud-session-setup.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,10 @@ Command definitions live where they're produced — colocated with the update fu
 
 Apps in `examples/` ship with the `@foldkit/devtools-mcp` relay wired up. When debugging behavior in a running example, reach for the `foldkit_*` MCP tools before adding logs. If they aren't visible, see `packages/devtools-mcp/README.md` for setup.
 
+## Workspace Setup Errors Are Not Pre-Existing
+
+If `pnpm typecheck`, `pnpm lint`, `pnpm build`, or the pre-push hook surfaces errors like `Cannot find module 'foldkit'`, `Cannot find module 'foldkit/html'`, or `Property X does not exist on type Y` against an Effect API, the workspace itself is out of sync. These are not pre-existing branch failures. Run `bash scripts/cloud-session-setup.sh` to reconcile `node_modules` to the lockfile and build the prerequisite packages (`foldkit`, `@foldkit/vite-plugin`, `@typing-game/shared`). The SessionStart hook runs this automatically, so this is only relevant if dependencies drift mid-session.
+
 ## Communication
 
 - When I ask a question or make a comment that sounds rhetorical, opinion-based, or conversational (e.g., 'what do you think about X?', 'im asking you'), respond with discussion — not code edits. Only make code changes when explicitly asked to.

--- a/scripts/cloud-session-setup.sh
+++ b/scripts/cloud-session-setup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Prepare the workspace for a Claude Code cloud session.
+#
+# Cloud sandboxes are provisioned with a node_modules that may be stale (wrong
+# package versions) and never has packages built. Both states produce errors
+# that look like pre-existing branch problems but are not:
+#
+#   * Stale node_modules -> downstream typecheck/build hits "Property X does not
+#     exist on type Y" because the wrong dependency version resolved.
+#   * Missing dist/      -> downstream typecheck fails with "Cannot find module
+#     'foldkit'" because foldkit's package.json `exports` map points at dist/.
+#
+# Reconciling node_modules to the lockfile and building the three prerequisite
+# packages eliminates both classes of phantom error before the agent runs any
+# checks.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "[setup] reconciling node_modules with pnpm-lock.yaml"
+pnpm install --frozen-lockfile
+
+prerequisite_packages=(
+  'foldkit:packages/foldkit'
+  '@foldkit/vite-plugin:packages/vite-plugin-foldkit'
+  '@typing-game/shared:packages/typing-game/shared'
+)
+
+build_filters=()
+for spec in "${prerequisite_packages[@]}"; do
+  pkg="${spec%%:*}"
+  dir="${spec#*:}"
+  if [[ ! -d "$dir/dist" ]]; then
+    build_filters+=("-F" "$pkg")
+  fi
+done
+
+if (( ${#build_filters[@]} > 0 )); then
+  echo "[setup] building prerequisite packages: ${build_filters[*]}"
+  pnpm "${build_filters[@]}" build
+else
+  echo "[setup] prerequisite package dist/ directories already present"
+fi


### PR DESCRIPTION
## Summary

This PR adds a dedicated setup script for Claude Code cloud sessions and integrates it into the SessionStart hook to automatically reconcile the workspace state before agent execution.

## Key Changes

- **New `scripts/cloud-session-setup.sh`**: A bash script that prepares the workspace for cloud sessions by:
  - Reconciling `node_modules` with `pnpm-lock.yaml` using `pnpm install --frozen-lockfile`
  - Building prerequisite packages (`foldkit`, `@foldkit/vite-plugin`, `@typing-game/shared`) if their `dist/` directories are missing
  - Preventing phantom errors caused by stale dependencies or missing built artifacts

- **Updated `.claude/settings.json`**: Changed the SessionStart hook from a simple git-hooks check to invoke the new setup script, ensuring the workspace is properly initialized at the start of each cloud session

- **Updated `CLAUDE.md`**: Added documentation explaining that workspace sync errors are not pre-existing branch failures and how to resolve them using the setup script

## Implementation Details

The setup script uses a declarative approach to identify prerequisite packages, checking for the existence of `dist/` directories to determine which packages need building. This avoids unnecessary rebuilds while ensuring all required artifacts are present before downstream tools run typecheck or build operations.

https://claude.ai/code/session_01YH2FDcKvri8Zg6zmpK852U