### PR TITLE
chore: bump effect to 4.0.0-beta.64 and use firstSuccessOf in oneOf

### DIFF
--- a/.changeset/effect-beta-64-upgrade.md
+++ b/.changeset/effect-beta-64-upgrade.md
@@ -1,0 +1,17 @@
+---
+'foldkit': patch
+'@foldkit/vite-plugin': patch
+'@foldkit/devtools-mcp': patch
+'create-foldkit-app': patch
+---
+
+Bump Effect to `4.0.0-beta.64` (from `4.0.0-beta.59`) across the workspace, and replace the hand-rolled fallback cascade in `route/parser.ts:oneOf` with `Effect.firstSuccessOf`, which was reintroduced in beta.61 ([effect-smol#2120](https://github.com/Effect-TS/effect-smol/pull/2120)).
+
+Consumers should align their `effect`, `@effect/platform-browser`, `@effect/platform-node`, and `@effect/vitest` pins to `4.0.0-beta.64`.
+
+```bash
+pnpm add effect@4.0.0-beta.64
+pnpm add -D @effect/platform-browser@4.0.0-beta.64 @effect/platform-node@4.0.0-beta.64 @effect/vitest@4.0.0-beta.64
+```
+
+Behavior is unchanged. The `oneOf` route parser still tries each parser in order and returns the first success (or the last failure if all fail).

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/crash-view/package.json
+++ b/examples/crash-view/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/form/package.json
+++ b/examples/form/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/job-application/package.json
+++ b/examples/job-application/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "fractional-indexing": "^3.2.0",
     "tailwindcss": "^4.1.18"

--- a/examples/map/package.json
+++ b/examples/map/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "maplibre-gl": "^5.0.0",
     "tailwindcss": "^4.1.18"

--- a/examples/pixel-art/package.json
+++ b/examples/pixel-art/package.json
@@ -10,10 +10,10 @@
     "bench": "vitest run --config vitest.bench.config.ts"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/query-sync/package.json
+++ b/examples/query-sync/package.json
@@ -8,10 +8,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/routing/package.json
+++ b/examples/routing/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/shopping-cart/package.json
+++ b/examples/shopping-cart/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/snake/package.json
+++ b/examples/snake/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/stopwatch/package.json
+++ b/examples/stopwatch/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/ui-showcase/package.json
+++ b/examples/ui-showcase/package.json
@@ -8,10 +8,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/weather/package.json
+++ b/examples/weather/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/examples/websocket-chat/package.json
+++ b/examples/websocket-chat/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@tailwindcss/vite": "^4.1.18",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.1.18"
   },

--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
-    "@effect/platform-node": "4.0.0-beta.59",
+    "@effect/platform-node": "4.0.0-beta.64",
     "@eslint/js": "^9.39.2",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/node": "^25.1.0",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "eslint": "^9.39.2",
     "madge": "^8.0.0",
     "prettier": "^3.8.1",
@@ -80,10 +80,10 @@
       "simple-git-hooks"
     ],
     "overrides": {
-      "effect": "4.0.0-beta.59",
-      "@effect/platform-browser": "4.0.0-beta.59",
-      "@effect/platform-node": "4.0.0-beta.59",
-      "@effect/vitest": "4.0.0-beta.59"
+      "effect": "4.0.0-beta.64",
+      "@effect/platform-browser": "4.0.0-beta.64",
+      "@effect/platform-node": "4.0.0-beta.64",
+      "@effect/vitest": "4.0.0-beta.64"
     }
   },
   "engines": {

--- a/packages/create-foldkit-app/package.json
+++ b/packages/create-foldkit-app/package.json
@@ -18,9 +18,9 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.59",
+    "@effect/platform-node": "4.0.0-beta.64",
     "chalk": "^5.6.2",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "rimraf": "^6.1.2",
     "typescript": "^6.0.2"
   },

--- a/packages/devtools-mcp/package.json
+++ b/packages/devtools-mcp/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc -b --noEmit"
   },
   "peerDependencies": {
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:^0"
   },
   "dependencies": {
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.13",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "rimraf": "^6.0.0",
     "typescript": "^6.0.2"

--- a/packages/foldkit/package.json
+++ b/packages/foldkit/package.json
@@ -205,13 +205,13 @@
     "docs": "typedoc"
   },
   "peerDependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
