### PR TITLE
Migrate Task helpers to Dom module and update Effect service references

### DIFF
--- a/.changeset/scaffold-slim-agents-md.md
+++ b/.changeset/scaffold-slim-agents-md.md
@@ -1,0 +1,14 @@
+---
+'create-foldkit-app': patch
+---
+
+Slim the scaffolded `AGENTS.md` and point it at the live Foldkit code as the canonical reference.
+
+Two problems with the previous template:
+
+1. It was 215 lines and duplicated rules from the foldkit project's `CLAUDE.md` and the `foldkit-skills` plugin docs (a fourth source of truth). It also included Day-N material like the full Mount section that a freshly scaffolded project doesn't need on Day 1.
+2. It called `repos/foldkit/CLAUDE.md` the "canonical convention guide." That's wrong on two counts: `CLAUDE.md` is foldkit-repo-internal (has repo-specific scopes, file paths, dev rules) and isn't designed for consumer dev, and even within the foldkit repo, the live code (`examples/`, `packages/foldkit/src/`, the production apps) is more authoritative than any written summary.
+
+The new version focuses on the Day-1 bootstrap brief: framing, the subtree prompt, the critical idioms (`update`, `view`, `evo`, `Dom`, `html` factory, file split), the highest-frequency code-style rules, Message naming prefixes, and the DevTools pointer. It consistently treats the live Foldkit code as canonical. API-specific examples that drift on signature changes (e.g. the `Command.define` shape, which is curried and has already changed once) are replaced with prose plus pointers to the actual example files. Advanced patterns (Mount, ManagedResource, Submodels, OutMessage, Subscriptions, routing, accessibility) defer to the live code via a "Going Deeper" pointer.
+
+Existing scaffolded apps are unaffected. The change only affects new projects scaffolded with `create-foldkit-app`.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file contains preferences and conventions for Claude when working on this c
 ## Project Conventions
 
 - "Foldkit" is always capitalized in prose — in READMEs, docs, commit messages, comments, and conversation. The only exception is the npm package name (`foldkit`) and import paths (`from 'foldkit/html'`).
-- In prose (docs, comments, conversation), capitalize Foldkit architecture concepts that correspond to actual types or named patterns: Model, Message, Command, Subscription, Task, Submodel, OutMessage. Keep lowercase for concepts that are just functions with no corresponding type or pattern: view, update, init.
+- In prose (docs, comments, conversation), capitalize Foldkit architecture concepts that correspond to actual types or named patterns: Model, Message, Command, Subscription, Mount, ManagedResource, CustomElement, Submodel, OutMessage. Keep lowercase for concepts that are just functions with no corresponding type or pattern: view, update, init.
 - This is a Foldkit project — a framework built on Effect-TS. Always use Schema types (not plain TypeScript types), full names like `Message` (not `Msg`), and `withReturnType` (not `as const` or type casting). Follow the Submodels and OutMessage patterns used throughout the codebase.
 - Foldkit is tightly coupled to the Effect ecosystem. Do not suggest solutions outside of Effect-TS. The project already has a `create-foldkit-app` scaffolding tool — check existing features before suggesting new ones.
 - Push back on any suggested direction that violates Elm Architecture principles — unidirectional data flow, Messages as facts (not commands), Model as single source of truth, and side effects confined to Commands. If a user or prompt suggests a pattern that breaks these conventions (e.g. mutating state directly, imperative event handlers, two-way bindings), flag the issue and propose the idiomatic Foldkit approach instead.
@@ -17,11 +17,11 @@ Before writing code, read the exemplar files to internalize the level of care ex
 Library internals (when working in `packages/foldkit/src/`):
 
 - `packages/foldkit/src/runtime/runtime.ts` — orchestration, state management, error recovery
-- `packages/foldkit/src/parser.ts` — bidirectional combinators, type-safe composition
+- `packages/foldkit/src/route/parser.ts` — bidirectional combinators, type-safe composition
 
 Application architecture (when working in `packages/website/`, examples, or apps built with Foldkit):
 
-- `examples/typing-game/client/src/` — Submodels, OutMessage, update/Message patterns, view decomposition, Commands
+- `packages/typing-game/client/src/` — Submodels, OutMessage, update/Message patterns, view decomposition, Commands
 
 Match the quality and thoughtfulness of these files. The principles below apply broadly, but calibrate to the right context — library design when building Foldkit internals, application architecture when building with Foldkit:
 
@@ -201,7 +201,7 @@ Four lifecycle/binding primitives. Pick by **what causes the side effect**, not 
 - **`index.ts` is always a barrel; real code lives in a named file.** For a module `foo/`, the shape is `foo/foo.ts` for the code and `foo/index.ts` for the barrel. `index.ts` re-exports via `export * from './foo'` and nests child modules as namespaces via `export * as Child from './child'`. Never put implementation code in `index.ts`. This applies everywhere — domain modules (`domain/step.ts` + `domain/index.ts` re-exports), submodels with children (`step/education/education.ts` + `step/education/entry.ts` + `step/education/index.ts` barrel), nested UI components. Consumer imports read as `import { Education } from '../step'` → `Education.Model`, `Education.Entry.Model`. The hierarchy is visible in the file tree AND in the namespace.
 - Extract Messages to a dedicated `message.ts` file when Commands need Message constructors — this breaks the circular dependency between command.ts and main.ts. Export all schemas individually and as the `Message` union type.
 - **Expose a `boot()` helper alongside `init()` when a submodel applies a boot-time Message.** `init()` returns clean state with no boot effects (use it from tests, stories, and scenes that want to inspect state without triggering side effects). `boot()` calls `init()`, applies any boot-time Message via `update`, and returns the consolidated `[Model, Commands]` tuple. The parent's `init` calls `boot()` instead of inlining the init + update + concat dance. The benefit is that the state transition for "we just decided to start loading" goes through the same `update` handler whether it's triggered at boot, on a route change, or by a user action — one source of truth for the loading rules (NotAsked → Loading transition, dedupe via the state machine, DevTools message log entry). If the boot Message is conditional (e.g. only fire if the initial route matches), `boot()` takes the discriminator as an argument (typically `Option<T>`) and routes internally. Submodels with no boot-time Message just expose `init()` and skip `boot()`.
-- Use the `ViteEnvConfig` Context.Service pattern for environment variables in RPC layers (see `examples/typing-game/client/src/config.ts`). For values needed synchronously in views (e.g. photo URLs), keep a simple module-level `const` alongside the service.
+- Use the `ViteEnvConfig` Context.Service pattern for environment variables in RPC layers (see `packages/typing-game/client/src/config.ts`). For values needed synchronously in views (e.g. photo URLs), keep a simple module-level `const` alongside the service.
 - Extract repeated inline style values (colors, shadows) to constants. Use Tailwind `@theme` for colors that map to utility classes (e.g. `--color-valentine: #ff2d55` → `text-valentine`). Use a `theme.ts` for values Tailwind can't express as utilities (textShadow, boxShadow).
 
 ### Commits and Releases

--- a/packages/create-foldkit-app/templates/base/AGENTS.md
+++ b/packages/create-foldkit-app/templates/base/AGENTS.md
@@ -1,21 +1,33 @@
 # Agent Development Notes
 
-This is a Foldkit app — a framework built on Effect-TS.
+This is a Foldkit app, a framework built on Effect-TS, architected like Elm.
 
-If `./repos/foldkit` exists, it contains the full Foldkit repository, vendored in as a git subtree. The `examples/` directory and `packages/typing-game/client/src/` in particular are the best reference for what idiomatic Foldkit apps look like. Treat the subtree as read-only reference: never import from `repos/foldkit/` in your project source. Imports must come from the `foldkit` npm package.
+## Getting the canonical references
+
+The live Foldkit code is the canonical reference for everything: which APIs exist, what idiomatic apps look like, what the current conventions are. Written docs (including this one) can drift; the code can't.
+
+If `./repos/foldkit` exists, it contains the full Foldkit repository, vendored in as a git subtree. Read from it directly:
+
+- `repos/foldkit/examples/`: runnable example apps spanning every complexity tier. Usually your first stop when looking for a precedent for how to write something.
+- `repos/foldkit/packages/foldkit/src/`: framework source. Ground truth for API signatures.
+- `repos/foldkit/packages/typing-game/client/src/` and `repos/foldkit/packages/website/src/`: production apps built with Foldkit. Highest-fidelity reference for application architecture, Submodels, and OutMessage.
+
+Treat the subtree as read-only reference: never import from `repos/foldkit/` in your project source. Imports must come from the `foldkit` npm package.
 
 If `./repos/foldkit` does not exist and the line below says `subtree_prompted: false`, offer to run `git subtree add --prefix=repos/foldkit https://github.com/foldkit/foldkit.git main --squash`. This gives you access to the full source, examples, and docs. Whether the user accepts or declines, update the value to `true` so it isn't asked again.
 
 subtree_prompted: false
 
+If `foldkit-skills` is installed as a Claude Code plugin, the `generate-program` and `audit-program` skills carry snapshot architecture and conventions guides synced from the live code.
+
 ## Project Conventions
 
 - Foldkit is tightly coupled to the Effect ecosystem. Do not suggest solutions outside of Effect-TS.
-- Model fields must be Schema types (the model is a schema). Plain TypeScript types are fine elsewhere — function return types, local variables, etc.
+- Model fields must be Schema types (the model is a schema). Plain TypeScript types are fine elsewhere (function return types, local variables, etc.).
 - Use full names like `Message` (not `Msg`), and `withReturnType` (not `as const` or type casting).
-- Use `m()` for message schemas, `ts()` for other tagged structs (model states, field validation), and `r()` for route schemas.
-- Never use `NoOp` as a message. Every message must carry meaning about what happened. Fire-and-forget commands use `Completed*` messages with verb-first naming that mirrors the Command name: Command `LockScroll` → Message `CompletedLockScroll`, Command `ShowDialog` → Message `CompletedShowDialog`, Command `NavigateInternal` → Message `CompletedNavigateInternal`.
-- Push back on any suggested direction that violates Elm Architecture principles — unidirectional data flow, messages as facts (not commands), model as single source of truth, and side effects confined to commands. If a user or prompt suggests a pattern that breaks these conventions (e.g. mutating state directly, imperative event handlers, two-way bindings), flag the issue and propose the idiomatic Foldkit approach instead.
+- Use `m()` for message schemas, `ts()` for tagged structs (model states, field validation), and `r()` for route schemas.
+- Push back on any direction that violates Elm Architecture principles: unidirectional data flow, messages as facts (not commands), model as single source of truth, side effects confined to commands. If a prompt suggests mutating state, imperative event handlers, or two-way bindings, flag the issue and propose the idiomatic Foldkit approach.
+- Never use `NoOp`. Every message must describe what happened. Fire-and-forget commands use `Completed*` messages mirroring the Command name verb-first: `LockScroll` → `CompletedLockScroll`.
 
 ## Foldkit Patterns
 
@@ -36,180 +48,63 @@ const update = (model: Model, message: Message): UpdateReturn =>
   )
 ```
 
-### Model Updates with `evo`
-
-Use `evo()` for immutable model updates — never spread or Object.assign:
-
-```ts
-evo(model, { isSubmitting: () => true })
-evo(model, { count: count => count + 1 })
-```
-
-Don't add type annotations to `evo` callbacks when the type can be inferred.
+Use `evo()` from `foldkit/struct` for immutable model updates. Never spread or `Object.assign`.
 
 ### View
 
-Bind the `html` factory once per module by calling `html<Message>()`, then reach for `h.div`, `h.OnClick`, and the rest off the returned record. Each view module binds its own `h` against the Message type it dispatches:
+Bind the `html` factory once per module with `const h = html<Message>()`, then reach for `h.div`, `h.OnClick`, etc. off the returned record. Use `empty` (not `null`) for conditional rendering, `M.value().pipe(M.tagsExhaustive({...}))` for discriminated unions, and `Array.match` for lists that may be empty.
 
-```ts
-const h = html<Message>()
-
-export const view = (model: Model): Html =>
-  h.div(
-    [h.Class('flex flex-col gap-2')],
-    [
-      h.h1([], [`Hello, ${model.name}`]),
-      h.button([h.OnClick(ClickedRefresh())], ['Refresh']),
-    ],
-  )
-```
-
-For child views that should be agnostic to their parent, take `ParentMessage` as a function generic and bind `html<ParentMessage>()` inside. The view stays decoupled from any particular parent and composes through the `toParentMessage` callback the parent supplies.
-
-Use `empty` (not `null`) for conditional rendering. Use `M.value().pipe(M.tagsExhaustive({...}))` for rendering discriminated unions and `Array.match` for rendering lists that may be empty.
-
-Use `keyed` wrappers whenever the view branches into structurally different layouts based on route or model state. Without keying, the virtual DOM will try to diff one layout into another (e.g. a full-width landing page into a sidebar docs layout), which causes stale DOM, mismatched event handlers, and subtle rendering bugs. Key the outermost container of each layout branch with a stable string (e.g. `keyed('div')('landing', ...)` vs `keyed('div')('docs', ...)`). Within a single layout, key the content area on the route tag (e.g. `keyed('div')(model.route._tag, ...)`) so page transitions replace rather than patch.
+Use `keyed` wrappers whenever the view branches into structurally different layouts based on route or model state. Without keying, the virtual DOM tries to diff one layout into another, causing stale DOM and event handler mismatches.
 
 ### Commands
 
-Define Command identities with `Command.define`, passing the result Message schemas after the name — result types are required. Always assign definitions to PascalCase constants — never use `Command.define` inline in a pipe chain:
+Define a Command with `Command.define`, which is curried: the first call binds the name (and optionally args + result Message schemas), and the second call binds the Effect. Assign definitions to PascalCase constants. Never inline in pipe chains. Commands catch all errors via `Effect.catch(() => Effect.succeed(FailedX(...)))` so side effects never crash the app. Definitions live colocated with the update function that returns them.
 
-```ts
-const FetchWeather = Command.define(
-  'FetchWeather',
-  SucceededFetchWeather,
-  FailedFetchWeather,
-)
+For the with-args shape, see `repos/foldkit/examples/weather/src/main.ts` or `repos/foldkit/examples/kanban/src/command.ts`. For an argless DOM-side-effect Command, the argless form in `kanban/src/command.ts` (`FocusAddCardInput`) is the canonical reference.
 
-const fetchWeather = (city: string) =>
-  Effect.gen(function* () {
-    // ...
-    return SucceededFetchWeather({ data })
-  }).pipe(
-    Effect.catch(error =>
-      Effect.succeed(FailedFetchWeather({ error: String(error) })),
-    ),
-    FetchWeather,
-  )
-```
-
-Commands catch all errors and return Messages — side effects never crash the app. Let TypeScript infer Command return types from the Effect — the result Message schemas passed to `Command.define` constrain the Effect's return type at the type level.
-
-Command definitions live where they're produced — colocated with the update function that returns them. Don't centralize all definitions in one file.
-
-### Mount
-
-For per-element DOM work that needs the live `Element` handle (anchor positioning, portaling an overlay, attaching observers, handing the element to a third-party library), define a Mount with `Mount.define` and attach it to a view element with `OnMount`. The runtime runs the Effect when the element mounts, dispatches its result Message back through `update`, and runs the paired cleanup on unmount.
-
-```ts
-const CompletedPortalToBody = m('CompletedPortalToBody')
-
-const PortalToBody = Mount.define('PortalToBody', CompletedPortalToBody)
-
-const portalToBody = PortalToBody(element =>
-  Effect.sync(() => {
-    document.body.appendChild(element)
-    return {
-      message: CompletedPortalToBody(),
-      cleanup: () => element.remove(),
-    }
-  }),
-)
-
-// In view:
-div([Class('fixed inset-0 bg-black/50'), OnMount(portalToBody)])
-```
-
-Cleanup is data, paired with setup as a single value. For setup with no cleanup, pass `Function.constVoid`. The `Completed*` Message marks the lifecycle without forcing a meaningful response in update.
-
-Two rules for Mount, both must hold:
-
-1. **The Effect uses the element parameter.** Mount provides the live element handle, and that handle is what makes Mount distinct from Command. If your Effect doesn't read or write the element, pick a different primitive.
-2. **The work is DOM measurement or DOM manipulation on that element.** Read its geometry, mutate its CSS, attach an observer to it, portal it, hand it to a third-party library. Anything else (network, storage, focus-on-transition, scroll lock for the page) belongs in a Command returned from `update`.
-
-Mount Effects re-run during DevTools time-travel renders. The two rules above keep Mount work inherently replay-safe (read-only measurement, idempotent DOM mutation, paired observer attach + cleanup).
-
-Don't reach for Mount just because the work happens to coincide with an element appearing. Check what causes the work. If a Message just dispatched (like `Opened`), the cause is the Message, not the element. Use a Command returned from `update`'s handler instead. Example: focusing a search input when its dialog opens. The cause is `Opened`, not the input's existence; return a `FocusInput` Command from the `Opened` handler.
+For DOM operations (focus, scroll, modals, scroll lock), Foldkit ships a `Dom` module. For time, randomness, UUIDs, and delays, use Effect's built-ins directly (`Clock`, `Random`, `Effect.uuid`, `Effect.sleep`). Don't reach for raw `document.querySelector`, `setTimeout`, `Date.now()`, or `Math.random()`.
 
 ### File Organization
 
-A Foldkit app lives in two files. `src/main.ts` holds the pure definitions: Model, Messages, init, update, view. `src/entry.ts` imports them and boots the runtime with `Runtime.makeProgram` and `Runtime.run`. `index.html` references `entry.ts`. The split keeps `main.ts` importable from tests without booting a runtime as a side effect. Never call `Runtime.run` from `main.ts`.
+A Foldkit app lives in two files. `src/main.ts` holds the pure definitions (Model, Messages, init, update, view). `src/entry.ts` imports them and boots the runtime with `Runtime.makeProgram` and `Runtime.run`. `index.html` references `entry.ts`. The split keeps `main.ts` importable from tests without booting a runtime as a side effect. Never call `Runtime.run` from `main.ts`.
 
-Use uppercase section headers (`// MODEL`, `// MESSAGE`, `// INIT`, `// UPDATE`, `// COMMAND`, `// VIEW`) to make files easier to skim. These are for wayfinding — they make it clear where things live and where new code should go. Use domain-specific headers too when it helps (e.g. `// PHYSICS`, `// ROUTING`).
-
-Even after extracting some sections to their own files (e.g. `message.ts`), the remaining file may still benefit from headers. Extract to separate files when it helps with organization.
+Use uppercase section headers (`// MODEL`, `// MESSAGE`, `// INIT`, `// UPDATE`, `// COMMAND`, `// VIEW`) for wayfinding.
 
 ### Testing
 
