### PR TITLE
test(examples-e2e): add Playwright e2e suite for examples

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -36,6 +36,7 @@
     "generative-art-example",
     "web-components-example",
     "pixel-art-react-comparison",
-    "@foldkit/performance-harness"
+    "@foldkit/performance-harness",
+    "@foldkit/examples-e2e"
   ]
 }

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -1,0 +1,78 @@
+name: Examples E2E
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  examples-e2e:
+    name: ${{ matrix.example }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - counter
+          - todo
+          - stopwatch
+          - crash-view
+          - form
+          - job-application
+          - weather
+          - routing
+          - query-sync
+          - snake
+          - auth
+          - shopping-cart
+          - pixel-art
+          - websocket-chat
+          - kanban
+          - map
+          - canvas-art
+          - generative-art
+          - web-components
+          - ui-showcase
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace packages
+        run: pnpm -r --filter './packages/**' build
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium
+
+      - name: Run examples e2e for ${{ matrix.example }}
+        env:
+          EXAMPLE_SLUG: ${{ matrix.example }}
+        run: pnpm --filter @foldkit/examples-e2e test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.example }}
+          path: packages/examples-e2e/playwright-report/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ Four lifecycle/binding primitives. Pick by **what causes the side effect**, not 
 - Use Conventional Commits. Add `!` after the scope for breaking changes (e.g. `refactor(schema)!:` when renaming or removing a public export)
 - **Commit messages are historical records, not live docs.** Time-bound claims ("first component to X", "replaces the old Y approach", "before this, Z") are appropriate in commit bodies — they describe the state of the world at the moment the commit landed. A reader of `git log` already understands they're reading through time. Don't flag such claims as "will rot" during commit review; rotting is a concern for TSDoc, README, and live documentation, not the git log.
 - Scope must identify the **package, example, or top-level tooling directory**, not an internal module. Valid scopes:
-  - Packages: `foldkit`, `create-foldkit-app`, `vite-plugin`, `devtools-mcp`, `website`, `typing-game`
+  - Packages: `foldkit`, `create-foldkit-app`, `vite-plugin`, `devtools-mcp`, `website`, `typing-game`, `examples-e2e`
   - Examples: the directory name — `pixel-art`, `auth`, `weather`, `counter`, etc.
   - Tooling: `skills` (for `skills/`)
   - Infrastructure: `ci`, `release`

--- a/packages/examples-e2e/.gitignore
+++ b/packages/examples-e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/packages/examples-e2e/e2e/auth.spec.ts
+++ b/packages/examples-e2e/e2e/auth.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('auth example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('redirects to login when no session', async ({ page }) => {
+    await page.goto('/dashboard')
+    await expect(page).toHaveURL(/\/login/)
+  })
+})

--- a/packages/examples-e2e/e2e/canvas-art.spec.ts
+++ b/packages/examples-e2e/e2e/canvas-art.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('canvas-art example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('Pause toggles to Play', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Pause' }).click()
+    await expect(page.getByRole('button', { name: 'Play' })).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/counter.spec.ts
+++ b/packages/examples-e2e/e2e/counter.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('counter example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('increments when + is clicked', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: '+' }).click()
+    await expect(page).toHaveTitle(/Counter: 1/)
+  })
+})

--- a/packages/examples-e2e/e2e/crash-view.spec.ts
+++ b/packages/examples-e2e/e2e/crash-view.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('crash-view example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('renders crash fallback when Crash is clicked', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Crash' }).click()
+    await expect(page.getByText('Something went wrong')).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/form.spec.ts
+++ b/packages/examples-e2e/e2e/form.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('form example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('shows validation error for invalid email', async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('Email').fill('not-an-email')
+    await expect(
+      page.getByText('Please enter a valid email address'),
+    ).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/generative-art.spec.ts
+++ b/packages/examples-e2e/e2e/generative-art.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('generative-art example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('Pause toggles to Play', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Pause' }).click()
+    await expect(page.getByRole('button', { name: 'Play' })).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/job-application.spec.ts
+++ b/packages/examples-e2e/e2e/job-application.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('job-application example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('opening the Pronouns listbox reveals options', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Select pronouns' }).click()
+    await expect(page.getByRole('option').first()).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/kanban.spec.ts
+++ b/packages/examples-e2e/e2e/kanban.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('kanban example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('clicking "Add card" reveals the new card input', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: '+ Add card' }).first().click()
+    await expect(page.getByPlaceholder('Card title...')).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/map.spec.ts
+++ b/packages/examples-e2e/e2e/map.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('map example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('filters the locations sidebar by search query', async ({ page }) => {
+    await page.goto('/')
+    await page.getByPlaceholder('Filter locations').fill('zzznoresult')
+    await expect(page.getByText(/No locations match/)).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/pixel-art.spec.ts
+++ b/packages/examples-e2e/e2e/pixel-art.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('pixel-art example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('selecting Eraser updates the tool radio group', async ({ page }) => {
+    await page.goto('/')
+    const eraser = page.getByRole('radio', { name: /Eraser/ })
+    await eraser.click()
+    await expect(eraser).toBeChecked()
+  })
+})