-    "effect": "4.0.0-beta.59"
+    "@effect/platform-browser": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.64"
   },
   "devDependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
-    "@effect/vitest": "4.0.0-beta.59",
-    "effect": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/vitest": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.64",
     "happy-dom": "^20.0.0",
     "typescript": "^6.0.2",
     "vitest": "^3.2.4"

--- a/packages/foldkit/src/route/parser.ts
+++ b/packages/foldkit/src/route/parser.ts
@@ -262,9 +262,9 @@ export const oneOf = <Parsers extends ReadonlyArray<ParserInput>>(
             message: `No parsers provided for path: /${Array.join(segments, '/')}`,
           }),
         ),
-      onNonEmpty: (head, tail) =>
-        Array.reduce(tail, head.parse(segments, search), (acc, parser) =>
-          acc.pipe(Effect.catch(() => parser.parse(segments, search))),
+      onNonEmpty: () =>
+        Effect.firstSuccessOf(
+          Array.map(parsers, parser => parser.parse(segments, search)),
         ),
     }),
 })

--- a/packages/vite-plugin-foldkit/package.json
+++ b/packages/vite-plugin-foldkit/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc -b --noEmit"
   },
   "peerDependencies": {
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:^0",
     "vite": "^7.0.0"
   },
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/ws": "^8.5.13",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "typescript": "^6.0.2",
     "vite": "^7.3.1"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -22,20 +22,20 @@
     "preview:search": "pnpm build && pnpm prerender && vite preview"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.64",
     "@stackblitz/sdk": "^1.11.0",
     "@tailwindcss/vite": "^4.1.18",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.64",
     "foldkit": "workspace:*",
     "shiki": "^3.22.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
-    "@effect/platform-node": "4.0.0-beta.59",
+    "@effect/platform-node": "4.0.0-beta.64",
     "@eslint/js": "^9.39.2",
     "@foldkit/vite-plugin": "workspace:*",
     "@playwright/test": "^1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  effect: 4.0.0-beta.59
-  '@effect/platform-browser': 4.0.0-beta.59
-  '@effect/platform-node': 4.0.0-beta.59
-  '@effect/vitest': 4.0.0-beta.59
+  effect: 4.0.0-beta.64
+  '@effect/platform-browser': 4.0.0-beta.64
+  '@effect/platform-node': 4.0.0-beta.64
+  '@effect/vitest': 4.0.0-beta.64
 
 importers:
 
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.29.8
         version: 2.29.8(@types/node@25.1.0)
       '@effect/platform-node':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
@@ -36,8 +36,8 @@ importers:
         specifier: ^8.58.2
         version: 8.59.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.3)
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -118,8 +118,8 @@ importers:
   examples/auth:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -127,8 +127,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -173,14 +173,14 @@ importers:
   examples/counter:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -219,14 +219,14 @@ importers:
   examples/crash-view:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -265,8 +265,8 @@ importers:
   examples/form:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -274,8 +274,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -320,8 +320,8 @@ importers:
   examples/job-application:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -329,8 +329,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -375,8 +375,8 @@ importers:
   examples/kanban:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -384,8 +384,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -433,14 +433,14 @@ importers:
   examples/map:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -488,8 +488,8 @@ importers:
   examples/pixel-art:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -497,8 +497,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -543,8 +543,8 @@ importers:
   examples/query-sync:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -552,8 +552,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -592,14 +592,14 @@ importers:
   examples/routing:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -638,14 +638,14 @@ importers:
   examples/shopping-cart:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -684,14 +684,14 @@ importers:
   examples/snake:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -730,14 +730,14 @@ importers:
   examples/stopwatch:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -776,14 +776,14 @@ importers:
   examples/todo:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -828,8 +828,8 @@ importers:
   examples/ui-showcase:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -837,8 +837,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -877,14 +877,14 @@ importers:
   examples/weather:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -929,14 +929,14 @@ importers:
   examples/websocket-chat:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -975,14 +975,14 @@ importers:
   internal/performance-harness:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -1003,14 +1003,14 @@ importers:
   packages/create-foldkit-app:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