-Test update functions with `foldkit/test`. Since update is pure — `(Model, Message) → [Model, Commands]` — tests run without a runtime, DOM, or side effects.
+Test update functions with `foldkit/test`. Since update is pure, tests run without a runtime, DOM, or side effects. Use `Story.story` for update-level tests (send Messages, assert on Model and Commands) and `Scene.scene` for feature-level testing through the view with accessible locators. If the `repos/foldkit` subtree is available, study the `.story.test.ts` and `.scene.test.ts` files in `repos/foldkit/examples/`.
 
-Use `Story.story` to chain steps into a readable narrative: set initial Model → send Message → assert → resolve Command → assert again. Use `Scene.scene` for feature-level testing through the view — clicking buttons, typing into inputs, pressing keys — with accessible locators (`Scene.role`, `Scene.label`, `Scene.placeholder`). Every `Command.define` must include result Message schemas so Commands can be resolved in tests.
+## Code Style
 
-If the `repos/foldkit` subtree is available, study the `.test.ts` files in `repos/foldkit/examples/` for patterns — they cover simple Command resolution, multi-step interactions, and Submodel OutMessage assertions.
+- Encode state in discriminated unions, not booleans or nullable fields. `Idle | Loading | Error | Ok`, not `isLoading: boolean`. Make impossible states unrepresentable.
+- Use `Option` instead of `null` or `undefined`. Prefix Option-typed values with `maybe*`. Match with `Option.match`; don't unwrap with `Option.map(...)` + `Option.getOrElse(...)` when you can just match.
+- Use Effect modules over native methods in `pipe` chains (`Array.map`, `String.startsWith`, `Array.findFirst`). Native methods are fine when calling directly on a named variable.
+- Never cast Schema values with `as Type`. Use the callable constructor: `SucceededLogin({ sessionId })`, not `{ _tag: 'SucceededLogin', sessionId } as Message`.
+- Always `Array.isEmptyArray` / `Array.isNonEmptyArray` (not `.length === 0`). Use `Array.match` when handling both empty and non-empty cases.
+- Never use `for` loops or `let` for iteration. Reach for `Array.map`, `Array.filterMap`, `Array.makeBy`, `Array.reduce`.
+- Never use `T[]`. Always `Array<T>` or `ReadonlyArray<T>`.
+- Always use `Effect.Match`, never `switch`.
+- Always use braces for control flow: `if (foo) { return true }`.
+- Don't add inline comments to explain code. Use better names instead. Reserve `// NOTE:` for behavior that would mislead a careful reader.
 
-## Debugging with Foldkit DevTools
+## Message Layout
 
-This project ships with `@foldkit/devtools-mcp` pre-wired. When the dev server is running and the app is open in a browser tab, `foldkit_*` MCP tools are available for inspecting Model, Message history, and time-travel. Reach for them before adding `console.log` whenever the question is about state or Message flow.
-
-If the `foldkit_*` tools aren't visible, see `@foldkit/devtools-mcp` on npm for setup.
-
-## Code Quality Standards
-
-- Every name should eliminate ambiguity. Prefix Option-typed values with `maybe` (e.g. `maybeSession`). Name functions by their precise effect (e.g. `enqueueMessage` not `addMessage`). A reader should never need to check a type signature to understand what a name refers to.
-- Each function should operate at a single abstraction level. Orchestrators delegate to focused helpers — they don't mix coordination with implementation. If a function reads like it's doing two things, extract one.
-- Encode state in discriminated unions, not booleans or nullable fields. Use `Idle | Loading | Error | Ok` instead of `isLoading: boolean`. Make impossible states unrepresentable.
-- Name messages as verb-first, past-tense events describing what happened (`SubmittedUsernameForm`, `CreatedRoom`, `PressedKey`), not imperative commands. The verb prefix acts as a category marker: `Clicked*` for button presses, `Updated*` for input changes, `Succeeded*`/`Failed*` for command results that can meaningfully fail (e.g. `SucceededFetchWeather`, `FailedFetchWeather`), `Completed*` for fire-and-forget command acknowledgments where the result is uninteresting and the update function is a no-op (e.g. `CompletedLockScroll`, `CompletedShowDialog`, `CompletedNavigateInternal`), `Got*` exclusively for receiving child module results via the OutMessage pattern (e.g. `GotProductsMessage`). Never use `NoOp` — every message must describe what happened. The update function decides what to do — messages are facts.
-- Use `Option` instead of `null` or `undefined`. Match explicitly with `Option.match` or chain with `Option.map`/`Option.flatMap`. No `if (x != null)` checks. Prefer `Option.match` over `Option.map` + `Option.getOrElse` — if you're unwrapping at the end, just match.
-- Prefer curried, data-last functions that compose in `pipe` chains.
-- Every line should serve a purpose. No dead code, no empty catch blocks, no placeholder types, no defensive code for impossible cases.
-
-## Code Style Conventions
-
-### Effect-TS Patterns
-
-- Prefer `pipe()` for multi-step data flow. Never use `pipe` with a single operation — call the function directly instead: `Option.match(value, {...})` not `pipe(value, Option.match({...}))`.
-- Use `Effect.gen()` for imperative-style async operations.
-- Always use Effect.Match instead of switch.
-- Prefer Effect module functions over native methods when available — e.g. `Array.map`, `Array.filter`, `Option.map`, `String.startsWith` from Effect instead of their native equivalents. This includes Effect's `String` module: use `String.includes`, `String.indexOf` (returns `Option<number>`), `String.slice`, `String.startsWith`, `String.replaceAll`, `String.length`, `String.isNonEmpty`, `String.trim` etc. in `pipe` chains. Exception: native `.map`, `.filter`, `.indexOf()`, `.slice()`, etc. are fine when calling directly on a named variable — use Effect's curried, data-last forms in `pipe` chains where they compose naturally.
-- Never use `for` loops or `let` for iteration. Use `Array.makeBy` for index-based construction, `Array.range` + `Array.findFirst`/`Array.findLast` for searches, and `Array.filterMap`/`Array.flatMap` for transforms.
-- Never cast Schema values with `as Type`. Use callable constructors: `LoginSucceeded({ sessionId })` not `{ _tag: 'LoginSucceeded', sessionId } as Message`.
-- Use `Option` for model fields that may be absent — not empty strings or zero values. `loginError: S.Option(S.String)` not `loginError: S.String` with `''` as the "none" state. Use `Option.match` in views to conditionally render.
-- Use `Array.take` instead of `.slice(0, n)`.
-- Always use `Array.isEmptyArray(foo)` instead of `foo.length === 0`. Use `Array.isNonEmptyArray(foo)` for non-empty checks. When handling both cases, prefer `Array.match`.
-
-### Message Layout
-
-Message definitions follow a strict layout:
+Group all `m()` declarations together with no blank lines between them, then put `S.Union([...])` and `type Message = typeof Message.Type` on adjacent lines:
 
 ```ts
 const ClickedSubmit = m('ClickedSubmit')
-const ChangedEmail = m('ChangedEmail', { value: S.String })
-const CompletedNavigateInternal = m('CompletedNavigateInternal')
+const UpdatedEmail = m('UpdatedEmail', { value: S.String })
 
-const Message = S.Union([
-  ClickedSubmit,
-  ChangedEmail,
-  CompletedNavigateInternal,
-])
+const Message = S.Union([ClickedSubmit, UpdatedEmail])
 type Message = typeof Message.Type
 ```
 
-1. **Values** — all `m()` declarations, no blank lines between them
-2. **Union + type** — `S.Union([...])` followed by `type Message = typeof Message.Type` on adjacent lines (no blank line between them)
+Messages are verb-first past-tense. Common prefixes: `Clicked*`, `Updated*` (input changes and external state updates), `Submitted*`, `Pressed*`, `Selected*`, `Succeeded*` / `Failed*` (paired async results), `Completed*` (fire-and-forget), `Got*` (child OutMessage in the Submodel pattern).
 
-Use `typeof ClickedSubmit` in type positions to reference a schema value's type.
+## Debugging
 
-### General Preferences
+This project ships with `@foldkit/devtools-mcp` pre-wired. When the dev server is running and the app is open in a browser, `foldkit_*` MCP tools let you inspect Model, Message history, and time-travel. Reach for them before adding `console.log` whenever the question is about state or Message flow.
 
-- Never abbreviate names. Use full, descriptive names everywhere — variables, types, functions, parameters, including callback parameters. e.g. `signature` not `sig`, `Message` not `Msg`, `(tickCount) => tickCount + 1` not `(t) => t + 1`.
-- Don't suffix Command variables with `Command`. Name them by what they do: `focusButton` not `focusButtonCommand`, `scrollToItem` not `scrollToItemCommand`. The type already communicates that it's a Command. Command definitions are PascalCase (`FocusButton`, `ScrollToItem`); Command instances and factory functions are camelCase (`focusButton`, `scrollToItem`).
-- Avoid `let`. Use `const` and prefer immutable patterns.
-- Always use braces for control flow. `if (foo) { return true }` not `if (foo) return true`.
-- Use `is*` for boolean naming e.g. `isPlaying`, `isValid`.
-- Don't add inline or block comments to explain code. If code needs explanation, refactor for clarity or use better names. Exceptions: section headers (see File Organization above), TSDoc (`/** ... */`) on public exports, and `// NOTE:` comments. Reserve `// NOTE:` for behavior that would mislead a careful reader into breaking things: a timing dependency that's silent if violated, a workaround for an upstream bug, a browser quirk that costs real debugging time to rediscover. The bar is high. When in doubt, delete it.
-- Use capitalized string literals for Schema literal types: `S.Literals(['Horizontal', 'Vertical'])` not `S.Literals(['horizontal', 'vertical'])`.
-- Capitalize namespace imports: `import * as Command from './command'` not `import * as command from './command'`.
-- Extract magic numbers to named constants. No raw numeric literals in logic.
-- Never use `T[]` syntax. Always use `Array<T>` or `ReadonlyArray<T>`.
-- For inline object types in `ReadonlyArray`, put `Readonly<{...}>` on the element type rather than `ReadonlyArray<{ readonly a: ...; readonly b: ... }>`. e.g. `ReadonlyArray<Readonly<{ model: Foo; toParentMessage: (m: Bar) => Baz }>>` not `ReadonlyArray<{ readonly model: Foo; readonly toParentMessage: ... }>`.
-- Extract repeated inline style values (colors, shadows) to constants. Use Tailwind `@theme` for colors that map to utility classes (e.g. `--color-valentine: #ff2d55` → `text-valentine`). Use a `theme.ts` for values Tailwind can't express as utilities (textShadow, boxShadow).
+## Going Deeper
+
+For Submodels and OutMessage, Subscriptions, Mount / ManagedResource / CustomElement, field validation, routing, accessibility, and the full convention set, read the live Foldkit code in `repos/foldkit/`. The `examples/` directory and the production apps (`packages/typing-game/`, `packages/website/`) are the highest-fidelity references for any specific pattern. The `foldkit-skills` plugin's `generate-program` and `audit-program` skills carry written snapshot guides if you want a structured walkthrough.

--- a/skills/audit-program/SKILL.md
+++ b/skills/audit-program/SKILL.md
@@ -6,6 +6,8 @@ argument-hint: '[optional: path or focus area like a11y/effects/naming/decomposi
 
 Audit an existing Foldkit program against the same bar `generate-program` targets: this code should be **indistinguishable in quality from hand-written code in `packages/typing-game/client/src/` or `packages/website/src/`**. Not "works." Not "structurally valid." Typing-game quality.
 
+> **Recommended setup:** the audit is dramatically higher fidelity when `repos/foldkit/` is vendored as a git subtree in the audited project. Without it, you grade against the snapshots in `generate-program/architecture.md` and `conventions.md`. With it, you grade against the live exemplars (`examples/`, `packages/typing-game/`, `packages/website/`), which is what those snapshots are summarizing in the first place. If the subtree is missing, recommend adding it with `git subtree add --prefix=repos/foldkit https://github.com/foldkit/foldkit.git main --squash` before the audit begins.
+
 ## Operating principle: report first, change nothing without consent
 
 The audit is **read-only through Phase 6**. The output is a structured report. **Never edit a file before the user has seen the report and explicitly approved fixes**, no matter how unambiguous a finding seems, no matter how trivial the change, no matter how confident you are. Phase 7 (Offer fixes) is opt-in and gated on user consent per item or per batch.
@@ -59,7 +61,7 @@ Before deep review, build a model of the audited code:
    - **Tier 5**: nested domain, CRUD
    - **Tier 6**: Submodels, OutMessage, multi-step flows
    - **Tier 7**: real-time, WebSocket, ManagedResources
-3. **Foldkit modules used**. Grep imports for `Calendar`, `File`, `fieldValidation`, `Ui.*`, `Subscription`, `Command`, `Task`, `HttpClient`, etc. Tells you which checklist sections apply.
+3. **Foldkit modules used**. Grep imports for `Calendar`, `File`, `FieldValidation`, `Ui.*`, `Subscription`, `Command`, `Mount`, `ManagedResource`, `CustomElement`, `Dom`, `HttpClient`, etc. Tells you which checklist sections apply.
 4. **Tier-matching exemplar**. Pick at least one to read alongside the audited code:
    - Tier 1-2 → `${CLAUDE_SKILL_DIR}/../../examples/counter/src/main.ts`, `${CLAUDE_SKILL_DIR}/../../examples/stopwatch/src/main.ts`
    - Tier 3 → `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.ts`, `${CLAUDE_SKILL_DIR}/../../examples/form/src/main.ts`
@@ -93,7 +95,7 @@ For non-trivial audits, parallelize. Spawn subagents in a single message so they
 
 Use `Agent` with `subagent_type: general-purpose`. Suggested fan-out:
 
-- **Subagent A (Structural correctness)**. Model schema completeness, Message union coverage, `M.tagsExhaustive` exhaustiveness, every `Succeeded*` paired with `Failed*`, every Command identity defined as a PascalCase constant via `Command.define`, every route variant rendered, no dead state variants. Native web components bound via `CustomElement.define`, not via `OnMount` + Subscription + tag-name registry — flag any custom element wired through `OnMount` when its surface is just typed properties + observed attributes + dispatched `CustomEvent`s.
+- **Subagent A (Structural correctness)**. Model schema completeness, Message union coverage, `M.tagsExhaustive` exhaustiveness, every `Succeeded*` paired with `Failed*`, every Command identity defined as a PascalCase constant via `Command.define`, every route variant rendered, no dead state variants. Native web components bound via `CustomElement.define`, not via `OnMount` + Subscription + tag-name registry. Flag any custom element wired through `OnMount` when its surface is just typed properties + observed attributes + dispatched `CustomEvent`s.
 - **Subagent B (Effect-TS idioms)**. `pipe` only for multi-step (no single-op pipes), `Option.match` over `Option.map(...).pipe(Option.getOrElse(...))`, `Array.match` for empty/non-empty branching, `Array.isEmptyArray` over `.length === 0`, `evo` over spread, callable constructors over `as Type`, `Array.fromOption` for "zero or one Command", `Equal.equals` in predicates, no `Effect.ignore` on infallible Effects.
 - **Subagent C (Naming and decomposition)**. `maybe*` reserved for `Option<T>`, `nullable*` for `T | undefined`, `is*` for booleans, no abbreviations, `Updated*` not `Changed*`, `Completed*` mirrors Command name verb-first, named helpers use specific verbs not generic ones, handlers over ~15 lines extracted, view branches over ~30 lines extracted, no function exceeds ~40 lines.
 - **Subagent D (Foldkit UI and accessibility)**. Hand-rolled `input` / `textarea` / `button` / `dialog` flagged unless NOTE-justified, label/input pairing via `For(id)` + `Id(id)`, dynamic errors announce via `Role('alert')` or `AriaLive('polite')`, icon-only buttons have `AriaLabel`, external links carry `Rel('noopener noreferrer')`, exactly one `h1` per route, semantic landmarks (`main`, `nav`, `header`, `footer`) over `div` soup, focus visibility preserved (no `outline-none` without `focus-visible:` replacement).

--- a/skills/foldkit/SKILL.md
+++ b/skills/foldkit/SKILL.md
@@ -30,7 +30,7 @@ Stable top-level entry points:
 
 Names below the top level (subdirectories, individual filenames) can drift over time. List the directory contents to find what you need rather than relying on a path quoted from this skill.
 
