### PR TITLE
Fix resolveAll to queue repeated command matchers

### DIFF
--- a/.changeset/foldkit-resolve-all-queue.md
+++ b/.changeset/foldkit-resolve-all-queue.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Fix `Story.Command.resolveAll` silently dropping all but the first dispatch when multiple entries shared a `CommandDefinition` or instance fingerprint. Repeated entries within a single `resolveAll` call now form a queue: each entry is consumed by exactly one matching dispatch in declaration order. Single-entry resolvers remain sticky and are reused for every matching dispatch in the cascade.

--- a/packages/foldkit/src/test/apps/counter.ts
+++ b/packages/foldkit/src/test/apps/counter.ts
@@ -5,7 +5,10 @@ import { m } from '../../message/index.js'
 
 // MODEL
 
-export const Model = S.Struct({ count: S.Number })
+export const Model = S.Struct({
+  count: S.Number,
+  log: S.Array(S.Number),
+})
 export type Model = typeof Model.Type
 
 // MESSAGE
@@ -14,6 +17,9 @@ export const ClickedIncrement = m('ClickedIncrement')
 export const ClickedDecrement = m('ClickedDecrement')
 export const ClickedFetch = m('ClickedFetch')
 export const ClickedFetchById = m('ClickedFetchById', { id: S.Number })
+export const StartedThreeFetches = m('StartedThreeFetches')
+export const StartedThreeFetchesById = m('StartedThreeFetchesById')
+export const StartedMixedFetches = m('StartedMixedFetches')
 export const SucceededFetchCount = m('SucceededFetchCount', { count: S.Number })
 export const FailedFetchCount = m('FailedFetchCount', { error: S.String })
 
@@ -22,6 +28,9 @@ export const Message = S.Union([
   ClickedDecrement,
   ClickedFetch,
   ClickedFetchById,
+  StartedThreeFetches,
+  StartedThreeFetchesById,
+  StartedMixedFetches,
   SucceededFetchCount,
   FailedFetchCount,
 ])
@@ -44,7 +53,7 @@ export const FetchCountById = Command.define(
 
 // INIT
 
-export const initialModel: Model = { count: 0 }
+export const initialModel: Model = { count: 0, log: [] }
 
 // UPDATE
 
@@ -57,11 +66,31 @@ export const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
-      ClickedDecrement: () => [{ count: model.count - 1 }, []],
+      ClickedIncrement: () => [{ ...model, count: model.count + 1 }, []],
+      ClickedDecrement: () => [{ ...model, count: model.count - 1 }, []],
       ClickedFetch: () => [model, [FetchCount()]],
       ClickedFetchById: ({ id }) => [model, [FetchCountById({ id })]],
-      SucceededFetchCount: ({ count }) => [{ count }, []],
+      StartedThreeFetches: () => [
+        model,
+        [FetchCount(), FetchCount(), FetchCount()],
+      ],
+      StartedThreeFetchesById: () => [
+        model,
+        [FetchCountById({ id: 5 }), FetchCountById({ id: 5 })],
+      ],
+      StartedMixedFetches: () => [
+        model,
+        [
+          FetchCount(),
+          FetchCount(),
+          FetchCountById({ id: 99 }),
+          FetchCountById({ id: 99 }),
+        ],
+      ],
+      SucceededFetchCount: ({ count }) => [
+        { count, log: [...model.log, count] },
+        [],
+      ],
       FailedFetchCount: () => [model, []],
     }),
   )

--- a/packages/foldkit/src/test/internal.ts
+++ b/packages/foldkit/src/test/internal.ts
@@ -142,10 +142,14 @@ export type MountResolver<ResultMessage = unknown> =
 /** A resolver entry pairs a Command matcher with the Message that should be
  *  fed back through update when a pending Command matches. Stored as a list
  *  (not a name-keyed map) so Instance matchers with the same name but
- *  different args can coexist. */
+ *  different args can coexist. `isQueued` is `true` when the entry was
+ *  declared alongside one or more sibling entries sharing its fingerprint in
+ *  the same `resolveAll` call. Queued entries are consumed on first match;
+ *  non-queued entries are sticky and reused for every matching dispatch. */
 export type ResolverEntry<Message> = Readonly<{
   matcher: CommandMatcher
   message: Message
+  isQueued: boolean
 }>
 
 /** Base shape of an internal simulation — shared between Story and Scene. */