@@ -1034,8 +1034,8 @@ importers:
         specifier: ^8.5.13
         version: 8.18.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../foldkit
@@ -1059,14 +1059,14 @@ importers:
         version: 3.6.3
     devDependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@effect/vitest':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)(vitest@3.2.4(@types/node@25.1.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(vitest@3.2.4(@types/node@25.1.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       happy-dom:
         specifier: ^20.0.0
         version: 20.9.0
@@ -1080,8 +1080,8 @@ importers:
   packages/typing-game/client:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -1092,8 +1092,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../../foldkit
@@ -1141,14 +1141,14 @@ importers:
   packages/typing-game/server:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
       '@typing-game/shared':
         specifier: workspace:*
         version: link:../shared
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.2
@@ -1178,8 +1178,8 @@ importers:
   packages/typing-game/shared:
     dependencies:
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
     devDependencies:
       typescript:
         specifier: ^6.0.2
@@ -1195,8 +1195,8 @@ importers:
         specifier: ^8.5.13
         version: 8.18.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../foldkit
@@ -1210,8 +1210,8 @@ importers:
   packages/website:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
       '@stackblitz/sdk':
         specifier: ^1.11.0
         version: 1.11.0
@@ -1228,8 +1228,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
       foldkit:
         specifier: workspace:*
         version: link:../foldkit
@@ -1244,8 +1244,8 @@ importers:
         version: 4.1.18
     devDependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.59
-        version: 4.0.0-beta.59(effect@4.0.0-beta.59)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
@@ -1502,28 +1502,28 @@ packages:
     resolution: {integrity: sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==}
     engines: {node: '>=18'}
 
-  '@effect/platform-browser@4.0.0-beta.59':
-    resolution: {integrity: sha512-P4OFrPwDFk2iTnlsS6nFk8fNk5kX4a2kCABGSAPFNJpBsA1yDbCGLgkKVS4lonB7b0YgR+lH85Qp9viSYrf2Hw==}
+  '@effect/platform-browser@4.0.0-beta.64':
+    resolution: {integrity: sha512-RTNOMeSxh2Gef1ola+DGsBm9MSEM2+TQLrbNDMLPuBa5ngFk5L5Kphqf8bDGaQh03oSoeojIJJdA+KqTLpF4Ow==}
     peerDependencies:
-      effect: 4.0.0-beta.59
+      effect: 4.0.0-beta.64
 
