### PR TITLE
feat(foldkit)!: stop devtools auto-scroll when user has scrolled away

### DIFF
--- a/.changeset/devtools-message-list-scroll.md
+++ b/.changeset/devtools-message-list-scroll.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+DevTools no longer auto-scrolls the message list back to the top when the user has manually scrolled away. A "Jump to top" pill appears at the top of the list when scrolled, and clicking it (or scrolling back to within 8px of the top) re-engages auto-scroll. Selection-follow ("Follow Latest") and scroll-follow are now independent: clicking a row stops selection-follow without affecting scroll, and the new pill controls scroll without affecting selection.
+
+**Breaking:** `h.OnScroll` now takes `(scrollTop: number) => Message` instead of a fixed `Message`, matching the `h.OnInput` / `h.OnChange` extractor pattern. Migration: `h.OnScroll(MyMessage())` becomes `h.OnScroll(() => MyMessage())`, or use the `scrollTop` argument to build a richer Message.

--- a/packages/foldkit/src/devTools/overlay.css
+++ b/packages/foldkit/src/devTools/overlay.css
@@ -231,6 +231,28 @@ ul {
 .dt-resume-button:hover {
   opacity: 0.7;
 }
+.dt-scroll-pill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 6px 12px;
+  background-color: var(--dt-surface-selected);
+  border: none;
+  border-bottom: 1px solid var(--dt-border);
+  color: var(--dt-accent);
+  font-family:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 13px;
+  cursor: pointer;
+}
+.dt-scroll-pill:hover {
+  background-color: var(--dt-tree-hover);
+}
+.dt-scroll-pill:focus-visible {
+  outline: 1px solid var(--dt-accent);
+  outline-offset: -1px;
+}
 .dt-filter-wrapper {
   position: relative;
   flex-shrink: 0;

--- a/packages/foldkit/src/devTools/overlay.ts
+++ b/packages/foldkit/src/devTools/overlay.ts
@@ -112,6 +112,7 @@ const Model = S.Struct({
   pausedAtIndex: S.Number,
   selectedIndex: S.Number,
   isFollowingLatest: S.Boolean,
+  isScrollFollowing: S.Boolean,
   maybeInspectedModel: S.Option(UnknownByReference),
   maybeInspectedMessage: S.Option(UnknownByReference),
   submodelTags: S.Array(S.String),
@@ -143,6 +144,8 @@ const ClickedClear = m('ClickedClear')
 const CompletedJump = m('CompletedJump')
 const CompletedResume = m('CompletedResume')
 const ClickedFollowLatest = m('ClickedFollowLatest')
+const ClickedScrollToTopPill = m('ClickedScrollToTopPill')
+const ScrolledMessageList = m('ScrolledMessageList', { scrollTop: S.Number })
 const CompletedClear = m('CompletedClear')
 const LockedScroll = m('LockedScroll')
 const UnlockedScroll = m('UnlockedScroll')
@@ -181,6 +184,8 @@ const Message = S.Union([
   ClickedResume,
   ClickedClear,
   ClickedFollowLatest,
+  ClickedScrollToTopPill,
+  ScrolledMessageList,
   CompletedJump,
   CompletedResume,
   CompletedClear,
@@ -216,6 +221,8 @@ const formatTimeDelta = (deltaMs: number): string =>
   )
 
 const MESSAGE_LIST_SELECTOR = '.message-list'
+
+const SCROLL_FOLLOW_THRESHOLD_PX = 8
 
 const computeSubmodelTags = (
   entries: ReadonlyArray<typeof DisplayEntry.Type>,
@@ -463,22 +470,24 @@ const makeUpdate = (
           ),
         ClickedResume: () => [
           evo(model, {
+            isScrollFollowing: () => true,
             expandedPaths: () => HashSet.empty<string>(),
             changedPaths: () => HashSet.empty<string>(),
             affectedPaths: () => HashSet.empty<string>(),
           }),
-          [resume, inspectLatest],
+          [resume, inspectLatest, scrollToTop],
         ],
         ClickedClear: () => [
           evo(model, {
             selectedIndex: () => INIT_INDEX,
             isFollowingLatest: () => true,
+            isScrollFollowing: () => true,
             maybeSubmodelFilter: () => Option.none(),
             expandedPaths: () => HashSet.empty<string>(),
             changedPaths: () => HashSet.empty<string>(),
             affectedPaths: () => HashSet.empty<string>(),
           }),
-          [clear, inspectLatest],
+          [clear, inspectLatest, scrollToTop],
         ],
         ClickedFollowLatest: () => {
           const latestIndex = Array_.match(model.entries, {
@@ -490,12 +499,25 @@ const makeUpdate = (
             evo(model, {
               selectedIndex: () => latestIndex,
               isFollowingLatest: () => true,
+              isScrollFollowing: () => true,
               expandedPaths: () => HashSet.empty<string>(),
               changedPaths: () => HashSet.empty<string>(),
               affectedPaths: () => HashSet.empty<string>(),
             }),
             [inspectLatest, scrollToTop],
           ]
+        },
+        ClickedScrollToTopPill: () => [
+          evo(model, {
+            isScrollFollowing: () => true,
+          }),
+          [scrollToTop],
+        ],
+        ScrolledMessageList: ({ scrollTop }) => {
+          const isAtTop = scrollTop <= SCROLL_FOLLOW_THRESHOLD_PX
+          return isAtTop === model.isScrollFollowing
+            ? [model, []]
+            : [evo(model, { isScrollFollowing: () => isAtTop }), []]
         },
         ReceivedInspectedState: ({
           model: inspectedModel,
@@ -548,9 +570,15 @@ const makeUpdate = (
           isPaused,
           pausedAtIndex,
         }) => {
-          const shouldFollowLatest = M.value(mode).pipe(
+          const shouldFollowSelection = M.value(mode).pipe(
             M.when('TimeTravel', () => !isPaused),
             M.when('Inspect', () => model.isFollowingLatest),
+            M.exhaustive,
+          )
+
+          const shouldFollowScroll = M.value(mode).pipe(
+            M.when('TimeTravel', () => !isPaused && model.isScrollFollowing),
+            M.when('Inspect', () => model.isScrollFollowing),
             M.exhaustive,
           )
 
@@ -583,9 +611,12 @@ const makeUpdate = (
                     })
                   : current,
               selectedIndex: current =>
-                shouldFollowLatest ? latestIndex : current,
+                shouldFollowSelection ? latestIndex : current,
             }),
-            shouldFollowLatest ? [scrollToTop, inspectLatest] : [],
+            [
+              ...(shouldFollowSelection ? [inspectLatest] : []),
+              ...(shouldFollowScroll ? [scrollToTop] : []),
+            ],
           ]
         },
         GotSubmodelFilterMessage: ({ message: listboxMessage }) => {
@@ -1523,6 +1554,11 @@ const makeView = (
   const filterItemLabel = (item: string): string =>
     String_.isNonEmpty(item) ? submodelLabel(item) : 'All Messages'
 
+  const scrollToTopPillView: Html = h.button(
+    [h.Class('dt-scroll-pill'), h.OnClick(ClickedScrollToTopPill())],
+    ['↑ Jump to top'],
+  )
+
   const submodelFilterView = (model: Model): Html => {
     const buttonLabel = Option.match(model.maybeSubmodelFilter, {
       onNone: () => 'All Messages',
@@ -1782,7 +1818,10 @@ const makeView = (
     )
 
     return h.ul(
-      [h.Class('message-list flex-1 overflow-y-auto min-h-0 overscroll-none')],
+      [
+        h.Class('message-list flex-1 overflow-y-auto min-h-0 overscroll-none'),
+        h.OnScroll(scrollTop => ScrolledMessageList({ scrollTop })),
+      ],
       isFiltered
         ? messageRows
         : [
@@ -1854,6 +1893,10 @@ const makeView = (
                   onEmpty: () => [],
                   onNonEmpty: () => [submodelFilterView(model)],
                 }),
+                ...OptionExt.when(
+                  !model.isScrollFollowing,
+                  scrollToTopPillView,
+                ).pipe(Option.toArray),
                 messageListView(model),
               ],
             ),
@@ -1948,6 +1991,7 @@ export const createOverlay = (
         ...flags,
         selectedIndex: INIT_INDEX,
         isFollowingLatest: true,
+        isScrollFollowing: true,
         submodelTags: computeSubmodelTags(flags.entries),
         maybeSubmodelFilter: Option.none(),
         submodelFilterListbox: Listbox.init({

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -426,7 +426,7 @@ export type Attribute<Message> = Data.TaggedEnum<{
   OnFileChange: { readonly f: (files: ReadonlyArray<File>) => Message }
   OnSubmit: { readonly message: Message }
   OnReset: { readonly message: Message }
-  OnScroll: { readonly message: Message }
+  OnScroll: { readonly f: (scrollTop: number) => Message }
   OnWheel: { readonly message: Message }
   OnCopy: { readonly message: Message }
   OnCut: { readonly message: Message }
@@ -1125,9 +1125,13 @@ const buildVNodeData = <Message>(
             updateDataOn({
               reset: () => dispatchSync(message),
             }),
-          OnScroll: ({ message }) =>
+          OnScroll: ({ f }) =>
             updateDataOn({
-              scroll: () => dispatchSync(message),
+              scroll: (event: Event) => {
+                /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+                const target = event.target as HTMLElement
+                dispatchSync(f(target.scrollTop))
+              },
             }),
           OnWheel: ({ message }) =>
             updateDataOn({
@@ -2321,9 +2325,9 @@ type HtmlAttributes<Message> = {
     readonly _tag: 'OnReset'
     readonly message: Message
   }
-  OnScroll: (message: Message) => {
+  OnScroll: (f: (scrollTop: number) => Message) => {
     readonly _tag: 'OnScroll'
-    readonly message: Message
+    readonly f: (scrollTop: number) => Message
   }
   OnWheel: (message: Message) => {
     readonly _tag: 'OnWheel'
@@ -3048,7 +3052,7 @@ const htmlAttributes = <Message>(): HtmlAttributes<Message> => ({
     OnFileChange({ f }),
   OnSubmit: (message: Message) => OnSubmit({ message }),
   OnReset: (message: Message) => OnReset({ message }),
-  OnScroll: (message: Message) => OnScroll({ message }),
+  OnScroll: (f: (scrollTop: number) => Message) => OnScroll({ f }),
   OnWheel: (message: Message) => OnWheel({ message }),
   OnCopy: (message: Message) => OnCopy({ message }),
   OnCut: (message: Message) => OnCut({ message }),


### PR DESCRIPTION
The devtools overlay used to snap the message list back to the top on every
new entry, which made high-frequency apps unusable. The user could not scroll
to read prior messages, and could not click a row to inspect it. Now the
overlay tracks scroll position and only auto-scrolls when the list is within
8px of the top. A "Jump to top" pill appears between the submodel filter and
the list when the user has scrolled away. Clicking the pill scrolls back to
top and re-engages auto-scroll.

Selection-follow ("Follow Latest") and scroll-follow are independent. Clicking
a row pauses selection-follow without freezing the list; manual scroll pauses
scroll-follow without affecting selection. Both flags reset to true on
Resume, Clear, and Follow Latest.

BREAKING CHANGE: h.OnScroll now takes (scrollTop: number) => Message instead
of a fixed Message, matching h.OnInput / h.OnChange. Migrate by wrapping the
existing message in an arrow: h.OnScroll(MyMessage()) becomes
h.OnScroll(() => MyMessage()).