### PR TITLE
refactor(foldkit): use Option.fromNullishOr for resources layer

### DIFF
--- a/.changeset/runtime-resources-option-from-nullish.md
+++ b/.changeset/runtime-resources-option-from-nullish.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Internal: replace a ternary that wrapped the optional `resources` Layer in `Option.some`/`Option.none` with `Option.fromNullishOr`, the idiomatic primitive for `T | undefined` → `Option<T>`.

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -596,9 +596,7 @@ const makeRuntime = <
             ),
           )
         }
-        const maybeResourceLayer = resources
-          ? Option.some(resources)
-          : Option.none()
+        const maybeResourceLayer = Option.fromNullishOr(resources)
 
         const managedResourceEntries: ReadonlyArray<
           [string, ManagedResourceConfig<Model, Message>]


### PR DESCRIPTION
The ternary around `resources` was a verbose way to spell a nullish
check on a `Layer | undefined`. `Option.fromNullishOr` is the
idiomatic Effect primitive for this boundary.