### PR TITLE
Rename SubscriptionDeps to SubscriptionDependencies

### DIFF
--- a/.changeset/rename-subscription-deps-to-subscription-dependencies.md
+++ b/.changeset/rename-subscription-deps-to-subscription-dependencies.md
@@ -1,0 +1,19 @@
+---
+'foldkit': minor
+---
+
+**Breaking:** Rename the exported `SubscriptionDeps` struct on UI components to `SubscriptionDependencies`. Affects `Ui.Slider`, `Ui.VirtualList`, and `Ui.DragAndDrop`. Update every callsite that references the old name:
+
+```ts
+// before
+Ui.Slider.SubscriptionDeps.fields['dragPointer']
+Ui.VirtualList.SubscriptionDeps.fields['containerEvents']
+Ui.DragAndDrop.SubscriptionDeps.fields['documentPointer']
+
+// after
+Ui.Slider.SubscriptionDependencies.fields['dragPointer']
+Ui.VirtualList.SubscriptionDependencies.fields['containerEvents']
+Ui.DragAndDrop.SubscriptionDependencies.fields['documentPointer']
+```
+
+By convention application code that names a local subscription dependency schema should also rename it from `SubscriptionDeps` to `SubscriptionDependencies` to match. The runtime API (`Subscription.makeSubscriptions`) accepts any schema name, so this convention change is not enforced by the types.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/examples/canvas-art/src/main.ts
+++ b/examples/canvas-art/src/main.ts
@@ -175,14 +175,13 @@ export const update = (
 
 // SUBSCRIPTION
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   frame: S.Boolean,
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   frame: Subscription.animationFrame({
     isActive: model => model.isRunning,
     toMessage: deltaTime => TickedFrame({ deltaTime }),

--- a/examples/generative-art/src/subscription.ts
+++ b/examples/generative-art/src/subscription.ts
@@ -9,9 +9,9 @@ import {
 import type { Message } from './message'
 import type { Model } from './model'
 
-const sliderFields = Ui.Slider.SubscriptionDeps.fields
+const sliderFields = Ui.Slider.SubscriptionDependencies.fields
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   frame: S.Boolean,
   flowStrengthSliderPointer: sliderFields['dragPointer'],
   flowStrengthSliderEscape: sliderFields['dragEscape'],
@@ -25,10 +25,9 @@ const mapFlowStrengthStream = (stream: Stream.Stream<Ui.Slider.Message>) =>
 const mapNoiseScaleStream = (stream: Stream.Stream<Ui.Slider.Message>) =>
   stream.pipe(Stream.map(message => GotNoiseScaleSliderMessage({ message })))
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   frame: Subscription.animationFrame({
     isActive: model => model.isRunning,
     toMessage: deltaTimeMs => TickedFrame({ deltaTimeMs }),

--- a/examples/kanban/src/subscription.ts
+++ b/examples/kanban/src/subscription.ts
@@ -5,9 +5,9 @@ import { GotDragAndDropMessage } from './message'
 import type { Message } from './message'
 import type { Model } from './model'
 
-const dragAndDropFields = Ui.DragAndDrop.SubscriptionDeps.fields
+const dragAndDropFields = Ui.DragAndDrop.SubscriptionDependencies.fields
 
-export const SubscriptionDeps = S.Struct({
+export const SubscriptionDependencies = S.Struct({
   dragPointer: dragAndDropFields['documentPointer'],
   dragEscape: dragAndDropFields['documentEscape'],
   dragKeyboard: dragAndDropFields['documentKeyboard'],
@@ -19,10 +19,9 @@ const dragAndDropSubscriptions = Ui.DragAndDrop.subscriptions
 const mapDragStream = (stream: Stream.Stream<Ui.DragAndDrop.Message>) =>
   stream.pipe(Stream.map(message => GotDragAndDropMessage({ message })))
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   dragPointer: {
     modelToDependencies: model =>
       dragAndDropSubscriptions.documentPointer.modelToDependencies(

--- a/examples/map/src/main.ts
+++ b/examples/map/src/main.ts
@@ -395,7 +395,7 @@ export const MountMap = Mount.define(
 
 // SUBSCRIPTIONS
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   mapEvents: S.Option(S.String),
 })
 
@@ -409,10 +409,9 @@ const boundsFromMap = (map: MapInstance): Bounds => {
   }
 }
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   mapEvents: {
     modelToDependencies: model => model.maybeMapHostId,
     dependenciesToStream: maybeHostId =>

--- a/examples/pixel-art/src/subscription.ts
+++ b/examples/pixel-art/src/subscription.ts
@@ -40,15 +40,14 @@ export const handleKeyboardEvent = (
     return Option.none()
   })
 
-export const SubscriptionDeps = S.Struct({
+export const SubscriptionDependencies = S.Struct({
   keyboard: S.Null,
   mouseRelease: S.Struct({ isDrawing: S.Boolean }),
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   keyboard: {
     modelToDependencies: () => null,
     dependenciesToStream: () =>

--- a/examples/snake/src/main.ts
+++ b/examples/snake/src/main.ts
@@ -245,7 +245,7 @@ export const GenerateApplePosition = Command.define(
 
 // SUBSCRIPTION
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   gameClock: S.Struct({
     isPlaying: S.Boolean,
     interval: S.Number,
@@ -253,10 +253,9 @@ const SubscriptionDeps = S.Struct({
   keyboard: S.Null,
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   gameClock: {
     modelToDependencies: (model: Model) => ({
       isPlaying: model.gameState === 'Playing',

--- a/examples/stopwatch/src/main.ts
+++ b/examples/stopwatch/src/main.ts
@@ -139,16 +139,15 @@ export const init: Runtime.ProgramInit<Model, Message> = () => [
 
 // SUBSCRIPTION
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   tick: S.Struct({
     isRunning: S.Boolean,
   }),
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   tick: {
     modelToDependencies: (model: Model) => ({ isRunning: model.isRunning }),
     dependenciesToStream: ({ isRunning }) =>

--- a/examples/ui-showcase/src/main.ts
+++ b/examples/ui-showcase/src/main.ts
@@ -636,10 +636,10 @@ export const view = (model: Model): Document => ({
 
 // SUBSCRIPTION
 
-const sliderFields = Ui.Slider.SubscriptionDeps.fields
-const dragAndDropFields = Ui.DragAndDrop.SubscriptionDeps.fields
+const sliderFields = Ui.Slider.SubscriptionDependencies.fields
+const dragAndDropFields = Ui.DragAndDrop.SubscriptionDependencies.fields
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   sliderRatingPointer: sliderFields['dragPointer'],
   sliderRatingEscape: sliderFields['dragEscape'],
   sliderVolumePointer: sliderFields['dragPointer'],
@@ -649,9 +649,9 @@ const SubscriptionDeps = S.Struct({
   dragKeyboard: dragAndDropFields['documentKeyboard'],
   autoScroll: dragAndDropFields['autoScroll'],
   virtualListContainerEvents:
-    Ui.VirtualList.SubscriptionDeps.fields['containerEvents'],
+    Ui.VirtualList.SubscriptionDependencies.fields['containerEvents'],
   virtualListVariableContainerEvents:
-    Ui.VirtualList.SubscriptionDeps.fields['containerEvents'],
+    Ui.VirtualList.SubscriptionDependencies.fields['containerEvents'],
 })
 
 const sliderSubscriptions = Ui.Slider.subscriptions
@@ -678,10 +678,9 @@ const mapDragStream = (stream: Stream.Stream<Ui.DragAndDrop.Message>) =>
     ),
   )
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   sliderRatingPointer: {
     modelToDependencies: model =>
       sliderSubscriptions.dragPointer.modelToDependencies(

--- a/examples/websocket-chat/src/main.ts
+++ b/examples/websocket-chat/src/main.ts
@@ -298,15 +298,13 @@ export const managedResources = ManagedResource.makeManagedResources(
 
 // SUBSCRIPTION
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   isConnected: S.Boolean,
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message,
-  ChatSocketService
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message, ChatSocketService>({
   isConnected: {
     modelToDependencies: model =>
       model.connection._tag === 'ConnectionConnected',

--- a/packages/foldkit/src/devTools/overlay.ts
+++ b/packages/foldkit/src/devTools/overlay.ts
@@ -723,7 +723,7 @@ const makeUpdate = (
 
 const ScrubberDragActivity = S.Literals(['Idle', 'Active'])
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   storeUpdates: S.Boolean,
   mobileBreakpoint: S.Null,
   scrubberPointer: S.Struct({
@@ -740,7 +740,7 @@ const SubscriptionDeps = S.Struct({
 const makeOverlaySubscriptions = (store: DevToolsStore, shadow: ShadowRoot) => {
   const sliderSubscriptions = Slider.subscriptionsForRoot(() => shadow)
 
-  return makeSubscriptions(SubscriptionDeps)<Model, Message>({
+  return makeSubscriptions(SubscriptionDependencies)<Model, Message>({
     storeUpdates: {
       modelToDependencies: () => true,
       dependenciesToStream: () =>

--- a/packages/foldkit/src/runtime/subscription.ts
+++ b/packages/foldkit/src/runtime/subscription.ts
@@ -20,44 +20,51 @@ type SubscriptionConfig<Model, Message, StreamDeps, Resources = never> = {
 export type Subscriptions<
   Model,
   Message,
-  SubscriptionDeps extends Schema.Struct<any>,
+  SubscriptionDependencies extends Schema.Struct<any>,
   Resources = never,
 > = {
-  readonly [K in keyof Schema.Schema.Type<SubscriptionDeps>]: SubscriptionConfig<
+  readonly [K in keyof Schema.Schema.Type<SubscriptionDependencies>]: SubscriptionConfig<
     Model,
     Message,
-    Schema.Schema.Type<SubscriptionDeps>[K],
+    Schema.Schema.Type<SubscriptionDependencies>[K],
     Resources
   >
 }
 
 /** Creates type-safe subscription configurations from a dependency schema. */
 export const makeSubscriptions =
-  <SubscriptionDeps extends Schema.Struct<any>>(
-    SubscriptionDeps: SubscriptionDeps,
+  <SubscriptionDependencies extends Schema.Struct<any>>(
+    SubscriptionDependencies: SubscriptionDependencies,
   ) =>
   <Model, Message, Resources = never>(configs: {
-    readonly [K in keyof Schema.Schema.Type<SubscriptionDeps>]: {
+    readonly [K in keyof Schema.Schema.Type<SubscriptionDependencies>]: {
       readonly modelToDependencies: (
         model: Model,
-      ) => Schema.Schema.Type<SubscriptionDeps>[K]
+      ) => Schema.Schema.Type<SubscriptionDependencies>[K]
       readonly equivalence?:
-        | Equivalence.Equivalence<Schema.Schema.Type<SubscriptionDeps>[K]>
+        | Equivalence.Equivalence<
+            Schema.Schema.Type<SubscriptionDependencies>[K]
+          >
         | undefined
       readonly dependenciesToStream: (
-        deps: Schema.Schema.Type<SubscriptionDeps>[K],
-        readDependencies: () => Schema.Schema.Type<SubscriptionDeps>[K],
+        deps: Schema.Schema.Type<SubscriptionDependencies>[K],
+        readDependencies: () => Schema.Schema.Type<SubscriptionDependencies>[K],
       ) => Stream.Stream<ResolveMessage<Message>, never, Resources>
     }
-  }): Subscriptions<Model, Message, SubscriptionDeps, Resources> =>
+  }): Subscriptions<Model, Message, SubscriptionDependencies, Resources> =>
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     Record.map(
       configs,
       ({ modelToDependencies, equivalence, dependenciesToStream }, key) => ({
-        schema: SubscriptionDeps.fields[key],
+        schema: SubscriptionDependencies.fields[key],
         modelToDependencies,
         equivalence,
         dependenciesToStream,
       }),
-    ) as unknown as Subscriptions<Model, Message, SubscriptionDeps, Resources>
+    ) as unknown as Subscriptions<
+      Model,
+      Message,
+      SubscriptionDependencies,
+      Resources
+    >
 /* eslint-enable @typescript-eslint/consistent-type-assertions */

--- a/packages/foldkit/src/subscription/animationFrame.ts
+++ b/packages/foldkit/src/subscription/animationFrame.ts
@@ -53,15 +53,15 @@ const makeAnimationFrameStream = <Message>(
  * Build a Subscription field config that emits a Message on every
  * `requestAnimationFrame` tick, with the inter-frame delta in milliseconds.
  *
- * Pair with `S.Boolean` in the `SubscriptionDeps` schema:
+ * Pair with `S.Boolean` in the `SubscriptionDependencies` schema:
  *
  * @example
  * ```typescript
- * const SubscriptionDeps = S.Struct({
+ * const SubscriptionDependencies = S.Struct({
  *   frame: S.Boolean,
  * })
  *
- * const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+ * const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
  *   Model,
  *   Message
  * >({

--- a/packages/foldkit/src/ui/dragAndDrop/index.ts
+++ b/packages/foldkit/src/ui/dragAndDrop/index.ts
@@ -626,7 +626,7 @@ const keyboardDragActivityFromModel = (
   )
 
 /** Schema describing the subscription dependencies for document-level drag tracking. */
-export const SubscriptionDeps = S.Struct({
+export const SubscriptionDependencies = S.Struct({
   documentPointer: S.Struct({
     dragActivity: PointerDragActivity,
     orientation: Orientation,
@@ -640,7 +640,7 @@ export const SubscriptionDeps = S.Struct({
 })
 
 /** Document-level subscriptions for pointer and keyboard events during drag operations. */
-export const subscriptions = makeSubscriptions(SubscriptionDeps)<
+export const subscriptions = makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/foldkit/src/ui/dragAndDrop/public.ts
+++ b/packages/foldkit/src/ui/dragAndDrop/public.ts
@@ -9,7 +9,7 @@ export {
   maybeDraggedItemId,
   maybeDropTarget,
   subscriptions,
-  SubscriptionDeps,
+  SubscriptionDependencies,
   Model,
   Message,
   OutMessage,

--- a/packages/foldkit/src/ui/slider/index.ts
+++ b/packages/foldkit/src/ui/slider/index.ts
@@ -388,7 +388,7 @@ const valueFromClientX = (
 }
 
 /** Schema describing the subscription dependencies for slider drag. */
-export const SubscriptionDeps = S.Struct({
+export const SubscriptionDependencies = S.Struct({
   dragPointer: S.Struct({
     dragActivity: DragActivity,
     id: S.String,
@@ -407,7 +407,7 @@ export const SubscriptionDeps = S.Struct({
 export const subscriptionsForRoot = (
   getTrackRoot: () => Document | ShadowRoot,
 ) =>
-  makeSubscriptions(SubscriptionDeps)<Model, Message>({
+  makeSubscriptions(SubscriptionDependencies)<Model, Message>({
     dragPointer: {
       modelToDependencies: model => ({
         dragActivity: dragActivityFromModel(model),

--- a/packages/foldkit/src/ui/slider/public.ts
+++ b/packages/foldkit/src/ui/slider/public.ts
@@ -11,7 +11,7 @@ export {
   Model,
   Message,
   OutMessage,
-  SubscriptionDeps,
+  SubscriptionDependencies,
 } from './index.js'
 
 export type {

--- a/packages/foldkit/src/ui/virtualList/index.ts
+++ b/packages/foldkit/src/ui/virtualList/index.ts
@@ -403,7 +403,7 @@ const containerElement = (id: string): Option.Option<HTMLElement> =>
 
 /** Schema describing the subscription dependencies for container scroll and
  *  resize tracking. */
-export const SubscriptionDeps = S.Struct({
+export const SubscriptionDependencies = S.Struct({
   containerEvents: S.Struct({
     id: S.String,
   }),
@@ -422,7 +422,7 @@ export const SubscriptionDeps = S.Struct({
  *  makes the subscription robust across SPA route changes: navigating to a
  *  page that mounts the list, away, and back all reattach correctly without
  *  the consumer having to teach the framework about navigation. */
-export const subscriptions = makeSubscriptions(SubscriptionDeps)<
+export const subscriptions = makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/foldkit/src/ui/virtualList/public.ts
+++ b/packages/foldkit/src/ui/virtualList/public.ts
@@ -13,7 +13,7 @@ export {
   ScrolledContainer,
   MeasuredContainer,
   CompletedApplyScroll,
-  SubscriptionDeps,
+  SubscriptionDependencies,
 } from './index.js'
 
 export type { InitConfig, ViewConfig, VisibleWindow } from './index.js'

--- a/packages/typing-game/client/src/subscription.ts
+++ b/packages/typing-game/client/src/subscription.ts
@@ -12,7 +12,7 @@ import { Home, Room } from './page'
 import { AppRoute } from './route'
 import { RoomsClient, RoomsClientLive } from './rpc.js'
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   roomSubscription: S.Option(
     S.Struct({ roomId: S.String, playerId: S.String }),
   ),
@@ -22,10 +22,9 @@ const SubscriptionDeps = S.Struct({
   }),
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   roomSubscription: {
     modelToDependencies: (model: Model) =>
       M.value(model.route).pipe(

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -1290,14 +1290,14 @@ const routeTitle = (route: AppRoute): string =>
 // SUBSCRIPTION
 
 const dragAndDropDemoFields =
-  Subscription.DragAndDropDemo.SubscriptionDeps.fields
+  Subscription.DragAndDropDemo.SubscriptionDependencies.fields
 
-const sliderDemoFields = Subscription.SliderDemo.SubscriptionDeps.fields
+const sliderDemoFields = Subscription.SliderDemo.SubscriptionDependencies.fields
 
 const virtualListDemoFields =
-  Subscription.VirtualListDemo.SubscriptionDeps.fields
+  Subscription.VirtualListDemo.SubscriptionDependencies.fields
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   aiHeading: S.Struct({
     isLandingPage: S.Boolean,
   }),
@@ -1329,9 +1329,9 @@ const SubscriptionDeps = S.Struct({
   viewportWidth: S.Null,
 })
 
-export type SubscriptionDeps = typeof SubscriptionDeps.Type
+export type SubscriptionDependencies = typeof SubscriptionDependencies.Type
 
-export const subscriptions = makeSubscriptions(SubscriptionDeps)<
+export const subscriptions = makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/page/core/subscriptions.ts
+++ b/packages/website/src/page/core/subscriptions.ts
@@ -100,7 +100,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
       para(
         'The key concept is ',
-        inlineCode('SubscriptionDeps'),
+        inlineCode('SubscriptionDependencies'),
         '. This schema defines what parts of the Model your Subscriptions depend on. Each Subscription has two functions:',
       ),
       h.ul(
@@ -179,7 +179,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         ' alongside any other dependency. Pair with ',
         inlineCode('S.Boolean'),
         ' in your ',
-        inlineCode('SubscriptionDeps'),
+        inlineCode('SubscriptionDependencies'),
         ' schema.',
       ),
       para(

--- a/packages/website/src/snippet/canvasBasic.ts
+++ b/packages/website/src/snippet/canvasBasic.ts
@@ -1,9 +1,9 @@
 import { Schema as S } from 'effect'
 import { Canvas, Subscription } from 'foldkit'
 
-const SubscriptionDeps = S.Struct({ frame: S.Boolean })
+const SubscriptionDependencies = S.Struct({ frame: S.Boolean })
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/snippet/comparisonFoldkitSubscription.ts
+++ b/packages/website/src/snippet/comparisonFoldkitSubscription.ts
@@ -1,12 +1,11 @@
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   keyboard: S.Null,
   mouseRelease: S.Struct({ isDrawing: S.Boolean }),
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   keyboard: {
     modelToDependencies: () => null,
     dependenciesToStream: () =>

--- a/packages/website/src/snippet/counterAutoCount.ts
+++ b/packages/website/src/snippet/counterAutoCount.ts
@@ -22,13 +22,13 @@ type Model = typeof Model.Type
 
 // SUBSCRIPTION
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   tick: S.Struct({
     isAutoCounting: S.Boolean,
   }),
 })
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/snippet/foldkitCounterAutoPlay.ts
+++ b/packages/website/src/snippet/foldkitCounterAutoPlay.ts
@@ -32,11 +32,11 @@ type Message = typeof Message.Type
 
 // SUBSCRIPTION
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   tick: S.Struct({ isAutoCounting: S.Boolean }),
 })
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/snippet/foldkitCounterReset.ts
+++ b/packages/website/src/snippet/foldkitCounterReset.ts
@@ -25,11 +25,11 @@ type Message = typeof Message.Type
 
 // SUBSCRIPTION
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   tick: S.Struct({ isAutoCounting: S.Boolean }),
 })
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/snippet/stopwatchSubscription.ts
+++ b/packages/website/src/snippet/stopwatchSubscription.ts
@@ -19,13 +19,13 @@ type Model = typeof Model.Type
 
 // SUBSCRIPTION
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   tick: S.Struct({
     isRunning: S.Boolean,
   }),
 })
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/snippet/subscriptionEquivalence.ts
+++ b/packages/website/src/snippet/subscriptionEquivalence.ts
@@ -14,14 +14,14 @@ const Model = S.Struct({
 
 type Model = typeof Model.Type
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   autoScroll: S.Struct({
     isDragging: S.Boolean,
     clientY: S.Number,
   }),
 })
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/snippet/uiDragAndDropBasic.ts
+++ b/packages/website/src/snippet/uiDragAndDropBasic.ts
@@ -85,16 +85,16 @@ const dragAndDropSubs = Ui.DragAndDrop.subscriptions
 const mapDragStream = stream =>
   stream.pipe(Stream.map(message => GotDragAndDropMessage({ message })))
 
-const dragFields = Ui.DragAndDrop.SubscriptionDeps.fields
+const dragFields = Ui.DragAndDrop.SubscriptionDependencies.fields
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   dragPointer: dragFields['documentPointer'],
   dragEscape: dragFields['documentEscape'],
   dragKeyboard: dragFields['documentKeyboard'],
   autoScroll: dragFields['autoScroll'],
 })
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)({
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)({
   dragPointer: {
     modelToDependencies: model =>
       dragAndDropSubs.documentPointer.modelToDependencies(model.dragAndDrop),

--- a/packages/website/src/snippet/uiSliderBasic.ts
+++ b/packages/website/src/snippet/uiSliderBasic.ts
@@ -53,17 +53,17 @@ GotSliderMessage: ({ message }) => {
 // NOTE: wire BOTH dragPointer and dragEscape. Without dragEscape, pressing
 // Escape during a drag won't cancel back to the origin value, but every
 // other drag mechanic still works. Silent partial breakage.
-const sliderFields = Ui.Slider.SubscriptionDeps.fields
+const sliderFields = Ui.Slider.SubscriptionDependencies.fields
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   sliderPointer: sliderFields['dragPointer'],
   sliderEscape: sliderFields['dragEscape'],
-  // ...your other subscription deps
+  // ...your other subscription dependencies
 })
 
 const sliderSubscriptions = Ui.Slider.subscriptions
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/snippet/uiVirtualListBasic.ts
+++ b/packages/website/src/snippet/uiVirtualListBasic.ts
@@ -54,18 +54,18 @@ GotActivityListMessage: ({ message }) => {
 }
 
 // Wire the VirtualList container subscription into your app's
-// SubscriptionDeps and subscriptions. This powers scroll tracking and
+// SubscriptionDependencies and subscriptions. This powers scroll tracking and
 // container resize observation:
-const virtualListFields = Ui.VirtualList.SubscriptionDeps.fields
+const virtualListFields = Ui.VirtualList.SubscriptionDependencies.fields
 
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   activityListEvents: virtualListFields['containerEvents'],
-  // ...your other subscription deps
+  // ...your other subscription dependencies
 })
 
 const virtualListSubscriptions = Ui.VirtualList.subscriptions
 
-const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
   Model,
   Message
 >({

--- a/packages/website/src/subscription/activeSection.ts
+++ b/packages/website/src/subscription/activeSection.ts
@@ -13,14 +13,14 @@ import {
 import { Render } from 'foldkit'
 import { Subscription } from 'foldkit/subscription'
 
-import { Model, SubscriptionDeps } from '../main'
+import { Model, SubscriptionDependencies } from '../main'
 import { ChangedActiveSection } from '../message'
 import * as Page from '../page'
 
 export const activeSection: Subscription<
   Model,
   typeof ChangedActiveSection,
-  SubscriptionDeps['activeSection']
+  SubscriptionDependencies['activeSection']
 > = {
   modelToDependencies: (model: Model) => {
     const currentPageTableOfContents = M.value(model.route).pipe(

--- a/packages/website/src/subscription/aiHeading.ts
+++ b/packages/website/src/subscription/aiHeading.ts
@@ -1,7 +1,7 @@
 import { Duration, Effect, Stream } from 'effect'
 import { Subscription } from 'foldkit/subscription'
 
-import { type Model, type SubscriptionDeps } from '../main'
+import { type Model, type SubscriptionDependencies } from '../main'
 import { ToggledAiHeading } from '../message'
 
 const TOGGLE_INTERVAL_MS = 3000
@@ -14,7 +14,7 @@ const isPrerender = window.__FOLDKIT_PRERENDER__ === true
 export const aiHeading: Subscription<
   Model,
   typeof ToggledAiHeading,
-  SubscriptionDeps['aiHeading']
+  SubscriptionDependencies['aiHeading']
 > = {
   modelToDependencies: (model: Model) => ({
     isLandingPage: model.route._tag === 'Home',

--- a/packages/website/src/subscription/dragAndDropDemo.ts
+++ b/packages/website/src/subscription/dragAndDropDemo.ts
@@ -5,9 +5,9 @@ import type { Model } from '../main'
 import { GotUiPageMessage, type Message } from '../message'
 import { GotDragAndDropDemoMessage } from '../page/ui/message'
 
-const dragAndDropFields = Ui.DragAndDrop.SubscriptionDeps.fields
+const dragAndDropFields = Ui.DragAndDrop.SubscriptionDependencies.fields
 
-export const SubscriptionDeps = S.Struct({
+export const SubscriptionDependencies = S.Struct({
   dragPointer: dragAndDropFields['documentPointer'],
   dragEscape: dragAndDropFields['documentEscape'],
   dragKeyboard: dragAndDropFields['documentKeyboard'],
@@ -27,10 +27,9 @@ const mapDragStream = (stream: Stream.Stream<Ui.DragAndDrop.Message>) =>
 
 const getDragAndDropModel = (model: Model) => model.uiPages.dragAndDropDemo
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   dragPointer: {
     modelToDependencies: model =>
       dragAndDropSubscriptions.documentPointer.modelToDependencies(

--- a/packages/website/src/subscription/exampleUrl.ts
+++ b/packages/website/src/subscription/exampleUrl.ts
@@ -1,7 +1,7 @@
 import { Effect, Option, Queue, Stream, pipe } from 'effect'
 import { Subscription } from 'foldkit/subscription'
 
-import { type Model, type SubscriptionDeps } from '../main'
+import { type Model, type SubscriptionDependencies } from '../main'
 import { GotExampleDetailMessage } from '../message'
 import { ChangedExampleUrl } from '../page/example/exampleDetail'
 import { ExampleDetailRoute } from '../route'
@@ -11,7 +11,7 @@ const BRIDGE_MESSAGE_TYPE = 'foldkit-example-url'
 export const exampleUrl: Subscription<
   Model,
   typeof GotExampleDetailMessage,
-  SubscriptionDeps['exampleUrl']
+  SubscriptionDependencies['exampleUrl']
 > = {
   modelToDependencies: (model: Model) =>
     pipe(

--- a/packages/website/src/subscription/heroVisibility.ts
+++ b/packages/website/src/subscription/heroVisibility.ts
@@ -2,14 +2,14 @@ import { Effect, Queue, Stream } from 'effect'
 import { Render } from 'foldkit'
 import { Subscription } from 'foldkit/subscription'
 
-import { type Model, type SubscriptionDeps } from '../main'
+import { type Model, type SubscriptionDependencies } from '../main'
 import { ChangedHeroVisibility } from '../message'
 import { HERO_SECTION_ID } from '../page/landing'
 
 export const heroVisibility: Subscription<
   Model,
   typeof ChangedHeroVisibility,
-  SubscriptionDeps['heroVisibility']
+  SubscriptionDependencies['heroVisibility']
 > = {
   modelToDependencies: (model: Model) => ({
     isLandingPage: model.route._tag === 'Home',

--- a/packages/website/src/subscription/searchShortcut.ts
+++ b/packages/website/src/subscription/searchShortcut.ts
@@ -2,14 +2,14 @@ import { Effect, Queue, Stream } from 'effect'
 import { Ui } from 'foldkit'
 import { Subscription } from 'foldkit/subscription'
 
-import type { Model, SubscriptionDeps } from '../main'
+import type { Model, SubscriptionDependencies } from '../main'
 import { GotSearchMessage } from '../message'
 import { GotSearchDialogMessage } from '../search'
 
 export const searchShortcut: Subscription<
   Model,
   typeof GotSearchMessage,
-  SubscriptionDeps['searchShortcut']
+  SubscriptionDependencies['searchShortcut']
 > = {
   modelToDependencies: model => ({
     isDocsPage:

--- a/packages/website/src/subscription/sliderDemo.ts
+++ b/packages/website/src/subscription/sliderDemo.ts
@@ -8,9 +8,9 @@ import {
   GotSliderVolumeDemoMessage,
 } from '../page/ui/message'
 
-const sliderFields = Ui.Slider.SubscriptionDeps.fields
+const sliderFields = Ui.Slider.SubscriptionDependencies.fields
 
-export const SubscriptionDeps = S.Struct({
+export const SubscriptionDependencies = S.Struct({
   ratingPointer: sliderFields['dragPointer'],
   ratingEscape: sliderFields['dragEscape'],
   volumePointer: sliderFields['dragPointer'],
@@ -40,10 +40,9 @@ const mapVolumeStream = (stream: Stream.Stream<Ui.Slider.Message>) =>
     ),
   )
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   ratingPointer: {
     modelToDependencies: model =>
       sliderSubscriptions.dragPointer.modelToDependencies(

--- a/packages/website/src/subscription/systemTheme.ts
+++ b/packages/website/src/subscription/systemTheme.ts
@@ -1,13 +1,13 @@
 import { Effect, Queue, Stream } from 'effect'
 import { Subscription } from 'foldkit/subscription'
 
-import { type Model, type SubscriptionDeps } from '../main'
+import { type Model, type SubscriptionDependencies } from '../main'
 import { ChangedSystemTheme } from '../message'
 
 export const systemTheme: Subscription<
   Model,
   typeof ChangedSystemTheme,
-  SubscriptionDeps['systemTheme']
+  SubscriptionDependencies['systemTheme']
 > = {
   modelToDependencies: (model: Model) => ({
     isSystemPreference: model.themePreference === 'System',

--- a/packages/website/src/subscription/viewportWidth.ts
+++ b/packages/website/src/subscription/viewportWidth.ts
@@ -4,14 +4,14 @@ import { Subscription } from 'foldkit/subscription'
 import {
   type Model,
   NARROW_VIEWPORT_QUERY,
-  type SubscriptionDeps,
+  type SubscriptionDependencies,
 } from '../main'
 import { ChangedViewportWidth } from '../message'
 
 export const viewportWidth: Subscription<
   Model,
   typeof ChangedViewportWidth,
-  SubscriptionDeps['viewportWidth']
+  SubscriptionDependencies['viewportWidth']
 > = {
   modelToDependencies: () => null,
   dependenciesToStream: () =>

--- a/packages/website/src/subscription/virtualListDemo.ts
+++ b/packages/website/src/subscription/virtualListDemo.ts
@@ -8,16 +8,16 @@ import {
   GotVirtualListVariableDemoMessage,
 } from '../page/ui/message'
 
-export const SubscriptionDeps = S.Struct({
-  containerEvents: Ui.VirtualList.SubscriptionDeps.fields['containerEvents'],
+export const SubscriptionDependencies = S.Struct({
+  containerEvents:
+    Ui.VirtualList.SubscriptionDependencies.fields['containerEvents'],
   variableContainerEvents:
-    Ui.VirtualList.SubscriptionDeps.fields['containerEvents'],
+    Ui.VirtualList.SubscriptionDependencies.fields['containerEvents'],
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   containerEvents: {
     modelToDependencies: model =>
       Ui.VirtualList.subscriptions.containerEvents.modelToDependencies(

--- a/skills/generate-program/architecture.md
+++ b/skills/generate-program/architecture.md
@@ -286,14 +286,13 @@ When Model state changes such that `modelToDependencies` returns `None`, the Sub
 Some Subscriptions are always active (e.g., keyboard listeners, window resize). Use `S.Null` for the dependency type:
 
 ```ts
-const SubscriptionDeps = S.Struct({
+const SubscriptionDependencies = S.Struct({
   keyboard: S.Null,
 })
 
-export const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
-  Model,
-  Message
->({
+export const subscriptions = Subscription.makeSubscriptions(
+  SubscriptionDependencies,
+)<Model, Message>({
   keyboard: {
     modelToDependencies: () => null,
     dependenciesToStream: () =>


### PR DESCRIPTION
Renames the `SubscriptionDeps` struct export to `SubscriptionDependencies` across the Foldkit library and all examples and applications. This change improves naming clarity by using the full, unabbreviated term throughout the codebase.

## Changes

- **Runtime API**: Updated the `Subscriptions` type and `makeSubscriptions` function in `packages/foldkit/src/runtime/subscription.ts` to use `SubscriptionDependencies` as the generic parameter name
- **UI Components**: Renamed `SubscriptionDeps` exports to `SubscriptionDependencies` in:
  - `packages/foldkit/src/ui/slider/index.ts`
  - `packages/foldkit/src/ui/dragAndDrop/index.ts`
  - `packages/foldkit/src/ui/virtualList/index.ts`
- **Public exports**: Updated public API exports in `public.ts` files for Slider, DragAndDrop, and VirtualList
- **Examples and applications**: Updated all callsites in example projects and the website to use the new name
- **Documentation**: Updated JSDoc examples in `packages/foldkit/src/subscription/animationFrame.ts` to reflect the new naming convention
- **DevTools**: Updated internal devTools overlay to use the new naming

## Breaking Change

This is a breaking change for any code that references the exported `SubscriptionDeps` struct on UI components. Consumers must update their code to use `SubscriptionDependencies` instead. The runtime API (`Subscription.makeSubscriptions`) accepts any schema name, so the change is not enforced by types for local subscription dependency schemas, though the convention is recommended for consistency.

https://claude.ai/code/session_013Cc6wF3tHFbg3ub2zBuduk