### PR TITLE
fix(foldkit): prevent DevTools clicks from blurring app focus

### DIFF
--- a/.changeset/devtools-prevent-app-blur.md
+++ b/.changeset/devtools-prevent-app-blur.md
@@ -1,0 +1,7 @@
+---
+'foldkit': patch
+---
+
+Fix DevTools clicks triggering app focus/blur Messages. Clicking inside the DevTools panel previously caused the app's currently-focused element to blur, which would dispatch any blur-driven Messages the app had wired up (e.g. inputs that re-focus themselves on blur). In a typing-game-style app this made the message list unselectable: every click on a row immediately triggered a new blur Message, which was appended to history and auto-selected.
+
+The fix is two-part. First, a capture-phase `pointerdown` listener on the DevTools shadow host calls `preventDefault()` whenever focus lives outside the shadow, suppressing the implicit "click-shifts-focus-to-the-clicked-element" browser default for the common case (clicking message rows, buttons, etc.). Second, the `OnBlur` event handler in `html` filters out blur events whose `relatedTarget` is the DevTools shadow host, which closes the remaining leak when DevTools widgets (e.g. the submodel-filter Listbox) move focus into the panel programmatically via `Dom.focus` Commands. With both in place, DevTools interactions never dispatch app Messages.

--- a/packages/foldkit/src/devTools/overlay.ts
+++ b/packages/foldkit/src/devTools/overlay.ts
@@ -24,6 +24,7 @@ import * as Command from '../command/index.js'
 import { lockScroll, unlockScroll } from '../dom/scrollLock.js'
 import { OptionExt } from '../effectExtensions/index.js'
 import {
+  DEVTOOLS_HOST_ID,
   type Document,
   type Html,
   createKeyedLazy,
@@ -1894,8 +1895,6 @@ const makeView = (
 
 // CREATE
 
-const DEVTOOLS_HOST_ID = 'foldkit-devtools'
-
 const createShadowContainer = (): Readonly<{
   container: HTMLElement
   shadow: ShadowRoot
@@ -1907,6 +1906,20 @@ const createShadowContainer = (): Readonly<{
 
   const host = document.createElement('div')
   host.id = DEVTOOLS_HOST_ID
+  host.addEventListener(
+    'pointerdown',
+    event => {
+      const activeElement = document.activeElement
+      if (
+        activeElement !== null &&
+        activeElement !== host &&
+        activeElement !== document.body
+      ) {
+        event.preventDefault()
+      }
+    },
+    { capture: true },
+  )
   document.body.appendChild(host)
 
   const shadow = host.attachShadow({ mode: 'open' })

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -31,6 +31,15 @@ import {
 export { createKeyedLazy, createLazy } from './lazy.js'
 
 /**
+ * The `id` of the DOM element that hosts the Foldkit DevTools shadow root.
+ * Lives here (not in `devTools/`) because the `OnBlur` handler below uses it
+ * to suppress blur Messages whose `relatedTarget` is this host (i.e. when
+ * focus crosses into the DevTools UI). The DevTools overlay imports this
+ * constant when creating the host element, so the two stay in sync.
+ */
+export const DEVTOOLS_HOST_ID = 'foldkit-devtools'
+
+/**
  * Tag symbol attached to file-aware event handler functions so Scene test
  * helpers can distinguish `OnFileChange` from `OnChange` (both register on
  * the DOM `change` event) and `OnDropFiles` from `OnDrop` (both register on
@@ -1071,7 +1080,15 @@ const buildVNodeData = <Message>(
             }),
           OnBlur: ({ message }) =>
             updateDataOn({
-              blur: () => dispatchSync(message),
+              blur: (event: FocusEvent) => {
+                if (
+                  event.relatedTarget instanceof Element &&
+                  event.relatedTarget.id === DEVTOOLS_HOST_ID
+                ) {
+                  return
+                }
+                dispatchSync(message)
+              },
             }),
           OnInput: ({ f }) =>
             updateDataOn({

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -1400,7 +1400,7 @@ export const blur =
     simulation: SceneSimulation<Model, Message, OutMessage>,
   ): SceneSimulation<Model, Message, OutMessage> =>
     invokeAndCapture(simulation, target, 'blur', handler => {
-      handler()
+      handler({ relatedTarget: null })
     })
 
 /** Simulates a change event on the element matching the target.


### PR DESCRIPTION
Attach a capture-phase pointerdown listener on the DevTools shadow host
that calls preventDefault() when focus lives outside the shadow. Apps
that re-focus inputs on blur (the typing-game's username/room inputs do
this) would otherwise see every DevTools click emit a blur Message,
making the message list impossible to select since the latest entry was
always selected automatically.

The condition skips preventDefault when the active element is the host
itself (focus already inside the shadow, e.g. the submodel filter
listbox) or document.body, so DevTools' internal focus moves and
non-focused clicks continue to behave normally.