### PR TITLE
Handle null container gracefully in makeProgram

### DIFF
--- a/.changeset/fix-runtime-null-container.md
+++ b/.changeset/fix-runtime-null-container.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+`Runtime.makeProgram` now handles a null container gracefully. When the entry module is imported in a vitest scene test (where there is no `#root` element to mount on), `makeProgram` returns an `Inactive` runtime and `Runtime.run` becomes a no-op, so test output stays clean. Passing a real element without an `id` now throws synchronously at `makeProgram` time with a clear error, instead of dying asynchronously deep inside the runtime startup.
+
+`MakeRuntimeReturn` is now a discriminated union: `{ _tag: 'Active', runtimeId, start } | { _tag: 'Inactive' }`. Code that only calls `Runtime.run(program)` is unaffected.

--- a/packages/foldkit/src/devTools/overlay.ts
+++ b/packages/foldkit/src/devTools/overlay.ts
@@ -1829,5 +1829,7 @@ export const createOverlay = (
       freezeModel: false,
     })
 
-    yield* Effect.forkDetach(overlayRuntime.start())
+    if (overlayRuntime._tag === 'Active') {
+      yield* Effect.forkDetach(overlayRuntime.start())
+    }
   })

--- a/packages/foldkit/src/runtime/runtime.test.ts
+++ b/packages/foldkit/src/runtime/runtime.test.ts
@@ -1,0 +1,100 @@
+import { Schema as S } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { Command } from '../command/index.js'
+import { Document, html } from '../html/index.js'
+import { m } from '../message/public.js'
+import { type MakeRuntimeReturn, makeProgram, run } from './runtime.js'
+
+const Model = S.Struct({ count: S.Number })
+type Model = typeof Model.Type
+
+const Tick = m('Tick')
+
+const Message = S.Union([Tick])
+type Message = typeof Message.Type
+
+const init = (): readonly [Model, ReadonlyArray<Command.Command<Message>>] => [
+  { count: 0 },
+  [],
+]
+
+const update = (
+  model: Model,
+  _message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] => [model, []]
+
+const { div } = html<Message>()
+
+const view = (model: Model): Document => ({
+  title: 'Test',
+  body: div([], [model.count.toString()]),
+})
+
+describe('makeProgram', () => {
+  it('returns an Inactive runtime when container is null', () => {
+    const program = makeProgram({
+      Model,
+      init,
+      update,
+      view,
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      container: null as unknown as HTMLElement,
+    })
+
+    expect(program._tag).toBe('Inactive')
+  })
+
+  it('returns an Inactive runtime when container is undefined', () => {
+    const program = makeProgram({
+      Model,
+      init,
+      update,
+      view,
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      container: undefined as unknown as HTMLElement,
+    })
+
+    expect(program._tag).toBe('Inactive')
+  })
+
+  it('throws synchronously when container has no id', () => {
+    const container = document.createElement('div')
+
+    expect(() =>
+      makeProgram({
+        Model,
+        init,
+        update,
+        view,
+        container,
+      }),
+    ).toThrow(/Runtime container must have an `id`/)
+  })
+
+  it('returns an Active runtime when container has an id', () => {
+    const container = document.createElement('div')
+    container.id = 'app'
+
+    const program = makeProgram({
+      Model,
+      init,
+      update,
+      view,
+      container,
+    })
+
+    expect(program._tag).toBe('Active')
+    if (program._tag === 'Active') {
+      expect(program.runtimeId).toBe('app')
+    }
+  })
+})
+
+describe('run', () => {
+  it('is a no-op when the program is Inactive', () => {
+    const inactive: MakeRuntimeReturn = { _tag: 'Inactive' }
+
+    expect(() => run(inactive)).not.toThrow()
+  })
+})

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -442,11 +442,26 @@ export type RoutingProgramInit<
       >,
     ]
 
-/** A configured Foldkit runtime returned by `makeProgram`, passed to `run` to start the application. */
-export type MakeRuntimeReturn = Readonly<{
-  runtimeId: string
-  start: (hmrModel?: unknown) => Effect.Effect<void>
-}>
+/**
+ * A configured Foldkit runtime returned by `makeProgram`, passed to `run` to
+ * start the application.
+ *
+ * `Active` is the normal case: the host page has a mount target, so the
+ * runtime is fully wired up.
+ *
+ * `Inactive` is returned when `makeProgram` was called without a DOM mount
+ * target (e.g. the entry module was imported by a vitest scene test that
+ * doesn't render the app HTML). `run` becomes a no-op so test output stays
+ * clean instead of logging a misleading container-id error and a vite-plugin
+ * timeout warning.
+ */
+export type MakeRuntimeReturn =
+  | Readonly<{
+      _tag: 'Active'
+      runtimeId: string
+      start: (hmrModel?: unknown) => Effect.Effect<void>
+    }>
+  | Readonly<{ _tag: 'Inactive' }>
 
 const makeRuntime = <
   Model,