--- a/packages/examples-e2e/e2e/query-sync.spec.ts
+++ b/packages/examples-e2e/e2e/query-sync.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('query-sync example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('search filters the table and updates the URL', async ({ page }) => {
+    await page.goto('/')
+    await page.getByPlaceholder('Search by name…').fill('Tyrannosaurus')
+    await expect(page).toHaveURL(/search=Tyrannosaurus/)
+    await expect(
+      page.getByRole('cell', { name: /Tyrannosaurus/ }),
+    ).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/routing.spec.ts
+++ b/packages/examples-e2e/e2e/routing.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('routing example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('navigates to people route', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('link', { name: 'People', exact: true }).click()
+    await expect(page).toHaveURL(/\/people/)
+  })
+})

--- a/packages/examples-e2e/e2e/shopping-cart.spec.ts
+++ b/packages/examples-e2e/e2e/shopping-cart.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('shopping-cart example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('navigates to the Cart route', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('link', { name: 'Cart', exact: true }).click()
+    await expect(page).toHaveURL(/\/cart/)
+  })
+})

--- a/packages/examples-e2e/e2e/snake.spec.ts
+++ b/packages/examples-e2e/e2e/snake.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('snake example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('space starts the game', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('Press SPACE to start')).toBeVisible()
+    await page.keyboard.press(' ')
+    await expect(page.getByText(/Playing/)).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/stopwatch.spec.ts
+++ b/packages/examples-e2e/e2e/stopwatch.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('stopwatch example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('Start swaps to Stop when clicked', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Start' }).click()
+    await expect(page.getByRole('button', { name: 'Stop' })).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/todo.spec.ts
+++ b/packages/examples-e2e/e2e/todo.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('todo example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('adds a todo', async ({ page }) => {
+    await page.goto('/')
+    await page
+      .getByPlaceholder('What needs to be done?')
+      .fill('Write Playwright tests')
+    await page.getByRole('button', { name: 'Add' }).click()
+    await expect(page.getByText('Write Playwright tests')).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/ui-showcase.spec.ts
+++ b/packages/examples-e2e/e2e/ui-showcase.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('ui-showcase example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('navigates to the Button component page', async ({ page }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Button', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/button$/)
+  })
+})

--- a/packages/examples-e2e/e2e/weather.spec.ts
+++ b/packages/examples-e2e/e2e/weather.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('weather example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('renders weather for a zip code with mocked APIs', async ({ page }) => {
+    await page.route('**/geocoding-api.open-meteo.com/**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [
+            {
+              name: 'Test City',
+              latitude: 33.99,
+              longitude: -118.4,
+              admin1: 'California',
+            },
+          ],
+        }),
+      }),
+    )
+    await page.route('**/api.open-meteo.com/**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          current: {
+            temperature_2m: 72,
+            relative_humidity_2m: 50,
+            wind_speed_10m: 5,
+            weather_code: 0,
+          },
+        }),
+      }),
+    )
+
+    await page.goto('/')
+    await page.getByPlaceholder('Enter a zip code').fill('90210')
+    await page.getByRole('button', { name: 'Get Weather' }).click()
+    await expect(page.getByText('72°F')).toBeVisible()
+    await expect(page.getByText('Clear sky')).toBeVisible()
+    await expect(page.getByText('Test City, California')).toBeVisible()
+  })
+})

--- a/packages/examples-e2e/e2e/web-components.spec.ts
+++ b/packages/examples-e2e/e2e/web-components.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('web-components example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('encoded value propagates to the QR code element', async ({ page }) => {
+    await page.goto('/')
+    await page.getByLabel('Encoded value').fill('hello-foldkit')
+    await expect(page.locator('sl-qr-code')).toHaveJSProperty(
+      'value',
+      'hello-foldkit',
+    )
+  })
+})