@@ -203,15 +207,26 @@ const matcherFingerprint = (matcher: CommandMatcher): string =>
     : `inst:${matcher.name}:${JSON.stringify(matcher.args ?? null)}`
 
 /** Resolves all listed Commands, cascading through any Commands produced by
- *  the result. Resolvers stay applicable across the cascade so multiple
- *  Commands matching the same matcher reuse it. When a new resolver shares a
- *  fingerprint with an existing one (same Definition, or same Instance shape),
- *  the new resolver replaces the old. Mirrors the prior name-keyed semantics
- *  where the latest wins. */
+ *  the result. Single-fingerprint resolvers are sticky: one entry covers every
+ *  matching dispatch in the cascade. When the same call declares 2+ entries
+ *  sharing a fingerprint, those entries form a queue: each is consumed by
+ *  exactly one matching dispatch in declaration order. Across calls, a new
+ *  resolver evicts any existing one with the same fingerprint (latest wins). */
 export const resolveAllInternal = <Model, Message, OutMessage>(
   internal: BaseInternal<Model, Message, OutMessage>,
   resolvers: ReadonlyArray<Resolver>,
 ): BaseInternal<Model, Message, OutMessage> => {
+  const seenFingerprints = new Set<string>()
+  const queuedFingerprints = new Set<string>()
+  for (const [matcher] of resolvers) {
+    const fingerprint = matcherFingerprint(matcher)
+    if (seenFingerprints.has(fingerprint)) {
+      queuedFingerprints.add(fingerprint)
+    } else {
+      seenFingerprints.add(fingerprint)
+    }
+  }
+
   const newEntries: ReadonlyArray<ResolverEntry<Message>> = Array.map(
     resolvers,
     resolver => {
@@ -220,7 +235,8 @@ export const resolveAllInternal = <Model, Message, OutMessage>(
       const message = (
         resolver.length === 3 ? resolver[2](resultMessage) : resultMessage
       ) as Message
-      return { matcher, message }
+      const isQueued = queuedFingerprints.has(matcherFingerprint(matcher))
+      return { matcher, message, isQueued }
     },
   )
 
@@ -240,10 +256,18 @@ export const resolveAllInternal = <Model, Message, OutMessage>(
 
   const findNextMatch = (
     state: BaseInternal<Model, Message, unknown>,
-  ): Option.Option<ResolverEntry<Message>> =>
+  ): Option.Option<{ entry: ResolverEntry<Message>; resolverIndex: number }> =>
     Array.findFirst(state.commands, command =>
-      Array.findFirst(state.resolvers, ({ matcher }) =>
-        commandMatches(matcher, command),
+      pipe(
+        state.resolvers,
+        Array.findFirstIndex(({ matcher }) => commandMatches(matcher, command)),
+        Option.flatMap(resolverIndex =>
+          pipe(
+            state.resolvers,
+            Array.get(resolverIndex),
+            Option.map(entry => ({ entry, resolverIndex })),
+          ),
+        ),
       ),
     )
 
@@ -256,15 +280,20 @@ export const resolveAllInternal = <Model, Message, OutMessage>(
 
     const next = resolveByMatcher(
       current,
-      matched.value.matcher,
-      matched.value.message,
+      matched.value.entry.matcher,
+      matched.value.entry.message,
     )
 
     if (Predicate.isUndefined(next)) {
       break
     }
 
-    current = next
+    current = matched.value.entry.isQueued
+      ? {
+          ...next,
+          resolvers: Array.remove(next.resolvers, matched.value.resolverIndex),
+        }
+      : next
 
     if (depth === MAX_CASCADE_DEPTH - 1) {
       throw new Error(

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -661,7 +661,15 @@ const resolveCommand: {
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }
 
-/** Resolves all listed Commands with their result Messages. Handles cascading resolution. */
+/** Resolves listed Commands with their result Messages, cascading through any
+ *  Commands the result produces. A single entry for a Command Definition or
+ *  instance is sticky: it resolves every matching dispatch in the cascade with
+ *  the same Message. Two or more entries sharing a Definition or instance form
+ *  a queue: each is consumed by exactly one matching dispatch in declaration
+ *  order, so `[Def, m1], [Def, m2], [Def, m3]` reads as a sequence of three
+ *  responses. Resolvers carry across `resolveAll` calls: unused queue entries
+ *  can match later dispatches, and a new entry whose Definition or instance
+ *  shape matches an existing resolver replaces it (latest wins). */
 const resolveAllCommands =
   <R extends ReadonlyArray<unknown>>(
     ...resolvers: { [K in keyof R]: Resolver<R[K]> }
@@ -891,7 +899,12 @@ const expectEndedMountsStep =
 export const Command = {
   /** Resolves a specific pending Command with the given result Message. */
   resolve: resolveCommand,
-  /** Resolves all listed Commands with their result Messages. Handles cascading resolution. */
+  /** Resolves listed Commands with their result Messages, cascading through any
+   *  Commands the result produces. Single entries are sticky (reused for every
+   *  matching dispatch); repeated entries sharing a Definition or instance form
+   *  a queue (consumed in declaration order, one per dispatch). Resolvers
+   *  carry across calls; a new entry with the same Definition or instance
+   *  shape replaces an existing one (latest wins). */
   resolveAll: resolveAllCommands,
   /** Asserts that every given Command is among the pending Commands. */
   expectHas: expectHasCommandsStep,

--- a/packages/foldkit/src/test/story.test.ts
+++ b/packages/foldkit/src/test/story.test.ts
@@ -7,6 +7,9 @@ import {
   ClickedIncrement,
   FetchCount,
   FetchCountById,
+  StartedMixedFetches,
+  StartedThreeFetches,
+  StartedThreeFetchesById,
   SucceededFetchCount,
   update,
 } from './apps/counter.js'
@@ -32,7 +35,7 @@ describe('message', () => {
   test('multiple Messages update the Model sequentially', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedIncrement()),
       Story.message(ClickedIncrement()),
       Story.message(ClickedDecrement()),
@@ -45,7 +48,7 @@ describe('message', () => {
   test('Message produces Commands that stay pending', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetch()),
       Story.Command.expectHas(FetchCount),
       Story.Command.resolveAll([
@@ -61,7 +64,7 @@ describe('resolve', () => {
     expect(() =>
       Story.story(
         update,
-        Story.with({ count: 0 }),
+        Story.with({ count: 0, log: [] }),
         Story.message(ClickedIncrement()),
         Story.Command.resolve(FetchCount, SucceededFetchCount({ count: 42 })),
       ),
@@ -74,7 +77,7 @@ describe('resolve', () => {
     expect(() =>
       Story.story(
         update,
-        Story.with({ count: 0 }),
+        Story.with({ count: 0, log: [] }),
         Story.message(ClickedFetch()),
         Story.Command.resolve(SubmitForm, SucceededSubmit({ id: 'abc' })),
       ),
@@ -86,7 +89,7 @@ describe('resolve', () => {
   test('resolve feeds the result Message through update', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetch()),
       Story.model(model => {
         expect(model.count).toBe(0)
@@ -103,7 +106,7 @@ describe('resolveAll', () => {
   test('resolveAll resolves multiple Commands at once', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetch()),
       Story.Command.resolveAll([
         FetchCount,
@@ -129,13 +132,110 @@ describe('resolveAll', () => {
       }),
     )
   })
+
+  test('repeated Definition entries dispatch as a queue in declaration order', () => {
+    Story.story(
+      update,
+      Story.with({ count: 0, log: [] }),
+      Story.message(StartedThreeFetches()),
+      Story.Command.resolveAll(
+        [FetchCount, SucceededFetchCount({ count: 1 })],
+        [FetchCount, SucceededFetchCount({ count: 2 })],
+        [FetchCount, SucceededFetchCount({ count: 3 })],
+      ),
+      Story.model(model => {
+        expect(model.log).toEqual([1, 2, 3])
+        expect(model.count).toBe(3)
+      }),
+    )
+  })
+
+  test('single-entry Definition stays sticky across multiple matching dispatches', () => {
+    Story.story(
+      update,
+      Story.with({ count: 0, log: [] }),
+      Story.message(StartedThreeFetches()),
+      Story.Command.resolveAll([FetchCount, SucceededFetchCount({ count: 7 })]),
+      Story.model(model => {
+        expect(model.log).toEqual([7, 7, 7])
+        expect(model.count).toBe(7)
+      }),
+    )
+  })
+
+  test('repeated Instance entries dispatch as a queue in declaration order', () => {
+    Story.story(
+      update,
+      Story.with({ count: 0, log: [] }),
+      Story.message(StartedThreeFetchesById()),
+      Story.Command.resolveAll(
+        [FetchCountById({ id: 5 }), SucceededFetchCount({ count: 10 })],
+        [FetchCountById({ id: 5 }), SucceededFetchCount({ count: 20 })],
+      ),
+      Story.model(model => {
+        expect(model.log).toEqual([10, 20])
+      }),
+    )
+  })
+
+  test('mixed queue and sticky fingerprints in the same call', () => {
+    Story.story(
+      update,
+      Story.with({ count: 0, log: [] }),
+      Story.message(StartedMixedFetches()),
+      Story.Command.resolveAll(
+        [FetchCount, SucceededFetchCount({ count: 1 })],
+        [FetchCount, SucceededFetchCount({ count: 2 })],
+        [FetchCountById, SucceededFetchCount({ count: 99 })],
+      ),
+      Story.model(model => {
+        expect(model.log).toEqual([1, 2, 99, 99])
+      }),
+    )
+  })
+
+  test('queue with more entries than pending Commands leaves leftovers without error', () => {
+    Story.story(
+      update,
+      Story.with({ count: 0, log: [] }),
+      Story.message(ClickedFetch()),
+      Story.Command.resolveAll(
+        [FetchCount, SucceededFetchCount({ count: 1 })],
+        [FetchCount, SucceededFetchCount({ count: 2 })],
+        [FetchCount, SucceededFetchCount({ count: 3 })],
+      ),
+      Story.model(model => {
+        expect(model.log).toEqual([1])
+      }),
+    )
+  })
+
+  test('queue entries left after a cascade are consumed by a later cascade', () => {
+    Story.story(
+      update,
+      Story.with({ count: 0, log: [] }),
+      Story.message(ClickedFetch()),
+      Story.Command.resolveAll(
+        [FetchCount, SucceededFetchCount({ count: 1 })],
+        [FetchCount, SucceededFetchCount({ count: 2 })],
+      ),
+      Story.model(model => {
+        expect(model.log).toEqual([1])
+      }),
+      Story.message(ClickedFetch()),
+      Story.Command.resolveAll(),
+      Story.model(model => {
+        expect(model.log).toEqual([1, 2])
+      }),
+    )
+  })
 })
 
 describe('expectExactCommands', () => {
   test('passes when pending Commands match exactly', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetch()),
       Story.Command.expectExact(FetchCount),
       Story.Command.resolveAll([
@@ -149,7 +249,7 @@ describe('expectExactCommands', () => {
     expect(() =>
       Story.story(
         update,
-        Story.with({ count: 0 }),
+        Story.with({ count: 0, log: [] }),
         Story.message(ClickedFetch()),
         Story.Command.expectExact(FetchCount, SubmitForm),
         Story.Command.resolveAll([
@@ -164,7 +264,7 @@ describe('expectExactCommands', () => {
     expect(() =>
       Story.story(
         update,
-        Story.with({ count: 0 }),
+        Story.with({ count: 0, log: [] }),
         Story.message(ClickedFetch()),
         Story.Command.expectExact(),
         Story.Command.resolveAll([
@@ -180,7 +280,7 @@ describe('instance-strict Command matching', () => {
   test('expectHas with a Command instance matches by name AND args', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetchById({ id: 7 })),
       Story.Command.expectHas(FetchCountById({ id: 7 })),
       Story.Command.resolveAll([
@@ -194,7 +294,7 @@ describe('instance-strict Command matching', () => {
     expect(() =>
       Story.story(
         update,
-        Story.with({ count: 0 }),
+        Story.with({ count: 0, log: [] }),
         Story.message(ClickedFetchById({ id: 7 })),
         Story.Command.expectHas(FetchCountById({ id: 99 })),
         Story.Command.resolveAll([
@@ -208,7 +308,7 @@ describe('instance-strict Command matching', () => {
   test('expectExact with a Command instance asserts the exact args', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetchById({ id: 42 })),
       Story.Command.expectExact(FetchCountById({ id: 42 })),
       Story.Command.resolveAll([
@@ -222,7 +322,7 @@ describe('instance-strict Command matching', () => {
     expect(() =>
       Story.story(
         update,
-        Story.with({ count: 0 }),
+        Story.with({ count: 0, log: [] }),
         Story.message(ClickedFetchById({ id: 7 })),
         Story.Command.resolve(
           FetchCountById({ id: 99 }),
@@ -237,7 +337,7 @@ describe('instance-strict Command matching', () => {
   test('resolve with a Command instance feeds the result through update', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetchById({ id: 42 })),
       Story.Command.resolve(
         FetchCountById({ id: 42 }),
@@ -252,7 +352,7 @@ describe('instance-strict Command matching', () => {
   test('resolveAll keeps Instance matchers distinct across Messages', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetchById({ id: 1 })),
       Story.Command.resolveAll([
         FetchCountById({ id: 1 }),
@@ -272,7 +372,7 @@ describe('instance-strict Command matching', () => {
   test('mixed Definition and Instance matchers in resolveAll', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedFetchById({ id: 5 })),
       Story.Command.resolveAll([
         FetchCountById,
@@ -290,7 +390,7 @@ describe('story', () => {
     expect(() =>
       Story.story(
         update,
-        Story.with({ count: 0 }),
+        Story.with({ count: 0, log: [] }),
         Story.message(ClickedFetch()),
       ),
     ).toThrow('I found Commands without resolvers')
@@ -300,7 +400,7 @@ describe('story', () => {
     expect(() =>
       Story.story(
         update,
-        Story.with({ count: 0 }),
+        Story.with({ count: 0, log: [] }),
         Story.message(ClickedFetch()),
         Story.message(ClickedIncrement()),
       ),
@@ -310,7 +410,7 @@ describe('story', () => {
   test('succeeds with a Message that produces no Commands', () => {
     Story.story(
       update,
-      Story.with({ count: 0 }),
+      Story.with({ count: 0, log: [] }),
       Story.message(ClickedIncrement()),
       Story.model(model => {
         expect(model.count).toBe(1)
@@ -401,7 +501,7 @@ describe('resolveAll with toParentMessage', () => {
 
 describe('type safety', () => {
   test('with returns a WithStep', () => {
-    const step = Story.with({ count: 0 })
+    const step = Story.with({ count: 0, log: [] })
     expectTypeOf(step).toMatchTypeOf<Story.WithStep<{ count: number }>>()
   })
 

--- a/packages/foldkit/src/test/story.ts
+++ b/packages/foldkit/src/test/story.ts
@@ -198,7 +198,15 @@ const resolveCommand: {
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }
 
-/** Resolves all listed Commands with their result Messages. Handles cascading resolution. */
+/** Resolves listed Commands with their result Messages, cascading through any
+ *  Commands the result produces. A single entry for a Command Definition or
+ *  instance is sticky: it resolves every matching dispatch in the cascade with
+ *  the same Message. Two or more entries sharing a Definition or instance form
+ *  a queue: each is consumed by exactly one matching dispatch in declaration
+ *  order, so `[Def, m1], [Def, m2], [Def, m3]` reads as a sequence of three
+ *  responses. Resolvers carry across `resolveAll` calls: unused queue entries
+ *  can match later dispatches, and a new entry whose Definition or instance
+ *  shape matches an existing resolver replaces it (latest wins). */
 const resolveAllCommands =
   <R extends ReadonlyArray<unknown>>(
     ...resolvers: { [K in keyof R]: Resolver<R[K]> }
@@ -263,7 +271,12 @@ const expectNoCommandsStep =
 export const Command = {
   /** Resolves a specific pending Command with the given result Message. */
   resolve: resolveCommand,
-  /** Resolves all listed Commands with their result Messages. Handles cascading resolution. */
+  /** Resolves listed Commands with their result Messages, cascading through any
+   *  Commands the result produces. Single entries are sticky (reused for every
+   *  matching dispatch); repeated entries sharing a Definition or instance form
+   *  a queue (consumed in declaration order, one per dispatch). Resolvers
+   *  carry across calls; a new entry with the same Definition or instance
+   *  shape replaces an existing one (latest wins). */
   resolveAll: resolveAllCommands,
   /** Asserts that every given Command is among the pending Commands. */
   expectHas: expectHasCommandsStep,

--- a/packages/website/src/page/testingScene.ts
+++ b/packages/website/src/page/testingScene.ts
@@ -612,7 +612,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
           [
             [plainCode('Scene.Command.resolveAll([Def, ResultMessage], ...)')],
             [
-              'Resolves a batch of pending Commands in order, walking cascades.',
+              'Resolves a batch of pending Commands, walking cascades. A single entry per Definition or instance is sticky (reused for every matching dispatch); repeated entries sharing a Definition or instance form a queue (consumed in declaration order, one per dispatch).',
             ],
           ],
           [

--- a/packages/website/src/page/testingStory.ts
+++ b/packages/website/src/page/testingStory.ts
@@ -181,6 +181,16 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         ' is a scene check: \u201Cthe weather is showing.\u201D',
       ),
       infoCallout(
+        'Sticky vs queued resolvers',
+        'A single ',
+        inlineCode('[Def, ResultMessage]'),
+        ' entry in ',
+        inlineCode('resolveAll'),
+        ' is sticky: it resolves every matching dispatch in the cascade with the same Message. Pass two or more entries sharing the same Definition (or instance shape) to form a queue, where each entry is consumed by exactly one matching dispatch in declaration order. ',
+        inlineCode('[FetchCount, m1], [FetchCount, m2], [FetchCount, m3]'),
+        ' reads as three responses to three dispatches. Resolvers carry across calls: unused queue entries can match later dispatches, and a new entry with the same Definition or instance shape replaces any existing resolver (latest wins).',
+      ),
+      infoCallout(
         'Unresolved Commands',
         inlineCode('Story.message'),
         ' throws if there are pending Commands from a previous step. Resolve all Commands before sending the next Message. ',

--- a/packages/website/src/snippet/testingApi.ts
+++ b/packages/website/src/snippet/testingApi.ts
@@ -14,11 +14,13 @@ Story.Command.resolve(
   SucceededFetchWeather({ data }),
 )
 
-// Resolve many Commands at once.
-Story.Command.resolveAll([
+// Resolve many Commands at once. A single entry per Definition or instance
+// is sticky (reused for every matching dispatch); repeated entries sharing
+// a Definition or instance form a queue (consumed in declaration order).
+Story.Command.resolveAll(
   [FocusInput, CompletedFocusInput()],
   [ScrollToTop, CompletedScrollToTop()],
-])
+)
 
 // Assert on the Model.
 Story.model(model => {


### PR DESCRIPTION
## Summary

Fixed a bug in `Story.Command.resolveAll` where multiple resolver entries sharing the same command matcher (same `CommandDefinition` or instance fingerprint) would silently drop all but the first dispatch. Repeated entries within a single `resolveAll` call now form a queue that is consumed in declaration order.

## Key Changes

- **Model updates**: Added a `log` field to the test counter model to track resolved command results
- **New test messages**: Added `StartedThreeFetches`, `StartedThreeFetchesById`, and `StartedMixedFetches` messages to test various queueing scenarios
- **ResolverEntry type**: Added `isQueued` boolean flag to track whether an entry is part of a multi-entry queue or a single sticky resolver
- **Fingerprint tracking**: Modified `resolveAllInternal` to count how many entries share each matcher fingerprint and mark entries as queued when count > 1
- **Cascade logic**: Updated the cascade resolution loop to remove queued entries after they match (consuming them), while keeping single-entry resolvers sticky for reuse
- **Test coverage**: Added comprehensive tests covering:
  - Repeated Definition entries dispatching as a queue in order
  - Single-entry Definitions staying sticky across multiple matches
  - Repeated Instance entries queuing in order
  - Mixed queue and sticky fingerprints in the same call
  - Queue entries left over after a cascade being consumed by later cascades

## Implementation Details

The fix distinguishes between two resolver behaviors:
- **Queued resolvers**: When 2+ entries in a `resolveAll` call share a fingerprint, they form a queue. Each entry is consumed by exactly one matching dispatch in declaration order.
- **Sticky resolvers**: Single-entry resolvers are reused for every matching dispatch in the cascade.

The resolver index is now tracked during cascade resolution to enable removal of consumed queued entries while preserving sticky ones.

https://claude.ai/code/session_01TVMuRTFiAyXtJChhGoVb9t