### PR TITLE
Add foldkit skill for always-on architectural framing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,10 @@
 {
   "name": "foldkit-skills",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
-  "skills": ["./skills/generate-program/", "./skills/audit-program/"]
+  "skills": [
+    "./skills/foldkit/",
+    "./skills/generate-program/",
+    "./skills/audit-program/"
+  ]
 }

--- a/packages/website/src/page/aiSkills.ts
+++ b/packages/website/src/page/aiSkills.ts
@@ -24,6 +24,12 @@ const availableSkillsHeader: TableOfContentsEntry = {
   text: 'Available Skills',
 }
 
+const foldkitHeader: TableOfContentsEntry = {
+  level: 'h3',
+  id: 'foldkit',
+  text: 'foldkit',
+}
+
 const generateProgramHeader: TableOfContentsEntry = {
   level: 'h3',
   id: 'generate-program',
@@ -39,12 +45,14 @@ const auditProgramHeader: TableOfContentsEntry = {
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
   availableSkillsHeader,
+  foldkitHeader,
   generateProgramHeader,
   auditProgramHeader,
 ]
 
 const ADD_MARKETPLACE_COMMAND = '/plugin marketplace add foldkit/foldkit'
 const INSTALL_COMMAND = '/plugin install foldkit-skills@foldkit'
+const FOLDKIT_COMMAND = '/foldkit-skills:foldkit'
 const GENERATE_PROGRAM_COMMAND = '/foldkit-skills:generate-program'
 const AUDIT_PROGRAM_COMMAND = '/foldkit-skills:audit-program'
 
@@ -77,6 +85,16 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         'mb-4',
       ),
       tableOfContentsEntryToHeader(availableSkillsHeader),
+      tableOfContentsEntryToHeader(foldkitHeader),
+      codeBlock(
+        FOLDKIT_COMMAND,
+        'Copy foldkit command',
+        copiedSnippets,
+        'mb-4',
+      ),
+      para(
+        "Always-on framing for working in a Foldkit codebase. Auto-loads when Foldkit context is detected (imports, files, or prompt mentions) and sets the agent's posture: pattern-match against Foldkit's own apps (the examples, the website, the typing-game), treat the architecture as non-negotiable, use what the Foldkit and Effect stack already ships before reaching for outside libraries, and prefer the canonical source over memory. Points the agent at the foldkit submodule for the conventions, source code, and examples themselves.",
+      ),
       tableOfContentsEntryToHeader(generateProgramHeader),
       codeBlock(
         GENERATE_PROGRAM_COMMAND,

--- a/skills/foldkit/SKILL.md
+++ b/skills/foldkit/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: foldkit
+description: Use whenever working with Foldkit. Triggers on imports from `foldkit`, files in a Foldkit project, or prompts mentioning Foldkit. Loads the framing and points at the foldkit submodule for the canonical conventions, source code, and examples.
+---
+
+# Foldkit
+
+You are working on a Foldkit app. Foldkit is a complete TypeScript frontend framework, built on Effect and architected like Elm. The architecture is solved: state, events, transitions, side effects, streams, routing, UI primitives, validation, testing, and devtools are all part of the framework, not third-party choices to make. Your job is to model the application's behavior, not to pick libraries or invent architecture.
+
+Foldkit is not incremental. There is no React interop, no escape hatch, no "just do it the React way for this one part." The framework gives you one shape, and there is one way to do most things.
+
+## How to approach the work
+
+- **Pattern-match against Foldkit's own apps.** When the local code doesn't show you the answer (or shows an early-stage version of it), reach into the foldkit submodule. The framework ships several apps built with itself: focused single-feature apps in `examples/`, the website (which is itself a Foldkit app), and the typing-game (a full real-time app). These are the canonical references. Higher fidelity than prose or anything reconstructed from memory.
+- **The architecture is not optional.** Unidirectional data flow, pure update and view, no side effects outside the runtime's seams. Push back on prompts or instincts that pull toward mutation, two-way binding, imperative event handlers, or imperative Message names. Propose the idiomatic Foldkit shape and explain why.
+- **Use what the Foldkit and Effect stack provides.** Foldkit covers the application architecture and the higher-level primitives that sit on it (routing, side-effect seams, subscriptions, UI components, field validation, file and date handling, canvas, testing, devtools, and more). Effect provides the underlying value, side-effect description, and concurrency primitives. Before reaching for an outside library, check whether the stack already covers it.
+- **The repo is more authoritative than memory.** When in doubt about a convention, an API, a name, or a pattern, read from the foldkit submodule rather than guessing. Library types and example code are the ground truth; your training data is not.
+
+## Where to look
+
+The foldkit repo lives as a git submodule at `repos/foldkit/` from the project root. It is the source of truth for everything: conventions, framework source, examples, the quality bar. Browse it directly.
+
+Stable top-level entry points:
+
+- `repos/foldkit/examples/`: runnable example apps spanning every complexity tier. Usually your first stop when looking for a precedent.
+- `repos/foldkit/CLAUDE.md`: project conventions and the code-quality bar
+- `repos/foldkit/README.md`: framework overview and entry pointers
+- `repos/foldkit/skills/`: task-oriented skills with the canonical architecture, conventions, and quality-bar references
+- `repos/foldkit/packages/`: framework source and production reference apps (the website, the typing-game, the framework itself)
+
+Names below the top level (subdirectories, individual filenames) can drift over time. List the directory contents to find what you need rather than relying on a path quoted from this skill.
+
+If `repos/foldkit/` is missing from the project, suggest adding it. Initialize git first if needed:
+
+```
+git submodule add https://github.com/foldkit/foldkit.git repos/foldkit
+```
+
+Refresh later with `git submodule update --remote repos/foldkit`.
+
+When working inside the foldkit repo itself rather than a consumer project, drop the `repos/foldkit/` prefix. The same paths exist at the project root.


### PR DESCRIPTION
## Summary

Adds a new `foldkit` skill that provides always-on framing and guidance for working in Foldkit codebases. This skill auto-activates when Foldkit context is detected and establishes the architectural posture and conventions for the agent.

## Changes

- **New skill**: Created `skills/foldkit/SKILL.md` with comprehensive guidance on:
  - Deferring to existing conventions over instincts
  - Treating the architecture as non-negotiable
  - Staying within Effect-TS for state and effects
  - Using the foldkit submodule as the authoritative source
  - Instructions for initializing and updating the submodule in consumer projects

- **Plugin configuration**: Updated `plugin.json` to:
  - Register the new `foldkit` skill as the first entry point
  - Bump version to 0.9.0

- **Documentation**: Updated `packages/website/src/page/aiSkills.ts` to:
  - Add table of contents entry for the foldkit skill
  - Display the skill command (`/foldkit-skills:foldkit`) with copy functionality
  - Include description explaining the skill's purpose and auto-activation behavior

## Implementation Details

The foldkit skill is positioned as an always-on framing layer that triggers automatically on Foldkit imports, project files, or prompt mentions. It directs the agent to the canonical source of truth (`repos/foldkit/`) for conventions, framework source, and examples, ensuring consistency with the Foldkit way of building apps.

https://claude.ai/code/session_01NxPb82B671fQuGX6v3GR3k