@@ -477,7 +492,7 @@ const makeRuntime = <
   Flags,
   Resources,
   ManagedResourceServices
->): MakeRuntimeReturn => {
+>): Extract<MakeRuntimeReturn, { _tag: 'Active' }> => {
   const resolvedSlowView = pipe(
     slowView ?? {},
     Option.liftPredicate(config => config !== false),
@@ -499,7 +514,7 @@ const makeRuntime = <
   const maybeFreezeModel = (model: Model): Model =>
     isFreezeModelActive ? deepFreeze(model) : model
 
-  const runtimeId = container?.id ?? ''
+  const runtimeId = container.id
 
   // NOTE: When the message queue drains a chain of dispatches (e.g. recursive
   // Commands, websocket bursts), processing all of them inside one macrotask
@@ -529,14 +544,6 @@ const makeRuntime = <
   const start = (hmrModel?: unknown): Effect.Effect<void> =>
     Effect.scoped(
       Effect.gen(function* () {
-        if (runtimeId === '') {
-          return yield* Effect.die(
-            new Error(
-              '[foldkit] Runtime container must have an `id` for HMR model preservation. ' +
-                'Set `container.id = "app"` (or any unique string) before passing it to makeProgram.',
-            ),
-          )
-        }
         const maybeResourceLayer = resources
           ? Option.some(resources)
           : Option.none()
@@ -1225,7 +1232,7 @@ const makeRuntime = <
       }),
     )
 
-  return { runtimeId, start }
+  return { _tag: 'Active', runtimeId, start }
 }
 
 const patchVNode = (
@@ -1444,6 +1451,17 @@ export function makeProgram<
         ManagedResourceServices
       >,
 ): MakeRuntimeReturn {
+  const container: HTMLElement | null | undefined = config.container
+  if (container === null || container === undefined) {
+    return { _tag: 'Inactive' }
+  }
+  if (container.id === '') {
+    throw new Error(
+      '[foldkit] Runtime container must have an `id` for HMR model preservation. ' +
+        'Set `container.id = "app"` (or any unique string) before passing it to makeProgram.',
+    )
+  }
+
   const hasRouting = 'routing' in config
   const hasFlags = 'Flags' in config
 
@@ -1623,9 +1641,14 @@ const provideBrowserScheduler = <A, E, R>(
 
 /** Starts a Foldkit runtime, with HMR support for development. */
 export const run = (program: MakeRuntimeReturn): void => {
+  if (program._tag === 'Inactive') {
+    return
+  }
+
+  const { runtimeId, start } = program
+
   if (import.meta.hot) {
     const hot = import.meta.hot
-    const { runtimeId, start } = program
 
     const requestPreservedModel = pipe(
       Effect.callback<unknown>(resume => {
@@ -1664,6 +1687,6 @@ export const run = (program: MakeRuntimeReturn): void => {
 
     BrowserRuntime.runMain(provideBrowserScheduler(requestPreservedModel))
   } else {
-    BrowserRuntime.runMain(provideBrowserScheduler(program.start()))
+    BrowserRuntime.runMain(provideBrowserScheduler(start()))
   }
 }


### PR DESCRIPTION
## Summary

This PR improves the robustness of `makeProgram` by gracefully handling cases where no DOM container is provided, which commonly occurs when entry modules are imported in test environments. The runtime now returns an `Inactive` state instead of failing asynchronously, and validation errors are thrown synchronously with clear messaging.

## Key Changes

- **Discriminated Union Type**: `MakeRuntimeReturn` is now a discriminated union with two states:
  - `Active`: Normal case with `_tag: 'Active'`, `runtimeId`, and `start` function
  - `Inactive`: Returned when container is null/undefined, allowing graceful no-op behavior

- **Early Validation in makeProgram**: 
  - Null/undefined containers now return `{ _tag: 'Inactive' }` immediately
  - Missing container `id` throws synchronously with a clear error message
  - Validation happens before runtime initialization, preventing async failures

- **No-op run() for Inactive**: The `run()` function now checks the `_tag` and returns early for `Inactive` runtimes, keeping test output clean

- **Updated Consumers**: 
  - `devTools/overlay.ts` updated to check `_tag` before calling `start()`
  - Error handling moved from async `start()` effect to synchronous `makeProgram()` validation

## Implementation Details

- The container validation is now synchronous and happens at `makeProgram` time rather than deep inside the runtime startup effect
- This prevents misleading error messages and vite-plugin timeout warnings in test environments
- The change is backward compatible for code that only calls `Runtime.run(program)` without pattern matching on the return type
- Comprehensive test coverage added for both null/undefined containers and the Inactive runtime behavior

https://claude.ai/code/session_017vwypL5wbgJMZ3Yd5wudAA