-If `repos/foldkit/` is missing from the project, suggest adding it. Initialize git first if needed (subtree requires at least one commit):
+If `repos/foldkit/` is missing from the project, strongly recommend adding it. The subtree is the difference between working from memory and pattern-matching against canonical references. Assistance quality drops noticeably without it. Initialize git first if needed (subtree requires at least one commit):
 
 ```
 git subtree add --prefix=repos/foldkit https://github.com/foldkit/foldkit.git main --squash

--- a/skills/generate-program/SKILL.md
+++ b/skills/generate-program/SKILL.md
@@ -12,33 +12,33 @@ Generate a complete Foldkit program based on this description:
 
 Before writing any code, analyze the description to identify:
 
-1. **Domain entities** — nouns that become Model fields (e.g., "todos", "user", "score")
-2. **User interactions** — verbs that become Messages (e.g., "add", "delete", "filter", "submit")
-3. **Async operations** — external data that becomes Commands (e.g., "fetch weather", "save to localStorage")
-4. **Real-time needs** — streaming data that becomes Subscriptions (e.g., "live updates", "countdown", "WebSocket")
-5. **Pages/navigation** — URL structure that becomes routes (e.g., "home page", "detail page")
-6. **UI component needs** — interactive widgets that map to Foldkit UI components (e.g., "dropdown" → Menu, "modal" → Dialog, "tabs" → Tabs, "autocomplete" → Combobox, "date picker" → DatePicker, "file upload" → FileDrop, "reorderable list" → DragAndDrop, "toast/notification" → Toast, "hover tooltip" → Tooltip)
-7. **Form validation needs** — required fields, format checks, async uniqueness → `foldkit/fieldValidation` module (see Phase 4)
-8. **Date handling** — birthdays, deadlines, scheduling → `Calendar` module + `Ui.DatePicker` or `Ui.Calendar`
-9. **File handling** — uploads, attachments, images → `File` module + `Ui.FileDrop`
+1. **Domain entities**: nouns that become Model fields (e.g., "todos", "user", "score")
+2. **User interactions**: verbs that become Messages (e.g., "add", "delete", "filter", "submit")
+3. **Async operations**: external data that becomes Commands (e.g., "fetch weather", "save to localStorage")
+4. **Real-time needs**: streaming data that becomes Subscriptions (e.g., "live updates", "countdown", "WebSocket")
+5. **Pages/navigation**: URL structure that becomes routes (e.g., "home page", "detail page")
+6. **UI component needs**: interactive widgets that map to Foldkit UI components (e.g., "dropdown" → Menu, "modal" → Dialog, "tabs" → Tabs, "autocomplete" → Combobox, "date picker" → DatePicker, "file upload" → FileDrop, "reorderable list" → DragAndDrop, "toast/notification" → Toast, "hover tooltip" → Tooltip)
+7. **Form validation needs**: required fields, format checks, async uniqueness → `foldkit/fieldValidation` module (see Phase 4)
+8. **Date handling**: birthdays, deadlines, scheduling → `Calendar` module + `Ui.DatePicker` or `Ui.Calendar`
+9. **File handling**: uploads, attachments, images → `File` module + `Ui.FileDrop`
 
 Present this analysis to the user before proceeding.
 
-If the description is detailed and unambiguous, summarize the analysis and confirm before moving on. But if there are gaps — unclear state transitions, vague UI requirements, unspecified error handling, missing edge cases, ambiguous domain boundaries, unclear counter/reset semantics — ask targeted clarifying questions before proceeding. Don't ask open-ended questions like "anything else?" — ask specific questions about the gaps you found.
+If the description is detailed and unambiguous, summarize the analysis and confirm before moving on. But if there are gaps (unclear state transitions, vague UI requirements, unspecified error handling, missing edge cases, ambiguous domain boundaries, unclear counter/reset semantics), ask targeted clarifying questions before proceeding. Don't ask open-ended questions like "anything else?". Ask specific questions about the gaps you found.
 
 **UX/behavior gaps:**
 
 - "Should the todo list persist across page reloads (localStorage), or start fresh each session?"
 - "When the API call fails, should the app show an inline error or a dialog?"
-- "You mentioned 'users can edit items' — is that inline editing or a separate edit page?"
+- "You mentioned 'users can edit items'. Is that inline editing or a separate edit page?"
 
-**Domain-logic gaps — easy to miss, expensive to fix:**
+**Domain-logic gaps (easy to miss, expensive to fix):**
 
 - "When the user skips an interval, does that count as 'completed' for purposes of the streak?"
 - "Does a counter that tracks 'completed' increments on successful actions only, or on skipped actions too?"
 - "If the user triggers a reset mid-flow, does the counter reset with it, or persist across resets?"
-- "You mentioned 'after N events, trigger X' — is that N events total, or N events since the last X?"
-- "On the Nth action in a cycle, which action does it trigger — the cycle's first or last?"
+- "You mentioned 'after N events, trigger X'. Is that N events total, or N events since the last X?"
+- "On the Nth action in a cycle, which action does it trigger, the cycle's first or last?"
 
 Domain-logic questions often surface off-by-one bugs before they hit the code. If the description has any counter, cycle, streak, or "after N" phrase, ask about edge cases at 0 and 1 and N specifically.
 
@@ -48,44 +48,44 @@ The goal is to resolve ambiguity early so the generated code matches what the us
 
 Read the architecture and conventions guides to internalize the rules:
 
-- [Architecture guide](architecture.md) — TEA structure, file organization, type patterns
-- [Conventions guide](conventions.md) — naming, Effect-TS patterns, anti-patterns
-- [Verification checklist](checklist.md) — not just for Phase 5, also the generation bar. Skim the **Quality Bar** section now so you generate code that already meets it rather than code that will fail review.
+- [Architecture guide](architecture.md): TEA structure, file organization, type patterns
+- [Conventions guide](conventions.md): naming, Effect-TS patterns, anti-patterns
+- [Verification checklist](checklist.md): not just for Phase 5, also the generation bar. Skim the **Quality Bar** section now so you generate code that already meets it rather than code that will fail review.
 
-If you have access to a context7 MCP tool, use it to look up Effect-TS documentation when you're unsure about an API. Effect is a large library — verify function signatures rather than guessing.
+If you have access to a context7 MCP tool, use it to look up Effect-TS documentation when you're unsure about an API. Effect is a large library. Verify function signatures rather than guessing.
 
 ### Quality exemplars
 
-Two codebases are the _quality bar_ for generated apps — not just "patterns to copy" but "the level of craft to match":
+Two codebases are the _quality bar_ for generated apps. Not just "patterns to copy" but "the level of craft to match":
 
-- `${CLAUDE_SKILL_DIR}/../../packages/typing-game/client/src/` — production multi-page app: Submodels, OutMessage, update/view decomposition, curried handler extraction, subscription patterns, domain modules.
-- `${CLAUDE_SKILL_DIR}/../../packages/website/src/` — production Foldkit website: page organization, shared view primitives, route-driven rendering, idiomatic domain separation.
+- `${CLAUDE_SKILL_DIR}/../../packages/typing-game/client/src/`: production multi-page app: Submodels, OutMessage, update/view decomposition, curried handler extraction, subscription patterns, domain modules.
+- `${CLAUDE_SKILL_DIR}/../../packages/website/src/`: production Foldkit website: page organization, shared view primitives, route-driven rendering, idiomatic domain separation.
 
-Before generating, spot-check at least ONE file from each — the shape of `update.ts` / how handlers get extracted / how domain files are structured — and match that level of craft in your output. The generated code should be indistinguishable from hand-written exemplar code.
+Before generating, spot-check at least ONE file from each (the shape of `update.ts` / how handlers get extracted / how domain files are structured) and match that level of craft in your output. The generated code should be indistinguishable from hand-written exemplar code.
 
-Then read the tier-specific example files that match the app's complexity. **Always read at least one tier-specific example** — never generate from memory alone.
+Then read the tier-specific example files that match the app's complexity. **Always read at least one tier-specific example.** Never generate from memory alone.
 
 ### Complexity tiers
 
-**Tier 1 — Single page, no async, minimal state:**
+**Tier 1: Single page, no async, minimal state:**
 Read `${CLAUDE_SKILL_DIR}/../../examples/counter/src/main.ts`
 
-**Tier 2 — Timers, subscriptions, simple stateful apps:**
+**Tier 2: Timers, subscriptions, simple stateful apps:**
 Read `${CLAUDE_SKILL_DIR}/../../examples/stopwatch/src/main.ts` (timer via subscription, `Duration` field pattern) and `${CLAUDE_SKILL_DIR}/../../examples/todo/src/main.ts` (CRUD with localStorage via flags)
 
-**Tier 3 — Async operations, loading/error states, API calls, form validation:**
-Read `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.ts` (HTTP with `HttpClient`) and `${CLAUDE_SKILL_DIR}/../../examples/form/src/main.ts` (uses `foldkit/fieldValidation` — see the Form Validation section in Phase 4)
+**Tier 3: Async operations, loading/error states, API calls, form validation:**
+Read `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.ts` (HTTP with `HttpClient`) and `${CLAUDE_SKILL_DIR}/../../examples/form/src/main.ts` (uses `foldkit/fieldValidation`; see the Form Validation section in Phase 4)
 
-**Tier 4 — URL routing, multiple pages, query parameters:**
+**Tier 4: URL routing, multiple pages, query parameters:**
 Read `${CLAUDE_SKILL_DIR}/../../examples/routing/src/main.ts` and `${CLAUDE_SKILL_DIR}/../../examples/query-sync/src/main.ts`
 
-**Tier 5 — Complex state, nested domain models, CRUD, drag-and-drop:**
+**Tier 5: Complex state, nested domain models, CRUD, drag-and-drop:**
 Read `${CLAUDE_SKILL_DIR}/../../examples/shopping-cart/src/main.ts` (nested domain schemas, cart state) and `${CLAUDE_SKILL_DIR}/../../examples/kanban/src/main.ts` (CRUD with `Ui.DragAndDrop`, flags restoring from localStorage, subscriptions)
 
-**Tier 6 — Submodels, OutMessage, multi-step forms, auth flows, multi-module apps:**
+**Tier 6: Submodels, OutMessage, multi-step forms, auth flows, multi-module apps:**
 Read `${CLAUDE_SKILL_DIR}/../../examples/auth/src/main.ts` (login/signup with Submodels, OutMessage, protected routes) and `${CLAUDE_SKILL_DIR}/../../examples/job-application/src/main.ts` (multi-step form with deeply nested Submodels in `step/`, `Ui.DatePicker`, `Ui.FileDrop`, `Ui.Menu`, `Calendar` module for date handling)
 
-**Tier 7 — Real-time, WebSocket, managed resources, production-grade:**
+**Tier 7: Real-time, WebSocket, managed resources, production-grade:**
 Read `${CLAUDE_SKILL_DIR}/../../packages/typing-game/client/src/update.ts`, then explore its `page/home/` and `page/room/` directories for the full Submodel/OutMessage pattern.
 
 Read examples from the target tier AND all lower tiers. A Tier 4 app should reflect patterns from Tiers 1-3 as well.
@@ -128,28 +128,28 @@ Each component is a Foldkit Submodel with its own Model, Message, init, update, 
 
 **Always prefer Foldkit UI components over hand-rolling interactive widgets.** They make accessibility the default, not an afterthought.
 
-**For form inputs specifically:** every text input, textarea, and button in a form MUST use `Ui.Input`, `Ui.Textarea`, and `Ui.Button` respectively — this is not optional, even though raw `input`/`textarea` HTML elements are available from `html<Message>()`. The form example (`examples/form/src/main.ts:347-403`) defines `inputFieldView` and `textareaFieldView` helpers that wrap `Ui.Input.view` and `Ui.Textarea.view` with label + validation feedback. Copy that helper pattern. Raw `input`/`textarea` are for non-form cases (search fields, inline editors) where you're intentionally working below the Ui component layer, and even then, reach for the Ui component first.
+**For form inputs specifically:** every text input, textarea, and button in a form MUST use `Ui.Input`, `Ui.Textarea`, and `Ui.Button` respectively. This is not optional, even though raw `input`/`textarea` HTML elements are available from `html<Message>()`. The form example (`examples/form/src/main.ts:347-403`) defines `inputFieldView` and `textareaFieldView` helpers that wrap `Ui.Input.view` and `Ui.Textarea.view` with label + validation feedback. Copy that helper pattern. Raw `input`/`textarea` are for non-form cases (search fields, inline editors) where you're intentionally working below the Ui component layer, and even then, reach for the Ui component first.
 
-If the app uses UI components, **always read the ui-showcase example first** to understand how components are wired — this is the canonical reference for Foldkit UI integration patterns:
+If the app uses UI components, **always read the ui-showcase example first** to understand how components are wired. This is the canonical reference for Foldkit UI integration patterns:
 
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/main.ts` — root wiring, `Got*` delegation, `toParentMessage` helpers
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/message.ts` — how UI component Messages are structured
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/model.ts` — how UI component Models are composed
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/update.ts` — how UI component updates are delegated
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/toast.ts` — read when using `Ui.Toast`: Toast is unique in that it's parameterized on a payload schema via `Ui.Toast.make(PayloadSchema)`, returning a typed module you import from
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/main.ts`: root wiring, `Got*` delegation, `toParentMessage` helpers
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/message.ts`: how UI component Messages are structured
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/model.ts`: how UI component Models are composed
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/update.ts`: how UI component updates are delegated
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/toast.ts`: read when using `Ui.Toast`: Toast is unique in that it's parameterized on a payload schema via `Ui.Toast.make(PayloadSchema)`, returning a typed module you import from
 
-For apps using `Ui.DatePicker`, `Ui.FileDrop`, or other recently-added components, also read the `job-application` example (see Tier 6 below) — it's the most complete real-world integration of these components together.
+For apps using `Ui.DatePicker`, `Ui.FileDrop`, or other recently-added components, also read the `job-application` example (see Tier 6 below). It's the most complete real-world integration of these components together.
 
 ## Phase 3: Determine File Organization
 
-Match the file structure to the app's complexity. The architecture stays the same at every scale — only the file organization changes.
+Match the file structure to the app's complexity. The architecture stays the same at every scale; only the file organization changes.
 
 ### What lives in which file
 
 Beyond the tier-based layouts below, follow these "schema placement" rules to avoid model.ts bloat:
 
 - **`model.ts`** holds the `Model` schema + any schemas that are fields of Model (or composed into fields, like form state / submit state unions). Nothing else.
-- **`command.ts`** holds schemas for the payloads commands send to / receive from external systems — in particular, the persistence schema that `saveState` serializes and `flags` deserializes. The persistence schema is a command-layer concern, not a model concern; it often looks like a subset of Model but it isn't part of Model.
+- **`command.ts`** holds schemas for the payloads commands send to / receive from external systems, in particular the persistence schema that `saveState` serializes and `flags` deserializes. The persistence schema is a command-layer concern, not a model concern; it often looks like a subset of Model but it isn't part of Model.
 - **`domain/*.ts`** holds domain entity schemas and pure operations on them.
 - **`message.ts`** holds messages (only).
 - **`route.ts`** holds route variants + router pipelines.
@@ -172,7 +172,7 @@ src/message.ts       ← Message definitions
 src/command.ts       ← Command functions
 ```
 
-**Important rule:** if you extract `command.ts`, you MUST also extract `message.ts`. Commands reference Message constructors (e.g. `SucceededFetchWeather({...})`) as their Effect return values. If Messages live in `main.ts` and Commands live in `command.ts`, `command.ts` imports from `main.ts` _and_ `main.ts` uses Commands from `command.ts` — a circular import. Pull Messages out first, then both `main.ts` and `command.ts` import from `message.ts`.
+**Important rule:** if you extract `command.ts`, you MUST also extract `message.ts`. Commands reference Message constructors (e.g. `SucceededFetchWeather({...})`) as their Effect return values. If Messages live in `main.ts` and Commands live in `command.ts`, `command.ts` imports from `main.ts` _and_ `main.ts` uses Commands from `command.ts`, a circular import. Pull Messages out first, then both `main.ts` and `command.ts` import from `message.ts`.
 
 **Full split** (Tier 4-5, multiple concerns):
 
@@ -208,15 +208,15 @@ src/page/
 
 ## Phase 3.3: Architecture sketch (Tier 4+ only)
 
-For Tier 4+ apps — routing, domain modules, multiple entities, submodels — produce a compact sketch BEFORE generating implementations. Tier 1-3 apps are small enough to generate in one pass; Tier 4+ apps burn a lot of effort if the structure is wrong.
+For Tier 4+ apps (routing, domain modules, multiple entities, submodels) produce a compact sketch BEFORE generating implementations. Tier 1-3 apps are small enough to generate in one pass; Tier 4+ apps burn a lot of effort if the structure is wrong.
 
 The sketch has five parts. Emit them inline in the conversation, get confirmation, THEN scaffold:
 
-1. **File tree** — the exact paths you will create. Match Phase 3's organization.
-2. **Model shape** — the top-level `S.Struct` fields and their types. Not the full schema, just the shape.
-3. **Message list** — every Message you plan to define, grouped by category (clicks, inputs, commands, out-messages).
-4. **Route list** — if routing, every `r('...', {...})` with params and the path each maps to.
-5. **Domain operations** — for each file in `domain/`, the operations it will expose (`Link.byNewest`, `Link.filterByTag`, etc.).
+1. **File tree**: the exact paths you will create. Match Phase 3's organization.
+2. **Model shape**: the top-level `S.Struct` fields and their types. Not the full schema, just the shape.
+3. **Message list**: every Message you plan to define, grouped by category (clicks, inputs, commands, out-messages).
+4. **Route list**: if routing, every `r('...', {...})` with params and the path each maps to.
+5. **Domain operations**: for each file in `domain/`, the operations it will expose (`Link.byNewest`, `Link.filterByTag`, etc.).
 
 Example for a Tier 4 link saver:
 
@@ -250,9 +250,9 @@ Domain:
   Link: schema + byNewest, filterByTag, toggleFavorite, remove, updateById
 ```
 
-After emitting the sketch, ask the user to confirm or adjust. Don't start scaffolding or generation until they do. If the user confirms silently (e.g. "looks good, continue"), proceed. If they adjust, iterate on the sketch — don't write code against a version they haven't approved.
+After emitting the sketch, ask the user to confirm or adjust. Don't start scaffolding or generation until they do. If the user confirms silently (e.g. "looks good, continue"), proceed. If they adjust, iterate on the sketch. Don't write code against a version they haven't approved.
 
-This step is frequently tempting to skip because the agent "knows what it's doing." Skip it and you ship a fully-generated app that turns out to need structural changes — that's the expensive form of iteration. The sketch is the cheap form.
+This step is frequently tempting to skip because the agent "knows what it's doing." Skip it and you ship a fully-generated app that turns out to need structural changes. That's the expensive form of iteration. The sketch is the cheap form.
 
 ## Phase 3.5: Scaffold the Project
 
@@ -314,10 +314,15 @@ For each Foldkit module you plan to use, read the `.d.ts` at the paths below. Re
 
 # If using async / side effects
 <project>/node_modules/foldkit/dist/command/index.d.ts  # Command.define — result schemas are required
-<project>/node_modules/foldkit/dist/task/index.d.ts     # focus, uuid, getTime (returns DateTime.Utc, not number), delay, scrollIntoView, showModal
+<project>/node_modules/foldkit/dist/dom/index.d.ts      # focus, advanceFocus, scrollIntoView, showModal, closeModal, clickElement, lockScroll, unlockScroll, inertOthers, restoreInert, detectElementMovement, waitForAnimationSettled. For time/random/uuid/delay use Effect's Clock, Random, Effect.uuid, Effect.sleep + Duration directly.
 
 # If using subscriptions
 <project>/node_modules/foldkit/dist/subscription/index.d.ts # Subscription.makeSubscriptions(Deps)<Model, Message>
+
+# If using mount / managed-resource / custom-element
+<project>/node_modules/foldkit/dist/mount/index.d.ts             # Mount.define — for per-instance VNode lifecycle
+<project>/node_modules/foldkit/dist/managedResource/index.d.ts   # ManagedResource — for stateful runtime objects keyed on Model condition
+<project>/node_modules/foldkit/dist/customElement/index.d.ts     # CustomElement.define — for typed bindings to native web components
 
 # If using forms
 <project>/node_modules/foldkit/dist/fieldValidation/public.d.ts # Field (tagged union), makeRules({required?, rules: Rule[]}), validate, url(options), email, minLength, allValid
@@ -328,7 +333,7 @@ For each Foldkit module you plan to use, read the `.d.ts` at the paths below. Re
 # Check: does ViewConfig have the props you need? Does toView destructure label/input/description/button attribute groups?
 
 # If using dates
-<project>/node_modules/foldkit/dist/calendar/index.d.ts # CalendarDate, today.local (returns DateTime, use Clock.currentTimeMillis for raw millis)
+<project>/node_modules/foldkit/dist/calendar/index.d.ts # CalendarDate, today.local (returns Effect<CalendarDate>); for raw millis use Clock.currentTimeMillis
 ```
 
 ### What to record in the crib
@@ -349,18 +354,18 @@ Field (schema): NotValidated | Validating | Valid | Invalid(errors: NonEmpty<Rul
 
 Record these in the crib and keep them visible while generating:
 
-- **`input` and `br` and other void elements take ONLY attributes** — `input([...])`, never `input([...], [])`. `textarea` and `button` DO take children.
+- **`input` and `br` and other void elements take ONLY attributes**: `input([...])`, never `input([...], [])`. `textarea` and `button` DO take children.
 - **`UrlRequest` tags are `Internal` and `External`**, not `InternalUrl` / `ExternalUrl`.
 - **`OnClick` and `OnSubmit` take a Message directly**, not a `() => Message`. Only `OnInput` takes `(value) => Message` because it needs the input value.
-- **`keyed`, `empty` are properties on the record returned by `html<M>()`** — accessed as `h.keyed` and `h.empty` after `const h = html<M>()`. They are not top-level exports of `foldkit/html`.
-- **Attribute helpers are specific** — `Value(...)`, `Type(...)`, `Placeholder(...)`, `Href(...)`, `Target(...)`, `Rel(...)`, `Rows(n)`, `Id(...)`, `For(...)`, `Role(...)`, `AriaLabel(...)`. There is no generic `Attr('...', '...')`.
-- **`ProgramInit<Model, Message, Flags>` has no URL parameter.** For routed apps, use `RoutingProgramInit<Model, Message, Flags>` — the second arg is `url: Url`.
-- **`Route.mapTo` takes the route schema, not a factory function.** `pipe(literal('new'), Route.mapTo(NewLinkRoute))` — NOT `Route.mapTo(() => NewLinkRoute())`.
-- **`Effect.ignore` is ONLY for fallible Effects.** `pushUrl(path).pipe(Effect.as(Message()))` — no `Effect.ignore` because `pushUrl` returns `Effect<void>`.
+- **`keyed`, `empty` are properties on the record returned by `html<M>()`**: accessed as `h.keyed` and `h.empty` after `const h = html<M>()`. They are not top-level exports of `foldkit/html`.
+- **Attribute helpers are specific**: `Value(...)`, `Type(...)`, `Placeholder(...)`, `Href(...)`, `Target(...)`, `Rel(...)`, `Rows(n)`, `Id(...)`, `For(...)`, `Role(...)`, `AriaLabel(...)`. There is no generic `Attr('...', '...')`.
+- **`ProgramInit<Model, Message, Flags>` has no URL parameter.** For routed apps, use `RoutingProgramInit<Model, Message, Flags>`: the second arg is `url: Url`.
+- **`Route.mapTo` takes the route schema, not a factory function.** `pipe(literal('new'), Route.mapTo(NewLinkRoute))`. NOT `Route.mapTo(() => NewLinkRoute())`.
+- **`Effect.ignore` is ONLY for fallible Effects.** `pushUrl(path).pipe(Effect.as(Message()))`. No `Effect.ignore` because `pushUrl` returns `Effect<void>`.
 - **`Command.define` requires result Message schemas after the name**: `Command.define('Fetch', SucceededFetch, FailedFetch)`. Infallible Commands only need one result: `Command.define('ReadClock', RecordedTime)`.
-- **`makeRules` takes `{ required?: RuleMessage, rules: Rule[] }` where `Rule = [Predicate, RuleMessage]`** — a tuple, NOT `{ test, message }`. Use the built-in rule constructors (`url({ message })`, `email(message?)`, `minLength(n, message?)`, `pattern(regex, message?)`).
+- **`makeRules` takes `{ required?: RuleMessage, rules: Rule[] }` where `Rule = [Predicate, RuleMessage]`**: a tuple, NOT `{ test, message }`. Use the built-in rule constructors (`url({ message })`, `email(message?)`, `minLength(n, message?)`, `pattern(regex, message?)`).
 - **`Field.Invalid` has `errors: NonEmptyArray<RuleMessage>`, not `error: string`.** Use `Array.headNonEmpty(errors)` to get the first message; use `resolveMessage(rule, value)` to get the final string.
-- **Route variants are `HomeRoute`, `NewLinkRoute`, etc. — with the `Route` suffix.** Every exemplar uses this convention.
+- **Route variants are `HomeRoute`, `NewLinkRoute`, etc., with the `Route` suffix.** Every exemplar uses this convention.
 - **Routers are callable for printing**: `homeRouter()` returns `'/'`, `tagFilterRouter({ tag: 'foo' })` returns `'/tag/foo'`. Never hand-construct URLs.
 
 ## Phase 4: Generate the App
@@ -371,9 +376,9 @@ Generate files following the architecture and conventions guides exactly. Write 
 
 - Define as `S.Struct` with Effect Schema types
 - Use discriminated unions for state: `Idle | Loading | Error | Ok`, never booleans for multi-valued state
-- Use `Option` for fields that may be absent — never empty strings or null
+- Use `Option` for fields that may be absent. Never empty strings or null
 - Prefix Option-typed fields with `maybe`: `maybeCurrentUser`, `maybeError`
-- For async data, define `Idle`, `Loading`, `Error`, `Ok` variants with `ts()` and compose into an `S.Union` — see Discriminated Unions for State in [conventions.md](conventions.md)
+- For async data, define `Idle`, `Loading`, `Error`, `Ok` variants with `ts()` and compose into an `S.Union`. See Discriminated Unions for State in [conventions.md](conventions.md)
 - For apps with multiple domain entities referenced across modules, extract shared schemas into `src/domain/` (e.g., `domain/product.ts`, `domain/session.ts`). See the shopping-cart and auth examples for this pattern, and read `${CLAUDE_SKILL_DIR}/../../packages/website/src/page/projectOrganization.ts` for guidance on when and how to structure domain modules
 
 ### Messages
@@ -401,17 +406,17 @@ type Message = typeof Message.Type
 
 Name messages by category:
 
-- `Clicked*` — button/link clicks
-- `Updated*` — input value changes (with `{ value: S.String }`) and external state updates from subscriptions (`UpdatedRoom`, `UpdatedPlayerProgress`)
-- `Submitted*` — form submissions
-- `Succeeded*` / `Failed*` — paired, for commands that can meaningfully fail
-- `Completed*` — fire-and-forget (verb+object: `CompletedFocusInput`)
-- `Got*` — child module results via OutMessage pattern
-- `Loaded*` — data restored from storage
-- `Pressed*` — keyboard input
-- `Blurred*` — focus loss
-- `Selected*` — choice made from a list
-- `Toggled*` — binary state flip
+- `Clicked*`: button/link clicks
+- `Updated*`: input value changes (with `{ value: S.String }`) and external state updates from subscriptions (`UpdatedRoom`, `UpdatedPlayerProgress`)
+- `Submitted*`: form submissions
+- `Succeeded*` / `Failed*`: paired, for commands that can meaningfully fail
+- `Completed*`: fire-and-forget (verb+object: `CompletedFocusInput`)
+- `Got*`: child module results via OutMessage pattern
+- `Loaded*`: data restored from storage
+- `Pressed*`: keyboard input
+- `Blurred*`: focus loss
+- `Selected*`: choice made from a list
+- `Toggled*`: binary state flip
 
 Every message must carry meaning. No `NoOp`.
 
@@ -419,7 +424,7 @@ Every message must carry meaning. No `NoOp`.
 
 - Define a `Flags` Schema for data the initial Model needs from side effects
 - Define `flags` as an `Effect<Flags>` that computes the values (localStorage reads, current time, etc.)
-- Pass the result into init — never perform side effects at module level or inside init directly
+- Pass the result into init. Never perform side effects at module level or inside init directly
 - See the flags section in [architecture.md](architecture.md) for the full pattern
 
 ### Init
@@ -431,30 +436,30 @@ Every message must carry meaning. No `NoOp`.
 
 ### Update
 
-- Use `M.value(message).pipe(withUpdateReturn, M.tagsExhaustive({...}))` — never switch
+- Use `M.value(message).pipe(withUpdateReturn, M.tagsExhaustive({...}))`. Never switch
 - Every case returns `[Model, ReadonlyArray<Command<Message>>]`
 - Use `evo(model, { field: () => newValue })` for immutable updates
 - Extract complex handlers to separate functions when a case exceeds ~15 lines
 - For Submodels: return `[Model, ReadonlyArray<Command<Message>>, Option.Option<OutMessage>]`
-- See the OutMessage pattern in [architecture.md](architecture.md) — child modules signal to parents via `Option.some(OutMessage)`, parents handle with `Got*` Messages and `M.tagsExhaustive`
+- See the OutMessage pattern in [architecture.md](architecture.md). Child modules signal to parents via `Option.some(OutMessage)`, parents handle with `Got*` Messages and `M.tagsExhaustive`
 
 ### Commands
 
-- Define Command identities with `Command.define`, passing result Message schemas after the name — result types are required
-- Always assign definitions to PascalCase constants — never inline in pipe chains
+- Define Command identities with `Command.define`, passing result Message schemas after the name. Result types are required
+- Always assign definitions to PascalCase constants. Never inline in pipe chains
 - Definitions live where they're produced, colocated with the update function
-- Let TypeScript infer return types — no explicit `Command<typeof A>` annotations
+- Let TypeScript infer return types. No explicit `Command<typeof A>` annotations
 - Use `Effect.gen` for multi-step async
-- Always `Effect.catch(() => Effect.succeed(FailedX(...)))` for fallible Effects — Commands never throw. **Exception:** if the Effect is infallible at the type level (`Clock.currentTimeMillis`, `Task.getTime`, `Task.randomInt`, `Task.uuid`, etc.), no `catch` is needed and no `Failed*` Message is needed. Follow the types — if there's no error channel, there's nothing to catch.
+- Always `Effect.catch(() => Effect.succeed(FailedX(...)))` for fallible Effects. Commands never throw. **Exception:** if the Effect is infallible at the type level (`Clock.currentTimeMillis`, `Effect.uuid`, `Random.nextIntBetween`, etc.), no `catch` is needed and no `Failed*` Message is needed. Follow the types: if there's no error channel, there's nothing to catch.
 - Use `Effect.provide` for services
 - Factory functions named by action: `fetchWeather`, not `fetchWeatherCommand`
 - Fire-and-forget Commands return `Completed*` Messages
-- Use `Task` helpers for DOM operations (`Task.focus`, `Task.scrollIntoView`, `Task.showModal`, `Task.delay`, `Task.uuid`, etc.) — see Task Helpers in [architecture.md](architecture.md)
-- For HTTP requests, use `HttpClient` from `@effect/platform` — see the weather example for the pattern
+- Use Foldkit's `Dom` module for DOM operations (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showModal`, `Dom.lockScroll`, etc.) and Effect built-ins for everything else (`Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep(Duration.millis(...))`). See DOM and Effect Helpers in [architecture.md](architecture.md)
+- For HTTP requests, use `HttpClient` from `@effect/platform`. See the weather example for the pattern
 
 ### Form Validation
 
-When the app has form inputs that need validation (required fields, format checks, async uniqueness checks), use `foldkit/fieldValidation` — do not hand-roll validation state.
+When the app has form inputs that need validation (required fields, format checks, async uniqueness checks), use `foldkit/fieldValidation`. Do not hand-roll validation state.
 
 ```ts
 import {
@@ -496,13 +501,13 @@ For date handling (birthday, deadlines, scheduling):
 
 - Use the `Calendar` module: `Calendar.CalendarDate`, `Calendar.today.local` (Effect returning today's date in the user's timezone), `Calendar.make(year, month, day)`, `Calendar.addDays`, etc.
 - Use `Ui.DatePicker` (input + popover calendar) or `Ui.Calendar` (inline grid) for the UI
-- Seed the initial date via flags when needed — see `job-application` example, which uses `Calendar.today.local` in its flags Effect
+- Seed the initial date via flags when needed. See `job-application` example, which uses `Calendar.today.local` in its flags Effect
 
 For file uploads (resumes, images, attachments):
 
 - Use the `File` module for file primitives
 - Use `Ui.FileDrop` for a drag-and-drop + click-to-browse zone with validation
-- `Ui.FileDrop.ReceivedFiles` is a `NonEmptyArray<File>` OutMessage — empty selections never fire
+- `Ui.FileDrop.ReceivedFiles` is a `NonEmptyArray<File>` OutMessage. Empty selections never fire
 - Canonical reference: `${CLAUDE_SKILL_DIR}/../../examples/job-application/src/step/attachments.ts`
 
 ### View
@@ -519,8 +524,8 @@ For file uploads (resumes, images, attachments):
 
 ### Runtime Wiring
 
-- Use `Runtime.makeProgram` — add `routing: { onUrlRequest, onUrlChange }` for apps with URL routing
-- Add `title: model => ...` to set `document.title` after every render — derive from route or any model state
+- Use `Runtime.makeProgram`. Add `routing: { onUrlRequest, onUrlChange }` for apps with URL routing
+- Add `title: model => ...` to set `document.title` after every render. Derive from route or any model state
 - See the With and Without URL Routing section in [architecture.md](architecture.md) for the full pattern
 - Include `ClickedLink` and `ChangedUrl` Messages for programs with routing, with proper `InternalUrl`/`ExternalUrl` handling in update
 - Always end with `Runtime.run(program)`
@@ -530,10 +535,10 @@ For file uploads (resumes, images, attachments):
 - Use bidirectional parser: `r()`, `string()`, `int()`, `literal()`, `slash()`, `Route.mapTo()`, `Route.oneOf()`
 - Define route schemas with `r('RouteName', { param: S.String })`
 - **Suffix route variant constants with `Route`**: `HomeRoute`, `NewLinkRoute`, `NotFoundRoute`. Every exemplar (auth, shopping-cart, routing) does this. Disambiguates the route schema from views, models, or UI components with matching tag names.
-- Build each route as a Router: `const homeRouter = pipe(Route.root, Route.mapTo(HomeRoute))`. **Routers are callable** — `homeRouter()` returns `'/'`, `tagFilterRouter({ tag: 'foo' })` returns `'/tag/foo'`. This is the print side of the bidirectional parser.
+- Build each route as a Router: `const homeRouter = pipe(Route.root, Route.mapTo(HomeRoute))`. **Routers are callable**: `homeRouter()` returns `'/'`, `tagFilterRouter({ tag: 'foo' })` returns `'/tag/foo'`. This is the print side of the bidirectional parser.
 - **Never hand-construct paths with template strings.** `Href(homeRouter())` not `Href('/')`. `navigateInternal(newLinkRouter())` not `navigateInternal('/new')`. `Href(tagFilterRouter({ tag: tagName }))` not ``Href(`/tag/${encodeURIComponent(tagName)}`)``. The router handles encoding and keeps the URL shape in one place so a refactor changes one file, not every call site.
 - Key view content on `model.route._tag`
-- Use `pushUrl` from `foldkit/navigation` in Commands for programmatic navigation. In the `ClickedLink` handler's `Internal` case, use `urlToString(url)` from `foldkit/url` — never reconstruct the URL from `url.pathname + search + hash` manually, that path drops the `?` prefix and hash silently.
+- Use `pushUrl` from `foldkit/navigation` in Commands for programmatic navigation. In the `ClickedLink` handler's `Internal` case, use `urlToString(url)` from `foldkit/url`. Never reconstruct the URL from `url.pathname + search + hash` manually; that path drops the `?` prefix and hash silently.
 - In the `ClickedLink` handler, **don't pre-update `model.route`**. The runtime fires `ChangedUrl` after `pushUrl` resolves, which updates the route. Pre-updating creates a double-write.
 
 ### Subscriptions (if real-time)
@@ -541,14 +546,14 @@ For file uploads (resumes, images, attachments):
 - Define with `Subscription.makeSubscriptions(Deps)<Model, Message>`
 - `modelToDependencies` extracts Subscription parameters from Model
 - `dependenciesToStream` builds `Stream<Message>` from dependencies
-- Subscriptions auto-start/stop based on Model state — never manually managed
+- Subscriptions auto-start/stop based on Model state. Never manually managed
 - For Subscriptions with no Model dependencies (always active), use `S.Null` as the dependency type and return `null` from `modelToDependencies`
 
 ## Phase 4.5: Self-check before verification
 
 Before running `tsc` or opening the browser, do a quick mechanical pass over the generated files. The reviewer in Phase 6 catches these, but catching them at write-time is cheaper than catching them after a full review round. Skip this and you inflate round-1 review noise with preventable items.
 
-**Run the "Mechanical scans" block in `checklist.md`** against `src/`. That's the canonical list of greps — it covers empty-object constructors, hard-coded route paths, hand-rolled form inputs, `.length > 0` checks, raw spread in `evo`, `as` casts on constructor returns, unpaired labels, `maybe*` on non-Option, `span([], [])` placeholders, redundant `Effect.ignore`, and focus-outline resets. Each hit is either a fix or a `// NOTE:` justification.
+**Run the "Mechanical scans" block in `checklist.md`** against `src/`. That's the canonical list of greps. It covers empty-object constructors, hard-coded route paths, hand-rolled form inputs, `.length > 0` checks, raw spread in `evo`, `as` casts on constructor returns, unpaired labels, `maybe*` on non-Option, `span([], [])` placeholders, redundant `Effect.ignore`, and focus-outline resets. Each hit is either a fix or a `// NOTE:` justification.
 
 Then eyeball each file you wrote:
 
@@ -563,7 +568,7 @@ This is ~2 minutes of reading per file. It saves ~15 minutes of review loop per 
 
 ### Gate: four commands must succeed before declaring Phase 5 complete
 
-Before moving to Phase 6, run ALL FOUR of these and fix everything they surface. Not one, not three — all four:
+Before moving to Phase 6, run ALL FOUR of these and fix everything they surface. Not one, not three. All four:
 
 ```bash
 npm run format      # or: npx prettier -w .   (run FIRST — rewrites files)
@@ -576,45 +581,45 @@ Run **format first** because it rewrites files; running it last would leave tsc/
 
 Each catches different classes of issue:
 
-- **Format** rewrites spacing, indentation, trailing commas, and line wrapping to project style. Not a "check" — a normalizer. Generated code rarely matches Prettier's exact formatting by accident; without this step, every `git commit` produces a cascade of formatting-only diffs.
+- **Format** rewrites spacing, indentation, trailing commas, and line wrapping to project style. Not a "check"; a normalizer. Generated code rarely matches Prettier's exact formatting by accident; without this step, every `git commit` produces a cascade of formatting-only diffs.
 - **Lint** catches unused imports, unused variables, and style-rule violations. Easy to miss because generated code often imports a symbol "for completeness" that turns out not to be referenced (e.g. importing `NotValidated`, `Invalid` from fieldValidation when they're only used as string literals inside `M.tag` keys). `tsc` doesn't flag these.
 - **Typecheck** catches API misuse, wrong parameter shapes, missing required props, and structural type errors. Doesn't catch unused imports.
 - **Tests** catch behavioral regressions. Don't catch either of the above.
 
-If the project doesn't have a format/lint script, check `package.json` and run `npx prettier -w .` / `npx eslint .` directly. Don't skip either because "there's no script" — the scaffolded `create-foldkit-app` project always ships both configured.
+If the project doesn't have a format/lint script, check `package.json` and run `npx prettier -w .` / `npx eslint .` directly. Don't skip either because "there's no script". The scaffolded `create-foldkit-app` project always ships both configured.
 
-Fix ALL output from all four before declaring Phase 5 done. "Typecheck clean and tests pass" is insufficient — unformatted code with unused imports is not at the bar.
+Fix ALL output from all four before declaring Phase 5 done. "Typecheck clean and tests pass" is insufficient. Unformatted code with unused imports is not at the bar.
 
 ### Type errors first
 
 Then generate tests using `foldkit/test`. There are two test styles:
 
-**Story tests** (`main.story.test.ts`) test the update function directly — you send Messages and assert on the Model and Commands. Study these exemplars:
+**Story tests** (`main.story.test.ts`) test the update function directly. You send Messages and assert on the Model and Commands. Study these exemplars:
 
-- `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.test.ts` — simple Command resolution (happy path + error path)
-- `${CLAUDE_SKILL_DIR}/../../examples/auth/src/page/loggedOut/page/login.test.ts` — Submodel with OutMessage assertions, field validation
-- `${CLAUDE_SKILL_DIR}/../../packages/website/src/search/update.test.ts` — multi-step interactions (arrow key cycling, stale result handling)
+- `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.story.test.ts`: simple Command resolution (happy path + error path)
+- `${CLAUDE_SKILL_DIR}/../../examples/auth/src/page/loggedOut/page/login.story.test.ts`: Submodel with OutMessage assertions, field validation
+- `${CLAUDE_SKILL_DIR}/../../packages/website/src/search/update.test.ts`: multi-step interactions (arrow key cycling, stale result handling)
 
 Write `Story.story` pipelines covering:
 
-- **Happy path** — the primary user flow from start to finish
-- **Error path** — every fallible Command resolved with its `Failed*` Message
-- **Multi-step interaction** — at least one test that chains multiple Messages and Command resolutions
-- **Edge cases** — empty states, boundary conditions, ignored inputs (e.g. stale results, duplicate submissions)
+- **Happy path**: the primary user flow from start to finish
+- **Error path**: every fallible Command resolved with its `Failed*` Message
+- **Multi-step interaction**: at least one test that chains multiple Messages and Command resolutions
+- **Edge cases**: empty states, boundary conditions, ignored inputs (e.g. stale results, duplicate submissions)
 
-**Scene tests** (`main.scene.test.ts`) test through the rendered view — you interact with elements by accessible locators (role, label, text) and assert on what the user sees. A `main.scene.test.ts` is **REQUIRED** for Tier 3+ apps. The review loop treats its absence as a BLOCKER, not a QUALITY item. No exceptions — don't "defer" this. Study these exemplars:
+**Scene tests** (`main.scene.test.ts`) test through the rendered view. You interact with elements by accessible locators (role, label, text) and assert on what the user sees. A `main.scene.test.ts` is **REQUIRED** for Tier 3+ apps. The review loop treats its absence as a BLOCKER, not a QUALITY item. No exceptions. Don't "defer" this. Study these exemplars:
 
-- `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.scene.test.ts` — basic Scene flow with form interaction and Command resolution
-- `${CLAUDE_SKILL_DIR}/../../examples/auth/src/page/loggedOut/page/login.scene.test.ts` — Submodel Scene testing, field validation through the view
-- `${CLAUDE_SKILL_DIR}/../../examples/kanban/src/main.scene.test.ts` — scoped queries with `within`, `toHaveValue`, explicit test data
+- `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.scene.test.ts`: basic Scene flow with form interaction and Command resolution
+- `${CLAUDE_SKILL_DIR}/../../examples/auth/src/page/loggedOut/page/login.scene.test.ts`: Submodel Scene testing, field validation through the view
+- `${CLAUDE_SKILL_DIR}/../../examples/kanban/src/main.scene.test.ts`: scoped queries with `within`, `toHaveValue`, explicit test data
 
 Write `Scene.scene` pipelines covering:
 
-- **View rendering** — initial view has expected elements (headings, inputs, buttons)
-- **User interactions** — click, type, submit produce visible changes
-- **Loading states** — submitting shows loading indicator
-- **Error states** — failed Commands show error messages in the view
-- **Scoped queries** — use `Scene.within(parent, child)` to compose a single scoped Locator (good for one-off scoped assertions or reusable named locators). Use `Scene.inside(parent, ...steps)` to scope a whole block of steps to the same parent — every Locator referenced by the nested steps resolves within the parent's subtree. Reach for `inside` when two or more steps share a scope; reach for `within` for single-use scoping.
+- **View rendering**: initial view has expected elements (headings, inputs, buttons)
+- **User interactions**: click, type, submit produce visible changes
+- **Loading states**: submitting shows loading indicator
+- **Error states**: failed Commands show error messages in the view
+- **Scoped queries**: use `Scene.within(parent, child)` to compose a single scoped Locator (good for one-off scoped assertions or reusable named locators). Use `Scene.inside(parent, ...steps)` to scope a whole block of steps to the same parent. Every Locator referenced by the nested steps resolves within the parent's subtree. Reach for `inside` when two or more steps share a scope; reach for `within` for single-use scoping.
 - Prefer accessible locators: `Scene.label(...)`, `Scene.role(...)`, `Scene.text(...)` over `Scene.placeholder(...)` or CSS selectors
 
 Run `npx vitest run` to verify tests pass.
@@ -629,7 +634,7 @@ Code review and automated tests don't catch rendering bugs or accessibility gaps
 
 Start the dev server (`npm run dev`) and open the app in a browser. Click through every route. Interact with every form. Watch for:
 
-- Inputs with missing backgrounds (Tailwind preflight strips the browser-default white — `bg-white` must be explicit on every `input`/`textarea` you don't route through `Ui.Input`)
+- Inputs with missing backgrounds (Tailwind preflight strips the browser-default white; `bg-white` must be explicit on every `input`/`textarea` you don't route through `Ui.Input`)
 - Text that's too dim or too small to read
 - Overlapping elements, broken spacing, layout shifts
 - Cursor/hover states that don't feel right
@@ -641,13 +646,13 @@ If the app has UI, **don't claim Phase 5 complete until you've loaded the app an
 
 ### A11y check
 
-Walk the **Accessibility** and **Foldkit UI** sections of `checklist.md`. Both have mechanical grep commands — run them against `src/`. Don't re-list them here; the checklist is the canonical reference for these greps, and duplicating them across files invites drift.
+Walk the **Accessibility** and **Foldkit UI** sections of `checklist.md`. Both have mechanical grep commands. Run them against `src/`. Don't re-list them here; the checklist is the canonical reference for these greps, and duplicating them across files invites drift.
 
-A11y items are not "nice-to-have" — they're correctness for a non-visual user.
+A11y items are not "nice-to-have". They're correctness for a non-visual user.
 
 ## Phase 6: Subagent Review Loop
 
-Self-review is weaker than fresh-eyes review. After Phase 5 passes, spin up subagents to review the generated code against the quality bar — and iterate until they sign off.
+Self-review is weaker than fresh-eyes review. After Phase 5 passes, spin up subagents to review the generated code against the quality bar, and iterate until they sign off.
 
 ### Loop mechanics
 
@@ -655,15 +660,15 @@ Run up to **three rounds**. Each round:
 
 1. Spawn a review subagent using the `Agent` tool with `subagent_type: general-purpose`.
 2. Read the subagent's response.
-3. If response is `PASS`, exit the loop — proceed to Phase 7.
+3. If response is `PASS`, exit the loop and proceed to Phase 7.
 4. If response contains `BLOCKERS` or `QUALITY` items, fix each, then loop.
 5. `NICE-TO-HAVE` items can be deferred to Phase 7's future-work list if the round budget is exhausted.
 
-After round 3, if issues remain, exit the loop and carry the unresolved items into Phase 7 as "known polish areas" — do not silently ship flagged code. Be explicit about what's still open.
+After round 3, if issues remain, exit the loop and carry the unresolved items into Phase 7 as "known polish areas". Do not silently ship flagged code. Be explicit about what's still open.
 
 ### Review subagent prompt
 
-Use a prompt of roughly this shape. Tailor only the file list and project path — keep the rubric, output format, blind-spots checklist, and bar-setting instructions intact.
+Use a prompt of roughly this shape. Tailor only the file list and project path. Keep the rubric, output format, blind-spots checklist, and bar-setting instructions intact.
 
 ```
 You are reviewing a freshly generated Foldkit program. The bar is:
@@ -879,7 +884,7 @@ imports that tsc does not, and those leak into review as noise.
 
 ### Between rounds: actually fix, don't just acknowledge
 
-Between rounds, the generator MUST actually apply fixes for every BLOCKER and every QUALITY item the reviewer flagged. Do not carry forward items with "I'll note this" or "deferring" unless the round budget is exhausted. A QUALITY item the reviewer flagged in round N that's still present in round N+1 is a process failure — it means the generator read the review and then didn't act.
+Between rounds, the generator MUST actually apply fixes for every BLOCKER and every QUALITY item the reviewer flagged. Do not carry forward items with "I'll note this" or "deferring" unless the round budget is exhausted. A QUALITY item the reviewer flagged in round N that's still present in round N+1 is a process failure. It means the generator read the review and then didn't act.
 
 Common failure mode: the reviewer flags `.length > 0` checks as QUALITY and notes `Array.match`/`String.isNonEmpty` as the fix. The generator moves to other fixes, the round 2 review flags the same thing again, and nothing happens because "round 2 is clean on BLOCKERS so we're good." It isn't good. Untriaged QUALITY items become silently-shipped rot.
 
@@ -889,9 +894,9 @@ Before running round N+1, produce a short written diff between "what round N fla
 
 After generating the program (and passing review), walk the user through what was built:
 
-1. **Files generated** — list each file with a one-line description of what it contains and why it exists as a separate file (or why everything is in one file)
-2. **Architecture decisions** — explain key modeling choices, for example: which discriminated unions were used and why, which Foldkit UI components were integrated, why flags were or weren't needed, any domain extraction decisions, etc.
-3. **Review outcome** — state how many review rounds ran and the final verdict. If `PASS`, say so. If `NEEDS-WORK` after round 3, list the outstanding items verbatim under "Known polish areas" so the user knows what the reviewer flagged that didn't get fixed.
-4. **How to run** — remind the user to start the dev server and what they should see
-5. **How to extend** — give concrete next steps: "to add bookmark editing, define `ClickedEditBookmark` and `UpdatedEditTitle` Messages, add an `Editing` variant to the Model, and handle both in update"
-6. **When to restructure** — mention signals that the program has outgrown its current file organization (e.g., "if update exceeds ~20 cases, consider extracting a Submodel")
+1. **Files generated**: list each file with a one-line description of what it contains and why it exists as a separate file (or why everything is in one file)
+2. **Architecture decisions**: explain key modeling choices, for example: which discriminated unions were used and why, which Foldkit UI components were integrated, why flags were or weren't needed, any domain extraction decisions, etc.
+3. **Review outcome**: state how many review rounds ran and the final verdict. If `PASS`, say so. If `NEEDS-WORK` after round 3, list the outstanding items verbatim under "Known polish areas" so the user knows what the reviewer flagged that didn't get fixed.
+4. **How to run**: remind the user to start the dev server and what they should see
+5. **How to extend**: give concrete next steps: "to add bookmark editing, define `ClickedEditBookmark` and `UpdatedEditTitle` Messages, add an `Editing` variant to the Model, and handle both in update"
+6. **When to restructure**: mention signals that the program has outgrown its current file organization (e.g., "if update exceeds ~20 cases, consider extracting a Submodel")

--- a/skills/generate-program/architecture.md
+++ b/skills/generate-program/architecture.md
@@ -1,8 +1,10 @@
 # Foldkit Architecture Guide
 
+> **Note:** This file is a snapshot of the architecture as practiced in the live Foldkit codebase. If anything here contradicts what `repos/foldkit/examples/` or `repos/foldkit/packages/foldkit/src/` actually do, the live code is canonical. The duplication is intentional so the skill works in downstream projects that haven't vendored the foldkit subtree.
+
 ## The TEA Loop
 
-Every Foldkit app follows The Elm Architecture (TEA). A Message arrives — the user clicked a button, a timer fired, an HTTP response came back. The update function receives the current Model and the Message and returns a new Model along with any Commands to execute. The view function renders the new Model as HTML. When the user interacts with the view, it produces another Message, and the loop continues.
+Every Foldkit app follows The Elm Architecture (TEA). A Message arrives. The user clicked a button, a timer fired, an HTTP response came back. The update function receives the current Model and the Message and returns a new Model along with any Commands to execute. The view function renders the new Model as HTML. When the user interacts with the view, it produces another Message, and the loop continues.
 
 The complete cycle, including Subscriptions and ManagedResources:
 
@@ -32,11 +34,11 @@ Every path on the right side produces a Message that feeds back into update. Com
 
 There are no escape hatches:
 
-- **Model** is the single source of truth — an Effect Schema struct
-- **Messages** are facts about what happened — past-tense, never imperative
-- **update** is a pure function — `(model, message) → [nextModel, commands]`
-- **view** is a pure function — `(model) → Html`
-- **Commands** are the only place side effects happen — they return Messages
+- **Model** is the single source of truth: an Effect Schema struct
+- **Messages** are facts about what happened: past-tense, never imperative
+- **update** is a pure function: `(model, message) → [nextModel, commands]`
+- **view** is a pure function: `(model) → Html`
+- **Commands** are the only place side effects happen. They return Messages
 
 ## Core Invariants
 
@@ -62,30 +64,20 @@ The view function takes the Model and returns Html. It must not:
 - Close over mutable variables
 - Call functions with side effects
 
-Event handlers in the view dispatch Messages — they don't perform actions directly.
+Event handlers in the view dispatch Messages. They don't perform actions directly.
 
 ### 3. Commands Catch All Errors
 
-Define Command identities with `Command.define`, passing the result Message schemas after the name — result types are required. Every Command must handle its own errors and convert them to Messages:
+Define Command identities with `Command.define`, which is curried: the first call binds the name (optional args schema, then result Message schemas), and the second call binds the Effect. Every Command must handle its own errors via `Effect.catch(() => Effect.succeed(FailedX(...)))` and convert them to Messages. Commands never throw, so the app never crashes from an unhandled side effect.
 
-```ts
-const FetchData = Command.define('FetchData', SucceededFetch, FailedFetch)
+Always assign definitions to PascalCase constants. Never use `Command.define` inline in a pipe chain. Definitions live where they're produced, colocated with the update function. Let TypeScript infer Command return types. The result Message schemas constrain the Effect's return type at the type level.
 
-const fetchData = (id: string) =>
-  Effect.gen(function* () {
-    const response = yield* httpClient.get(`/api/data/${id}`)
-    return SucceededFetch({ data: response })
-  }).pipe(
-    Effect.catch(error =>
-      Effect.succeed(FailedFetch({ error: String(error) })),
-    ),
-    FetchData,
-  )
-```
+For the canonical shapes, study the live examples directly. They stay synced with the API:
 
-Always assign definitions to PascalCase constants — never use `Command.define` inline in a pipe chain. Definitions live where they're produced, colocated with the update function. Let TypeScript infer Command return types — the result Message schemas constrain the Effect's return type at the type level.
-
-Commands never throw. The app never crashes from an unhandled side effect.
+- **With args, fallible** (HTTP fetch): `repos/foldkit/examples/weather/src/main.ts` (`FetchWeather`)
+- **With args, infallible** (random + return): `repos/foldkit/examples/kanban/src/command.ts` (`GenerateCardId`)
+- **With args, storage**: `repos/foldkit/examples/kanban/src/command.ts` (`SaveBoard`)
+- **Argless, DOM side effect**: `repos/foldkit/examples/kanban/src/command.ts` (`FocusAddCardInput`)
 
 ### 4. Model Encodes All Possible States
 
@@ -112,11 +104,11 @@ const Model = S.Struct({
 })
 ```
 
-With booleans, you can have `isLoading: true` AND `isError: true` — an impossible state. With unions, you're always in exactly one state.
+With booleans, you can have `isLoading: true` AND `isError: true`, an impossible state. With unions, you're always in exactly one state.
 
 ### 5. Messages Are Facts, Not Commands
 
-Messages describe what happened, not what should happen. The update function decides what to do — Messages don't dictate the response:
+Messages describe what happened, not what should happen. The update function decides what to do. Messages don't dictate the response:
 
 ```ts
 // WRONG: imperative, tells the system what to do
@@ -132,7 +124,7 @@ const ClickedOpenModal = m('ClickedOpenModal')
 
 ## Flags: Side Effects That Seed the Initial Model
 
-When the initial Model needs data from a side effect (current time, localStorage, browser APIs), use flags — not module-level constants:
+When the initial Model needs data from a side effect (current time, localStorage, browser APIs), use flags, not module-level constants:
 
 ```ts
 // WRONG: module-level side effect — stale on HMR, non-deterministic, untestable
@@ -145,8 +137,7 @@ const Flags = S.Struct({
 })
 
 const flags: Effect.Effect<Flags> = Effect.gen(function* () {
-  const clock = yield* Clock.Clock
-  const now = yield* clock.currentTimeMillis
+  const now = yield* Clock.currentTimeMillis
   return Flags({ createdAt: now })
 })
 
@@ -156,7 +147,7 @@ const init: Runtime.ProgramInit<Model, Message, Flags> = (flags) => [
 ]
 ```
 
-Flags are an `Effect<Flags>` — the runtime executes them once before init, and passes the result in. This keeps init pure while still allowing side effects to populate the initial Model. Common uses:
+Flags are an `Effect<Flags>`. The runtime executes them once before init, and passes the result in. This keeps init pure while still allowing side effects to populate the initial Model. Common uses:
 
 - Reading from localStorage/sessionStorage (restoring saved state)
 - Getting the current time
@@ -178,7 +169,7 @@ const program = Runtime.makeProgram({
 
 ## The Submodel Pattern
 
-When a module grows too large, extract a Submodel — a child module with its own Model, Message, init, update, and view.
+When a module grows too large, extract a Submodel: a child module with its own Model, Message, init, update, and view.
 
 ### Communication
 
@@ -250,61 +241,21 @@ const view = <ParentMessage>(
 
 ## Subscriptions
 
-Subscriptions are model-driven streams. They automatically start and stop based on model state:
+Subscriptions are model-driven streams. They automatically start and stop based on model state.
 
-```ts
-const subscriptions = Subscription.makeSubscriptions(Deps)<Model, Message>({
-  mySubscription: {
-    // Extract parameters from model — return Option.none() to stop
-    modelToDependencies: model =>
-      Option.map(model.maybeSession, session => ({
-        userId: session.id,
-      })),
+Build them with `Subscription.makeSubscriptions(Deps)<Model, Message>(...)`. For each subscription, you provide:
 
-    // Build stream from dependencies
-    dependenciesToStream: maybeDeps =>
-      Option.match(maybeDeps, {
-        onNone: () => Stream.empty,
-        onSome: ({ userId }) =>
-          someStream(userId).pipe(
-            Stream.map(data => Effect.succeed(UpdatedData({ data }))),
-            Stream.catch(error =>
-              Stream.make(
-                Effect.succeed(FailedStream({ error: String(error) })),
-              ),
-            ),
-          ),
-      }),
-  },
-})
-```
+- A `modelToDependencies(model)` function that returns the parameters the stream needs, wrapped in `Option`. When it returns `Option.some(...)`, the Subscription is active. When it returns `Option.none()`, the Subscription stops. The runtime restarts the stream whenever the dependencies change.
+- A `dependenciesToStream(maybeDeps)` function that turns those parameters into a `Stream<Message>`. Errors should be mapped to a `Failed*` Message inside the stream rather than thrown.
 
-When Model state changes such that `modelToDependencies` returns `None`, the Subscription stops. When it returns `Some`, the Subscription starts with the new dependencies.
+For always-active Subscriptions (keyboard listeners, window resize, animation frame ticks), set the dependency type to `S.Null` and return `null` from `modelToDependencies`. The Subscription then never stops.
 
-### Subscriptions With No Model Dependencies
+Canonical live examples:
 
-Some Subscriptions are always active (e.g., keyboard listeners, window resize). Use `S.Null` for the dependency type:
-
-```ts
-const SubscriptionDeps = S.Struct({
-  keyboard: S.Null,
-})
-
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
-  keyboard: {
-    modelToDependencies: () => null,
-    dependenciesToStream: () =>
-      Stream.fromEventListener<KeyboardEvent>(document, 'keydown').pipe(
-        Stream.map(event => Effect.succeed(PressedKey({ key: event.key }))),
-      ),
-  },
-})
-```
-
-The `S.Null` dependency means the Subscription is always active — it never stops based on Model state.
+- **Always-active keyboard input**: `repos/foldkit/examples/snake/src/main.ts`
+- **Animation-frame-driven game tick**: `repos/foldkit/examples/canvas-art/src/main.ts`
+- **Conditional WebSocket connection** (active only when a session exists): `repos/foldkit/examples/websocket-chat/src/main.ts`
+- **Production multi-stream pattern**: `repos/foldkit/packages/typing-game/client/src/subscription.ts`
 
 ## Keyed Views
 
@@ -321,41 +272,41 @@ keyed('div')(model.route._tag, [...], [...])
 
 Without keying, the virtual DOM tries to patch one layout into another, causing stale DOM, mismatched event handlers, and rendering bugs.
 
-## Task Helpers
+## DOM and Effect Helpers
 
-Commands that interact with the DOM or browser APIs should use `Task` helpers — pure Effect wrappers around browser operations:
+Commands that interact with the DOM use Foldkit's `Dom` module. Time, randomness, and delays use Effect's built-in services. Both are pure Effect wrappers, so they compose naturally in Commands.
 
-| Helper                              | What it does                                             |
-| ----------------------------------- | -------------------------------------------------------- |
-| `Task.focus(selector)`              | Focus a DOM element by CSS selector                      |
-| `Task.scrollIntoView(selector)`     | Scroll an element into view                              |
-| `Task.showModal(selector)`          | Show a `<dialog>` element as a modal                     |
-| `Task.closeModal(selector)`         | Close a `<dialog>` element                               |
-| `Task.clickElement(selector)`       | Programmatically click an element                        |
-| `Task.delay(duration)`              | Wait for a duration (e.g., `'1 second'`, `'500 millis'`) |
-| `Task.nextFrame`                    | Wait for the next animation frame                        |
-| `Task.waitForTransitions(selector)` | Wait for CSS transitions to finish                       |
-| `Task.getTime`                      | Get current time via Effect's Clock service              |
-| `Task.randomInt(min, max)`          | Generate a random integer via Effect's Random service    |
+### Foldkit `Dom` module
 
-Use these instead of raw `document.querySelector`, `setTimeout`, `Date.now()`, or `Math.random()`. They return Effects that compose naturally in Commands:
+Import as `import { Dom } from 'foldkit'` (or `import * as Dom from 'foldkit/dom'`).
 
-```ts
-const FocusInput = Command.define('FocusInput', CompletedFocusInput)
-const ShowConfirmation = Command.define('ShowConfirmation', CompletedShowDialog)
+| Helper                             | What it does                                                 |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `Dom.focus(selector)`              | Focus a DOM element by CSS selector                          |
+| `Dom.advanceFocus(direction)`      | Move focus to the next/previous focusable element            |
+| `Dom.scrollIntoView(selector)`     | Scroll an element into view                                  |
+| `Dom.showModal(selector)`          | Show a `<dialog>` element as a modal                         |
+| `Dom.closeModal(selector)`         | Close a `<dialog>` element                                   |
+| `Dom.clickElement(selector)`       | Programmatically click an element                            |
+| `Dom.lockScroll` / `unlockScroll`  | Prevent / restore page scroll (e.g. behind modals)           |
+| `Dom.inertOthers` / `restoreInert` | Toggle `inert` on siblings of an element (focus containment) |
+| `Dom.detectElementMovement(...)`   | Observe an element for layout-affecting movement             |
+| `Dom.waitForAnimationSettled(sel)` | Wait for CSS animations/transitions on an element to finish  |
 
-const focusInput = Task.focus(`#${EMAIL_INPUT_ID}`).pipe(
-  Effect.ignore,
-  Effect.as(CompletedFocusInput()),
-  FocusInput,
-)
+### Effect built-ins
 
-const showConfirmation = Task.showModal(`#${CONFIRM_DIALOG_ID}`).pipe(
-  Effect.ignore,
-  Effect.as(CompletedShowDialog()),
-  ShowConfirmation,
-)
-```
+Use these directly from the `effect` package for non-DOM concerns. No Foldkit wrapper is needed.
+
+| Need                  | Use                                                    |
+| --------------------- | ------------------------------------------------------ |
+| Current time (millis) | `yield* Clock.currentTimeMillis`                       |
+| Current calendar date | `yield* Calendar.today.local` (returns `CalendarDate`) |
+| Random integer        | `yield* Random.nextIntBetween(min, max)`               |
+| Random float          | `yield* Random.nextBetween(min, max)`                  |
+| UUID                  | `yield* Effect.uuid`                                   |
+| Delay                 | `yield* Effect.sleep(Duration.millis(500))`            |
+
+Use these instead of raw `document.querySelector`, `setTimeout`, `Date.now()`, or `Math.random()`. They compose naturally inside `Command.define`. For canonical wiring, see `repos/foldkit/examples/kanban/src/command.ts` (`FocusAddCardInput` wraps `Dom.focus`) and `repos/foldkit/examples/stopwatch/src/main.ts` (`Clock.currentTimeMillis` inside an `Effect.gen`).
 
 ## With and Without URL Routing
 
@@ -400,32 +351,11 @@ Runtime.run(program)
 
 ### Document Title
 
-Pass a `title` function to set `document.title` after every render. It receives the current Model and returns a string. This is optional — programs that omit `title` don't touch the document title, which is the right default for embedded widgets. The `title` function is independent of `routing` — non-routed programs can set titles based on any model state (e.g. a game showing "Level 3" or "Game Over").
+Pass a `title` function to set `document.title` after every render. It receives the current Model and returns a string. This is optional. Programs that omit `title` don't touch the document title, which is the right default for embedded widgets. The `title` function is independent of `routing`. Non-routed programs can set titles based on any model state (e.g. a game showing "Level 3" or "Game Over").
 
-`onUrlRequest` fires when the user clicks a link. The Message receives a `UrlRequest` (either `InternalUrl` or `ExternalUrl`). Handle it in update:
+`onUrlRequest` fires when the user clicks a link. The Message receives a `UrlRequest` (a tagged union from the `Navigation` namespace) which you handle in update by matching on its `_tag`. `onUrlChange` fires when the browser URL changes (back/forward buttons); the handler updates the route from the new URL.
 
-```ts
-ClickedLink: ({ request }) =>
-  M.value(request).pipe(
-    withUpdateReturn,
-    M.tagsExhaustive({
-      InternalUrl: ({ url }) => [
-        evo(model, { route: () => urlToAppRoute(url) }),
-        [pushUrl(url)],
-      ],
-      ExternalUrl: ({ href }) => [model, [loadExternalUrl(href)]],
-    }),
-  ),
-```
-
-`onUrlChange` fires when the browser URL changes (back/forward buttons). Update the route from the new URL:
-
-```ts
-ChangedUrl: ({ url }) => [
-  evo(model, { route: () => urlToAppRoute(url) }),
-  [],
-],
-```
+For the canonical update-handler shapes (the exact `UrlRequest` tag names, how to dispatch `pushUrl` vs an external load Command, and how to derive the route from a `Url`), see `repos/foldkit/examples/routing/src/main.ts`.
 
 ### How to Choose
 

--- a/skills/generate-program/checklist.md
+++ b/skills/generate-program/checklist.md
@@ -2,20 +2,20 @@
 
 Run through each category after generating an app. Fix any issues before presenting the result.
 
-> **This is the canonical reference for mechanical checks.** `SKILL.md` phases 4.5, 5, and 5.5 point here rather than duplicating the grep commands inline, to prevent drift. If you update a grep or add a new one, update it here — the phases will inherit the change.
+> **This is the canonical reference for mechanical checks.** `SKILL.md` phases 4.5, 5, and 5.5 point here rather than duplicating the grep commands inline, to prevent drift. If you update a grep or add a new one, update it here. The phases will inherit the change.
 
 ## Gate commands (run ALL FOUR; fix everything they surface)
 
-- [ ] `npm run format` (or `npx prettier -w .`) — run FIRST; rewrites files so subsequent gates see the committed shape.
-- [ ] `npm run lint` (or `npx eslint .`) — output clean. Catches unused imports, unused vars, style-rule violations that `tsc` does not.
-- [ ] `npm run typecheck` (or `npx tsc --noEmit`) — no errors.
-- [ ] `npm run test` (or `npx vitest run`) — all tests pass.
+- [ ] `npm run format` (or `npx prettier -w .`): run FIRST; rewrites files so subsequent gates see the committed shape.
+- [ ] `npm run lint` (or `npx eslint .`): output clean. Catches unused imports, unused vars, style-rule violations that `tsc` does not.
+- [ ] `npm run typecheck` (or `npx tsc --noEmit`): no errors.
+- [ ] `npm run test` (or `npx vitest run`): all tests pass.
 
 "Typecheck clean and tests pass" is NOT sufficient. Generated code is rarely Prettier-exact out of the box, and frequently has unused imports (`Invalid`, `NotValidated`, `Valid` imported as values when only used as string-literal tag keys in `M.tag(...)`) that only the linter catches. Skipping either means the user's first `git commit` produces a cascade of formatting/lint fixes they have to clean up.
 
 ## Mechanical scans (run on every file before tsc)
 
-These are the fast greps that catch the common write-time violations. Run them against `src/`. Each hit is either a fix or a `// NOTE:` justification — silent hits aren't allowed. Phase 4.5 of SKILL.md runs this block; the reviewer in Phase 6 runs it again as sanity.
+These are the fast greps that catch the common write-time violations. Run them against `src/`. Each hit is either a fix or a `// NOTE:` justification. Silent hits aren't allowed. Phase 4.5 of SKILL.md runs this block; the reviewer in Phase 6 runs it again as sanity.
 
 ```bash
 # Empty-object constructor calls — no-field tagged structs should call with no arg
@@ -84,7 +84,7 @@ grep -rn "Target('_blank')" src/ -A 2 | grep -B 1 "Rel(" || echo "(all _blank ha
 grep -rn "outline-none" src/ | grep -v "focus-visible:"
 ```
 
-Alongside the greps, eyeball each file's imports. Every symbol you imported should be called. ESLint flags this, but so do you — at write-time.
+Alongside the greps, eyeball each file's imports. Every symbol you imported should be called. ESLint flags this, but so do you, at write-time.
 
 ## Structural completeness
 
@@ -107,24 +107,24 @@ Alongside the greps, eyeball each file's imports. Every symbol you imported shou
 
 - [ ] Every Command identity defined with `Command.define` and assigned to a PascalCase constant
 - [ ] Every `Command.define` includes result Message schemas after the name
-- [ ] No inline `Command.define` in pipe chains — always stored as a constant
+- [ ] No inline `Command.define` in pipe chains. Always stored as a constant
 - [ ] Definitions colocated with the update that produces them
-- [ ] Every _fallible_ Command catches all errors: `Effect.catch(() => Effect.succeed(FailedX(...)))`. Infallible Effects (Clock, Random, Task.uuid, Task.getTime) do NOT need catch — if the type system shows no error channel, there's nothing to catch, and no paired `Failed*` Message is needed either.
-- [ ] Return types inferred — no explicit `Command<typeof A>` annotations
+- [ ] Every _fallible_ Command catches all errors: `Effect.catch(() => Effect.succeed(FailedX(...)))`. Infallible Effects (`Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Calendar.today.local`) do NOT need catch. If the type system shows no error channel, there's nothing to catch, and no paired `Failed*` Message is needed either.
+- [ ] Return types inferred. No explicit `Command<typeof A>` annotations
 - [ ] Factory functions named by action: `fetchWeather`, not `fetchWeatherCommand`
 - [ ] Fire-and-forget Commands return `Completed*` Messages
 
-## Mount, Command, ManagedResource, CustomElement — pick by what causes the side effect
+## Mount, Command, ManagedResource, CustomElement: pick by what causes the side effect
 
-- [ ] **One-time effect after a Message dispatched** → Command. Focus-on-open, navigation, network, storage, analytics, scroll lock paired with a modal opening/closing — all belong in `update`'s return, not in `OnMount`.
+- [ ] **One-time effect after a Message dispatched** → Command. Focus-on-open, navigation, network, storage, analytics, scroll lock paired with a modal opening/closing all belong in `update`'s return, not in `OnMount`.
 - [ ] **Per-instance lifecycle bound to a VNode existing**, where the live `Element` handle is needed → Mount. Anchor positioning, backdrop portaling, attaching observers/listeners to a specific element, third-party library instantiation that takes the element as host.
-- [ ] **Stateful runtime object** (websocket, camera stream, library instance) keyed on a Model condition, with Commands consuming the handle via `yield*` → ManagedResource. Not a generic "lifecycle on Model condition" — there must be a handle for Commands to use.
+- [ ] **Stateful runtime object** (websocket, camera stream, library instance) keyed on a Model condition, with Commands consuming the handle via `yield*` → ManagedResource. Not a generic "lifecycle on Model condition". There must be a handle for Commands to use.
 - [ ] **Native web component** (Shoelace, vanilla-colorful, emoji-picker-element, anything that speaks typed JS properties + observed attributes + dispatched `CustomEvent`s) → CustomElement. Side-effect-import the package to register the element with the browser, then declare its surface with `CustomElement.define({ tag, properties, events })` to get a typed inline builder. Do NOT reach for Mount + Subscription + tag-name registry to wrap a web component; `CustomElement.define` is the higher-level fit when those three surfaces are available.
 
 ### Two practical rules for Mount (both must hold)
 
 - [ ] **The Effect uses the element parameter.** If the Effect doesn't read or write the element, Mount is the wrong primitive. Pick Command (transition-driven) or paired Commands (lifecycle-bound but element-handle-not-used).
-- [ ] **The work is DOM measurement or DOM manipulation on that element.** Read geometry, mutate CSS, attach an observer/listener, portal the element, hand it to a third-party library. Anything else — network, storage, analytics, focus-on-transition, scroll lock for the page — is a Command.
+- [ ] **The work is DOM measurement or DOM manipulation on that element.** Read geometry, mutate CSS, attach an observer/listener, portal the element, hand it to a third-party library. Anything else (network, storage, analytics, focus-on-transition, scroll lock for the page) is a Command.
 
 ### Replay safety
 
@@ -136,7 +136,7 @@ Alongside the greps, eyeball each file's imports. Every symbol you imported shou
 
 ### Naming
 
-- [ ] Mount Definition names are verb-first imperatives: `AnchorPopover`, `PortalPopoverBackdrop`, `AttachComboboxPreventBlur` — not `PopoverAnchor` or `ComboboxPreventBlurAttachment`. Mount result Messages are verb-first past-tense: `CompletedAnchorPopover`.
+- [ ] Mount Definition names are verb-first imperatives: `AnchorPopover`, `PortalPopoverBackdrop`, `AttachComboboxPreventBlur`, not `PopoverAnchor` or `ComboboxPreventBlurAttachment`. Mount result Messages are verb-first past-tense: `CompletedAnchorPopover`.
 
 ## Naming
 
@@ -164,7 +164,7 @@ Alongside the greps, eyeball each file's imports. Every symbol you imported shou
 - [ ] `Array.isEmptyArray` / `Array.isNonEmptyArray` (not `.length === 0` or `.length > 0`)
 - [ ] `evo()` for Model updates (not spread)
 - [ ] Callable constructors (not `as` casts or manual `_tag` objects)
-- [ ] No-field tagged structs called with NO argument: `Idle()`, `Work()`, `ClickedSubmit()` — never `Idle({})`, `Work({})`, `ClickedSubmit({})`
+- [ ] No-field tagged structs called with NO argument: `Idle()`, `Work()`, `ClickedSubmit()`. Never `Idle({})`, `Work({})`, `ClickedSubmit({})`
 - [ ] `Option.match` preferred over `Option.map` + `Option.getOrElse`
 
 ## View
@@ -175,7 +175,7 @@ Alongside the greps, eyeball each file's imports. Every symbol you imported shou
 
 ## Foldkit UI
 
-- [ ] Foldkit UI components used where interaction matches (Dialog, Tabs, Menu, Combobox, DatePicker, FileDrop, Toast, Tooltip, DragAndDrop, etc.) — never hand-roll accessible widgets
+- [ ] Foldkit UI components used where interaction matches (Dialog, Tabs, Menu, Combobox, DatePicker, FileDrop, Toast, Tooltip, DragAndDrop, etc.). Never hand-roll accessible widgets
 - [ ] **Form inputs use `Ui.Input.view`, `Ui.Textarea.view`, `Ui.Button`.** Hand-rolled `input`/`textarea`/`button` elements in a form are a fail unless the file has a NOTE comment explaining why the component couldn't be used.
 - [ ] Each UI component has its Model in the app Model, a `Got*` Message, init in init, and delegation in update
 - [ ] `Ui.Toast` uses `Ui.Toast.make(PayloadSchema)` to bind to a consumer-defined payload type
@@ -192,13 +192,13 @@ grep -rn "OnClick(.*) .*button(" src/   # raw <button> with click handler — sh
 grep -rn "role.*dialog\|role.*menu" src/  # hand-rolled ARIA — should use Ui.Dialog / Ui.Menu
 ```
 
-The rule: **if the interaction pattern appears in the Ui.\* component table (Phase 2.5 of SKILL.md), use the component.** Hand-rolling is permitted only when: (a) the component doesn't exist yet, AND (b) you add a `// NOTE: hand-rolling because <specific reason>` comment above the element. Without the NOTE, the reviewer treats hand-rolling as a BLOCKER — not a style preference.
+The rule: **if the interaction pattern appears in the Ui.\* component table (Phase 2.5 of SKILL.md), use the component.** Hand-rolling is permitted only when: (a) the component doesn't exist yet, AND (b) you add a `// NOTE: hand-rolling because <specific reason>` comment above the element. Without the NOTE, the reviewer treats hand-rolling as a BLOCKER, not a style preference.
 
 **A NOTE is not a free pass.** Before writing one, read the component's `.d.ts` and confirm the concern is real. Common false-justifications to avoid:
 
-- _"Using the Ui component would require a per-row Model instance and duplicate state"_ — check the component's Model shape. Most Ui components (Checkbox, Switch) have small Models (`{ id, isChecked }`) that can be constructed inline from derived state: `Ui.Checkbox.view({ model: { id: ..., isChecked: derivedFromState }, toParentMessage: () => MyMessage(...), ... })`. No app-Model entry needed. The component's internal `update` is never called; your update dispatches your own Message when `toParentMessage` fires.
-- _"The component needs a toParentMessage and I don't want to wire one"_ — that's always the wiring cost. The whole point of Ui components is that you pay it once per use and get a11y for free.
-- _"The interaction is too custom for the component"_ — check the `toView` callback signature. It lets you render whatever HTML you want inside the component's attribute-scaffolding. Custom visual = fine, custom a11y = never needed.
+- _"Using the Ui component would require a per-row Model instance and duplicate state"_: check the component's Model shape. Most Ui components (Checkbox, Switch) have small Models (`{ id, isChecked }`) that can be constructed inline from derived state: `Ui.Checkbox.view({ model: { id: ..., isChecked: derivedFromState }, toParentMessage: () => MyMessage(...), ... })`. No app-Model entry needed. The component's internal `update` is never called; your update dispatches your own Message when `toParentMessage` fires.
+- _"The component needs a toParentMessage and I don't want to wire one"_: that's always the wiring cost. The whole point of Ui components is that you pay it once per use and get a11y for free.
+- _"The interaction is too custom for the component"_: check the `toView` callback signature. It lets you render whatever HTML you want inside the component's attribute-scaffolding. Custom visual = fine, custom a11y = never needed.
 
 Reviewers should challenge every NOTE: "Is this justification actually true, or is it defensive rationalization? What does the `.d.ts` say?" Look up the component's actual API before accepting the NOTE.
 
@@ -213,16 +213,16 @@ Foldkit UI components ARE the a11y pass for their covered patterns. These checks
 - [ ] Icon-only buttons have `AriaLabel(...)` describing the action. `button([OnClick(...)], ['★'])` without an aria label is unreadable to screen readers.
 - [ ] Dynamic error messages wrap in `role="alert"` (for immediate errors) or `aria-live="polite"` (for non-urgent updates). Validation errors that appear after blur should be announced. Example: `p([Role('alert'), ...], [errorMessage])`. Grep for error-class CSS (e.g. `text-red`) and verify each error container has `Role('alert')` or a parent with `AriaLive('polite')`.
 - [ ] External links (`Target('_blank')`) also have `Rel('noopener noreferrer')`.
-- [ ] Images have `Alt(...)`. Decorative images use `Alt('')` explicitly — never omitted.
+- [ ] Images have `Alt(...)`. Decorative images use `Alt('')` explicitly. Never omitted.
 - [ ] Interactive lists (navigable items, selectable rows) use `ul`/`ol` + `li`, not `div` stacks. Screen readers announce "list with N items" for real lists.
 - [ ] Required form fields are marked `AriaRequired(true)` OR the `Ui.Input` `required: true` is set. The `required` HTML attribute alone is not enough for every screen reader.
-- [ ] Focus is visible — either via Tailwind's `focus-visible:` classes or the browser default. If you've reset outline, you must replace it. Grep for `outline-none` without a paired `focus-visible:` class.
+- [ ] Focus is visible, either via Tailwind's `focus-visible:` classes or the browser default. If you've reset outline, you must replace it. Grep for `outline-none` without a paired `focus-visible:` class.
 - [ ] Color is not the only carrier of meaning. A red border on an invalid input needs an accompanying error message or icon. Don't ship "invalid = red only."
 - [ ] Page `<title>` is set via `Runtime.makeProgram`'s `title: model => ...` for routed apps. Each route returns a distinct title.
 
 ### Mechanical check: a11y
 
-The greps below are **fast starting scans**, not authoritative. Attributes often span multiple lines (`Target('_blank')` on line N, `Rel('noopener noreferrer')` on line N+1), so line-only matches can false-positive. Every hit should be eyeballed in context before flagging it as a bug — but every hit DOES need to be eyeballed.
+The greps below are **fast starting scans**, not authoritative. Attributes often span multiple lines (`Target('_blank')` on line N, `Rel('noopener noreferrer')` on line N+1), so line-only matches can false-positive. Every hit should be eyeballed in context before flagging it as a bug, but every hit DOES need to be eyeballed.
 
 ```bash
 grep -rn "label(\[" src/ | grep -v "For("                # labels without For
@@ -236,9 +236,9 @@ Each confirmed miss is a concrete a11y bug a screen reader user would hit.
 
 ## Forms, dates, and files
 
-- [ ] Form validation uses `foldkit/fieldValidation` (`Field`, `makeRules`, `validate`, `allValid`) — no hand-rolled `Valid | Invalid` unions when validation is the concern
-- [ ] Date handling uses the `Calendar` module (`Calendar.CalendarDate`, `Calendar.today.local`) — no raw `Date` objects in Model
-- [ ] File handling uses the `File` module with `Ui.FileDrop` — no direct `File` API usage in update/view
+- [ ] Form validation uses `foldkit/fieldValidation` (`Field`, `makeRules`, `validate`, `allValid`). No hand-rolled `Valid | Invalid` unions when validation is the concern
+- [ ] Date handling uses the `Calendar` module (`Calendar.CalendarDate`, `Calendar.today.local`). No raw `Date` objects in Model
+- [ ] File handling uses the `File` module with `Ui.FileDrop`. No direct `File` API usage in update/view
 
 ## File organization
 
@@ -255,16 +255,16 @@ Each confirmed miss is a concrete a11y bug a screen reader user would hit.
 - [ ] Every fallible Command (`Succeeded*`/`Failed*` pair) tested for both outcomes
 - [ ] At least one multi-step test that chains Messages and Command resolutions
 - [ ] Submodel tests assert `outMessage` when the child signals to parent
-- [ ] Tests use `Story.Command.resolve(Definition, resultMessage)` — never run Command Effects directly in story tests
+- [ ] Tests use `Story.Command.resolve(Definition, resultMessage)`. Never run Command Effects directly in story tests
 - [ ] All tests pass with `npx vitest run`
 
 **Scene tests** (REQUIRED at Tier 3+; strongly encouraged at Tier 2):
 
-For Tier 3+ apps (routing, async Commands, forms), missing `main.scene.test.ts` is a **BLOCKER** — the app has not been tested from the user's perspective without it.
+For Tier 3+ apps (routing, async Commands, forms), missing `main.scene.test.ts` is a **BLOCKER**. The app has not been tested from the user's perspective without it.
 
 - [ ] `main.scene.test.ts` exists
-- [ ] View rendering test — initial view has expected elements (headings, inputs, buttons)
-- [ ] User interactions test — click, type, submit produce visible changes
+- [ ] View rendering test: initial view has expected elements (headings, inputs, buttons)
+- [ ] User interactions test: click, type, submit produce visible changes
 - [ ] At minimum one test per discriminated-union state that has distinct view output (loading, error, empty, populated)
 - [ ] Uses accessible locators: `Scene.role(...)`, `Scene.label(...)`, `Scene.text(...)`. Not `Scene.placeholder` or CSS selectors.
 - [ ] Scoped queries with `Scene.within` or `Scene.inside` when a parent container contains multiple similar elements
@@ -277,17 +277,17 @@ The sections above cover correctness. The sections below cover the craft details
 
 **Tier-aware:** every item below applies at every tier UNLESS marked otherwise:
 
-- `[T2+]` — applies once the app has subscriptions or persisted state
-- `[T3+]` — applies once the app has async Commands or routing
-- `[T5+]` — applies once the app has nested domain state, multiple entities, or submodels
+- `[T2+]`: applies once the app has subscriptions or persisted state
+- `[T3+]`: applies once the app has async Commands or routing
+- `[T5+]`: applies once the app has nested domain state, multiple entities, or submodels
 
 Items without a tier marker apply universally (even to a 50-line counter). When in doubt, assume universal.
 
 ## Decomposition
 
-- [ ] Every function operates at a single abstraction level — orchestrators delegate, implementations implement. If a function reads like it's doing two things, extract one.
+- [ ] Every function operates at a single abstraction level: orchestrators delegate, implementations implement. If a function reads like it's doing two things, extract one.
 - [ ] **Update handlers over ~15 lines are extracted** to named functions in the same file. [T3+] If a handler exceeds ~50 lines, extract to its own file under `src/update/` (e.g. `update/handleRoomUpdates.ts`).
-- [ ] **Extracted handlers are curried `(model: Model) => (message: M) => UpdateReturn`** so they compose in pipelines — not `(model, message) => UpdateReturn`. See `packages/typing-game/client/src/page/home/update/handleKeyPressed.ts:33-40`.
+- [ ] **Extracted handlers are curried `(model: Model) => (message: M) => UpdateReturn`** so they compose in pipelines, not `(model, message) => UpdateReturn`. See `packages/typing-game/client/src/page/home/update/handleKeyPressed.ts:33-40`.
 - [ ] **View branches over ~30 lines are extracted** to named view functions (e.g. `enterUsernameView`, `selectActionView`). [T5+] If the view for a single route/state exceeds ~100 lines, extract to `src/view/` or `src/page/*/view.ts`.
 - [ ] No function exceeds ~40 lines without extraction. Long functions are the primary smell.
 
@@ -295,12 +295,12 @@ Items without a tier marker apply universally (even to a 50-line counter). When 
 
 - [ ] Native methods replaced with Effect equivalents _in pipe chains_: `Array.map(items, f)` not `items.map(f)` when composing; `String.startsWith(s, 'foo')` in a pipe not `s.startsWith('foo')`.
 - [ ] `Option.match({ onNone, onSome })` preferred over `Option.map(...).pipe(Option.getOrElse(...))`. The labeled branches are self-documenting.
-- [ ] `Array.match({ onEmpty, onNonEmpty })` when handling both empty and non-empty cases. Not `isEmptyArray ? ... : ...` ternaries. Grep for `.length > 0` and `.length === 0` on arrays and strings — should be zero. Use `Array.isNonEmptyArray` / `String.isNonEmpty` for pure checks, `Array.match` for branching renders.
+- [ ] `Array.match({ onEmpty, onNonEmpty })` when handling both empty and non-empty cases. Not `isEmptyArray ? ... : ...` ternaries. Grep for `.length > 0` and `.length === 0` on arrays and strings; should be zero. Use `Array.isNonEmptyArray` / `String.isNonEmpty` for pure checks, `Array.match` for branching renders.
 - [ ] `Equal.equals(target)` in predicates: `Array.findFirst(items, Equal.equals('Other'))` not `item => item === 'Other'`.
-- [ ] `Array.fromOption(maybeCommand)` for "zero or one command based on Option" — not `Option.match` that returns `[]` vs `[cmd]`.
+- [ ] `Array.fromOption(maybeCommand)` for "zero or one command based on Option", not `Option.match` that returns `[]` vs `[cmd]`.
 - [ ] `OptionExt.when(condition, value)` instead of `condition ? Option.some(value) : Option.none()`.
-- [ ] `pipe(...)` is multi-step only. Never `pipe(x, singleOp(...))` — call `singleOp(x, ...)` directly. (Exception: `.pipe(Effect.catch(...))` as a tail suffix is fine.)
-- [ ] When piping, data leads on its own line: `pipe(\n  data,\n  Array.map(f),\n  ...\n)` — not `pipe(data, Array.map(f), ...)`.
+- [ ] `pipe(...)` is multi-step only. Never `pipe(x, singleOp(...))`; call `singleOp(x, ...)` directly. (Exception: `.pipe(Effect.catch(...))` as a tail suffix is fine.)
+- [ ] When piping, data leads on its own line: `pipe(\n  data,\n  Array.map(f),\n  ...\n)`, not `pipe(data, Array.map(f), ...)`.
 - [ ] Callback destructuring when accessing a single field: `({ id }) => id === cardId` not `card => card.id === cardId`.
 
 ## Domain organization [T5+]
@@ -314,7 +314,7 @@ Items without a tier marker apply universally (even to a 50-line counter). When 
 ## Naming precision
 
 - [ ] Every Option-typed value is prefixed `maybe*`: `maybeCurrentUser`, `maybeFocusUsernameInput`, `maybeOutMessage`, `maybeNewCardColumnId`. No exceptions.
-- [ ] Every native `T | undefined` is prefixed `nullable*`. No `maybe*` for nullable; that's reserved for `Option`. Grep `maybe[A-Z]` against function signatures and variable types — each hit should be `Option<T>`, not `T | undefined`.
+- [ ] Every native `T | undefined` is prefixed `nullable*`. No `maybe*` for nullable; that's reserved for `Option`. Grep `maybe[A-Z]` against function signatures and variable types; each hit should be `Option<T>`, not `T | undefined`.
 - [ ] Internal API boundaries (helper function configs, view builders, domain operations) use `Option<T>` for optional fields, not `T | undefined`. Call sites then read `Option.some(x)` / `Option.none()` instead of `x` / `undefined`. The `T | undefined` form is only acceptable at framework boundaries (React props, vendored library configs, JSON decoding) that already use it.
 - [ ] Boolean fields prefixed `is*`: `isPlaying`, `isDismissed`, `isMenuOpen`.
 - [ ] Command function names are verbs describing the action: `fetchWeather`, `focusButton`, `scrollToItem`. Never `fetchWeatherCommand` or `weatherFetcher`.
@@ -335,14 +335,14 @@ Items without a tier marker apply universally (even to a 50-line counter). When 
 ## Submodel and Command extraction [T5+]
 
 - [ ] [T5+] If the app has multiple Submodels, each has its own directory with at minimum `main.ts` (init/update/view), `message.ts` (messages + OutMessage schema), and optionally `command.ts` (submodel Commands).
-- [ ] [T3+] If update returns Commands across multiple handlers AND the Commands involve non-trivial Effect pipelines (HTTP, Task compositions), Commands are defined in their own `command.ts` file, not inline in update.
+- [ ] [T3+] If update returns Commands across multiple handlers AND the Commands involve non-trivial Effect pipelines (HTTP, Dom compositions), Commands are defined in their own `command.ts` file, not inline in update.
 - [ ] Command factories are pre-wrapped and named by action: `const fetchWeather = (city) => ...` returns the Command-wrapped Effect. Call sites read as `[fetchWeather(city)]`, not `[FetchWeather(Effect.gen(...))]`.
 - [ ] [T5+] OutMessage unions are explicitly tagged with `// OUT MESSAGE` section comment when they appear in a submodel `message.ts`.
 
 ## Subscriptions [T2+]
 
 - [ ] Subscriptions use `Subscription.makeSubscriptions(Deps)<Model, Message>` with a dedicated `Deps` Schema.
