### PR TITLE
Add Bun support to create-foldkit-app

### DIFF
--- a/.changeset/tall-bags-juggle.md
+++ b/.changeset/tall-bags-juggle.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Add Bun as a supported package manager in the scaffold CLI.

--- a/packages/create-foldkit-app/README.md
+++ b/packages/create-foldkit-app/README.md
@@ -10,6 +10,8 @@ npx create-foldkit-app
 pnpm create foldkit-app
 # or
 yarn create foldkit-app
+# or
+bun create foldkit-app
 ```
 
 The CLI prompts you for a project name, starter example, and package manager. Pass `--name`, `--example`, and/or `--package-manager` to skip the matching prompts.

--- a/packages/create-foldkit-app/src/commands/create.ts
+++ b/packages/create-foldkit-app/src/commands/create.ts
@@ -8,7 +8,7 @@ import { createProject } from '../utils/files.js'
 import { installDependencies } from '../utils/packages.js'
 import { validateProjectName } from '../validateName.js'
 
-type PackageManager = 'pnpm' | 'npm' | 'yarn'
+type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
 type CreateInput = Readonly<{
   name: Option.Option<string>
@@ -42,6 +42,7 @@ const promptForPackageManager = Prompt.select<PackageManager>({
     { value: 'pnpm', title: 'pnpm' },
     { value: 'npm', title: 'npm' },
     { value: 'yarn', title: 'yarn' },
+    { value: 'bun', title: 'bun' },
   ],
 })
 
@@ -123,6 +124,7 @@ const runDevServerCommand = (packageManager: PackageManager) =>
     Match.when('pnpm', () => 'pnpm dev'),
     Match.when('npm', () => 'npm run dev'),
     Match.when('yarn', () => 'yarn dev'),
+    Match.when('bun', () => 'bun dev'),
     Match.exhaustive,
   )
 

--- a/packages/create-foldkit-app/src/index.ts
+++ b/packages/create-foldkit-app/src/index.ts
@@ -44,6 +44,7 @@ const packageManager = Flag.choice('package-manager', [
   'pnpm',
   'npm',
   'yarn',
+  'bun',
 ]).pipe(
   Flag.withAlias('p'),
   Flag.withDescription(

--- a/packages/create-foldkit-app/src/utils/packages.ts
+++ b/packages/create-foldkit-app/src/utils/packages.ts
@@ -2,7 +2,7 @@ import { Array, Effect, Match, Record, Schema, pipe } from 'effect'
 import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { spawn } from 'node:child_process'
 
-type PackageManager = 'pnpm' | 'npm' | 'yarn'
+type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
 const GITHUB_RAW_BASE_URL =
   'https://raw.githubusercontent.com/foldkit/foldkit/main/examples'
@@ -18,6 +18,7 @@ const getInstallArgs = (
     Match.when('npm', () => ['install']),
     Match.when('yarn', () => ['add']),
     Match.when('pnpm', () => ['add']),
+    Match.when('bun', () => ['add']),
     Match.exhaustive,
     args => (isDev ? [...args, '-D'] : args),
   )

--- a/packages/website/src/page/gettingStarted.ts
+++ b/packages/website/src/page/gettingStarted.ts
@@ -26,6 +26,7 @@ const CREATE_FOLDKIT_APP_COMMAND = 'npx create-foldkit-app@latest'
 const DEV_PNPM = 'pnpm dev'
 const DEV_NPM = 'npm run dev'
 const DEV_YARN = 'yarn dev'
+const DEV_BUN = 'bun dev'
 
 const quickStartHeader: TableOfContentsEntry = {
   level: 'h2',
@@ -80,6 +81,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
           codeBlock(DEV_PNPM, 'Copy pnpm command', copiedSnippets),
           codeBlock(DEV_NPM, 'Copy npm command', copiedSnippets),
           codeBlock(DEV_YARN, 'Copy yarn command', copiedSnippets),
+          codeBlock(DEV_BUN, 'Copy bun command', copiedSnippets),
         ],
       ),
       infoCallout(


### PR DESCRIPTION
Would be nice if `create-foldkit-app` supported Bun too.

This adds Bun to the package manager choices, install command mapping, success message, and the docs snippets that list package manager commands.

Checks run:

- `pnpm --filter create-foldkit-app build`
- `pnpm exec prettier --check packages/create-foldkit-app/src/commands/create.ts packages/create-foldkit-app/src/utils/packages.ts packages/create-foldkit-app/src/index.ts packages/create-foldkit-app/README.md packages/website/src/page/gettingStarted.ts .changeset/tall-bags-juggle.md`
- `node packages/create-foldkit-app/dist/index.js --help | rg "package-manager|pnpm, npm, yarn, bun"`

Closes #345.
