### PR TITLE
Add halfOpen option to Random.nextIntBetween calls

### DIFF
--- a/examples/snake/src/domain/apple.ts
+++ b/examples/snake/src/domain/apple.ts
@@ -6,8 +6,12 @@ import * as Snake from './snake'
 
 export const generatePosition = (snake: Snake.Snake) =>
   Effect.gen(function* () {
-    const x = yield* Random.nextIntBetween(0, GAME.GRID_SIZE)
-    const y = yield* Random.nextIntBetween(0, GAME.GRID_SIZE)
+    const x = yield* Random.nextIntBetween(0, GAME.GRID_SIZE, {
+      halfOpen: true,
+    })
+    const y = yield* Random.nextIntBetween(0, GAME.GRID_SIZE, {
+      halfOpen: true,
+    })
     const pos: Position = { x, y }
 
     if (Snake.contains(snake, pos)) {

--- a/packages/typing-game/server/src/gameText.ts
+++ b/packages/typing-game/server/src/gameText.ts
@@ -54,7 +54,7 @@ export const generateGameText = (
     }),
   )
 
-  return Random.nextIntBetween(0, Array.length(availableTexts)).pipe(
-    Effect.map(index => Array.getUnsafe(availableTexts, index)),
-  )
+  return Random.nextIntBetween(0, Array.length(availableTexts), {
+    halfOpen: true,
+  }).pipe(Effect.map(index => Array.getUnsafe(availableTexts, index)))
 }

--- a/packages/typing-game/server/src/room.ts
+++ b/packages/typing-game/server/src/room.ts
@@ -32,7 +32,7 @@ export const generateUniqueId = (
   })
 
 const generateRoomId = (words: ReadonlyArray<string>) =>
-  Random.nextIntBetween(0, Array.length(words)).pipe(
+  Random.nextIntBetween(0, Array.length(words), { halfOpen: true }).pipe(
     Effect.replicateEffect(NUM_WORDS_IN_ID),
     Effect.map(indicesToRoomId(words)),
   )

--- a/packages/website/src/snippet/pureUpdateGood.ts
+++ b/packages/website/src/snippet/pureUpdateGood.ts
@@ -20,8 +20,8 @@ const GenerateApplePosition = Command.define(
 
 const generateApplePosition = GenerateApplePosition(
   Effect.gen(function* () {
-    const x = yield* Random.nextIntBetween(0, GRID_SIZE)
-    const y = yield* Random.nextIntBetween(0, GRID_SIZE)
+    const x = yield* Random.nextIntBetween(0, GRID_SIZE, { halfOpen: true })
+    const y = yield* Random.nextIntBetween(0, GRID_SIZE, { halfOpen: true })
     return GeneratedApple({ position: { x, y } })
   }),
 )


### PR DESCRIPTION
## Summary
Updated all `Random.nextIntBetween` calls across the codebase to explicitly use the `{ halfOpen: true }` option, ensuring consistent half-open interval behavior (inclusive lower bound, exclusive upper bound).

## Key Changes
- **examples/snake/src/domain/apple.ts**: Added `{ halfOpen: true }` option to both x and y coordinate generation calls
- **packages/typing-game/server/src/gameText.ts**: Added `{ halfOpen: true }` option to text selection index generation
- **packages/website/src/snippet/pureUpdateGood.ts**: Added `{ halfOpen: true }` option to apple position generation calls
- **packages/typing-game/server/src/room.ts**: Added `{ halfOpen: true }` option to room ID generation

## Implementation Details
These changes make the half-open interval behavior explicit in all `Random.nextIntBetween` calls. The half-open interval `[min, max)` is the correct semantic for generating random indices and coordinates within bounded ranges, preventing potential off-by-one errors and ensuring values stay within valid grid/array bounds.

https://claude.ai/code/session_01VwKVdwJDVYbDMCwVnFYVFH