-- [ ] `modelToDependencies` extracts exactly the data the stream needs from Model — not the full Model. Returns `Option.none()` when the subscription should stop.
+- [ ] `modelToDependencies` extracts exactly the data the stream needs from Model, not the full Model. Returns `Option.none()` when the subscription should stop.
 - [ ] Always-active subscriptions use `S.Null` as the Deps type and return `null` from `modelToDependencies`.
 - [ ] Message mapping happens inside `Stream.map(event => Effect.succeed(UpdatedX({ data: event })))`, not scattered through update.
 - [ ] Subscription files live at `src/subscription.ts` (or `src/subscription/` directory for multiple), never inline in `main.ts`.
@@ -350,8 +350,8 @@ Items without a tier marker apply universally (even to a 50-line counter). When 
 ## Testing quality
 
 - [ ] Test names state the behavior being tested: `it('surfaces a validation error when email is malformed')`, not `it('tests validation')` or `it('handles the reported bug')`.
-- [ ] Each `Story.story` pipeline reads as a narrative — initial model → action → assert → action → assert. Not a dump of unrelated assertions.
-- [ ] Scene tests use accessible locators — `Scene.role('button', { name: /submit/i })`, `Scene.label('Email')` — over `Scene.placeholder` or CSS selectors.
+- [ ] Each `Story.story` pipeline reads as a narrative: initial model → action → assert → action → assert. Not a dump of unrelated assertions.
+- [ ] Scene tests use accessible locators (`Scene.role('button', { name: /submit/i })`, `Scene.label('Email')`) over `Scene.placeholder` or CSS selectors.
 - [ ] Commands in tests are resolved with `Story.Command.resolve(Definition, resultMessage)`. Never run Command Effects directly.
 
 ## Residual code smells (each is a fail)