--- a/packages/examples-e2e/e2e/websocket-chat.spec.ts
+++ b/packages/examples-e2e/e2e/websocket-chat.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('websocket-chat example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('Connect button transitions out of the disconnected state', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Connect to Chat' }).click()
+    await expect(
+      page.getByRole('button', { name: 'Connect to Chat' }),
+    ).toBeHidden()
+  })
+})

--- a/packages/examples-e2e/eslint.config.mjs
+++ b/packages/examples-e2e/eslint.config.mjs
@@ -1,0 +1,50 @@
+import js from '@eslint/js'
+import tsPlugin from '@typescript-eslint/eslint-plugin'
+import tsParser from '@typescript-eslint/parser'
+
+export default [
+  {
+    ...js.configs.recommended,
+    files: ['**/*.ts', '**/*.js'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      'no-redeclare': 'off',
+      'no-undef': 'off',
+      'no-unused-vars': 'off',
+      '@typescript-eslint/consistent-type-assertions': [
+        'error',
+        { assertionStyle: 'never' },
+      ],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+
+  {
+    ignores: [
+      'node_modules/',
+      'playwright-report/',
+      'test-results/',
+      'eslint.config.mjs',
+      '**/*.config.js',
+      '**/*.config.mjs',
+    ],
+  },
+]

--- a/packages/examples-e2e/package.json
+++ b/packages/examples-e2e/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@foldkit/examples-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "format": "prettier -w ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
+    "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "@types/node": "^25.6.0",
+    "@typescript-eslint/eslint-plugin": "^8.59.2",
+    "@typescript-eslint/parser": "^8.59.2",
+    "eslint": "^10.3.0",
+    "playwright": "^1.59.1",
+    "prettier": "^3.8.3",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/examples-e2e/page.ts
+++ b/packages/examples-e2e/page.ts
@@ -1,0 +1,16 @@
+import { type Page, expect } from '@playwright/test'
+
+const collectErrors = (page: Page): Array<string> => {
+  const errors: Array<string> = []
+  page.on('pageerror', error => {
+    errors.push(error.message)
+  })
+  return errors
+}
+
+export const assertLoadedCleanly = async (page: Page): Promise<void> => {
+  const errors = collectErrors(page)
+  await page.goto('/', { waitUntil: 'networkidle' })
+  await expect(page.locator('#root')).toHaveCount(0)
+  expect(errors).toEqual([])
+}

--- a/packages/examples-e2e/playwright.config.ts
+++ b/packages/examples-e2e/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const exampleSlug = process.env['EXAMPLE_SLUG']
+if (!exampleSlug) {
+  throw new Error(
+    'EXAMPLE_SLUG environment variable is required. ' +
+      'Example: EXAMPLE_SLUG=counter pnpm --filter @foldkit/examples-e2e test:e2e',
+  )
+}
+
+const PORT = 5180
+const BASE_URL = `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: `**/${exampleSlug}.spec.ts`,
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env['CI']),
+  retries: process.env['CI'] ? 2 : 1,
+  reporter: process.env['CI'] ? 'github' : 'list',
+  timeout: 60_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: devices['Desktop Chrome'] }],
+  webServer: {
+    command: `pnpm -C ../../examples/${exampleSlug} exec vite --port ${PORT} --strictPort`,
+    url: BASE_URL,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+})

--- a/packages/examples-e2e/tsconfig.json
+++ b/packages/examples-e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["playwright.config.ts", "page.ts", "e2e/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1253,6 +1253,39 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/examples-e2e:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.3.0(jiti@2.7.0))
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^6.0.2
+        version: 6.0.2(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.59.2
+        version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.59.2
+        version: 8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint:
+        specifier: ^10.3.0
+        version: 10.3.0(jiti@2.7.0)
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   packages/foldkit:
     dependencies:
       '@floating-ui/dom':
@@ -2212,28 +2245,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -2292,42 +2321,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -2463,28 +2486,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -3754,28 +3773,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
A new internal @foldkit/examples-e2e package runs a Playwright spec per
example. Each spec asserts the app loads with no pageerror events and
exercises one representative interaction. The weather spec mocks the
open-meteo endpoints to keep the test hermetic.

A GitHub Actions matrix workflow runs the suite per-example on PRs and
main, with one job per example for clearer failure attribution. The
package is added to the changeset ignore list since it is private.
