### PR TITLE
fix(website): wait for paint before scrolling to URL hash anchor

### DIFF
--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -432,7 +432,7 @@ const init: Runtime.RoutingProgramInit<Model, Message, Flags, AppResources> = (
       ...mappedExampleDetailCommands,
       ...Option.match(url.hash, {
         onNone: () => [],
-        onSome: hash => [ScrollToAnchor({ hash, afterRender: true })],
+        onSome: hash => [ScrollToAnchor({ hash })],
       }),
     ],
   ]
@@ -563,7 +563,7 @@ const update = (
             ),
             ...Option.match(url.hash, {
               onNone: () => [ScrollToTop()],
-              onSome: hash => [ScrollToAnchor({ hash, afterRender: false })],
+              onSome: hash => [ScrollToAnchor({ hash })],
             }),
           ],
         ]
@@ -1171,13 +1171,11 @@ const focusAndScrollToHash = (hash: string): void => {
 
 const ScrollToAnchor = Command.define(
   'ScrollToAnchor',
-  { hash: S.String, afterRender: S.Boolean },
+  { hash: S.String },
   CompletedScrollToAnchor,
-)(({ hash, afterRender }) =>
+)(({ hash }) =>
   Effect.gen(function* () {
-    if (afterRender) {
-      yield* Render.afterPaint
-    }
+    yield* Render.afterPaint
     focusAndScrollToHash(hash)
     return CompletedScrollToAnchor()
   }),


### PR DESCRIPTION
Internal navigation to a URL with a hash like `/core/subscriptions#animation-frames`
fired the scroll before the new page rendered, so `getElementById` returned
null and the user landed at the page top. Direct loads worked because init
already waited for paint.

`ScrollToAnchor` now always waits for `Render.afterPaint`, and the now-redundant
`afterRender` parameter is removed.