@@ -360,7 +360,7 @@ Items without a tier marker apply universally (even to a 50-line counter). When 
 - [ ] No commented-out code blocks. Delete, don't comment.
 - [ ] No TODO/FIXME/XXX comments in generated code. If something's incomplete, it shouldn't ship.
 - [ ] No `any` types. No `as` casts except where Schema decoders require them at boundaries (and those should be vanishingly rare).
-- [ ] No `let` outside tight imperative loops where mutation is genuinely unavoidable (rare — usually `Array.reduce` or `Array.makeBy` replaces it).
+- [ ] No `let` outside tight imperative loops where mutation is genuinely unavoidable (rare; usually `Array.reduce` or `Array.makeBy` replaces it).
 - [ ] No inline magic numbers in logic: `if (count > 5)` → `const FINAL_PHOTO_INDEX = 5; if (count > FINAL_PHOTO_INDEX)`.
 - [ ] No dead code, unused imports, unused exports, or stub types (`type Foo = {}`).
 - [ ] No `globalThis.*` references. Use Effect equivalents.

--- a/skills/generate-program/conventions.md
+++ b/skills/generate-program/conventions.md
@@ -1,5 +1,7 @@
 # Foldkit Conventions Guide
 
+> **Note:** This file is a snapshot of the conventions practiced in the live Foldkit codebase. If anything here contradicts what `repos/foldkit/examples/` or `repos/foldkit/packages/foldkit/src/` actually do, the live code is canonical. The duplication is intentional so the skill works in downstream projects that haven't vendored the foldkit subtree.
+
 ## Naming
 
 ### Messages
