### PR TITLE
Remove outdated comments from comparison DSL snippets

### DIFF
--- a/packages/website/src/snippet/comparisonDslButton.ts
+++ b/packages/website/src/snippet/comparisonDslButton.ts
@@ -7,8 +7,6 @@ const ClickedSave = m('ClickedSave')
 const Message = S.Union([ClickedSave])
 type Message = typeof Message.Type
 
-// In a real app, only saveButton is per-view code. The Message and the h
-// binding sit once at the top of the module.
 const h = html<Message>()
 
 const saveButton = (isSaving: boolean) =>

--- a/packages/website/src/snippet/comparisonDslInput.ts
+++ b/packages/website/src/snippet/comparisonDslInput.ts
@@ -7,8 +7,6 @@ const InputtedEmail = m('InputtedEmail', { value: S.String })
 const Message = S.Union([InputtedEmail])
 type Message = typeof Message.Type
 
-// In a real app, only emailInput is per-view code. The Message and the h
-// binding sit once at the top of the module.
 const h = html<Message>()
 
 const emailInput = (email: string) =>


### PR DESCRIPTION
## Summary
Removed explanatory comments from the comparison DSL code snippets that were no longer accurate or necessary for understanding the examples.

## Changes
- Removed outdated comment from `comparisonDslButton.ts` that incorrectly suggested only `saveButton` is per-view code
- Removed matching outdated comment from `comparisonDslInput.ts` with the same inaccuracy

These comments were misleading about the module structure and have been removed to keep the snippets clean and focused on demonstrating the DSL pattern without confusing guidance.

https://claude.ai/code/session_012B2PkrQfvXxtSecASQDk6g