-  '@effect/platform-node-shared@4.0.0-beta.59':
-    resolution: {integrity: sha512-fGwFJuG0Te9U/ZeqeDZ2HcSKZBhX5wLjX2/Rxb5+yaOkvvFAN9MvIh05R0QQK5DCcERvnbhHSl1CjSIAN4aEwQ==}
+  '@effect/platform-node-shared@4.0.0-beta.65':
+    resolution: {integrity: sha512-3rY8F3WLEax6Hj08GI/OvDIH+KqjfxH7RM2bAMfgR75NgRmwDtny1P49PtPkoRjH5dcdtThThtsvE4X9OTZkpQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: 4.0.0-beta.59
+      effect: 4.0.0-beta.64
 
-  '@effect/platform-node@4.0.0-beta.59':
-    resolution: {integrity: sha512-jHRW0l953FjYNhQHexr48jFiBu5iGEZH5nmKD6Ha+lPtm1MrKG2V4njfWA3Fv0nUmd3VN87eBJ557wU0twN1Hg==}
+  '@effect/platform-node@4.0.0-beta.64':
+    resolution: {integrity: sha512-HlY04TBxe1Z2+Jl4dbwG5uHiUpEH6jvasoNtII6oergaHHQbbD8fLgFzHdy09mJTMK5B1O1fSb95Yztu5jwHxw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: 4.0.0-beta.59
+      effect: 4.0.0-beta.64
       ioredis: ^5.7.0
 
-  '@effect/vitest@4.0.0-beta.59':
-    resolution: {integrity: sha512-jhpJbpDs1ED58SmFzcfmqLXxle84fiexaMEhV8SBl8WC2GM3FT5DW0WJYFjbZIH5/735brp3iGdjY5/uAxS7Bg==}
+  '@effect/vitest@4.0.0-beta.64':
+    resolution: {integrity: sha512-BI+ju06iC6adB6evHSIz/HTppp9r8Kg1aaoOR6XVUgquLA9h3DJKmR7NWZLh8EXl5fIBI7VXDGpqJVr7MWBUug==}
     peerDependencies:
-      effect: 4.0.0-beta.59
+      effect: 4.0.0-beta.64
       vitest: ^3.0.0 || ^4.0.0
 
   '@esbuild/aix-ppc64@0.25.12':
@@ -3259,8 +3259,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-beta.59:
-    resolution: {integrity: sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA==}
+  effect@4.0.0-beta.64:
+    resolution: {integrity: sha512-xI332I9guVLsqvLg7aO62IuWq9LiCMs+u5dhr4JDyND2ndYXAk5eaR8KMqtYLoJg1Ie28VQToYPM+xBLEBU3pQ==}
 
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
@@ -5396,24 +5396,24 @@ snapshots:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
 
-  '@effect/platform-browser@4.0.0-beta.59(effect@4.0.0-beta.59)':
+  '@effect/platform-browser@4.0.0-beta.64(effect@4.0.0-beta.64)':
     dependencies:
-      effect: 4.0.0-beta.59
+      effect: 4.0.0-beta.64
       multipasta: 0.2.7
 
-  '@effect/platform-node-shared@4.0.0-beta.59(effect@4.0.0-beta.59)':
+  '@effect/platform-node-shared@4.0.0-beta.65(effect@4.0.0-beta.64)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.59
+      effect: 4.0.0-beta.64
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.59(effect@4.0.0-beta.59)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.59(effect@4.0.0-beta.59)
-      effect: 4.0.0-beta.59
+      '@effect/platform-node-shared': 4.0.0-beta.65(effect@4.0.0-beta.64)
+      effect: 4.0.0-beta.64
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.1.0
@@ -5421,9 +5421,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.59(effect@4.0.0-beta.59)(vitest@3.2.4(@types/node@25.1.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@effect/vitest@4.0.0-beta.64(effect@4.0.0-beta.64)(vitest@3.2.4(@types/node@25.1.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      effect: 4.0.0-beta.59
+      effect: 4.0.0-beta.64
       vitest: 3.2.4(@types/node@25.1.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@esbuild/aix-ppc64@0.25.12':
@@ -6936,7 +6936,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-beta.59:
+  effect@4.0.0-beta.64:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.7.0


### PR DESCRIPTION
## Summary

- Bump `effect`, `@effect/platform-browser`, `@effect/platform-node`, and `@effect/vitest` from `4.0.0-beta.59` to `4.0.0-beta.64` across the workspace.
- Replace the hand-rolled `Array.reduce` + `Effect.catch` cascade in `route/parser.ts:oneOf` with `Effect.firstSuccessOf`, which was reintroduced upstream in beta.61 ([effect-smol#2120](https://github.com/Effect-TS/effect-smol/pull/2120)). Behavior is unchanged: try parsers in order, return the first success or the last failure.

## Changelog scan beta.59 → beta.64

The only potentially breaking changes upstream were in beta.60: `Inspectable.stringifyCircular` was removed and `Formatter.formatJson` behavior changed. Neither is used in this codebase (the `toInspectableValue` in `devTools/serialize.ts` is local code, not the Effect module). Everything else .60 → .64 is additive (Rpc additions, HttpApi additions, Schema additions, fiber metric timing fix, K8s allowance, soft-delete columns).

## Test plan

- [x] `pnpm check` (build prereqs, typecheck, lint, effect-prebundle) passes
- [x] `pnpm test` passes across all packages and examples (1630 foldkit tests, all green)
- [x] Route parser tests (`packages/foldkit/src/route/parser.test.ts`, 31 tests) pass with the swapped implementation
- [ ] `pnpm --filter website test:e2e` skipped locally; Playwright chromium binary couldn't be downloaded in the sandbox. CI should run it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6D6u3uF4QQAiVQeEgH9Tq)_