@@ -23,7 +25,7 @@ Messages use past-tense, verb-first naming. The verb prefix acts as a category m
 | `Hid*`       | UI element dismissed                        | `HidToast`, `HidCopiedIndicator`                    |
 | `Ticked*`    | Timer/interval tick                         | `TickedCountdown`, `TickedExitCountdown`            |
 
-`Updated*` covers both user input changes (`UpdatedEmail`, `UpdatedNewTodo`) and external state updates from subscriptions (`UpdatedRoom`, `UpdatedPlayerProgress`). The prefix describes the fact ("the value was updated") — whether it came from a keystroke or a WebSocket doesn't change the Message category.
+`Updated*` covers both user input changes (`UpdatedEmail`, `UpdatedNewTodo`) and external state updates from subscriptions (`UpdatedRoom`, `UpdatedPlayerProgress`). The prefix describes the fact ("the value was updated"). Whether it came from a keystroke or a WebSocket doesn't change the Message category.
 
 #### Completed\* naming
 
@@ -56,7 +58,7 @@ const FailedFetchWeather = m('FailedFetchWeather', { error: S.String })
 
 - Never abbreviate: `signature` not `sig`, `username` not `user`, `message` not `msg`
 - Full names in callbacks: `(tickCount) => tickCount + 1` not `(t) => t + 1`
-- Prefix Option values with `maybe`: `maybeCurrentUser`, `maybeSession`, `maybeError`. **`maybe*` is reserved for `Option<T>` specifically.** Use `nullable*` for native `T | undefined`. A helper named `maybePlaceholder` whose type is `string | undefined` is wrong on both counts: rename to `nullablePlaceholder` or change the type to `Option<string>` (usually the better fix — optional fields at internal API boundaries should be `Option<T>` so the call site reads `Option.some(...)` / `Option.none()`, not bare `undefined`).
+- Prefix Option values with `maybe`: `maybeCurrentUser`, `maybeSession`, `maybeError`. **`maybe*` is reserved for `Option<T>` specifically.** Use `nullable*` for native `T | undefined`. A helper named `maybePlaceholder` whose type is `string | undefined` is wrong on both counts: rename to `nullablePlaceholder` or change the type to `Option<string>` (usually the better fix: optional fields at internal API boundaries should be `Option<T>` so the call site reads `Option.some(...)` / `Option.none()`, not bare `undefined`).
 - Boolean fields use `is*`: `isPlaying`, `isVisible`, `isMenuOpen`
 - Command variables named by action: `fetchWeather`, not `fetchWeatherCommand`
 - Command names are verb-first imperatives: `FetchWeather`, `FocusButton`, `LockScroll`, `Tick`
@@ -148,7 +150,7 @@ Array.take(items, count)              // not .slice(0, n)
 
 ### String module
 
-Effect's `String` module is **data-last curried only** — there is no data-first overload. Use it inside `pipe`/`flow`, not as a direct call:
+Effect's `String` module is **data-last curried only**. There is no data-first overload. Use it inside `pipe`/`flow`, not as a direct call:
 
 ```ts
 // WRONG — Effect String functions don't take data-first
@@ -183,11 +185,11 @@ Effect.gen(function* () {
 )
 ```
 
-The `.pipe(Effect.catch(...), FetchWeather)` is multi-step (two tail operators) and even if it were one, suffix-style `.pipe` on a yielded Effect is the canonical shape. Don't mechanically flatten it to `FetchWeather(Effect.catch(Effect.gen(...), ...))` — that reads inside-out and obscures the pipeline.
+The `.pipe(Effect.catch(...), FetchWeather)` is multi-step (two tail operators) and even if it were one, suffix-style `.pipe` on a yielded Effect is the canonical shape. Don't mechanically flatten it to `FetchWeather(Effect.catch(Effect.gen(...), ...))`. That reads inside-out and obscures the pipeline.
 
 ### Effect.ignore only when there's an error channel
 
-`Effect.ignore` discards both the success value AND any error. If the Effect is infallible at the type level (`Effect.Effect<A>` with no error parameter), there's nothing to discard — `Effect.as(Message())` alone is enough.
+`Effect.ignore` discards both the success value AND any error. If the Effect is infallible at the type level (`Effect.Effect<A>` with no error parameter), there's nothing to discard. `Effect.as(Message())` alone is enough.
 
 ```ts
 // WRONG — pushUrl returns Effect.Effect<void>, no error to ignore
@@ -203,7 +205,7 @@ httpClient.get(url).pipe(
 )
 ```
 
-Same goes for `Task` primitives: `Task.focus` can fail (element may not exist), so `Task.focus(selector).pipe(Effect.ignore, Effect.as(CompletedFocusInput()))` is correct. But `pushUrl`, `load`, `back`, and `forward` from `foldkit/navigation` all return `Effect.Effect<void>` — skip the `ignore`.
+Same goes for `Dom` primitives: `Dom.focus` can fail (element may not exist), so `Dom.focus(selector).pipe(Effect.ignore, Effect.as(CompletedFocusInput()))` is correct. But `pushUrl`, `load`, `back`, and `forward` from `foldkit/navigation` all return `Effect.Effect<void>`. Skip the `ignore`.
 
 ### Iteration
 
@@ -245,7 +247,7 @@ evo(model, {
 })
 ```
 
-Never mutate the model directly. **Never use spread syntax for updates** — `evo` is the canonical pattern. This applies to nested updates too: `evo(model, { newLinkForm: () => ({ ...model.newLinkForm, title: value }) })` is wrong. Use a nested `evo`: `evo(model, { newLinkForm: () => evo(model.newLinkForm, { title: () => value }) })`. The spread-inside-evo pattern is a common mistake — you're using `evo` at the outer level but bypassing it inside, which loses the invariant that all updates go through one codepath.
+Never mutate the model directly. **Never use spread syntax for updates.** `evo` is the canonical pattern. This applies to nested updates too: `evo(model, { newLinkForm: () => ({ ...model.newLinkForm, title: value }) })` is wrong. Use a nested `evo`: `evo(model, { newLinkForm: () => evo(model.newLinkForm, { title: () => value }) })`. The spread-inside-evo pattern is a common mistake. You're using `evo` at the outer level but bypassing it inside, which loses the invariant that all updates go through one codepath.
 
 ## Schema Constructors
 
@@ -268,7 +270,7 @@ Loading()
 SucceededFetch({ data: response })
 ```
 
-**No-field tagged structs take no argument — not an empty object.** `ts('Work')` (and `m('Clicked')`) produces a callable that accepts no argument when the struct has no fields:
+**No-field tagged structs take no argument, not an empty object.** `ts('Work')` (and `m('Clicked')`) produces a callable that accepts no argument when the struct has no fields:
 
 ```ts
 const Work = ts('Work')
@@ -290,7 +292,7 @@ SucceededFetch({ data: response })
 Paused({ remainingMs: 400_000 })
 ```
 
-This matters for readability: `Work()` reads as "a Work value," while `Work({})` reads as "a Work value with some object in it" and makes the reader wonder what's in the object. The empty-object form compiles and works — but every exemplar in the codebase uses the no-arg form for no-field tagged structs.
+This matters for readability: `Work()` reads as "a Work value," while `Work({})` reads as "a Work value with some object in it" and makes the reader wonder what's in the object. The empty-object form compiles and works, but every exemplar in the codebase uses the no-arg form for no-field tagged structs.
 
 ## Discriminated Unions for State
 
@@ -340,17 +342,17 @@ const SignupStep = S.Union([EnterEmail, EnterPassword, Confirming])
 
 ## Code Style
 
-- No inline or block comments — if code needs explanation, use better names
+- No inline or block comments. If code needs explanation, use better names
 - Section headers are allowed: `// MODEL`, `// MESSAGE`, `// INIT`, `// UPDATE`, `// VIEW`
 - TSDoc (`/** ... */`) on public exports
 - Always use braces for control flow: `if (foo) { return true }` not `if (foo) return true`
-- Use `const` exclusively — `let` only when mutation is truly unavoidable
+- Use `const` exclusively. `let` only when mutation is truly unavoidable
 - Prefer curried, data-last functions that compose in `pipe` chains
 - No dead code, no empty catch blocks, no placeholder types
 
 ## Conditional Styles with clsx
 
-Use `clsx` for conditional class composition — never string concatenation, template literals, or `&&` expressions. Use the object syntax `{ 'class-name': condition }` for conditional classes:
+Use `clsx` for conditional class composition. Never string concatenation, template literals, or `&&` expressions. Use the object syntax `{ 'class-name': condition }` for conditional classes:
 
 ```ts
 import clsx from 'clsx'
@@ -378,7 +380,7 @@ const borderClass = (field: FieldState): string =>
 Class(clsx('w-full px-3 py-2 border rounded-md', borderClass(field)))
 ```
 
-`clsx` is a project dependency — add it to `package.json` when generating apps that use conditional styles.
+`clsx` is a project dependency. Add it to `package.json` when generating apps that use conditional styles.
 
 ## Imports
 
@@ -400,10 +402,10 @@ import {
 import {
   Calendar,
   Command,
+  Dom,
   File,
   Runtime,
   Subscription,
-  Task,
   Ui,
   Url,
 } from 'foldkit'
@@ -433,10 +435,10 @@ import {
 
 Notes:
 
-- Only import what you use. `Calendar`, `File`, and `foldkit/fieldValidation` are only needed when the app has dates, file uploads, or form validation respectively
-- When an Effect module name collides with a global, alias the Effect import with a trailing underscore: `String as String_`, `Array as Array_`, `Number as Number_`
-- `Match as M` is Effect's Match module — Foldkit re-exports `M.value`, `M.tagsExhaustive`, `M.withReturnType` etc. through Effect's `Match`
+- Only import what you actually use in the file. The lint pass catches unused imports.
+- Module-by-module reminders, for example: `Calendar` for `Calendar.CalendarDate`, `Calendar.today.local`, `Calendar.make`, `Calendar.addDays` etc., paired with `Ui.Calendar` or `Ui.DatePicker`. `Dom` for DOM-side-effect helpers (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showModal`, `Dom.closeModal`, `Dom.lockScroll`, `Dom.unlockScroll`, `Dom.waitForAnimationSettled`, etc.). `File` for file upload primitives paired with `Ui.FileDrop`. `foldkit/fieldValidation` for form validation.
+- For time, randomness, UUIDs, or delays, use Effect's built-ins directly rather than reaching for a Foldkit module: `Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep(Duration.millis(...))`.
+- When an Effect module name collides with a global, alias the Effect import with a trailing underscore: `String as String_`, `Array as Array_`, `Number as Number_`.
+- `Match as M` is Effect's Match module. Foldkit re-exports `M.value`, `M.tagsExhaustive`, `M.withReturnType` etc. through Effect's `Match`.
 - `Ui` from `foldkit` gives access to all UI components: `Ui.Dialog`, `Ui.Tabs`, `Ui.Menu`, `Ui.DatePicker`, `Ui.FileDrop`, `Ui.Toast`, `Ui.Tooltip`, etc.
-- `Calendar` provides `Calendar.CalendarDate`, `Calendar.today.local`, `Calendar.make`, `Calendar.addDays` etc. — used with `Ui.Calendar` and `Ui.DatePicker`
-- `File` provides file upload primitives used with `Ui.FileDrop`
-- `empty` and `keyed` can be imported from `foldkit/html` directly or accessed off `h` after binding `const h = html<Message>()`
+- `empty` and `keyed` can be imported from `foldkit/html` directly or accessed off `h` after binding `const h = html<Message>()`.


### PR DESCRIPTION
## Summary

Refactors DOM and side-effect helpers across documentation and skill files to reflect the new Foldkit architecture: DOM operations now live in the `Dom` module, while time, randomness, and delays use Effect's built-in services directly.

## Key Changes

- **Architecture documentation** (`architecture.md`):
  - Renamed "Task Helpers" section to "DOM and Effect Helpers"
  - Moved all DOM operations (`focus`, `scrollIntoView`, `showModal`, etc.) under `Foldkit Dom` module with updated import paths
  - Added new Dom helpers: `advanceFocus`, `lockScroll`/`unlockScroll`, `inertOthers`/`restoreInert`, `detectElementMovement`, `waitForAnimationSettled`
  - Documented Effect built-in services (`Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep`) as the canonical way to handle time, randomness, and delays
  - Updated code examples to use `Dom.*` instead of `Task.*`

- **Skill and convention files**:
  - Updated `SKILL.md` to reference `foldkit/dist/dom/index.d.ts` instead of `foldkit/dist/task/index.d.ts`
  - Updated `conventions.md` to import `Dom` instead of `Task` and use Effect services directly
  - Updated `checklist.md` to reference infallible Effect services by their actual names
  - Updated exemplar paths in `CLAUDE.md` (e.g., `examples/typing-game` → `packages/typing-game`)

- **Plugin version**: Bumped to 0.10.2

- **Capitalization conventions** (`CLAUDE.md`): Updated to reflect new architecture concepts (`Mount`, `ManagedResource`, `CustomElement`) instead of `Task`

## Implementation Details

- All references to `Task.focus`, `Task.delay`, `Task.getTime`, `Task.randomInt`, `Task.uuid` have been replaced with their proper locations: `Dom.*` for DOM operations, `Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep(Duration.millis(...))` for side effects
- Documentation now clearly separates concerns: DOM operations (Foldkit's responsibility) vs. time/randomness/delays (Effect's responsibility)
- Updated all skill guidance to point developers to the correct `.d.ts` files for type information

https://claude.ai/code/session_01D25NwtzD4aVDSBpS2rPJDr