### PR TITLE
Move html binding to function scope in view functions

### DIFF
--- a/.changeset/html-binding-function-level.md
+++ b/.changeset/html-binding-function-level.md
@@ -1,0 +1,6 @@
+---
+'foldkit': patch
+'create-foldkit-app': patch
+---
+
+Update README and template docs to recommend binding `const h = html<Message>()` inside view functions instead of at module level. The function-level binding accepts the function's actual Message type parameter (including `<ParentMessage>` for child views), keeps view functions portable across files, and removes the need to decide where the binding lives. Behavior unchanged.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/.claude/commands/ui-component.md
+++ b/.claude/commands/ui-component.md
@@ -44,7 +44,7 @@ Enter plan mode and design the component following these integration touchpoints
 - Use `evo()` from `foldkit/struct` for model updates
 - Use `Effect.Match` with `M.tagsExhaustive` in update — never switch statements
 - Use `M.withReturnType<[Model, ReadonlyArray<Command<Message>>]>()`
-- Destructure html elements/attributes from `html<Message>()` in view functions
+- Bind `const h = html<Message>()` inside each view function (never at module level), then reach for elements/attributes/events off `h`
 - Use `Option` for optional model fields, not null/undefined
 - Use `DataAttribute` for state-reflecting data attributes (data-open, data-active, data-disabled)
 - Disabled items: no event handlers, `AriaDisabled(true)`, `DataAttribute('disabled', '')`

--- a/README.md
+++ b/README.md
@@ -102,32 +102,43 @@ export const init: Runtime.ProgramInit<Model, Message> = () => [
 
 // VIEW
 
-const { div, button, Class, OnClick } = html<Message>()
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-export const view = (model: Model): Document => ({
-  title: `Counter: ${model.count}`,
-  body: div(
-    [
-      Class(
-        'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
-      ),
-    ],
-    [
-      div(
-        [Class('text-6xl font-bold text-gray-800')],
-        [model.count.toString()],
-      ),
-      div(
-        [Class('flex flex-wrap justify-center gap-4')],
-        [
-          button([OnClick(ClickedDecrement()), Class(buttonStyle)], ['-']),
-          button([OnClick(ClickedReset()), Class(buttonStyle)], ['Reset']),
-          button([OnClick(ClickedIncrement()), Class(buttonStyle)], ['+']),
-        ],
-      ),
-    ],
-  ),
-})
+  return {
+    title: `Counter: ${model.count}`,
+    body: h.div(
+      [
+        h.Class(
+          'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
+        ),
+      ],
+      [
+        h.div(
+          [h.Class('text-6xl font-bold text-gray-800')],
+          [model.count.toString()],
+        ),
+        h.div(
+          [h.Class('flex flex-wrap justify-center gap-4')],
+          [
+            h.button(
+              [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
+              ['-'],
+            ),
+            h.button(
+              [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
+              ['Reset'],
+            ),
+            h.button(
+              [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
+              ['+'],
+            ),
+          ],
+        ),
+      ],
+    ),
+  }
+}
 
 // STYLE
 

--- a/examples/auth/src/view.ts
+++ b/examples/auth/src/view.ts
@@ -4,37 +4,39 @@ import { type Document, html } from 'foldkit/html'
 import { GotLoggedInMessage, GotLoggedOutMessage, Message } from './message'
 import { LoggedIn, LoggedOut, Model } from './model'
 
-const h = html<Message>()
-
 const title = (model: Model): string =>
   M.value(model.route).pipe(
     M.tag('Home', () => 'Auth'),
     M.orElse(({ _tag }) => `${_tag} — Auth`),
   )
 
-export const view = (model: Model): Document => ({
-  title: title(model),
-  body: h.div(
-    [h.Class('min-h-screen bg-gray-100')],
-    [
-      h.keyed('div')(
-        model._tag,
-        [],
-        [
-          M.value(model).pipe(
-            M.tagsExhaustive({
-              LoggedOut: loggedOutModel =>
-                LoggedOut.view<Message>(loggedOutModel, message =>
-                  GotLoggedOutMessage({ message }),
-                ),
-              LoggedIn: loggedInModel =>
-                LoggedIn.view<Message>(loggedInModel, message =>
-                  GotLoggedInMessage({ message }),
-                ),
-            }),
-          ),
-        ],
-      ),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: title(model),
+    body: h.div(
+      [h.Class('min-h-screen bg-gray-100')],
+      [
+        h.keyed('div')(
+          model._tag,
+          [],
+          [
+            M.value(model).pipe(
+              M.tagsExhaustive({
+                LoggedOut: loggedOutModel =>
+                  LoggedOut.view<Message>(loggedOutModel, message =>
+                    GotLoggedOutMessage({ message }),
+                  ),
+                LoggedIn: loggedInModel =>
+                  LoggedIn.view<Message>(loggedInModel, message =>
+                    GotLoggedInMessage({ message }),
+                  ),
+              }),
+            ),
+          ],
+        ),
+      ],
+    ),
+  }
+}

--- a/examples/canvas-art/src/main.ts
+++ b/examples/canvas-art/src/main.ts
@@ -190,8 +190,6 @@ export const subscriptions = Subscription.makeSubscriptions(
 
 // VIEW
 
-const h = html<Message>()
-
 const backgroundShape = Canvas.Rect({
   x: 0,
   y: 0,
@@ -213,8 +211,10 @@ const sceneShapes = (model: Model): ReadonlyArray<Canvas.Shape> => [
   ...Array.map(model.balls, ballShape),
 ]
 
-const controlsView = (model: Model): Html =>
-  h.div(
+const controlsView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex gap-3 mt-4')],
     [
       h.button(
@@ -247,29 +247,34 @@ const controlsView = (model: Model): Html =>
       ),
     ],
   )
+}
 
-export const view = (model: Model): Document => ({
-  title: `Canvas Art (${model.balls.length} balls)`,
-  body: h.div(
-    [
-      h.Class(
-        'flex flex-col items-center justify-center min-h-screen bg-black text-white p-8',
-      ),
-    ],
-    [
-      h.h1([h.Class('text-4xl font-bold mb-2')], ['Canvas Art']),
-      h.p(
-        [h.Class('text-zinc-400 mb-6')],
-        ['Click the canvas to spawn a ball.'],
-      ),
-      Canvas.view<Message>({
-        width: CANVAS_WIDTH,
-        height: CANVAS_HEIGHT,
-        shapes: sceneShapes(model),
-        className: 'rounded-lg shadow-2xl cursor-crosshair',
-        onPointerDown: ({ x, y }) => ClickedCanvas({ x, y }),
-      }),
-      controlsView(model),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: `Canvas Art (${model.balls.length} balls)`,
+    body: h.div(
+      [
+        h.Class(
+          'flex flex-col items-center justify-center min-h-screen bg-black text-white p-8',
+        ),
+      ],
+      [
+        h.h1([h.Class('text-4xl font-bold mb-2')], ['Canvas Art']),
+        h.p(
+          [h.Class('text-zinc-400 mb-6')],
+          ['Click the canvas to spawn a ball.'],
+        ),
+        Canvas.view<Message>({
+          width: CANVAS_WIDTH,
+          height: CANVAS_HEIGHT,
+          shapes: sceneShapes(model),
+          className: 'rounded-lg shadow-2xl cursor-crosshair',
+          onPointerDown: ({ x, y }) => ClickedCanvas({ x, y }),
+        }),
+        controlsView(model),
+      ],
+    ),
+  }
+}

--- a/examples/counter/src/main.ts
+++ b/examples/counter/src/main.ts
@@ -47,41 +47,43 @@ export const init: Runtime.ProgramInit<Model, Message> = () => [
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-export const view = (model: Model): Document => ({
-  title: `Counter: ${model.count}`,
-  body: h.div(
-    [
-      h.Class(
-        'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
-      ),
-    ],
-    [
-      h.div(
-        [h.Class('text-6xl font-bold text-gray-800')],
-        [model.count.toString()],
-      ),
-      h.div(
-        [h.Class('flex flex-wrap justify-center gap-4')],
-        [
-          h.button(
-            [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
-            ['-'],
-          ),
-          h.button(
-            [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
-            ['Reset'],
-          ),
-          h.button(
-            [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
-            ['+'],
-          ),
-        ],
-      ),
-    ],
-  ),
-})
+  return {
+    title: `Counter: ${model.count}`,
+    body: h.div(
+      [
+        h.Class(
+          'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
+        ),
+      ],
+      [
+        h.div(
+          [h.Class('text-6xl font-bold text-gray-800')],
+          [model.count.toString()],
+        ),
+        h.div(
+          [h.Class('flex flex-wrap justify-center gap-4')],
+          [
+            h.button(
+              [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
+              ['-'],
+            ),
+            h.button(
+              [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
+              ['Reset'],
+            ),
+            h.button(
+              [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
+              ['+'],
+            ),
+          ],
+        ),
+      ],
+    ),
+  }
+}
 
 // STYLE
 

--- a/examples/crash-view/src/main.ts
+++ b/examples/crash-view/src/main.ts
@@ -30,25 +30,27 @@ export const init: Runtime.ProgramInit<Model, Message> = () => [null, []]
 
 // VIEW
 
-const h = html<Message>()
+export const view = (_model: Model): Document => {
+  const h = html<Message>()
 
-export const view = (_model: Model): Document => ({
-  title: 'Crash View Example',
-  body: h.div(
-    [h.Class('min-h-screen bg-white flex items-center justify-center')],
-    [
-      h.button(
-        [
-          h.OnClick(ClickedCrash()),
-          h.Class(
-            'bg-red-600 text-white text-lg font-semibold hover:bg-red-700 px-6 py-3 rounded transition cursor-pointer',
-          ),
-        ],
-        ['Crash'],
-      ),
-    ],
-  ),
-})
+  return {
+    title: 'Crash View Example',
+    body: h.div(
+      [h.Class('min-h-screen bg-white flex items-center justify-center')],
+      [
+        h.button(
+          [
+            h.OnClick(ClickedCrash()),
+            h.Class(
+              'bg-red-600 text-white text-lg font-semibold hover:bg-red-700 px-6 py-3 rounded transition cursor-pointer',
+            ),
+          ],
+          ['Crash'],
+        ),
+      ],
+    ),
+  }
+}
 
 // CRASH
 

--- a/examples/form/src/main.ts
+++ b/examples/form/src/main.ts
@@ -284,8 +284,6 @@ export const SubmitForm = Command.define(
 
 // VIEW
 
-const h = html<Message>()
-
 const LABEL_CLASS = 'text-sm font-medium text-gray-700'
 const DESCRIPTION_CLASS = 'text-sm mt-1'
 
@@ -305,8 +303,10 @@ const inputClassName = (field: Field): string =>
     borderClass(field),
   )
 
-const statusIndicator = (field: Field): Html =>
-  M.value(field).pipe(
+const statusIndicator = (field: Field): Html => {
+  const h = html<Message>()
+
+  return M.value(field).pipe(
     M.tagsExhaustive({
       NotValidated: () => h.empty,
       Validating: () =>
@@ -315,12 +315,15 @@ const statusIndicator = (field: Field): Html =>
       Invalid: () => h.empty,
     }),
   )
+}
 
 const descriptionView = (
   field: Field,
   descriptionAttributes: ReadonlyArray<Attribute<Message>>,
-): Html =>
-  M.value(field).pipe(
+): Html => {
+  const h = html<Message>()
+
+  return M.value(field).pipe(
     M.tagsExhaustive({
       NotValidated: () => h.empty,
       Validating: () =>
@@ -342,6 +345,7 @@ const descriptionView = (
         ),
     }),
   )
+}
 
 const inputFieldView = (
   id: string,
@@ -349,8 +353,10 @@ const inputFieldView = (
   field: Field,
   onUpdate: (value: string) => Message,
   type: string = 'text',
-): Html =>
-  Ui.Input.view({
+): Html => {
+  const h = html<Message>()
+
+  return Ui.Input.view({
     id,
     value: field.value,
     onInput: onUpdate,
@@ -372,14 +378,17 @@ const inputFieldView = (
         ],
       ),
   })
+}
 
 const textareaFieldView = (
   id: string,
   labelText: string,
   field: Field,
   onUpdate: (value: string) => Message,
-): Html =>
-  Ui.Textarea.view({
+): Html => {
+  const h = html<Message>()
+
+  return Ui.Textarea.view({
     id,
     value: field.value,
     onInput: onUpdate,
@@ -403,8 +412,11 @@ const textareaFieldView = (
         ],
       ),
   })
+}
 
 export const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const canSubmit = isFormValid(model) && model.submission._tag !== 'Submitting'
 
   const body = h.div(

--- a/examples/generative-art/src/view.ts
+++ b/examples/generative-art/src/view.ts
@@ -34,8 +34,6 @@ import {
 } from './message'
 import type { Model, Particle, Point } from './model'
 
-const h = html<Message>()
-
 const fadeAlpha = (particle: Particle): number => {
   const remainingMs = particle.lifespanMs - particle.ageMs
   const fadeIn = Math.min(1, particle.ageMs / FADE_IN_MS)
@@ -356,8 +354,10 @@ const controlButton = <ParentMessage>(
   })
 }
 
-const controlsView = (model: Model): Html =>
-  h.div(
+const controlsView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'flex flex-wrap items-end gap-6 mt-6 px-6 py-4 rounded-xl ' +
@@ -394,9 +394,12 @@ const controlsView = (model: Model): Html =>
       ),
     ],
   )
+}
 
-const headerView = (): Html =>
-  h.div(
+const headerView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex flex-col items-center mb-6 text-center')],
     [
       h.h1(
@@ -415,30 +418,35 @@ const headerView = (): Html =>
       ),
     ],
   )
+}
 
-export const view = (model: Model): Document => ({
-  title: `Prism Field · ${model.particles.length} particles`,
-  body: h.div(
-    [
-      h.Class(
-        'flex flex-col items-center justify-center min-h-screen p-8 ' +
-          'bg-[radial-gradient(ellipse_at_top,_#1a0a2c_0%,_#04010a_55%,_#000_100%)] ' +
-          'text-white font-mono select-none',
-      ),
-    ],
-    [
-      headerView(),
-      Canvas.view<Message>({
-        width: CANVAS_WIDTH,
-        height: CANVAS_HEIGHT,
-        shapes: sceneShapes(model),
-        className:
-          'rounded-2xl shadow-[0_0_120px_rgba(80,30,140,0.35)] ' +
-          'border border-white/10 cursor-crosshair',
-        onPointerDown: ({ x, y }) => PressedCanvas({ x, y }),
-        onPointerMove: ({ x, y }) => MovedPointer({ x, y }),
-      }),
-      controlsView(model),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: `Prism Field · ${model.particles.length} particles`,
+    body: h.div(
+      [
+        h.Class(
+          'flex flex-col items-center justify-center min-h-screen p-8 ' +
+            'bg-[radial-gradient(ellipse_at_top,_#1a0a2c_0%,_#04010a_55%,_#000_100%)] ' +
+            'text-white font-mono select-none',
+        ),
+      ],
+      [
+        headerView(),
+        Canvas.view<Message>({
+          width: CANVAS_WIDTH,
+          height: CANVAS_HEIGHT,
+          shapes: sceneShapes(model),
+          className:
+            'rounded-2xl shadow-[0_0_120px_rgba(80,30,140,0.35)] ' +
+            'border border-white/10 cursor-crosshair',
+          onPointerDown: ({ x, y }) => PressedCanvas({ x, y }),
+          onPointerMove: ({ x, y }) => MovedPointer({ x, y }),
+        }),
+        controlsView(model),
+      ],
+    ),
+  }
+}

--- a/examples/job-application/src/view/index.ts
+++ b/examples/job-application/src/view/index.ts
@@ -33,8 +33,6 @@ import { skillsView } from './skills'
 import { stepList, stepMenu } from './stepNav'
 import { workHistoryView } from './workHistory'
 
-const h = html<Message>()
-
 const stepHasErrors =
   (model: Model) =>
   (step: Step.Step): boolean =>
@@ -91,8 +89,10 @@ const isFirstStep = (model: Model): boolean =>
 const isLastStep = (model: Model): boolean =>
   pipe(Step.all, Array.last, Option.exists(Equal.equals(model.currentStep)))
 
-const navigationButtons = (model: Model): Html =>
-  h.keyed('div')(
+const navigationButtons = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.keyed('div')(
     'navigation',
     [h.Class('flex justify-between pt-6 mt-8 border-t border-gray-200')],
     [
@@ -128,9 +128,12 @@ const navigationButtons = (model: Model): Html =>
           ]),
     ],
   )
+}
 
-const pageHeader = (): Html =>
-  h.div(
+const pageHeader = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('mb-6')],
     [
       h.h1(
@@ -143,9 +146,12 @@ const pageHeader = (): Html =>
       ),
     ],
   )
+}
 
-const stepContentPanel = (model: Model): Html =>
-  h.keyed('div')(
+const stepContentPanel = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.keyed('div')(
     'step-content-panel',
     [h.Class('flex-1 min-w-0')],
     [
@@ -162,12 +168,15 @@ const stepContentPanel = (model: Model): Html =>
       ...(model.currentStep !== 'Review' ? [navigationButtons(model)] : []),
     ],
   )
+}
 
 const desktopStepSidebar = (
   model: Model,
   errorSteps: HashSet.HashSet<Step.Step>,
-): Html =>
-  h.keyed('div')(
+): Html => {
+  const h = html<Message>()
+
+  return h.keyed('div')(
     'desktop-sidebar',
     [h.Class('hidden w-60 shrink-0 lg:block')],
     [
@@ -181,9 +190,12 @@ const desktopStepSidebar = (
       ),
     ],
   )
+}
 
-const desktopPreviewSidebar = (model: Model): Html =>
-  h.keyed('div')(
+const desktopPreviewSidebar = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.keyed('div')(
     'desktop-preview',
     [h.Class('hidden w-80 shrink-0 xl:block')],
     [
@@ -211,9 +223,12 @@ const desktopPreviewSidebar = (model: Model): Html =>
       ),
     ],
   )
+}
 
-const mobilePreviewToggle = (model: Model): Html =>
-  h.keyed('div')(
+const mobilePreviewToggle = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.keyed('div')(
     'mobile-toggle',
     [h.Class('fixed bottom-4 right-4 xl:hidden')],
     [
@@ -234,9 +249,12 @@ const mobilePreviewToggle = (model: Model): Html =>
       ),
     ],
   )
+}
 
-const mobilePreviewOverlay = (model: Model): Html =>
-  h.keyed('div')(
+const mobilePreviewOverlay = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.keyed('div')(
     'mobile-overlay',
     [
       h.Class(
@@ -245,8 +263,11 @@ const mobilePreviewOverlay = (model: Model): Html =>
     ],
     [preview<Message>(model)],
   )
+}
 
 export const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const errorSteps = stepsWithErrors(model)
   const body = h.div(
     [h.Class('min-h-screen bg-gray-50')],

--- a/examples/kanban/src/view/index.ts
+++ b/examples/kanban/src/view/index.ts
@@ -7,8 +7,6 @@ import type { Model } from '../model'
 import { ghostCardView } from './card'
 import { columnView } from './column'
 
-const h = html<Message>()
-
 const findDraggedCard = (model: Model) =>
   pipe(
     model.dragAndDrop,
@@ -22,8 +20,10 @@ const findDraggedCard = (model: Model) =>
     ),
   )
 
-const ghostElement = (model: Model) =>
-  pipe(
+const ghostElement = (model: Model) => {
+  const h = html<Message>()
+
+  return pipe(
     Ui.DragAndDrop.ghostStyle(model.dragAndDrop),
     Option.flatMap(ghostStyle =>
       Option.map(findDraggedCard(model), card => ({ ghostStyle, card })),
@@ -37,36 +37,41 @@ const ghostElement = (model: Model) =>
         ),
     }),
   )
+}
 
-export const view = (model: Model): Document => ({
-  title: 'Kanban Board',
-  body: h.div(
-    [h.Class('flex flex-col min-h-screen bg-gray-100')],
-    [
-      h.div(
-        [h.Class('px-6 py-4 bg-white border-b border-gray-200')],
-        [
-          h.h1(
-            [h.Class('text-lg font-semibold text-gray-900')],
-            ['Kanban Board'],
-          ),
-        ],
-      ),
-      h.div(
-        [
-          h.Class(
-            'flex-1 p-6 grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-6 items-start',
-          ),
-        ],
-        Array.map(model.columns, column =>
-          columnView<Message>(model, column, message => message),
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: 'Kanban Board',
+    body: h.div(
+      [h.Class('flex flex-col min-h-screen bg-gray-100')],
+      [
+        h.div(
+          [h.Class('px-6 py-4 bg-white border-b border-gray-200')],
+          [
+            h.h1(
+              [h.Class('text-lg font-semibold text-gray-900')],
+              ['Kanban Board'],
+            ),
+          ],
         ),
-      ),
-      ghostElement(model),
-      h.div(
-        [h.Class('sr-only'), h.AriaLive('assertive')],
-        [model.announcement],
-      ),
-    ],
-  ),
-})
+        h.div(
+          [
+            h.Class(
+              'flex-1 p-6 grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-6 items-start',
+            ),
+          ],
+          Array.map(model.columns, column =>
+            columnView<Message>(model, column, message => message),
+          ),
+        ),
+        ghostElement(model),
+        h.div(
+          [h.Class('sr-only'), h.AriaLive('assertive')],
+          [model.announcement],
+        ),
+      ],
+    ),
+  }
+}

--- a/examples/map/src/main.ts
+++ b/examples/map/src/main.ts
@@ -481,8 +481,6 @@ export const subscriptions = Subscription.makeSubscriptions(
 
 // VIEW
 
-const h = html<Message>()
-
 const HOST_ID = nextHostId()
 
 const filterLocations = (
@@ -502,19 +500,25 @@ const filterLocations = (
   }
 }
 
-export const view = (model: Model): Document => ({
-  title: 'Foldkit Map',
-  body: h.div(
-    [h.Class('h-screen w-screen flex bg-slate-100 text-slate-900')],
-    [
-      sidebarView(model),
-      mapPaneView(model),
-      geolocateOverlayView(model.geolocateState),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: 'Foldkit Map',
+    body: h.div(
+      [h.Class('h-screen w-screen flex bg-slate-100 text-slate-900')],
+      [
+        sidebarView(model),
+        mapPaneView(model),
+        geolocateOverlayView(model.geolocateState),
+      ],
+    ),
+  }
+}
 
 const sidebarView = (model: Model): Html => {
+  const h = html<Message>()
+
   const visible = filterLocations(model.locations, model.searchQuery)
   return h.aside(
     [
@@ -566,8 +570,10 @@ const sidebarView = (model: Model): Html => {
   )
 }
 
-const emptySidebarView = (searchQuery: string): Html =>
-  h.li(
+const emptySidebarView = (searchQuery: string): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [h.Class('px-5 py-6 text-sm text-slate-500')],
     [
       String.isEmpty(searchQuery.trim())
@@ -575,10 +581,13 @@ const emptySidebarView = (searchQuery: string): Html =>
         : `No locations match "${searchQuery.trim()}".`,
     ],
   )
+}
 
 const locationListItemView =
   (maybeSelectedId: Option.Option<string>) =>
   (location: Location): Html => {
+    const h = html<Message>()
+
     const isSelected = Option.exists(maybeSelectedId, Equal.equals(location.id))
     return h.li(
       [],
@@ -607,6 +616,8 @@ const locationListItemView =
   }
 
 const footerView = (model: Model): Html => {
+  const h = html<Message>()
+
   const isLocating = model.geolocateState._tag === 'GeolocateLocating'
   return h.div(
     [h.Class('border-t border-slate-200 px-5 py-3 space-y-2')],
@@ -634,8 +645,10 @@ const footerView = (model: Model): Html => {
   )
 }
 
-const mapPaneView = (model: Model): Html =>
-  h.main(
+const mapPaneView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.main(
     [h.Class('flex-1 relative')],
     [
       h.div(
@@ -650,9 +663,12 @@ const mapPaneView = (model: Model): Html =>
       boundsBadgeView(model.maybeBounds),
     ],
   )
+}
 
-const mapErrorBannerView = (maybeReason: Option.Option<string>): Html =>
-  Option.match(maybeReason, {
+const mapErrorBannerView = (maybeReason: Option.Option<string>): Html => {
+  const h = html<Message>()
+
+  return Option.match(maybeReason, {
     onNone: () => h.empty,
     onSome: reason =>
       h.div(
@@ -668,9 +684,12 @@ const mapErrorBannerView = (maybeReason: Option.Option<string>): Html =>
         ],
       ),
   })
+}
 
-const boundsBadgeView = (maybeBounds: Option.Option<Bounds>): Html =>
-  Option.match(maybeBounds, {
+const boundsBadgeView = (maybeBounds: Option.Option<Bounds>): Html => {
+  const h = html<Message>()
+
+  return Option.match(maybeBounds, {
     onNone: () => h.empty,
     onSome: bounds =>
       h.div(
@@ -687,9 +706,12 @@ const boundsBadgeView = (maybeBounds: Option.Option<Bounds>): Html =>
         ],
       ),
   })
+}
 
-const geolocateOverlayView = (state: GeolocateState): Html =>
-  M.value(state).pipe(
+const geolocateOverlayView = (state: GeolocateState): Html => {
+  const h = html<Message>()
+
+  return M.value(state).pipe(
     M.tagsExhaustive({
       GeolocateIdle: () => h.empty,
       GeolocateLocating: () =>
@@ -698,9 +720,12 @@ const geolocateOverlayView = (state: GeolocateState): Html =>
         geolocateOverlayShellView(geolocateFailedContentView(reason)),
     }),
   )
+}
 
-const geolocateOverlayShellView = (content: Html): Html =>
-  h.keyed('div')(
+const geolocateOverlayShellView = (content: Html): Html => {
+  const h = html<Message>()
+
+  return h.keyed('div')(
     'Geolocate()-overlay',
     [
       h.Class(
@@ -710,9 +735,12 @@ const geolocateOverlayShellView = (content: Html): Html =>
     ],
     [content],
   )
+}
 
-const geolocateLocatingContentView = (): Html =>
-  h.keyed('article')(
+const geolocateLocatingContentView = (): Html => {
+  const h = html<Message>()
+
+  return h.keyed('article')(
     'Geolocate()-locating',
     [
       h.Class(
@@ -728,9 +756,12 @@ const geolocateLocatingContentView = (): Html =>
       spinnerView(),
     ],
   )
+}
 
-const geolocateFailedContentView = (reason: string): Html =>
-  h.keyed('article')(
+const geolocateFailedContentView = (reason: string): Html => {
+  const h = html<Message>()
+
+  return h.keyed('article')(
     'Geolocate()-failed',
     [
       h.Class(
@@ -755,9 +786,12 @@ const geolocateFailedContentView = (reason: string): Html =>
       ),
     ],
   )
+}
 
-const spinnerView = (): Html =>
-  h.div(
+const spinnerView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex justify-center mt-4')],
     [
       h.span(
@@ -771,6 +805,7 @@ const spinnerView = (): Html =>
       ),
     ],
   )
+}
 
 // STYLE
 

--- a/examples/pixel-art/src/view/dialog.ts
+++ b/examples/pixel-art/src/view/dialog.ts
@@ -11,8 +11,6 @@ import {
   type Message,
 } from '../message'
 
-const h = html<Message>()
-
 const errorDialogMessageToMessage = (message: Ui.Dialog.Message): Message =>
   GotErrorDialogMessage({ message })
 
@@ -22,8 +20,10 @@ const confirmDialogMessageToMessage = (message: Ui.Dialog.Message): Message =>
 export const errorDialogView = (
   errorDialog: typeof Ui.Dialog.Model.Type,
   maybeExportError: Option.Option<string>,
-): Html =>
-  Ui.Dialog.view({
+): Html => {
+  const h = html<Message>()
+
+  return Ui.Dialog.view({
     model: errorDialog,
     toParentMessage: errorDialogMessageToMessage,
     onClosed: () => DismissedErrorDialog(),
@@ -75,12 +75,15 @@ export const errorDialogView = (
         ),
     }),
   })
+}
 
 export const gridSizeConfirmDialogView = (
   gridSizeConfirmDialog: typeof Ui.Dialog.Model.Type,
   maybePendingGridSize: Option.Option<number>,
-): Html =>
-  Ui.Dialog.view({
+): Html => {
+  const h = html<Message>()
+
+  return Ui.Dialog.view({
     model: gridSizeConfirmDialog,
     toParentMessage: confirmDialogMessageToMessage,
     onClosed: () => DismissedGridSizeConfirmDialog(),
@@ -150,3 +153,4 @@ export const gridSizeConfirmDialogView = (
         ),
     }),
   })
+}

--- a/examples/pixel-art/src/view/history.ts
+++ b/examples/pixel-art/src/view/history.ts
@@ -14,10 +14,10 @@ import {
 import type { Grid } from '../model'
 import { type PaletteTheme, resolveColor } from '../palette'
 
-const h = html<Message>()
+const sectionLabel = (text: string): Html => {
+  const h = html<Message>()
 
-const sectionLabel = (text: string): Html =>
-  h.div(
+  return h.div(
     [
       h.Class(
         'text-[10px] font-semibold uppercase tracking-widest text-gray-400 mb-2',
@@ -25,6 +25,7 @@ const sectionLabel = (text: string): Html =>
     ],
     [text],
   )
+}
 
 export const historyPanelView = (
   undoStack: ReadonlyArray<Grid>,
@@ -33,6 +34,8 @@ export const historyPanelView = (
   gridSize: number,
   theme: PaletteTheme,
 ): Html => {
+  const h = html<Message>()
+
   const undoCount = undoStack.length
   const redoCount = redoStack.length
   const visibleUndoEntries = Array.takeRight(undoStack, VISIBLE_HISTORY_COUNT)
@@ -146,8 +149,10 @@ const thumbnailEntry = (
   label: string,
   maybeOnClick: Option.Option<Message>,
   theme: PaletteTheme,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         clsx('flex items-center gap-2 px-2 py-1.5 rounded', {
@@ -204,3 +209,4 @@ const thumbnailEntry = (
       ),
     ],
   )
+}

--- a/examples/pixel-art/src/view/toolbar.ts
+++ b/examples/pixel-art/src/view/toolbar.ts
@@ -21,8 +21,6 @@ import {
 import type { MirrorMode, PaletteIndex, Tool } from '../model'
 import { PALETTE_THEMES, type PaletteTheme } from '../palette'
 
-const h = html<Message>()
-
 const TOOLS: ReadonlyArray<Tool> = ['Brush', 'Fill', 'Eraser']
 
 const TOOL_SHORTCUTS: Record<Tool, string> = {
@@ -39,8 +37,10 @@ export const THEME_LISTBOX_ANCHOR: Ui.Listbox.AnchorConfig = {
   padding: 8,
 }
 
-const sectionLabel = (text: string): Html =>
-  h.div(
+const sectionLabel = (text: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'text-[10px] font-semibold uppercase tracking-widest text-gray-400 mb-2',
@@ -48,9 +48,12 @@ const sectionLabel = (text: string): Html =>
     ],
     [text],
   )
+}
 
-const trashIcon = (className: string): Html =>
-  h.svg(
+const trashIcon = (className: string): Html => {
+  const h = html<Message>()
+
+  return h.svg(
     [
       h.AriaHidden(true),
       h.Class(className),
@@ -73,9 +76,12 @@ const trashIcon = (className: string): Html =>
       ),
     ],
   )
+}
 
-const chevronDownIcon = (className: string): Html =>
-  h.svg(
+const chevronDownIcon = (className: string): Html => {
+  const h = html<Message>()
+
+  return h.svg(
     [
       h.AriaHidden(true),
       h.Class(className),
@@ -96,6 +102,7 @@ const chevronDownIcon = (className: string): Html =>
       ),
     ],
   )
+}
 
 export const toolPanelView = (
   mirrorMode: MirrorMode,
@@ -108,8 +115,10 @@ export const toolPanelView = (
   mirrorVerticalSwitch: typeof Ui.Switch.Model.Type,
   theme: PaletteTheme,
   themeListbox: typeof Ui.Listbox.Model.Type,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('w-full md:w-44 flex flex-col gap-5 flex-shrink-0')],
     [
       toolSectionView(toolRadioGroup),
@@ -128,11 +137,14 @@ export const toolPanelView = (
       clearCanvasView(isCanvasEmpty),
     ],
   )
+}
 
 const toolSectionView = (
   toolRadioGroup: typeof Ui.RadioGroup.Model.Type,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       sectionLabel('Tools'),
@@ -172,12 +184,15 @@ const toolSectionView = (
       }),
     ],
   )
+}
 
 const mirrorSectionView = (
   mirrorMode: MirrorMode,
   mirrorHorizontalSwitch: typeof Ui.Switch.Model.Type,
   mirrorVerticalSwitch: typeof Ui.Switch.Model.Type,
 ): Html => {
+  const h = html<Message>()
+
   const isMirrorHorizontal =
     mirrorMode === 'Horizontal' || mirrorMode === 'Both'
   const isMirrorVertical = mirrorMode === 'Vertical' || mirrorMode === 'Both'
@@ -259,8 +274,10 @@ const mirrorSectionView = (
 
 const sizeSectionView = (
   gridSizeRadioGroup: typeof Ui.RadioGroup.Model.Type,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       sectionLabel('Grid Size'),
@@ -296,6 +313,7 @@ const sizeSectionView = (
       }),
     ],
   )
+}
 
 const paletteSectionView = (
   selectedColorIndex: PaletteIndex,
@@ -303,6 +321,8 @@ const paletteSectionView = (
   theme: PaletteTheme,
   themeListbox: typeof Ui.Listbox.Model.Type,
 ): Html => {
+  const h = html<Message>()
+
   const paletteIndexStrings = theme.colors.map((_, index) => index.toString())
   const selectedHexColor = theme.colors[selectedColorIndex] ?? EMPTY_COLOR
 
@@ -357,8 +377,10 @@ const paletteSectionView = (
 const themeListboxView = (
   themeListbox: typeof Ui.Listbox.Model.Type,
   theme: PaletteTheme,
-): Html =>
-  Ui.Listbox.view<Message, string>({
+): Html => {
+  const h = html<Message>()
+
+  return Ui.Listbox.view<Message, string>({
     model: themeListbox,
     toParentMessage: message => GotThemeListboxMessage({ message }),
     onSelectedItem: value =>
@@ -400,9 +422,12 @@ const themeListboxView = (
     backdropAttributes: [h.Class('fixed inset-0 z-0')],
     attributes: [h.Class('relative w-full mt-3')],
   })
+}
 
-const clearCanvasView = (isCanvasEmpty: boolean): Html =>
-  Ui.Button.view({
+const clearCanvasView = (isCanvasEmpty: boolean): Html => {
+  const h = html<Message>()
+
+  return Ui.Button.view({
     onClick: ClickedClear(),
     isDisabled: isCanvasEmpty,
     toView: attributes =>
@@ -422,3 +447,4 @@ const clearCanvasView = (isCanvasEmpty: boolean): Html =>
         [trashIcon('w-4 h-4'), h.span([], ['Clear Canvas'])],
       ),
   })
+}

--- a/examples/pixel-art/src/view/view.ts
+++ b/examples/pixel-art/src/view/view.ts
@@ -12,10 +12,10 @@ import { errorDialogView, gridSizeConfirmDialogView } from './dialog'
 import { historyPanelView } from './history'
 import { toolPanelView } from './toolbar'
 
-const h = html<Message>()
+const downloadIcon = (className: string): Html => {
+  const h = html<Message>()
 
-const downloadIcon = (className: string): Html =>
-  h.svg(
+  return h.svg(
     [
       h.AriaHidden(true),
       h.Class(className),
@@ -38,6 +38,7 @@ const downloadIcon = (className: string): Html =>
       ),
     ],
   )
+}
 
 const secondaryButtonStyle =
   'px-3 py-1.5 rounded text-sm bg-gray-800 text-gray-200 transition motion-reduce:transition-none'
@@ -48,27 +49,33 @@ const lazyHistoryPanel = createLazy()
 const lazyErrorDialog = createLazy()
 const lazyGridSizeConfirmDialog = createLazy()
 
-export const view = (model: Model): Document => ({
-  title: 'Pixel Art',
-  body: h.div(
-    [h.Class('min-h-screen bg-gray-900 text-gray-100 flex flex-col')],
-    [
-      lazyHeader(headerView, []),
-      contentView(model),
-      lazyErrorDialog(errorDialogView, [
-        model.errorDialog,
-        model.maybeExportError,
-      ]),
-      lazyGridSizeConfirmDialog(gridSizeConfirmDialogView, [
-        model.gridSizeConfirmDialog,
-        model.maybePendingGridSize,
-      ]),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-const headerView = (): Html =>
-  h.div(
+  return {
+    title: 'Pixel Art',
+    body: h.div(
+      [h.Class('min-h-screen bg-gray-900 text-gray-100 flex flex-col')],
+      [
+        lazyHeader(headerView, []),
+        contentView(model),
+        lazyErrorDialog(errorDialogView, [
+          model.errorDialog,
+          model.maybeExportError,
+        ]),
+        lazyGridSizeConfirmDialog(gridSizeConfirmDialogView, [
+          model.gridSizeConfirmDialog,
+          model.maybePendingGridSize,
+        ]),
+      ],
+    ),
+  }
+}
+
+const headerView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'flex items-center justify-between px-4 py-3 border-b border-gray-800',
@@ -133,8 +140,11 @@ const headerView = (): Html =>
       ),
     ],
   )
+}
 
 const contentView = (model: Model): Html => {
+  const h = html<Message>()
+
   const theme = currentPaletteTheme(model)
 
   return h.div(

--- a/examples/query-sync/src/main.ts
+++ b/examples/query-sync/src/main.ts
@@ -446,8 +446,6 @@ export const update = (model: Model, message: Message): UpdateReturn =>
 
 // VIEW
 
-const h = html<Message>()
-
 const columnOrders: Record<SortColumn, Order.Order<Dinosaur>> = {
   Name: Order.mapInput(Order.String, ({ name }: Dinosaur) => name),
   Period: Order.mapInput(Order.String, ({ period }: Dinosaur) => period),
@@ -552,6 +550,8 @@ const sortableColumnHeader = (
   fields: BrowseFields,
   isRightAligned: boolean,
 ): Html => {
+  const h = html<Message>()
+
   const indicator = h.span(
     [h.Class(clsx(SORT_INDICATOR_WIDTH, 'inline-block text-center'))],
     [sortIndicator(column, fields.sorting)],
@@ -594,26 +594,32 @@ const listboxBackdropClassName = 'fixed inset-0 z-0'
 
 const listboxWrapperClassName = 'relative inline-block'
 
-const filterItemConfig = (label: string): Ui.Listbox.ItemConfig => ({
-  className: listboxItemClassName,
-  content: h.div(
-    [h.Class('flex items-center gap-2')],
-    [
-      h.span(
-        [
-          h.Class(
-            'w-4 text-center text-emerald-600 invisible group-data-[selected]:visible',
-          ),
-        ],
-        ['✓'],
-      ),
-      h.span([], [label]),
-    ],
-  ),
-})
+const filterItemConfig = (label: string): Ui.Listbox.ItemConfig => {
+  const h = html<Message>()
 
-const chevronDown = (className: string): Html =>
-  h.svg(
+  return {
+    className: listboxItemClassName,
+    content: h.div(
+      [h.Class('flex items-center gap-2')],
+      [
+        h.span(
+          [
+            h.Class(
+              'w-4 text-center text-emerald-600 invisible group-data-[selected]:visible',
+            ),
+          ],
+          ['✓'],
+        ),
+        h.span([], [label]),
+      ],
+    ),
+  }
+}
+
+const chevronDown = (className: string): Html => {
+  const h = html<Message>()
+
+  return h.svg(
     [
       h.AriaHidden(true),
       h.Class(className),
@@ -634,12 +640,16 @@ const chevronDown = (className: string): Html =>
       ),
     ],
   )
+}
 
-const filterButtonContent = (label: string): Html =>
-  h.div(
+const filterButtonContent = (label: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex w-full items-center justify-between gap-4')],
     [h.span([], [label]), chevronDown('w-4 h-4 text-gray-400')],
   )
+}
 
 const filterButtonLabel = (
   maybeSelectedItem: Option.Option<string>,
@@ -658,6 +668,8 @@ const periodLabel = (item: string): string =>
   String.isEmpty(item) ? 'All Periods' : item
 
 const browseView = (model: Model, route: typeof BrowseRoute.Type): Html => {
+  const h = html<Message>()
+
   const fields = routeToBrowseFields(route)
   const results = filterAndSort(fields)
 
@@ -858,8 +870,10 @@ const browseView = (model: Model, route: typeof BrowseRoute.Type): Html => {
   )
 }
 
-const notFoundView = (path: string): Html =>
-  h.div(
+const notFoundView = (path: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('max-w-4xl mx-auto px-4 text-center')],
     [
       h.h1(
@@ -879,6 +893,7 @@ const notFoundView = (path: string): Html =>
       ),
     ],
   )
+}
 
 const routeTitle = (route: Model['route']): string =>
   M.value(route).pipe(
@@ -887,6 +902,8 @@ const routeTitle = (route: Model['route']): string =>
   )
 
 export const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const routeContent = M.value(model.route).pipe(
     M.tagsExhaustive({
       Browse: route => browseView(model, route),

--- a/examples/routing/src/main.ts
+++ b/examples/routing/src/main.ts
@@ -187,9 +187,9 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
-
 const navigationView = (currentRoute: AppRoute): Html => {
+  const h = html<Message>()
+
   const navLinkClassName = (isActive: boolean) =>
     `hover:bg-blue-600 font-medium px-3 py-1 rounded transition ${isActive ? 'bg-blue-700 bg-opacity-50' : ''}`
 
@@ -246,8 +246,10 @@ const navigationView = (currentRoute: AppRoute): Html => {
   )
 }
 
-const homeView = (): Html =>
-  h.div(
+const homeView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('max-w-4xl mx-auto px-4')],
     [
       h.h1(
@@ -263,9 +265,12 @@ const homeView = (): Html =>
       h.p([h.Class('text-gray-600')], []),
     ],
   )
+}
 
-const nestedView = (): Html =>
-  h.div(
+const nestedView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('max-w-4xl mx-auto px-4')],
     [
       h.h1(
@@ -278,8 +283,11 @@ const nestedView = (): Html =>
       ),
     ],
   )
+}
 
 const peopleView = (searchText: Option.Option<string>): Html => {
+  const h = html<Message>()
+
   const filteredPeople = Option.match(searchText, {
     onNone: () => people,
     onSome: query =>
@@ -353,6 +361,8 @@ const peopleView = (searchText: Option.Option<string>): Html => {
 }
 
 const personView = (personId: number): Html => {
+  const h = html<Message>()
+
   const person = findPerson(personId)
 
   return Option.match(person, {
@@ -449,8 +459,10 @@ const personView = (personId: number): Html => {
   })
 }
 
-const notFoundView = (path: string): Html =>
-  h.div(
+const notFoundView = (path: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('max-w-4xl mx-auto px-4')],
     [
       h.h1(
@@ -467,6 +479,7 @@ const notFoundView = (path: string): Html =>
       ),
     ],
   )
+}
 
 const routeTitle = (route: Model['route']): string =>
   M.value(route).pipe(
@@ -476,6 +489,8 @@ const routeTitle = (route: Model['route']): string =>
   )
 
 export const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const routeContent = M.value(model.route).pipe(
     M.tagsExhaustive({
       Home: homeView,

--- a/examples/shopping-cart/src/main.ts
+++ b/examples/shopping-cart/src/main.ts
@@ -244,9 +244,9 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
-
 const navigationView = (currentRoute: AppRoute, cartCount: number): Html => {
+  const h = html<Message>()
+
   const navLinkClassName = (isActive: boolean) =>
     `hover:bg-blue-600 font-medium px-3 py-1 rounded transition ${isActive ? 'bg-blue-700 bg-opacity-50' : ''}`
 
@@ -323,8 +323,10 @@ const checkoutView = (model: Model): Html => {
   )
 }
 
-const notFoundView = (path: string): Html =>
-  h.div(
+const notFoundView = (path: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('max-w-4xl mx-auto px-4 text-center')],
     [
       h.h1(
@@ -344,6 +346,7 @@ const notFoundView = (path: string): Html =>
       ),
     ],
   )
+}
 
 const routeTitle = (route: Model['route']): string =>
   M.value(route).pipe(
@@ -352,6 +355,8 @@ const routeTitle = (route: Model['route']): string =>
   )
 
 export const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const routeContent = M.value(model.route).pipe(
     M.tagsExhaustive({
       Products: () => productsView(model),

--- a/examples/shopping-cart/src/page/cart.ts
+++ b/examples/shopping-cart/src/page/cart.ts
@@ -12,16 +12,16 @@ import {
   type ProductsRoute,
 } from '../main'
 
-const h = html<Message>()
-
 // VIEW
 
 export const view = (
   cart: Cart.Cart,
   productsRouter: Route.Router<ProductsRoute>,
   checkoutRouter: Route.Router<CheckoutRoute>,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('max-w-4xl mx-auto px-4')],
     [
       h.h1(
@@ -193,3 +193,4 @@ export const view = (
       ),
     ],
   )
+}

--- a/examples/shopping-cart/src/page/checkout.ts
+++ b/examples/shopping-cart/src/page/checkout.ts
@@ -11,8 +11,6 @@ import {
   UpdatedDeliveryInstructions,
 } from '../main'
 
-const h = html<Message>()
-
 // VIEW
 
 export const view = (
@@ -22,6 +20,8 @@ export const view = (
   productsRouter: Route.Router<ProductsRoute>,
   cartRouter: Route.Router<CartRoute>,
 ): Html => {
+  const h = html<Message>()
+
   if (orderPlaced) {
     return h.div(
       [h.Class('max-w-4xl mx-auto px-4 text-center')],

--- a/examples/snake/src/main.ts
+++ b/examples/snake/src/main.ts
@@ -288,9 +288,7 @@ export const subscriptions = Subscription.makeSubscriptions(
 
 // VIEW
 
-const h = html<Message>()
-
-const cellView = (x: number, y: number, model: Model): Html => {
+const cellClass = (x: number, y: number, model: Model): string => {
   const isSnakeHead = Position.equivalence({ x, y }, model.snake[0])
   const isSnakeTail = pipe(
     model.snake,
@@ -299,26 +297,29 @@ const cellView = (x: number, y: number, model: Model): Html => {
   )
   const isApple = Position.equivalence({ x, y }, model.apple)
 
-  const cellClass = M.value({ isSnakeHead, isSnakeTail, isApple }).pipe(
+  return M.value({ isSnakeHead, isSnakeTail, isApple }).pipe(
     M.when({ isSnakeHead: true }, () => 'bg-green-700'),
     M.when({ isSnakeTail: true }, () => 'bg-green-500'),
     M.when({ isApple: true }, () => 'bg-red-500'),
     M.orElse(() => 'bg-gray-800'),
   )
-
-  return h.div([h.Class(`w-6 h-6 ${cellClass}`)], [])
 }
 
-const gridView = (model: Model): Html =>
-  h.div(
+const gridView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('inline-block border-2 border-gray-600')],
     Array.makeBy(GAME.GRID_SIZE, y =>
       h.div(
         [h.Class('flex')],
-        Array.makeBy(GAME.GRID_SIZE, x => cellView(x, y, model)),
+        Array.makeBy(GAME.GRID_SIZE, x =>
+          h.div([h.Class(`w-6 h-6 ${cellClass(x, y, model)}`)], []),
+        ),
       ),
     ),
   )
+}
 
 const gameStateView = (gameState: GameState): string =>
   M.value(gameState).pipe(
@@ -329,8 +330,10 @@ const gameStateView = (gameState: GameState): string =>
     M.exhaustive,
   )
 
-const instructionsView = (): Html =>
-  h.div(
+const instructionsView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('mt-4 text-sm text-gray-400')],
     [
       h.p([], ['Use ARROW KEYS or WASD to move']),
@@ -338,27 +341,32 @@ const instructionsView = (): Html =>
       h.p([], ['R to restart']),
     ],
   )
+}
 
-export const view = (model: Model): Document => ({
-  title: `Snake — ${model.points} pts`,
-  body: h.div(
-    [
-      h.Class(
-        'flex flex-col items-center justify-center min-h-screen bg-black text-white p-8',
-      ),
-    ],
-    [
-      h.h1([h.Class('text-4xl font-bold mb-4')], ['Snake Game']),
-      h.div(
-        [h.Class('flex gap-8 mb-4')],
-        [
-          h.p([h.Class('text-xl')], [`Score: ${model.points}`]),
-          h.p([h.Class('text-xl')], [`High Score: ${model.highScore}`]),
-        ],
-      ),
-      h.p([h.Class('text-lg mb-4')], [gameStateView(model.gameState)]),
-      gridView(model),
-      instructionsView(),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: `Snake — ${model.points} pts`,
+    body: h.div(
+      [
+        h.Class(
+          'flex flex-col items-center justify-center min-h-screen bg-black text-white p-8',
+        ),
+      ],
+      [
+        h.h1([h.Class('text-4xl font-bold mb-4')], ['Snake Game']),
+        h.div(
+          [h.Class('flex gap-8 mb-4')],
+          [
+            h.p([h.Class('text-xl')], [`Score: ${model.points}`]),
+            h.p([h.Class('text-xl')], [`High Score: ${model.highScore}`]),
+          ],
+        ),
+        h.p([h.Class('text-lg mb-4')], [gameStateView(model.gameState)]),
+        gridView(model),
+        instructionsView(),
+      ],
+    ),
+  }
+}

--- a/examples/stopwatch/src/main.ts
+++ b/examples/stopwatch/src/main.ts
@@ -160,8 +160,6 @@ export const subscriptions = Subscription.makeSubscriptions(
 
 // VIEW
 
-const h = html<Message>()
-
 const formatTime = (ms: number): string => {
   const minutes = pipe(Duration.millis(ms), Duration.toMinutes, floorAndPad)
 
@@ -183,39 +181,45 @@ const formatTime = (ms: number): string => {
 
 const floorAndPad = flow(Math.floor, v => v.toString(), String.padStart(2, '0'))
 
-export const view = (model: Model): Document => ({
-  title: `Stopwatch ${formatTime(model.elapsedMs)}`,
-  body: h.div(
-    [h.Class('min-h-screen bg-gray-200 flex items-center justify-center')],
-    [
-      h.div(
-        [h.Class('bg-white text-center')],
-        [
-          h.div(
-            [h.Class('text-6xl font-mono font-bold text-gray-800 p-8')],
-            [formatTime(model.elapsedMs)],
-          ),
-          h.div(
-            [h.Class('flex')],
-            [
-              h.button(
-                [
-                  h.OnClick(ClickedReset()),
-                  h.Class(buttonStyle + ' bg-gray-500 hover:bg-gray-600'),
-                ],
-                ['Reset'],
-              ),
-              startStopButton(model.isRunning),
-            ],
-          ),
-        ],
-      ),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-const startStopButton = (isRunning: boolean): Html =>
-  isRunning
+  return {
+    title: `Stopwatch ${formatTime(model.elapsedMs)}`,
+    body: h.div(
+      [h.Class('min-h-screen bg-gray-200 flex items-center justify-center')],
+      [
+        h.div(
+          [h.Class('bg-white text-center')],
+          [
+            h.div(
+              [h.Class('text-6xl font-mono font-bold text-gray-800 p-8')],
+              [formatTime(model.elapsedMs)],
+            ),
+            h.div(
+              [h.Class('flex')],
+              [
+                h.button(
+                  [
+                    h.OnClick(ClickedReset()),
+                    h.Class(buttonStyle + ' bg-gray-500 hover:bg-gray-600'),
+                  ],
+                  ['Reset'],
+                ),
+                startStopButton(model.isRunning),
+              ],
+            ),
+          ],
+        ),
+      ],
+    ),
+  }
+}
+
+const startStopButton = (isRunning: boolean): Html => {
+  const h = html<Message>()
+
+  return isRunning
     ? h.button(
         [
           h.OnClick(ClickedStop()),
@@ -230,6 +234,7 @@ const startStopButton = (isRunning: boolean): Html =>
         ],
         ['Start'],
       )
+}
 
 // STYLE
 

--- a/examples/todo/src/main.ts
+++ b/examples/todo/src/main.ts
@@ -334,8 +334,6 @@ export const SaveTodos = Command.define(
 
 // VIEW
 
-const h = html<Message>()
-
 const todoItemView =
   (model: Model) =>
   (todo: Todo): Html =>
@@ -349,8 +347,10 @@ const todoItemView =
       }),
     )
 
-const editingTodoView = (todo: Todo, text: string): Html =>
-  h.li(
+const editingTodoView = (todo: Todo, text: string): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [h.Class('flex items-center gap-3 p-3 bg-gray-50 rounded-lg')],
     [
       h.input([
@@ -381,9 +381,12 @@ const editingTodoView = (todo: Todo, text: string): Html =>
       ),
     ],
   )
+}
 
-const nonEditingTodoView = (todo: Todo): Html =>
-  h.li(
+const nonEditingTodoView = (todo: Todo): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [h.Class('flex items-center gap-3 p-3 hover:bg-gray-50 rounded-lg group')],
     [
       h.input([
@@ -415,11 +418,14 @@ const nonEditingTodoView = (todo: Todo): Html =>
       ),
     ],
   )
+}
 
 const filterButtonView =
   (model: Model) =>
-  (filter: Filter, label: string): Html =>
-    h.button(
+  (filter: Filter, label: string): Html => {
+    const h = html<Message>()
+
+    return h.button(
       [
         h.OnClick(SelectedFilter({ filter })),
         h.Class(
@@ -432,13 +438,16 @@ const filterButtonView =
       ],
       [label],
     )
+  }
 
 const footerView = (
   model: Model,
   activeCount: number,
   completedCount: number,
-): Html =>
-  Array.match(model.todos, {
+): Html => {
+  const h = html<Message>()
+
+  return Array.match(model.todos, {
     onEmpty: () => h.empty,
     onNonEmpty: () =>
       h.div(
@@ -495,6 +504,7 @@ const footerView = (
         ],
       ),
   })
+}
 
 const filterTodos = (todos: Todos, filter: Filter): Todos =>
   M.value(filter).pipe(
@@ -505,6 +515,8 @@ const filterTodos = (todos: Todos, filter: Filter): Todos =>
   )
 
 export const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const filteredTodos = filterTodos(model.todos, model.filter)
   const activeCount = Array.length(
     Array.filter(model.todos, todo => !todo.completed),

--- a/examples/ui-showcase/src/main.ts
+++ b/examples/ui-showcase/src/main.ts
@@ -310,8 +310,6 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
-
 type NavItem = Readonly<{
   label: string
   routeTag: string
@@ -369,8 +367,10 @@ const mobileNavLinkClassName = (isActive: boolean): string =>
       : 'text-gray-700 hover:bg-gray-200',
   )
 
-const sidebarView = (currentRoute: AppRoute): Html =>
-  h.nav(
+const sidebarView = (currentRoute: AppRoute): Html => {
+  const h = html<Message>()
+
+  return h.nav(
     [
       h.Class(
         'hidden md:flex w-56 shrink-0 border-r border-gray-200 bg-gray-50 p-4 flex-col',
@@ -413,9 +413,12 @@ const sidebarView = (currentRoute: AppRoute): Html =>
       ),
     ],
   )
+}
 
-const mobileMenuContent = (currentRoute: AppRoute): Html =>
-  h.div(
+const mobileMenuContent = (currentRoute: AppRoute): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex flex-col h-full')],
     [
       h.div(
@@ -487,9 +490,12 @@ const mobileMenuContent = (currentRoute: AppRoute): Html =>
       ),
     ],
   )
+}
 
-const mobileHeaderView = (model: Model): Html =>
-  h.header(
+const mobileHeaderView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.header(
     [
       h.Class(
         'md:hidden sticky top-0 z-40 flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3',
@@ -527,9 +533,12 @@ const mobileHeaderView = (model: Model): Html =>
       ),
     ],
   )
+}
 
-const mobileMenuView = (model: Model): Html =>
-  Ui.Dialog.view({
+const mobileMenuView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return Ui.Dialog.view({
     model: model.uiModel.mobileMenuDialog,
     toParentMessage: toMobileMenuDialogMessage,
     panelContent: mobileMenuContent(model.route),
@@ -537,9 +546,12 @@ const mobileMenuView = (model: Model): Html =>
     backdropAttributes: [h.Class('fixed inset-0 z-[59]')],
     attributes: [h.Class('md:hidden')],
   })
+}
 
-const homeView = (): Html =>
-  h.div(
+const homeView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('max-w-2xl')],
     [
       h.h1(
@@ -560,9 +572,12 @@ const homeView = (): Html =>
       ),
     ],
   )
+}
 
-const notFoundView = (path: string): Html =>
-  h.div(
+const notFoundView = (path: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('max-w-2xl')],
     [
       h.h1(
@@ -579,6 +594,7 @@ const notFoundView = (path: string): Html =>
       ),
     ],
   )
+}
 
 const contentView = (model: Model): Html =>
   M.value(model.route).pipe(
@@ -618,21 +634,25 @@ const routeTitle = (route: Model['route']): string =>
     M.orElse(({ _tag }) => `${_tag} — Foldkit UI Showcase`),
   )
 
-export const view = (model: Model): Document => ({
-  title: routeTitle(model.route),
-  body: h.div(
-    [h.Class('flex flex-col md:flex-row min-h-screen bg-white')],
-    [
-      mobileHeaderView(model),
-      mobileMenuView(model),
-      sidebarView(model.route),
-      h.main(
-        [h.Class('flex-1 p-4 md:p-8 overflow-auto')],
-        [h.keyed('div')(model.route._tag, [], [contentView(model)])],
-      ),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: routeTitle(model.route),
+    body: h.div(
+      [h.Class('flex flex-col md:flex-row min-h-screen bg-white')],
+      [
+        mobileHeaderView(model),
+        mobileMenuView(model),
+        sidebarView(model.route),
+        h.main(
+          [h.Class('flex-1 p-4 md:p-8 overflow-auto')],
+          [h.keyed('div')(model.route._tag, [], [contentView(model)])],
+        ),
+      ],
+    ),
+  }
+}
 
 // SUBSCRIPTION
 

--- a/examples/weather/src/main.ts
+++ b/examples/weather/src/main.ts
@@ -245,80 +245,84 @@ export const FetchWeather = Command.define(
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-export const view = (model: Model): Document => ({
-  title: 'Weather',
-  body: h.div(
-    [
-      h.Class(
-        'min-h-screen bg-gradient-to-br from-blue-100 to-blue-300 flex flex-col items-center justify-center gap-6 p-6',
-      ),
-    ],
-    [
-      h.h1([h.Class('text-4xl font-bold text-blue-900 mb-8')], ['Weather']),
+  return {
+    title: 'Weather',
+    body: h.div(
+      [
+        h.Class(
+          'min-h-screen bg-gradient-to-br from-blue-100 to-blue-300 flex flex-col items-center justify-center gap-6 p-6',
+        ),
+      ],
+      [
+        h.h1([h.Class('text-4xl font-bold text-blue-900 mb-8')], ['Weather']),
 
-      h.form(
-        [
-          h.Class('flex flex-col gap-4 items-center w-full max-w-md'),
-          h.OnSubmit(SubmittedWeatherForm()),
-        ],
-        [
-          h.label([h.For('location'), h.Class('sr-only')], ['Zip code']),
-          h.input([
-            h.Id('location'),
-            h.Class(
-              'w-full px-4 py-2 rounded-lg border-2 border-blue-300 focus:border-blue-500 outline-none',
-            ),
-            h.Autocomplete('off'),
-            h.DataAttribute('1p-ignore', ''),
-            h.Placeholder('Enter a zip code'),
-            h.Value(model.zipCodeInput),
-            h.OnInput(value => UpdatedZipCodeInput({ value })),
-          ]),
-          h.button(
-            [
-              h.Type('submit'),
-              h.Disabled(model.weather._tag === 'WeatherLoading'),
+        h.form(
+          [
+            h.Class('flex flex-col gap-4 items-center w-full max-w-md'),
+            h.OnSubmit(SubmittedWeatherForm()),
+          ],
+          [
+            h.label([h.For('location'), h.Class('sr-only')], ['Zip code']),
+            h.input([
+              h.Id('location'),
               h.Class(
-                'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition disabled:opacity-50',
+                'w-full px-4 py-2 rounded-lg border-2 border-blue-300 focus:border-blue-500 outline-none',
               ),
-            ],
-            [
-              model.weather._tag === 'WeatherLoading'
-                ? 'Loading...'
-                : 'Get Weather',
-            ],
-          ),
-        ],
-      ),
-
-      M.value(model.weather).pipe(
-        M.tagsExhaustive({
-          WeatherInit: () => h.empty,
-          WeatherLoading: () =>
-            h.div(
-              [h.Class('text-blue-600 font-semibold text-center')],
-              ['Fetching weather...'],
-            ),
-          WeatherFailure: ({ error }) =>
-            h.div(
+              h.Autocomplete('off'),
+              h.DataAttribute('1p-ignore', ''),
+              h.Placeholder('Enter a zip code'),
+              h.Value(model.zipCodeInput),
+              h.OnInput(value => UpdatedZipCodeInput({ value })),
+            ]),
+            h.button(
               [
+                h.Type('submit'),
+                h.Disabled(model.weather._tag === 'WeatherLoading'),
                 h.Class(
-                  'p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg',
+                  'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition disabled:opacity-50',
                 ),
               ],
-              [error],
+              [
+                model.weather._tag === 'WeatherLoading'
+                  ? 'Loading...'
+                  : 'Get Weather',
+              ],
             ),
-          WeatherSuccess: ({ data: weather }) => weatherView(weather),
-        }),
-      ),
-    ],
-  ),
-})
+          ],
+        ),
 
-const weatherView = (weather: WeatherData): Html =>
-  h.article(
+        M.value(model.weather).pipe(
+          M.tagsExhaustive({
+            WeatherInit: () => h.empty,
+            WeatherLoading: () =>
+              h.div(
+                [h.Class('text-blue-600 font-semibold text-center')],
+                ['Fetching weather...'],
+              ),
+            WeatherFailure: ({ error }) =>
+              h.div(
+                [
+                  h.Class(
+                    'p-4 bg-red-100 border border-red-400 text-red-700 rounded-lg',
+                  ),
+                ],
+                [error],
+              ),
+            WeatherSuccess: ({ data: weather }) => weatherView(weather),
+          }),
+        ),
+      ],
+    ),
+  }
+}
+
+const weatherView = (weather: WeatherData): Html => {
+  const h = html<Message>()
+
+  return h.article(
     [h.Class('bg-white rounded-xl shadow-lg p-8 max-w-md w-full')],
     [
       h.h2(
@@ -368,3 +372,4 @@ const weatherView = (weather: WeatherData): Html =>
       ),
     ],
   )
+}

--- a/examples/web-components/src/main.ts
+++ b/examples/web-components/src/main.ts
@@ -97,30 +97,40 @@ const qr = qrCode.withMessage<Message>()
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-export const view = (model: Model): Document => ({
-  title: 'Foldkit QR Designer',
-  body: h.div(
-    [
-      h.Class(
-        'min-h-screen bg-slate-50 text-slate-900 px-6 py-10 flex flex-col items-center',
-      ),
-    ],
-    [
-      h.div(
-        [h.Class('w-full max-w-3xl flex flex-col gap-8')],
-        [headerView(), designerView(model)],
-      ),
-    ],
-  ),
-})
+  return {
+    title: 'Foldkit QR Designer',
+    body: h.div(
+      [
+        h.Class(
+          'min-h-screen bg-slate-50 text-slate-900 px-6 py-10 flex flex-col items-center',
+        ),
+      ],
+      [
+        h.div(
+          [h.Class('w-full max-w-3xl flex flex-col gap-8')],
+          [headerView(), designerView(model)],
+        ),
+      ],
+    ),
+  }
+}
 
-const codeView = (text: string): Html =>
-  h.code([h.Class('px-1 py-0.5 rounded bg-slate-200 text-[0.8em]')], [text])
+const codeView = (text: string): Html => {
+  const h = html<Message>()
 
-const headerView = (): Html =>
-  h.header(
+  return h.code(
+    [h.Class('px-1 py-0.5 rounded bg-slate-200 text-[0.8em]')],
+    [text],
+  )
+}
+
+const headerView = (): Html => {
+  const h = html<Message>()
+
+  return h.header(
     [h.Class('flex flex-col gap-2')],
     [
       h.h1([h.Class('text-3xl font-bold tracking-tight')], ['QR Designer']),
@@ -154,14 +164,17 @@ const headerView = (): Html =>
       ),
     ],
   )
+}
 
 const FIELD_LABEL_CLASS =
   'text-xs font-semibold uppercase tracking-wide text-slate-600'
 const FIELD_CONTROL_CLASS =
   'px-3 py-2 text-sm rounded-md border border-slate-300 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200'
 
-const designerView = (model: Model): Html =>
-  h.div(
+const designerView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6 bg-white rounded-xl shadow-sm border border-slate-200 p-6',
@@ -169,9 +182,12 @@ const designerView = (model: Model): Html =>
     ],
     [controlsView(model), previewView(model)],
   )
+}
 
-const controlsView = (model: Model): Html =>
-  h.div(
+const controlsView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex flex-col gap-5')],
     [
       contentFieldView(model),
@@ -189,9 +205,12 @@ const controlsView = (model: Model): Html =>
       }),
     ],
   )
+}
 
-const contentFieldView = (model: Model): Html =>
-  Ui.Input.view({
+const contentFieldView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return Ui.Input.view({
     id: 'qr-content',
     value: model.content,
     onInput: value => UpdatedContent({ value }),
@@ -214,6 +233,7 @@ const contentFieldView = (model: Model): Html =>
         ],
       ),
   })
+}
 
 const colorFieldView = (
   config: Readonly<{
@@ -222,8 +242,10 @@ const colorFieldView = (
     value: string
     onChange: (value: string) => Message
   }>,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex flex-col gap-1.5')],
     [
       h.label([h.For(config.id), h.Class(FIELD_LABEL_CLASS)], [config.label]),
@@ -250,6 +272,7 @@ const colorFieldView = (
       ),
     ],
   )
+}
 
 const PRESET_COLORS: ReadonlyArray<string> = [
   '#1e1b4b',
@@ -269,8 +292,10 @@ const swatchClass = (isActive: boolean): string =>
 const swatchRow = (
   active: string,
   onChange: (value: string) => Message,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex flex-wrap gap-1.5 max-w-[10rem]')],
     PRESET_COLORS.map(color =>
       h.button(
@@ -286,11 +311,14 @@ const swatchRow = (
       ),
     ),
   )
+}
 
 const QR_SIZE = 220
 
-const previewView = (model: Model): Html =>
-  h.div(
+const previewView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'flex flex-col items-center gap-3 self-start p-4 rounded-md bg-slate-50 border border-slate-200',
@@ -315,3 +343,4 @@ const previewView = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/examples/websocket-chat/src/main.ts
+++ b/examples/websocket-chat/src/main.ts
@@ -367,66 +367,70 @@ export const subscriptions = Subscription.makeSubscriptions(
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-export const view = (model: Model): Document => ({
-  title: 'WebSocket Chat',
-  body: h.div(
-    [
-      h.Class(
-        'min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex flex-col items-center justify-center p-6',
-      ),
-    ],
-    [
-      h.div(
-        [
-          h.Class(
-            'bg-white rounded-xl shadow-2xl w-full max-w-2xl flex flex-col h-[600px]',
-          ),
-        ],
-        [
-          h.div(
-            [
-              h.Class(
-                'p-6 border-b border-gray-200 flex items-center justify-between',
-              ),
-            ],
-            [
-              h.div(
-                [],
-                [
-                  h.div(
-                    [h.Class('text-2xl font-bold text-gray-800')],
-                    ['WebSocket Chat'],
-                  ),
-                  h.div(
-                    [h.Class('text-sm text-gray-500 mt-1')],
-                    ['Echo server demo'],
-                  ),
-                ],
-              ),
-              connectionStatusView(model.connection),
-            ],
-          ),
+  return {
+    title: 'WebSocket Chat',
+    body: h.div(
+      [
+        h.Class(
+          'min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex flex-col items-center justify-center p-6',
+        ),
+      ],
+      [
+        h.div(
+          [
+            h.Class(
+              'bg-white rounded-xl shadow-2xl w-full max-w-2xl flex flex-col h-[600px]',
+            ),
+          ],
+          [
+            h.div(
+              [
+                h.Class(
+                  'p-6 border-b border-gray-200 flex items-center justify-between',
+                ),
+              ],
+              [
+                h.div(
+                  [],
+                  [
+                    h.div(
+                      [h.Class('text-2xl font-bold text-gray-800')],
+                      ['WebSocket Chat'],
+                    ),
+                    h.div(
+                      [h.Class('text-sm text-gray-500 mt-1')],
+                      ['Echo server demo'],
+                    ),
+                  ],
+                ),
+                connectionStatusView(model.connection),
+              ],
+            ),
 
-          messagesView(model.messages),
+            messagesView(model.messages),
 
-          M.value(model.connection).pipe(
-            M.tagsExhaustive({
-              ConnectionDisconnected: connectButtonView,
-              ConnectionConnecting: connectingView,
-              ConnectionConnected: () => messageInputView(model.messageInput),
-              ConnectionError: ({ error }) => errorView(error),
-            }),
-          ),
-        ],
-      ),
-    ],
-  ),
-})
+            M.value(model.connection).pipe(
+              M.tagsExhaustive({
+                ConnectionDisconnected: connectButtonView,
+                ConnectionConnecting: connectingView,
+                ConnectionConnected: () => messageInputView(model.messageInput),
+                ConnectionError: ({ error }) => errorView(error),
+              }),
+            ),
+          ],
+        ),
+      ],
+    ),
+  }
+}
 
-const connectionStatusView = (connection: ConnectionState): Html =>
-  h.div(
+const connectionStatusView = (connection: ConnectionState): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex items-center gap-2')],
     [
       M.value(connection).pipe(
@@ -458,9 +462,12 @@ const connectionStatusView = (connection: ConnectionState): Html =>
       ),
     ],
   )
+}
 
-const messagesView = (messages: ReadonlyArray<ChatMessage>): Html =>
-  Array.match(messages, {
+const messagesView = (messages: ReadonlyArray<ChatMessage>): Html => {
+  const h = html<Message>()
+
+  return Array.match(messages, {
     onEmpty: () =>
       h.div(
         [
@@ -527,9 +534,12 @@ const messagesView = (messages: ReadonlyArray<ChatMessage>): Html =>
         ],
       ),
   })
+}
 
-const connectButtonView = (): Html =>
-  h.div(
+const connectButtonView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('p-6 border-t border-gray-200 flex items-center justify-center')],
     [
       h.button(
@@ -543,15 +553,21 @@ const connectButtonView = (): Html =>
       ),
     ],
   )
+}
 
-const connectingView = (): Html =>
-  h.div(
+const connectingView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('p-6 border-t border-gray-200 flex items-center justify-center')],
     [h.div([h.Class('text-gray-600 font-semibold')], ['Connecting...'])],
   )
+}
 
-const messageInputView = (messageInput: string): Html =>
-  h.form(
+const messageInputView = (messageInput: string): Html => {
+  const h = html<Message>()
+
+  return h.form(
     [h.Class('p-6 border-t border-gray-200'), h.OnSubmit(SubmittedMessage())],
     [
       h.div(
@@ -580,9 +596,12 @@ const messageInputView = (messageInput: string): Html =>
       ),
     ],
   )
+}
 
-const errorView = (error: string): Html =>
-  h.div(
+const errorView = (error: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('p-6 border-t border-gray-200')],
     [
       h.div(
@@ -606,3 +625,4 @@ const errorView = (error: string): Html =>
       ),
     ],
   )
+}

--- a/packages/create-foldkit-app/templates/base/AGENTS.md
+++ b/packages/create-foldkit-app/templates/base/AGENTS.md
@@ -52,7 +52,7 @@ Use `evo()` from `foldkit/struct` for immutable model updates. Never spread or `
 
 ### View
 
-Bind the `html` factory once per module with `const h = html<Message>()`, then reach for `h.div`, `h.OnClick`, etc. off the returned record. Use `empty` (not `null`) for conditional rendering, `M.value().pipe(M.tagsExhaustive({...}))` for discriminated unions, and `Array.match` for lists that may be empty.
+Bind the `html` factory inside each view function with `const h = html<Message>()` (never at module level), then reach for `h.div`, `h.OnClick`, etc. off the returned record. Use `empty` (not `null`) for conditional rendering, `M.value().pipe(M.tagsExhaustive({...}))` for discriminated unions, and `Array.match` for lists that may be empty.
 
 Use `keyed` wrappers whenever the view branches into structurally different layouts based on route or model state. Without keying, the virtual DOM tries to diff one layout into another, causing stale DOM and event handler mismatches.
 

--- a/packages/foldkit/README.md
+++ b/packages/foldkit/README.md
@@ -102,41 +102,43 @@ export const init: Runtime.ProgramInit<Model, Message> = () => [
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-export const view = (model: Model): Document => ({
-  title: `Counter: ${model.count}`,
-  body: h.div(
-    [
-      h.Class(
-        'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
-      ),
-    ],
-    [
-      h.div(
-        [h.Class('text-6xl font-bold text-gray-800')],
-        [model.count.toString()],
-      ),
-      h.div(
-        [h.Class('flex flex-wrap justify-center gap-4')],
-        [
-          h.button(
-            [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
-            ['-'],
-          ),
-          h.button(
-            [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
-            ['Reset'],
-          ),
-          h.button(
-            [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
-            ['+'],
-          ),
-        ],
-      ),
-    ],
-  ),
-})
+  return {
+    title: `Counter: ${model.count}`,
+    body: h.div(
+      [
+        h.Class(
+          'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
+        ),
+      ],
+      [
+        h.div(
+          [h.Class('text-6xl font-bold text-gray-800')],
+          [model.count.toString()],
+        ),
+        h.div(
+          [h.Class('flex flex-wrap justify-center gap-4')],
+          [
+            h.button(
+              [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
+              ['-'],
+            ),
+            h.button(
+              [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
+              ['Reset'],
+            ),
+            h.button(
+              [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
+              ['+'],
+            ),
+          ],
+        ),
+      ],
+    ),
+  }
+}
 
 // STYLE
 

--- a/packages/foldkit/src/test/apps/bubbling.ts
+++ b/packages/foldkit/src/test/apps/bubbling.ts
@@ -45,10 +45,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [],
     [
       h.div(
@@ -61,3 +61,4 @@ export const view = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/counter.ts
+++ b/packages/foldkit/src/test/apps/counter.ts
@@ -98,10 +98,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [],
     [
       h.span([h.Role('status')], [`count: ${model.count}`]),
@@ -115,3 +115,4 @@ export const view = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/disabledButton.ts
+++ b/packages/foldkit/src/test/apps/disabledButton.ts
@@ -65,30 +65,36 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+const submitButton = (isEnabled: boolean): Html => {
+  const h = html<Message>()
 
-const submitButton = (isEnabled: boolean): Html =>
-  h.button(
+  return h.button(
     [
       h.Class('submit'),
       ...(isEnabled ? [h.OnClick(ClickedSubmit())] : [h.Disabled(true)]),
     ],
     ['Submit'],
   )
+}
 
 /** Plain view — no dialog wrapper. */
-export const view = (model: Model): Html =>
-  h.div(
+export const view = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       h.button([h.OnClick(ClickedToggle())], ['Toggle']),
       submitButton(model.isEnabled),
     ],
   )
+}
 
 /** View with submit button inside a dialog's panelContent. */
-export const viewWithDialog = (model: Model): Html =>
-  h.div(
+export const viewWithDialog = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       h.button([h.OnClick(ClickedToggle())], ['Toggle']),
@@ -100,12 +106,15 @@ export const viewWithDialog = (model: Model): Html =>
       }),
     ],
   )
+}
 
 /** View using Dialog.lazy with panelContent passed dynamically. */
 const lazyDialogView = Dialog.lazy<Message>({})
 
-export const viewWithLazyDialog = (model: Model): Html =>
-  h.div(
+export const viewWithLazyDialog = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       h.button([h.OnClick(ClickedToggle())], ['Toggle']),
@@ -117,3 +126,4 @@ export const viewWithLazyDialog = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/fileUpload.ts
+++ b/packages/foldkit/src/test/apps/fileUpload.ts
@@ -34,10 +34,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [],
     [
       h.input([
@@ -64,3 +64,4 @@ export const view = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/interactions.ts
+++ b/packages/foldkit/src/test/apps/interactions.ts
@@ -66,10 +66,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [],
     [
       h.button(
@@ -96,3 +96,4 @@ export const view = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/keypress.ts
+++ b/packages/foldkit/src/test/apps/keypress.ts
@@ -50,10 +50,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [
       h.Id('key-app'),
       h.Role('application'),
@@ -70,3 +70,4 @@ export const view = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/login.ts
+++ b/packages/foldkit/src/test/apps/login.ts
@@ -89,10 +89,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [h.Id('app')],
     [
       M.value(model.status).pipe(
@@ -169,3 +169,4 @@ export const view = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/logoutButton.ts
+++ b/packages/foldkit/src/test/apps/logoutButton.ts
@@ -46,10 +46,11 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [],
     [h.button([h.OnClick(ClickedLogout()), h.Role('button')], [model.label])],
   )
+}

--- a/packages/foldkit/src/test/apps/mountPanel.ts
+++ b/packages/foldkit/src/test/apps/mountPanel.ts
@@ -99,10 +99,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [h.Class('panel-test')],
     [
       h.button(
@@ -129,12 +129,15 @@ export const view = (model: Model): Html =>
         : []),
     ],
   )
+}
 
 /** A view that always renders both the toggle button and the panel, exposing
  *  two MeasurePanel mounts simultaneously so we can exercise the (name,
  *  occurrence) tracking. */
-export const twoPanelView = (model: Model): Html =>
-  h.div(
+export const twoPanelView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('two-panels')],
     [
       h.div([h.Key('panel-a'), h.OnMount(MeasurePanel())], [h.span([], ['A'])]),
@@ -145,13 +148,17 @@ export const twoPanelView = (model: Model): Html =>
       ),
     ],
   )
+}
 
 /** A view that renders an arg-bearing Mount so Scene tests can exercise
  *  Instance-based mount matching (matcher's args structurally equal the
  *  pending Mount's args). The chosen `offset` flows through `ScrollList`'s
  *  args and is observable on the rendered Mount marker. */
-export const scrollListView = (offset: number): Html =>
-  h.div(
+export const scrollListView = (offset: number): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('scroll-list')],
     [h.div([h.Key('list'), h.OnMount(ScrollList({ offset }))], [])],
   )
+}

--- a/packages/foldkit/src/test/apps/multiRole.ts
+++ b/packages/foldkit/src/test/apps/multiRole.ts
@@ -34,10 +34,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [],
     [
       h.div(
@@ -46,3 +46,4 @@ export const view = (model: Model): Html =>
       ),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/pointer.ts
+++ b/packages/foldkit/src/test/apps/pointer.ts
@@ -58,10 +58,10 @@ export const update = (
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Html => {
+  const h = html<Message>()
 
-export const view = (model: Model): Html =>
-  h.div(
+  return h.div(
     [],
     [
       h.button(
@@ -88,3 +88,4 @@ export const view = (model: Model): Html =>
       h.span([h.AriaLabel('no handler')], ['orphan']),
     ],
   )
+}

--- a/packages/foldkit/src/test/apps/resumeUpload.ts
+++ b/packages/foldkit/src/test/apps/resumeUpload.ts
@@ -119,10 +119,10 @@ export const update = (model: Model, message: Message): UpdateReturn =>
 
 // VIEW
 
-const h = html<Message>()
+const previewView = (model: Model): Html => {
+  const h = html<Message>()
 
-const previewView = (model: Model): Html =>
-  Option.match(model.maybePreviewDataUrl, {
+  return Option.match(model.maybePreviewDataUrl, {
     onSome: dataUrl => h.img([h.Src(dataUrl), h.Alt('Resume preview')]),
     onNone: () =>
       M.value(model.readStatus).pipe(
@@ -137,9 +137,12 @@ const previewView = (model: Model): Html =>
         M.exhaustive,
       ),
   })
+}
 
-export const view = (model: Model): Html =>
-  h.div(
+export const view = (model: Model): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('resume-upload')],
     [
       Option.match(model.maybeResume, {
@@ -157,3 +160,4 @@ export const view = (model: Model): Html =>
       }),
     ],
   )
+}

--- a/packages/foldkit/src/ui/calendar/index.scene.test.ts
+++ b/packages/foldkit/src/ui/calendar/index.scene.test.ts
@@ -9,15 +9,15 @@ import { CompletedFocusGrid, FocusGrid, init, update, view } from './index.js'
 
 const resolveFocusGrid = Scene.Command.resolve(FocusGrid, CompletedFocusGrid())
 
-const h = html<Message>()
-
 const today = Calendar.make(2026, 4, 13)
 
 /** Wires Calendar attribute groups into actual HTML elements so the scene
  * can query them. Pattern-matches on `_tag` so each viewMode renders the
  * appropriate grid (days, months, years). */
-const testToView = (attrs: CalendarAttributes<Message>) =>
-  M.value(attrs).pipe(
+const testToView = (attrs: CalendarAttributes<Message>) => {
+  const h = html<Message>()
+
+  return M.value(attrs).pipe(
     M.tagsExhaustive({
       Days: days =>
         h.div(days.root, [
@@ -92,6 +92,7 @@ const testToView = (attrs: CalendarAttributes<Message>) =>
         ]),
     }),
   )
+}
 
 const sceneView =
   (overrides: Partial<ViewConfig<Message>> = {}) =>

--- a/packages/foldkit/src/ui/datePicker/index.scene.test.ts
+++ b/packages/foldkit/src/ui/datePicker/index.scene.test.ts
@@ -18,12 +18,12 @@ const acknowledgePopoverBackdrop = Scene.Mount.resolve(
   GotPopoverMessage({ message: Popover.CompletedPortalPopoverBackdrop() }),
 )
 
-const h = html<Message>()
-
 const today = Calendar.make(2026, 4, 13)
 
-const testToCalendarView = (attrs: UiCalendar.CalendarAttributes<Message>) =>
-  M.value(attrs).pipe(
+const testToCalendarView = (attrs: UiCalendar.CalendarAttributes<Message>) => {
+  const h = html<Message>()
+
+  return M.value(attrs).pipe(
     M.tagsExhaustive({
       Days: days =>
         h.div(days.root, [
@@ -98,9 +98,12 @@ const testToCalendarView = (attrs: UiCalendar.CalendarAttributes<Message>) =>
         ]),
     }),
   )
+}
 
-const triggerContent = (maybeDate: Option.Option<Calendar.CalendarDate>) =>
-  h.span(
+const triggerContent = (maybeDate: Option.Option<Calendar.CalendarDate>) => {
+  const h = html<Message>()
+
+  return h.span(
     [],
     [
       Option.match(maybeDate, {
@@ -109,6 +112,7 @@ const triggerContent = (maybeDate: Option.Option<Calendar.CalendarDate>) =>
       }),
     ],
   )
+}
 
 const sceneView =
   (overrides: Partial<ViewConfig<Message>> = {}) =>

--- a/packages/foldkit/src/ui/fileDrop/index.scene.test.ts
+++ b/packages/foldkit/src/ui/fileDrop/index.scene.test.ts
@@ -5,12 +5,12 @@ import * as Scene from '../../test/scene.js'
 import type { Message, Model, ViewConfig } from './index.js'
 import { EnteredDragZone, init, update, view } from './index.js'
 
-const h = html<Message>()
-
 const sceneView =
   (overrides: Partial<ViewConfig<Message>> = {}) =>
-  (model: Model) =>
-    view({
+  (model: Model) => {
+    const h = html<Message>()
+
+    return view({
       model,
       toParentMessage: message => message,
       toView: attrs =>
@@ -20,6 +20,7 @@ const sceneView =
         ]),
       ...overrides,
     })
+  }
 
 const dropZone = Scene.selector('label')
 const fileInput = Scene.selector('input[type="file"]')

--- a/packages/foldkit/src/ui/slider/index.scene.test.ts
+++ b/packages/foldkit/src/ui/slider/index.scene.test.ts
@@ -5,8 +5,6 @@ import * as Scene from '../../test/scene.js'
 import type { Message, Model, ViewConfig } from './index.js'
 import { PressedThumb, init, update, view } from './index.js'
 
-const h = html<Message>()
-
 const sceneView =
   (
     overrides: Omit<
@@ -14,8 +12,10 @@ const sceneView =
       'model' | 'toParentMessage'
     > = {},
   ) =>
-  (model: Model) =>
-    view({
+  (model: Model) => {
+    const h = html<Message>()
+
+    return view({
       toView: attributes =>
         h.div(
           [...attributes.root],
@@ -35,6 +35,7 @@ const sceneView =
       model,
       toParentMessage: message => message,
     })
+  }
 
 const defaultModel = init({
   id: 'test',

--- a/packages/foldkit/src/ui/toast/index.scene.test.ts
+++ b/packages/foldkit/src/ui/toast/index.scene.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from '@effect/vitest'
 import { Duration, Option, Schema as S } from 'effect'
 
-import { html } from '../../html/index.js'
+import { type Html, html } from '../../html/index.js'
 import * as Scene from '../../test/scene.js'
 import * as Animation from '../animation/index.js'
 import { type EntryHandlers, type Variant, make } from './index.js'
@@ -15,8 +15,6 @@ type Message = typeof Toast.Message.Type
 type Model = typeof Toast.Model.Type
 type Entry = typeof Toast.Entry.Type
 
-const h = html<Message>()
-
 const makeSettledEntry = (overrides: Partial<Entry> = {}): Entry => ({
   id: 'test-entry-0',
   variant: 'Info',
@@ -28,14 +26,17 @@ const makeSettledEntry = (overrides: Partial<Entry> = {}): Entry => ({
   ...overrides,
 })
 
-const defaultRenderEntry = (entry: Entry, _handlers: EntryHandlers<Message>) =>
-  h.div([], [h.span([], [entry.payload.body])])
+const defaultRenderEntry = (
+  entry: Entry,
+  _handlers: EntryHandlers<Message>,
+) => {
+  const h = html<Message>()
+
+  return h.div([], [h.span([], [entry.payload.body])])
+}
 
 type ViewOverrides = {
-  renderEntry?: (
-    entry: Entry,
-    handlers: EntryHandlers<Message>,
-  ) => ReturnType<typeof h.div>
+  renderEntry?: (entry: Entry, handlers: EntryHandlers<Message>) => Html
   ariaLabel?: string
   className?: string
   entryClassName?: string

--- a/packages/foldkit/src/ui/virtualList/index.scene.test.ts
+++ b/packages/foldkit/src/ui/virtualList/index.scene.test.ts
@@ -13,8 +13,6 @@ import {
   view,
 } from './index.js'
 
-const h = html<Message>()
-
 type DemoItem = Readonly<{ id: number; label: string }>
 
 const demoItems: ReadonlyArray<DemoItem> = [
@@ -39,8 +37,10 @@ const sceneView =
       'model' | 'items' | 'itemToKey' | 'itemToView'
     > = {},
   ) =>
-  (model: Model) =>
-    view({
+  (model: Model) => {
+    const h = html<Message>()
+
+    return view({
       items: demoItems,
       itemToKey: item => String(item.id),
       itemToView: item => h.div([], [h.span([], [item.label])]),
@@ -48,6 +48,7 @@ const sceneView =
       ...overrides,
       model,
     })
+  }
 
 const unmeasuredModel = init({ id: 'test', rowHeightPx: ROW_HEIGHT })
 

--- a/packages/typing-game/client/src/view/view.ts
+++ b/packages/typing-game/client/src/view/view.ts
@@ -6,8 +6,6 @@ import { Model } from '../model'
 import { Home, Room } from '../page'
 import { NotFoundRoute } from '../route'
 
-const h = html<Message>()
-
 const routeTitle = (route: Model['route']): string =>
   M.value(route).pipe(
     M.tagsExhaustive({
@@ -18,6 +16,8 @@ const routeTitle = (route: Model['route']): string =>
   )
 
 export const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const content = M.value(model.route).pipe(
     M.tagsExhaustive({
       Home: () =>
@@ -63,8 +63,10 @@ export const view = (model: Model): Document => {
   }
 }
 
-const notFound = ({ path }: NotFoundRoute): Html =>
-  h.section(
+const notFound = ({ path }: NotFoundRoute): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Class('max-w-4xl')],
     [
       h.h1([h.Class('mb-6 uppercase')], ['404 - Not Found']),
@@ -72,3 +74,4 @@ const notFound = ({ path }: NotFoundRoute): Html =>
       h.div([], ['> Enter to go home']),
     ],
   )
+}

--- a/packages/website/src/page/aiMcp.ts
+++ b/packages/website/src/page/aiMcp.ts
@@ -21,8 +21,6 @@ import {
   highlightedCodeBlock,
 } from '../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -201,8 +199,10 @@ const tools: ReadonlyArray<ToolRowSpec> = [
   },
 ]
 
-const toolRow = ({ name, description }: ToolRowSpec): Html =>
-  h.tr(
+const toolRow = ({ name, description }: ToolRowSpec): Html => {
+  const h = html<Message>()
+
+  return h.tr(
     [h.Class('border-b border-gray-200 dark:border-gray-700/50')],
     [
       h.td(
@@ -212,33 +212,40 @@ const toolRow = ({ name, description }: ToolRowSpec): Html =>
       h.td([h.Class(toolDescriptionCellClassName)], description),
     ],
   )
+}
 
-const toolsTable: Html = h.div(
-  [h.Class('mb-6')],
-  [
-    h.table(
-      [h.Class('w-full text-sm')],
-      [
-        h.thead(
-          [],
-          [
-            h.tr(
-              [],
-              [
-                h.th([h.Class(toolHeaderCellClassName)], ['Tool']),
-                h.th([h.Class(toolHeaderCellClassName)], ['Description']),
-              ],
-            ),
-          ],
-        ),
-        h.tbody([], tools.map(toolRow)),
-      ],
-    ),
-  ],
-)
+const toolsTable = (): Html => {
+  const h = html<Message>()
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+  return h.div(
+    [h.Class('mb-6')],
+    [
+      h.table(
+        [h.Class('w-full text-sm')],
+        [
+          h.thead(
+            [],
+            [
+              h.tr(
+                [],
+                [
+                  h.th([h.Class(toolHeaderCellClassName)], ['Tool']),
+                  h.th([h.Class(toolHeaderCellClassName)], ['Description']),
+                ],
+              ),
+            ],
+          ),
+          h.tbody([], tools.map(toolRow)),
+        ],
+      ),
+    ],
+  )
+}
+
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('ai/mcp', 'DevTools MCP Server'),
@@ -344,7 +351,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         inlineCode('runtime_id'),
         '. When omitted, the most recently connected runtime is used.',
       ),
-      toolsTable,
+      toolsTable(),
 
       tableOfContentsEntryToHeader(howItWorksHeader),
       para(
@@ -386,3 +393,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/aiOverview.ts
+++ b/packages/website/src/page/aiOverview.ts
@@ -17,8 +17,6 @@ import {
 } from '../route'
 import { type CopiedSnippets, codeBlock } from '../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -56,8 +54,10 @@ const SUBTREE_ADD_COMMAND =
 const SUBTREE_UPDATE_COMMAND =
   'git subtree pull --prefix=repos/foldkit https://github.com/foldkit/foldkit.git main --squash'
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('ai/overview', 'AI'),
@@ -114,3 +114,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/aiSkills.ts
+++ b/packages/website/src/page/aiSkills.ts
@@ -10,8 +10,6 @@ import {
 } from '../prose'
 import { type CopiedSnippets, codeBlock } from '../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -56,8 +54,10 @@ const FOLDKIT_COMMAND = '/foldkit-skills:foldkit'
 const GENERATE_PROGRAM_COMMAND = '/foldkit-skills:generate-program'
 const AUDIT_PROGRAM_COMMAND = '/foldkit-skills:audit-program'
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('ai/skills', 'Skills'),
@@ -120,3 +120,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/asyncCounterDemo.ts
+++ b/packages/website/src/page/asyncCounterDemo.ts
@@ -17,8 +17,6 @@ import demoCodeHtml from 'virtual:counter-demo-code'
 import type { Message as ParentMessage } from '../message'
 import * as DemoView from './demoView'
 
-const h = html<ParentMessage>()
-
 // CONSTANTS
 
 const PHASE_DURATION: Duration.Input = '300 millis'
@@ -314,8 +312,10 @@ export const view = (
 const appPanel = (
   model: Model,
   toParentMessage: (message: Message) => ParentMessage,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<ParentMessage>()
+
+  return h.div(
     [h.Class('relative')],
     [
       h.div(
@@ -336,6 +336,7 @@ const appPanel = (
       ),
     ],
   )
+}
 
 const MIN_RESET_DURATION = 1
 const MAX_RESET_DURATION = 5
@@ -354,8 +355,10 @@ const parseResetDuration = (value: string): number =>
 const viewAndControlsView = (
   model: Model,
   toParentMessage: (message: Message) => ParentMessage,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<ParentMessage>()
+
+  return h.div(
     [h.Class('flex flex-col gap-3')],
     [
       h.div(
@@ -504,6 +507,7 @@ const viewAndControlsView = (
       }),
     ],
   )
+}
 
 const phaseIndicatorView = (model: Model): Html => {
   const isCommand = model.phase === 'ResetCommand'
@@ -515,8 +519,10 @@ const phaseIndicatorView = (model: Model): Html => {
   )
 }
 
-const progressBarView = (model: Model, isCommand: boolean): Html =>
-  h.div(
+const progressBarView = (model: Model, isCommand: boolean): Html => {
+  const h = html<ParentMessage>()
+
+  return h.div(
     [
       h.AriaHidden(true),
       h.Class(
@@ -548,3 +554,4 @@ const progressBarView = (model: Model, isCommand: boolean): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/bestPractices/immutability.ts
+++ b/packages/website/src/page/bestPractices/immutability.ts
@@ -10,8 +10,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const immutableUpdatesHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'immutable-updates',
@@ -22,8 +20,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   immutableUpdatesHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('best-practices/immutability', 'Immutability'),
@@ -50,3 +50,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/bestPractices/keying.ts
+++ b/packages/website/src/page/bestPractices/keying.ts
@@ -15,8 +15,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const keyingHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'keying',
@@ -48,8 +46,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   conditionalInsertsHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('best-practices/keying', 'Keying'),
@@ -149,3 +149,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/bestPractices/messages.ts
+++ b/packages/website/src/page/bestPractices/messages.ts
@@ -10,8 +10,6 @@ import {
 } from '../../prose'
 import { patternsOutMessageRouter } from '../../route'
 
-const h = html<Message>()
-
 const messagesAsEventsHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'messages-as-events',
@@ -43,8 +41,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   everyMessageCarriesMeaningHeader,
 ]
 
-export const view = (): Html =>
-  h.div(
+export const view = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('best-practices/messages', 'Messages'),
@@ -170,3 +170,4 @@ export const view = (): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/bestPractices/sideEffectsAndPurity.ts
+++ b/packages/website/src/page/bestPractices/sideEffectsAndPurity.ts
@@ -21,8 +21,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -92,8 +90,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
 const effectModuleLink = (label: string) =>
   link('https://effect.website/docs/data-types/datetime/', label)
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle(
@@ -382,3 +382,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/architecture.ts
+++ b/packages/website/src/page/core/architecture.ts
@@ -13,8 +13,6 @@ import {
 import { coreDevToolsRouter, testingRouter } from '../../route'
 import { comparisonTable } from '../../view/table'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -46,8 +44,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   theRestaurantAnalogyHeader,
 ]
 
-export const view = (): Html =>
-  h.div(
+export const view = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/architecture', 'Architecture'),
@@ -315,3 +315,4 @@ export const view = (): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/canvas.ts
+++ b/packages/website/src/page/core/canvas.ts
@@ -16,8 +16,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -51,8 +49,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
 
 const canvasApiHref = apiModuleRouter({ moduleSlug: 'canvas' })
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/canvas', 'Canvas'),
@@ -172,3 +172,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/commands.ts
+++ b/packages/website/src/page/core/commands.ts
@@ -17,8 +17,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -57,8 +55,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   commandsWithArgsHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/commands', 'Commands'),
@@ -257,3 +257,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/counterExample.ts
+++ b/packages/website/src/page/core/counterExample.ts
@@ -12,8 +12,6 @@ import { coreArchitectureRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -24,8 +22,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/counter-example', 'A Simple Counter Example'),
@@ -80,3 +80,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/crashView.ts
+++ b/packages/website/src/page/core/crashView.ts
@@ -13,8 +13,6 @@ import { exampleDetailRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -32,8 +30,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   crashReportHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/crash-view', 'Crash View'),
@@ -151,3 +151,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/customElement.ts
+++ b/packages/website/src/page/core/customElement.ts
@@ -13,8 +13,6 @@ import { coreMountRouter, exampleDetailRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -46,8 +44,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   whenToReachHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/custom-element', 'CustomElement'),
@@ -199,3 +199,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/devtools.ts
+++ b/packages/website/src/page/core/devtools.ts
@@ -13,8 +13,6 @@ import { aiMcpRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -74,8 +72,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   maxEntriesHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/devtools', 'DevTools'),
@@ -215,3 +215,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/dom.ts
+++ b/packages/website/src/page/core/dom.ts
@@ -12,8 +12,6 @@ import { apiModuleRouter, coreCommandsRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -40,8 +38,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
 
 const domApiHref = apiModuleRouter({ moduleSlug: 'dom' })
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/dom', 'Dom'),
@@ -105,3 +105,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/file.ts
+++ b/packages/website/src/page/core/file.ts
@@ -10,8 +10,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -50,8 +48,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   testingHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/file', 'File'),
@@ -218,3 +218,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/freezeModel.ts
+++ b/packages/website/src/page/core/freezeModel.ts
@@ -8,8 +8,6 @@ import {
   tableOfContentsEntryToHeader,
 } from '../../prose'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -27,8 +25,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   scopeHeader,
 ]
 
-export const view = (): Html =>
-  h.div(
+export const view = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/freeze-model', 'Freeze Model'),
@@ -112,3 +112,4 @@ export const view = (): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/init.ts
+++ b/packages/website/src/page/core/init.ts
@@ -12,8 +12,6 @@ import { coreRuntimeRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const initHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'init',
@@ -31,8 +29,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   flagsHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/init', 'Init & Flags'),
@@ -103,3 +103,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/managedResources.ts
+++ b/packages/website/src/page/core/managedResources.ts
@@ -11,8 +11,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -30,8 +28,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   accessingManagedResourcesHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/managed-resources', 'Managed Resources'),
@@ -147,3 +147,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/messages.ts
+++ b/packages/website/src/page/core/messages.ts
@@ -13,8 +13,6 @@ import { coreArchitectureRouter, patternsSubmodelsRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -25,8 +23,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/messages', 'Messages'),
@@ -101,3 +101,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/model.ts
+++ b/packages/website/src/page/core/model.ts
@@ -13,8 +13,6 @@ import { coreArchitectureRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -25,8 +23,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/model', 'Model'),
@@ -85,3 +85,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/mount.ts
+++ b/packages/website/src/page/core/mount.ts
@@ -20,8 +20,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -60,8 +58,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   thirdPartyLibrariesHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/mount', 'Mount'),
@@ -384,3 +384,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/render.ts
+++ b/packages/website/src/page/core/render.ts
@@ -16,8 +16,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -44,8 +42,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
 
 const renderApiHref = apiModuleRouter({ moduleSlug: 'render' })
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/render', 'Render'),
@@ -109,3 +109,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/resources.ts
+++ b/packages/website/src/page/core/resources.ts
@@ -13,8 +13,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -32,8 +30,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   providingMultipleServicesHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/resources', 'Resources'),
@@ -143,3 +143,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/runtime.ts
+++ b/packages/website/src/page/core/runtime.ts
@@ -12,8 +12,6 @@ import { routingAndNavigationRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -45,8 +43,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   withRoutingHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/runtime', 'Runtime'),
@@ -140,3 +140,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/slowView.ts
+++ b/packages/website/src/page/core/slowView.ts
@@ -12,8 +12,6 @@ import { coreViewMemoizationRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -24,8 +22,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/slow-view', 'Slow View'),
@@ -112,3 +112,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/subscriptions.ts
+++ b/packages/website/src/page/core/subscriptions.ts
@@ -19,8 +19,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -59,8 +57,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   readDependenciesHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/subscriptions', 'Subscriptions'),
@@ -344,3 +344,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/update.ts
+++ b/packages/website/src/page/core/update.ts
@@ -13,8 +13,6 @@ import { coreArchitectureRouter, coreCommandsRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -25,8 +23,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/update', 'Update'),
@@ -75,3 +75,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/view.ts
+++ b/packages/website/src/page/core/view.ts
@@ -13,8 +13,6 @@ import { coreArchitectureRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -39,8 +37,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   eventHandlingHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/view', 'View'),
@@ -131,3 +131,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/core/viewMemoization.ts
+++ b/packages/website/src/page/core/viewMemoization.ts
@@ -16,8 +16,6 @@ import { bestPracticesImmutabilityRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -49,8 +47,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   whenToUseLazyHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('core/view-memoization', 'View Memoization'),
@@ -156,3 +156,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/demoView.ts
+++ b/packages/website/src/page/demoView.ts
@@ -3,10 +3,10 @@ import { Html, html } from 'foldkit/html'
 
 import type { Message } from '../message'
 
-const h = html<Message>()
+export const sectionLabel = (label: string): Html => {
+  const h = html<Message>()
 
-export const sectionLabel = (label: string): Html =>
-  h.p(
+  return h.p(
     [
       h.Class(
         'text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2',
@@ -14,9 +14,12 @@ export const sectionLabel = (label: string): Html =>
     ],
     [label],
   )
+}
 
-export const modelStateField = (name: string, value: string): Html =>
-  h.div(
+export const modelStateField = (name: string, value: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       h.span([h.Class('text-accent-700 dark:text-accent-400')], [name]),
@@ -24,9 +27,12 @@ export const modelStateField = (name: string, value: string): Html =>
       h.span([h.Class('text-amber-800 dark:text-amber-300')], [value]),
     ],
   )
+}
 
-export const modelStateView = (fields: ReadonlyArray<Html>): Html =>
-  h.div(
+export const modelStateView = (fields: ReadonlyArray<Html>): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('pt-3 border-t border-gray-300 dark:border-gray-800')],
     [
       sectionLabel('Model State'),
@@ -40,9 +46,12 @@ export const modelStateView = (fields: ReadonlyArray<Html>): Html =>
       ),
     ],
   )
+}
 
-export const eventLogView = (messageLog: ReadonlyArray<string>): Html =>
-  h.div(
+export const eventLogView = (messageLog: ReadonlyArray<string>): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex-1 flex flex-col min-h-0')],
     [
       sectionLabel('Message Log'),
@@ -66,13 +75,16 @@ export const eventLogView = (messageLog: ReadonlyArray<string>): Html =>
       ),
     ],
   )
+}
 
 export const phaseIndicatorView = (
   label: string,
   colorClass: string,
   extraChildren: ReadonlyArray<Html>,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       sectionLabel('Phase'),
@@ -90,14 +102,17 @@ export const phaseIndicatorView = (
       ),
     ],
   )
+}
 
 export const codePanelView = (
   panelClassName: string,
   dataAttributeName: string,
   phase: string,
   htmlString: string,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         panelClassName +
@@ -112,9 +127,12 @@ export const codePanelView = (
       ),
     ],
   )
+}
 
-export const demoViewShell = (codePanel: Html, appPanel: Html): Html =>
-  h.div(
+export const demoViewShell = (codePanel: Html, appPanel: Html): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'demo-container grid grid-cols-1 lg:grid-cols-[1fr_22rem] lg:grid-rows-[minmax(0,1fr)] gap-4 lg:gap-6',
@@ -136,3 +154,4 @@ export const demoViewShell = (codePanel: Html, appPanel: Html): Html =>
       appPanel,
     ],
   )
+}

--- a/packages/website/src/page/examples.ts
+++ b/packages/website/src/page/examples.ts
@@ -11,15 +11,15 @@ import {
 } from '../route'
 import { type ExampleMeta, examples as exampleMetas } from './example/meta'
 
-const h = html<Message>()
-
 export const exampleAppCount = exampleMetas.length + 1
 
 const nameClassName =
   'text-accent-600 dark:text-accent-500 underline decoration-accent-600/30 dark:decoration-accent-500/30 hover:decoration-accent-600 dark:hover:decoration-accent-500 font-medium'
 
-const exampleRow = (example: ExampleMeta): Html =>
-  h.tr(
+const exampleRow = (example: ExampleMeta): Html => {
+  const h = html<Message>()
+
+  return h.tr(
     [h.Class('border-b border-gray-200 dark:border-gray-700/50')],
     [
       h.td(
@@ -40,74 +40,85 @@ const exampleRow = (example: ExampleMeta): Html =>
       ),
     ],
   )
+}
 
-const typingTerminalRow: Html = h.tr(
-  [h.Class('border-b border-gray-200 dark:border-gray-700/50')],
-  [
-    h.td(
-      [h.Class('py-2.5 pr-4 whitespace-nowrap align-top')],
-      [
-        h.a(
-          [h.Href(typingTerminalRouter()), h.Class(nameClassName)],
-          ['Typing Terminal'],
-        ),
-      ],
-    ),
-    h.td(
-      [h.Class('py-2.5 text-gray-600 dark:text-gray-400')],
-      [
-        h.div(
-          [],
-          [
-            'A production real-time multiplayer typing speed game. Full stack Effect app with RPC backend and Foldkit frontend.',
-          ],
-        ),
-        h.a(
-          [
-            h.Href(Link.typingTerminal),
-            h.Class(
-              'text-accent-600 dark:text-accent-500 underline decoration-accent-600/30 dark:decoration-accent-500/30 hover:decoration-accent-600 dark:hover:decoration-accent-500 mt-1 inline-block',
-            ),
-          ],
-          ['Race your friends →'],
-        ),
-      ],
-    ),
-  ],
-)
+const typingTerminalRow = (): Html => {
+  const h = html<Message>()
+
+  return h.tr(
+    [h.Class('border-b border-gray-200 dark:border-gray-700/50')],
+    [
+      h.td(
+        [h.Class('py-2.5 pr-4 whitespace-nowrap align-top')],
+        [
+          h.a(
+            [h.Href(typingTerminalRouter()), h.Class(nameClassName)],
+            ['Typing Terminal'],
+          ),
+        ],
+      ),
+      h.td(
+        [h.Class('py-2.5 text-gray-600 dark:text-gray-400')],
+        [
+          h.div(
+            [],
+            [
+              'A production real-time multiplayer typing speed game. Full stack Effect app with RPC backend and Foldkit frontend.',
+            ],
+          ),
+          h.a(
+            [
+              h.Href(Link.typingTerminal),
+              h.Class(
+                'text-accent-600 dark:text-accent-500 underline decoration-accent-600/30 dark:decoration-accent-500/30 hover:decoration-accent-600 dark:hover:decoration-accent-500 mt-1 inline-block',
+              ),
+            ],
+            ['Race your friends →'],
+          ),
+        ],
+      ),
+    ],
+  )
+}
 
 const headerCellClassName =
   'py-2 pr-4 text-left font-medium text-gray-900 dark:text-gray-200 border-b border-gray-200 dark:border-gray-700/50'
 
-const examplesTable: Html = h.div(
-  [h.Class('mb-8')],
-  [
-    h.table(
-      [h.Class('w-full text-sm')],
-      [
-        h.thead(
-          [],
-          [
-            h.tr(
-              [],
-              [
-                h.th([h.Class(headerCellClassName)], ['Example']),
-                h.th([h.Class(headerCellClassName)], ['Description']),
-              ],
-            ),
-          ],
-        ),
-        h.tbody(
-          [],
-          [...Array.map(exampleMetas, exampleRow), typingTerminalRow],
-        ),
-      ],
-    ),
-  ],
-)
+const examplesTable = (): Html => {
+  const h = html<Message>()
 
-export const view = (): Html =>
-  h.div(
+  return h.div(
+    [h.Class('mb-8')],
+    [
+      h.table(
+        [h.Class('w-full text-sm')],
+        [
+          h.thead(
+            [],
+            [
+              h.tr(
+                [],
+                [
+                  h.th([h.Class(headerCellClassName)], ['Example']),
+                  h.th([h.Class(headerCellClassName)], ['Description']),
+                ],
+              ),
+            ],
+          ),
+          h.tbody(
+            [],
+            [...Array.map(exampleMetas, exampleRow), typingTerminalRow()],
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+export const view = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('examples', 'Examples'),
@@ -134,6 +145,7 @@ export const view = (): Html =>
         ),
         ' to get up and running.',
       ),
-      examplesTable,
+      examplesTable(),
     ],
   )
+}

--- a/packages/website/src/page/fieldValidation.ts
+++ b/packages/website/src/page/fieldValidation.ts
@@ -15,9 +15,11 @@ import * as Snippets from '../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../view/codeBlock'
 import { comparisonTable } from '../view/table'
 
-const h = html<Message>()
+const plainCode = (text: string): Html => {
+  const h = html<Message>()
 
-const plainCode = (text: string): Html => h.code([h.Class('text-sm')], [text])
+  return h.code([h.Class('text-sm')], [text])
+}
 
 const definingAFieldHeader: TableOfContentsEntry = {
   level: 'h2',
@@ -78,8 +80,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   builtInRulesHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('field-validation', 'Field Validation'),
@@ -384,3 +388,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/gettingStarted.ts
+++ b/packages/website/src/page/gettingStarted.ts
@@ -20,8 +20,6 @@ import {
 import { type CopiedSnippets, codeBlock } from '../view/codeBlock'
 import { comparisonTable } from '../view/table'
 
-const h = html<Message>()
-
 const CREATE_FOLDKIT_APP_COMMAND = 'npx create-foldkit-app@latest'
 const DEV_PNPM = 'pnpm dev'
 const DEV_NPM = 'npm run dev'
@@ -45,8 +43,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   projectStructureHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('getting-started', 'Getting Started'),
@@ -137,3 +137,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/landing.ts
+++ b/packages/website/src/page/landing.ts
@@ -39,14 +39,14 @@ import {
 } from '../view/codeBlock'
 import { exampleAppCount } from './examples'
 
-const h = html<Message>()
-
 // CONSTANTS
 
 export const HERO_SECTION_ID = 'hero'
 
-const glyph = (symbol: string, offsetY?: string): Html =>
-  h.div(
+const glyph = (symbol: string, offsetY?: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         '-my-[9rem] md:-my-[13.5rem] px-6 md:px-12 lg:px-20 select-none pointer-events-none',
@@ -73,6 +73,7 @@ const glyph = (symbol: string, offsetY?: string): Html =>
       ),
     ],
   )
+}
 
 // VIEW
 
@@ -82,8 +83,10 @@ export const view = (
   emailSignupView: Html,
   playgroundMenuView: Html,
   aiHeadingToggleCount: number,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('isolate overflow-x-hidden')],
     [
       heroSection(copiedSnippets, playgroundMenuView),
@@ -111,6 +114,7 @@ export const view = (
       finalCtaSection(emailSignupView),
     ],
   )
+}
 
 // MESSAGE
 
@@ -157,8 +161,10 @@ const INSTALL_COMMAND = 'npx create-foldkit-app@latest'
 const heroSection = (
   copiedSnippets: CopiedSnippets,
   playgroundMenuView: Html,
-): Html =>
-  h.section(
+): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [
       h.Id(HERO_SECTION_ID),
       h.AriaLabel('Hero'),
@@ -241,11 +247,14 @@ const heroSection = (
       ),
     ],
   )
+}
 
 // POWERED BY
 
-const poweredByItem = (text: string): Html =>
-  h.li(
+const poweredByItem = (text: string): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [h.Class('flex items-start gap-3')],
     [
       h.div(
@@ -255,9 +264,12 @@ const poweredByItem = (text: string): Html =>
       h.span([h.Class('font-normal text-gray-600 dark:text-gray-300')], [text]),
     ],
   )
+}
 
-const poweredBySection = (): Html =>
-  h.section(
+const poweredBySection = (): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('powered-by-effect'), h.Class('landing-section py-10 md:py-14')],
     [
       h.div(
@@ -312,11 +324,14 @@ const poweredBySection = (): Html =>
       ),
     ],
   )
+}
 
 // THE PROMISE
 
-const pillarCard = (icon: Html, title: string, description: string): Html =>
-  h.div(
+const pillarCard = (icon: Html, title: string, description: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('landing-card')],
     [
       h.div([h.Class('mb-3 text-accent-600 dark:text-accent-500')], [icon]),
@@ -330,9 +345,12 @@ const pillarCard = (icon: Html, title: string, description: string): Html =>
       ),
     ],
   )
+}
 
-const promiseSection = (): Html =>
-  h.section(
+const promiseSection = (): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('the-promise'), h.Class('landing-section')],
     [
       h.div(
@@ -380,11 +398,14 @@ const promiseSection = (): Html =>
       ),
     ],
   )
+}
 
 // DEMOS
 
-const demoSection = (demoTabsView: Html): Html =>
-  h.section(
+const demoSection = (demoTabsView: Html): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('peek-inside'), h.Class('landing-section')],
     [
       h.div(
@@ -413,6 +434,7 @@ const demoSection = (demoTabsView: Html): Html =>
       ),
     ],
   )
+}
 
 // WHAT'S INCLUDED
 
@@ -421,8 +443,10 @@ const includedFeature = (
   title: string,
   description: ReadonlyArray<string | Html>,
   link?: Readonly<{ href: string; label: string }>,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('landing-card')],
     [
       h.div([h.Class('mb-3 text-accent-600 dark:text-accent-500')], [icon]),
@@ -462,9 +486,12 @@ const includedFeature = (
         : []),
     ],
   )
+}
 
-const includedSection = (): Html =>
-  h.section(
+const includedSection = (): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('batteries-included'), h.Class('landing-section')],
     [
       h.div(
@@ -594,11 +621,14 @@ const includedSection = (): Html =>
       ),
     ],
   )
+}
 
 // TESTING
 
-const testingSection = (copiedSnippets: CopiedSnippets): Html =>
-  h.section(
+const testingSection = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('testing'), h.Class('landing-section')],
     [
       h.div(
@@ -649,11 +679,14 @@ const testingSection = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}
 
 // DEVTOOLS
 
-const devToolsSection = (): Html =>
-  h.section(
+const devToolsSection = (): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('devtools'), h.Class('landing-section')],
     [
       h.div(
@@ -732,11 +765,14 @@ const devToolsSection = (): Html =>
       ),
     ],
   )
+}
 
 // TRADE-OFFS & COMPARISON
 
-const tradeOffsSection = (): Html =>
-  h.section(
+const tradeOffsSection = (): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('whats-the-catch'), h.Class('landing-section')],
     [
       h.div(
@@ -822,11 +858,14 @@ const tradeOffsSection = (): Html =>
       ),
     ],
   )
+}
 
 // AUDIENCE
 
-const audienceSection = (): Html =>
-  h.section(
+const audienceSection = (): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('who-its-for'), h.Class('landing-section')],
     [
       h.div(
@@ -909,9 +948,12 @@ const audienceSection = (): Html =>
       ),
     ],
   )
+}
 
-const audienceForItem = (title: string, description: string): Html =>
-  h.li(
+const audienceForItem = (title: string, description: string): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [h.Class('mb-5 flex gap-3')],
     [
       h.div(
@@ -937,9 +979,12 @@ const audienceForItem = (title: string, description: string): Html =>
       ),
     ],
   )
+}
 
-const audienceNotItem = (title: string, description: string): Html =>
-  h.li(
+const audienceNotItem = (title: string, description: string): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [h.Class('mb-5 flex gap-3')],
     [
       h.div(
@@ -965,11 +1010,14 @@ const audienceNotItem = (title: string, description: string): Html =>
       ),
     ],
   )
+}
 
 // TRUST & MATURITY
 
-const trustSection = (): Html =>
-  h.section(
+const trustSection = (): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('trust'), h.Class('landing-section py-10 md:py-14')],
     [
       h.div(
@@ -1007,9 +1055,12 @@ const trustSection = (): Html =>
       ),
     ],
   )
+}
 
-const trustItem = (label: string, value: string): Html =>
-  h.li(
+const trustItem = (label: string, value: string): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [h.Class('landing-card')],
     [
       h.p(
@@ -1026,13 +1077,16 @@ const trustItem = (label: string, value: string): Html =>
       ),
     ],
   )
+}
 
 const trustItemWithLink = (
   label: string,
   linkText: string,
   href: string,
-): Html =>
-  h.li(
+): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [h.Class('landing-card')],
     [
       h.p(
@@ -1060,6 +1114,7 @@ const trustItemWithLink = (
       ),
     ],
   )
+}
 
 // AI
 
@@ -1068,6 +1123,8 @@ const AI_HEADING_B = 'Built for AI. Readable by humans.'
 const STATIC_PREFIX_LENGTH = 10
 
 const solariHeading = (toggleCount: number): Html => {
+  const h = html<Message>()
+
   const isSwapped = toggleCount % 2 === 1
 
   return h.h2(
@@ -1142,8 +1199,10 @@ const solariHeading = (toggleCount: number): Html => {
   )
 }
 
-const aiSection = (aiHeadingToggleCount: number): Html =>
-  h.section(
+const aiSection = (aiHeadingToggleCount: number): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('ai'), h.Class('landing-section py-10 md:py-14 relative')],
     [
       h.div(
@@ -1178,11 +1237,14 @@ const aiSection = (aiHeadingToggleCount: number): Html =>
       ),
     ],
   )
+}
 
 // FINAL CTA
 
-const finalCtaSection = (emailSignupView: Html): Html =>
-  h.section(
+const finalCtaSection = (emailSignupView: Html): Html => {
+  const h = html<Message>()
+
+  return h.section(
     [h.Id('get-started'), h.Class('landing-section')],
     [
       h.div(
@@ -1239,3 +1301,4 @@ const finalCtaSection = (emailSignupView: Html): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/manifesto.ts
+++ b/packages/website/src/page/manifesto.ts
@@ -4,8 +4,6 @@ import type { TableOfContentsEntry } from '../main'
 import type { Message } from '../message'
 import { pageTitle, para, tableOfContentsEntryToHeader } from '../prose'
 
-const h = html<Message>()
-
 const theArchitectureProblemHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'the-architecture-problem',
@@ -37,8 +35,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   buildYourProductHeader,
 ]
 
-export const view = (): Html =>
-  h.div(
+export const view = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('manifesto', 'Manifesto'),
@@ -96,3 +96,4 @@ export const view = (): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/notFound.ts
+++ b/packages/website/src/page/notFound.ts
@@ -3,10 +3,10 @@ import { Html, html } from 'foldkit/html'
 import type { Message } from '../message'
 import { link, para } from '../prose'
 
-const h = html<Message>()
+export const view = (path: string, introductionRoute: string): Html => {
+  const h = html<Message>()
 
-export const view = (path: string, introductionRoute: string): Html =>
-  h.div(
+  return h.div(
     [],
     [
       h.h1(
@@ -17,3 +17,4 @@ export const view = (path: string, introductionRoute: string): Html =>
       link(introductionRoute, '← Go Home'),
     ],
   )
+}

--- a/packages/website/src/page/notePlayerDemo.ts
+++ b/packages/website/src/page/notePlayerDemo.ts
@@ -24,8 +24,6 @@ import { Icon } from '../icon'
 import type { Message as ParentMessage } from '../message'
 import * as DemoView from './demoView'
 
-const h = html<ParentMessage>()
-
 // CONSTANTS
 
 const NOTE_FREQUENCIES: Record<Note, number> = {
@@ -548,6 +546,8 @@ const appPanel = (
   model: Model,
   toParentMessage: (message: Message) => ParentMessage,
 ): Html => {
+  const h = html<ParentMessage>()
+
   const isPlaying = model.playbackState._tag === 'Playing'
   const isPaused = model.playbackState._tag === 'Paused'
   const isInputLocked = isPlaying || isPaused
@@ -589,8 +589,10 @@ const noteInputView = (
   model: Model,
   isInputLocked: boolean,
   toParentMessage: (message: Message) => ParentMessage,
-): Html =>
-  Ui.Input.view<ParentMessage>({
+): Html => {
+  const h = html<ParentMessage>()
+
+  return Ui.Input.view<ParentMessage>({
     id: 'note-input',
     value: model.noteInput.value,
     onInput: value => toParentMessage(ChangedNoteInput({ value })),
@@ -653,6 +655,7 @@ const noteInputView = (
         ],
       ),
   })
+}
 
 const noteDurations: ReadonlyArray<NoteDuration> = ['Short', 'Medium', 'Long']
 
@@ -660,8 +663,10 @@ const durationSelectorView = (
   model: Model,
   isInputLocked: boolean,
   toParentMessage: (message: Message) => ParentMessage,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<ParentMessage>()
+
+  return h.div(
     [h.Class('flex flex-col gap-1.5')],
     [
       h.label(
@@ -700,12 +705,15 @@ const durationSelectorView = (
       }),
     ],
   )
+}
 
 const playbackControlView = (
   model: Model,
   canPlay: boolean,
   toParentMessage: (message: Message) => ParentMessage,
 ): Html => {
+  const h = html<ParentMessage>()
+
   const isPlaying = model.playbackState._tag === 'Playing'
   const isActive = isPlaying || model.playbackState._tag === 'Paused'
 
@@ -777,22 +785,28 @@ const playbackControlView = (
   )
 }
 
-const placeholderVisualizerView: Html = h.div(
-  [h.Class('flex gap-2')],
-  Array.makeBy(MIN_NOTES, index =>
-    h.keyed('div')(
-      `placeholder-${index}`,
-      [
-        h.Class(
-          'flex-1 h-10 rounded-lg flex items-center justify-center text-sm font-bold bg-gray-200 dark:bg-gray-800 text-gray-300 dark:text-gray-600',
-        ),
-      ],
-      [h.span([], ['–'])],
+const placeholderVisualizerView = (): Html => {
+  const h = html<ParentMessage>()
+
+  return h.div(
+    [h.Class('flex gap-2')],
+    Array.makeBy(MIN_NOTES, index =>
+      h.keyed('div')(
+        `placeholder-${index}`,
+        [
+          h.Class(
+            'flex-1 h-10 rounded-lg flex items-center justify-center text-sm font-bold bg-gray-200 dark:bg-gray-800 text-gray-300 dark:text-gray-600',
+          ),
+        ],
+        [h.span([], ['–'])],
+      ),
     ),
-  ),
-)
+  )
+}
 
 const noteSequenceView = (model: Model): Html => {
+  const h = html<ParentMessage>()
+
   const notes = parseNotes(model.noteInput.value)
 
   return h.div(
@@ -803,7 +817,7 @@ const noteSequenceView = (model: Model): Html => {
     ],
     [
       Array.match(notes, {
-        onEmpty: () => placeholderVisualizerView,
+        onEmpty: () => placeholderVisualizerView(),
         onNonEmpty: validNotes => noteVisualizerView(model, validNotes),
       }),
     ],
@@ -811,6 +825,8 @@ const noteSequenceView = (model: Model): Html => {
 }
 
 const noteVisualizerView = (model: Model, notes: ReadonlyArray<Note>): Html => {
+  const h = html<ParentMessage>()
+
   const maybeCurrentIndex = M.value(model.playbackState).pipe(
     M.tag('Playing', 'Paused', ({ currentNoteIndex }) =>
       Option.some(currentNoteIndex),

--- a/packages/website/src/page/onSsr.ts
+++ b/packages/website/src/page/onSsr.ts
@@ -13,8 +13,6 @@ import {
 } from '../prose'
 import { coreViewRouter } from '../route'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -60,8 +58,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   noPerRequestHeader,
 ]
 
-export const view = (): Html =>
-  h.div(
+export const view = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('on-ssr', 'On SSR'),
@@ -146,3 +146,4 @@ export const view = (): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/patterns/outMessage.ts
+++ b/packages/website/src/page/patterns/outMessage.ts
@@ -13,8 +13,6 @@ import { exampleDetailRouter } from '../../route'
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -46,8 +44,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   handlingInTheParentHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('patterns/parent-child-communication', 'OutMessage'),
@@ -160,3 +160,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/patterns/submodels.ts
+++ b/packages/website/src/page/patterns/submodels.ts
@@ -18,8 +18,6 @@ import {
 import * as Snippets from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -72,8 +70,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   wiringTheViewHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('patterns/submodels', 'Submodels'),
@@ -263,3 +263,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/playground.ts
+++ b/packages/website/src/page/playground.ts
@@ -9,8 +9,6 @@ import type { Message } from '../message'
 import { exampleDetailRouter, examplesRouter } from '../route'
 import { type ExampleMeta, findBySlug } from './example/meta'
 
-const h = html<Message>()
-
 export const SucceededPlaygroundEmbed = m('SucceededPlaygroundEmbed')
 export const FailedPlaygroundEmbed = m('FailedPlaygroundEmbed', {
   reason: S.String,
@@ -66,8 +64,10 @@ const PlaygroundEmbed = Mount.define(
       ),
 )
 
-const backToExampleButton = (maybeMeta: Option.Option<ExampleMeta>): Html =>
-  Option.match(maybeMeta, {
+const backToExampleButton = (maybeMeta: Option.Option<ExampleMeta>): Html => {
+  const h = html<Message>()
+
+  return Option.match(maybeMeta, {
     onNone: () =>
       h.a(
         [h.Href(examplesRouter()), h.Class('cta-secondary')],
@@ -82,13 +82,16 @@ const backToExampleButton = (maybeMeta: Option.Option<ExampleMeta>): Html =>
         [Icon.chevronLeft('w-4 h-4'), `Back to ${meta.title}`],
       ),
   })
+}
 
 const messageView = (
   heading: string,
   body: string,
   maybeMeta: Option.Option<ExampleMeta>,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex-1 flex items-center justify-center px-6 py-20 text-center')],
     [
       h.div(
@@ -111,6 +114,7 @@ const messageView = (
       ),
     ],
   )
+}
 
 // NOTE: this Mount registers no acquireRelease finalizer. The StackBlitz
 // SDK maintains an internal `connections` array that isn't exposed for
@@ -119,8 +123,10 @@ const messageView = (
 // unmount; there is no additional cleanup hook the SDK accepts. The
 // resulting per-visit leak is a few KB of JS state, negligible for a docs
 // site, tracked as a follow-up to request a public teardown method.
-const embedView = (meta: ExampleMeta, files: Record<string, string>): Html =>
-  h.div(
+const embedView = (meta: ExampleMeta, files: Record<string, string>): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex-1 min-h-0')],
     [
       h.div(
@@ -137,12 +143,15 @@ const embedView = (meta: ExampleMeta, files: Record<string, string>): Html =>
       ),
     ],
   )
+}
 
 export const view = (
   slug: string,
   isChromium: boolean,
   playgroundError: Option.Option<string>,
 ): Html => {
+  const h = html<Message>()
+
   const maybeMeta = findBySlug(slug)
   const maybeFiles = Option.fromNullishOr(filesBySlug[slug])
 

--- a/packages/website/src/page/projectOrganization.ts
+++ b/packages/website/src/page/projectOrganization.ts
@@ -18,8 +18,6 @@ import {
   highlightedCodeBlock,
 } from '../view/codeBlock'
 
-const h = html<Message>()
-
 const startingSimpleHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'starting-simple',
@@ -51,8 +49,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   indexReexportsHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('project-organization', 'Project Organization'),
@@ -166,3 +166,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/reactComparison.ts
+++ b/packages/website/src/page/reactComparison.ts
@@ -26,8 +26,6 @@ import * as Snippets from '../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../view/codeBlock'
 import { comparisonTable } from '../view/table'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -346,8 +344,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   conclusionHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle(
@@ -1445,3 +1445,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/routing.ts
+++ b/packages/website/src/page/routing.ts
@@ -15,8 +15,6 @@ import { bestPracticesKeyingRouter, exampleDetailRouter } from '../route'
 import * as Snippets from '../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../view/codeBlock'
 
-const h = html<Message>()
-
 const biparserHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'biparser',
@@ -76,8 +74,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   navigationHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('routing-and-navigation', 'Routing & Navigation'),
@@ -431,3 +431,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/testing.ts
+++ b/packages/website/src/page/testing.ts
@@ -17,8 +17,6 @@ import {
 import * as Snippets from '../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../view/codeBlock'
 
-const h = html<Message>()
-
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
@@ -43,8 +41,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   sceneHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('testing', 'Testing'),
@@ -128,3 +128,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/testingScene.ts
+++ b/packages/website/src/page/testingScene.ts
@@ -13,96 +13,106 @@ import * as Snippets from '../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../view/codeBlock'
 import { comparisonTable } from '../view/table'
 
-const h = html<Message>()
+const plainCode = (text: string): Html => {
+  const h = html<Message>()
 
-const plainCode = (text: string): Html => h.code([h.Class('text-sm')], [text])
+  return h.code([h.Class('text-sm')], [text])
+}
 
-const commandSemanticsList: Html = h.ul(
-  [h.Class('list-disc mb-8 space-y-2 pl-6')],
-  [
-    h.li(
-      [],
-      [
-        'Pending Commands accumulate in the order ',
-        inlineCode('update'),
-        ' returns them, across as many steps as the test takes.',
-      ],
-    ),
-    h.li(
-      [],
-      [
-        'Resolving a Command feeds its result Message through ',
-        inlineCode('update'),
-        '; new Commands produced by that update join the pending list.',
-      ],
-    ),
-    h.li(
-      [],
-      [
-        inlineCode('Scene.Command.resolveAll'),
-        ' walks cascades within the batch. If resolving Command A produces Command B and B’s resolver is in the same call, B resolves without a separate step.',
-      ],
-    ),
-    h.li(
-      [],
-      [
-        'Interactions throw if there are unresolved Commands when they try to dispatch a Message.',
-      ],
-    ),
-    h.li(
-      [],
-      [
-        inlineCode('Scene.scene'),
-        ' throws at the end if any Command remains unresolved.',
-      ],
-    ),
-  ],
-)
+const commandSemanticsList = (): Html => {
+  const h = html<Message>()
 
-const mountSemanticsList: Html = h.ul(
-  [h.Class('list-disc mb-8 space-y-2 pl-6')],
-  [
-    h.li(
-      [],
-      [
-        'Pending mounts persist across re-renders. Resolving a mount does not re-pend it on the next render.',
-      ],
-    ),
-    h.li(
-      [],
-      [
-        'Every mount that fires and unmounts during a scene must be acknowledged with ',
-        inlineCode('Scene.Mount.expectEnded'),
-        ', even if it was already resolved. ',
-        inlineCode('resolve'),
-        ' handles a mount’s result Message; ',
-        inlineCode('expectEnded'),
-        ' handles its unmount. Unacknowledged unmounts throw at the end of the scene.',
-      ],
-    ),
-    h.li(
-      [],
-      [
-        'Same-named mounts in the tree are disambiguated by occurrence. ',
-        inlineCode('Scene.Mount.resolve'),
-        ' resolves the first pending occurrence; a second call resolves the next.',
-      ],
-    ),
-    h.li(
-      [],
-      [
-        'Interactions throw if there are unresolved mounts or unacknowledged unmounts when they try to dispatch a Message. Same contract as Commands.',
-      ],
-    ),
-    h.li(
-      [],
-      [
-        inlineCode('Scene.scene'),
-        ' throws at the end if any mount remains unresolved.',
-      ],
-    ),
-  ],
-)
+  return h.ul(
+    [h.Class('list-disc mb-8 space-y-2 pl-6')],
+    [
+      h.li(
+        [],
+        [
+          'Pending Commands accumulate in the order ',
+          inlineCode('update'),
+          ' returns them, across as many steps as the test takes.',
+        ],
+      ),
+      h.li(
+        [],
+        [
+          'Resolving a Command feeds its result Message through ',
+          inlineCode('update'),
+          '; new Commands produced by that update join the pending list.',
+        ],
+      ),
+      h.li(
+        [],
+        [
+          inlineCode('Scene.Command.resolveAll'),
+          ' walks cascades within the batch. If resolving Command A produces Command B and B’s resolver is in the same call, B resolves without a separate step.',
+        ],
+      ),
+      h.li(
+        [],
+        [
+          'Interactions throw if there are unresolved Commands when they try to dispatch a Message.',
+        ],
+      ),
+      h.li(
+        [],
+        [
+          inlineCode('Scene.scene'),
+          ' throws at the end if any Command remains unresolved.',
+        ],
+      ),
+    ],
+  )
+}
+
+const mountSemanticsList = (): Html => {
+  const h = html<Message>()
+
+  return h.ul(
+    [h.Class('list-disc mb-8 space-y-2 pl-6')],
+    [
+      h.li(
+        [],
+        [
+          'Pending mounts persist across re-renders. Resolving a mount does not re-pend it on the next render.',
+        ],
+      ),
+      h.li(
+        [],
+        [
+          'Every mount that fires and unmounts during a scene must be acknowledged with ',
+          inlineCode('Scene.Mount.expectEnded'),
+          ', even if it was already resolved. ',
+          inlineCode('resolve'),
+          ' handles a mount’s result Message; ',
+          inlineCode('expectEnded'),
+          ' handles its unmount. Unacknowledged unmounts throw at the end of the scene.',
+        ],
+      ),
+      h.li(
+        [],
+        [
+          'Same-named mounts in the tree are disambiguated by occurrence. ',
+          inlineCode('Scene.Mount.resolve'),
+          ' resolves the first pending occurrence; a second call resolves the next.',
+        ],
+      ),
+      h.li(
+        [],
+        [
+          'Interactions throw if there are unresolved mounts or unacknowledged unmounts when they try to dispatch a Message. Same contract as Commands.',
+        ],
+      ),
+      h.li(
+        [],
+        [
+          inlineCode('Scene.scene'),
+          ' throws at the end if any mount remains unresolved.',
+        ],
+      ),
+    ],
+  )
+}
 
 const whyHeader: TableOfContentsEntry = {
   level: 'h2',
@@ -184,8 +194,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   storyVsSceneHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('testing-scene', 'Scene'),
@@ -596,7 +608,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         ' declares the Command, the test declares its outcome.',
       ),
       para('Command tracking has a few semantics worth knowing:'),
-      commandSemanticsList,
+      commandSemanticsList(),
       highlightedCodeBlock(
         h.div(
           [
@@ -677,7 +689,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
         ' shows up in the VNode tree, and Scene treats it as a pending mount. Acknowledging it advances the test through the same path the user takes: the view renders, the mount fires, the result Message updates the Model.',
       ),
       para('Mount tracking has a few semantics worth knowing:'),
-      mountSemanticsList,
+      mountSemanticsList(),
       highlightedCodeBlock(
         h.div(
           [
@@ -770,3 +782,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/testingStory.ts
+++ b/packages/website/src/page/testingStory.ts
@@ -14,8 +14,6 @@ import { coreCommandsRouter } from '../route'
 import * as Snippets from '../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../view/codeBlock'
 
-const h = html<Message>()
-
 const whyHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'testing-the-update-loop',
@@ -54,8 +52,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   commandEffectsHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('testing-story', 'Story'),
@@ -234,3 +234,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/typingTerminal.ts
+++ b/packages/website/src/page/typingTerminal.ts
@@ -17,8 +17,6 @@ import {
   exampleDetailRouter,
 } from '../route'
 
-const h = html<Message>()
-
 const fullStackEffectHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'a-full-stack-effect-app',
@@ -39,22 +37,28 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
 const ctaLinkClassName =
   'text-accent-600 dark:text-accent-500 underline decoration-accent-600/30 dark:decoration-accent-500/30 hover:decoration-accent-600 dark:hover:decoration-accent-500 font-medium'
 
-const ctaRow: Html = h.p(
-  [h.Class('mb-8 flex flex-wrap gap-x-6 gap-y-2')],
-  [
-    h.a(
-      [h.Href(Link.typingTerminal), h.Class(ctaLinkClassName)],
-      ['Race your friends →'],
-    ),
-    h.a(
-      [h.Href(Link.typingTerminalSource), h.Class(ctaLinkClassName)],
-      ['View source on GitHub →'],
-    ),
-  ],
-)
+const ctaRow = (): Html => {
+  const h = html<Message>()
 
-export const view = (): Html =>
-  h.div(
+  return h.p(
+    [h.Class('mb-8 flex flex-wrap gap-x-6 gap-y-2')],
+    [
+      h.a(
+        [h.Href(Link.typingTerminal), h.Class(ctaLinkClassName)],
+        ['Race your friends →'],
+      ),
+      h.a(
+        [h.Href(Link.typingTerminalSource), h.Class(ctaLinkClassName)],
+        ['View source on GitHub →'],
+      ),
+    ],
+  )
+}
+
+export const view = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('typing-terminal', 'Typing Terminal'),
@@ -66,7 +70,7 @@ export const view = (): Html =>
       para(
         'The other entries in this section are single-process apps that show one feature at a time. Typing Terminal is the full picture: a Foldkit client, an Effect-based RPC server, and a shared schema package that both ends import directly.',
       ),
-      ctaRow,
+      ctaRow(),
       tableOfContentsEntryToHeader(fullStackEffectHeader),
       para('The repo splits into three packages.'),
       bullets(
@@ -138,3 +142,4 @@ export const view = (): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/page/whyNoJsx.ts
+++ b/packages/website/src/page/whyNoJsx.ts
@@ -13,8 +13,6 @@ import { apiModuleRouter, coreViewRouter } from '../route'
 import * as Snippets from '../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../view/codeBlock'
 
-const h = html<Message>()
-
 const familiarityHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'recognition-speed-vs-readability',
@@ -60,8 +58,10 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   conditionalHeader,
 ]
 
-export const view = (copiedSnippets: CopiedSnippets): Html =>
-  h.div(
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       pageTitle('why-no-jsx', 'Why no JSX?'),
@@ -248,3 +248,4 @@ export const view = (copiedSnippets: CopiedSnippets): Html =>
       ),
     ],
   )
+}

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -6,10 +6,10 @@ import { Icon } from './icon'
 import { type TableOfContentsEntry } from './main'
 import { ClickedCopyLink, type Message } from './message'
 
-const h = html<Message>()
+export const headingLinkButton = (id: string, text: string): Html => {
+  const h = html<Message>()
 
-export const headingLinkButton = (id: string, text: string): Html =>
-  h.a(
+  return h.a(
     [
       h.Href(`#${id}`),
       h.Class(
@@ -20,9 +20,12 @@ export const headingLinkButton = (id: string, text: string): Html =>
     ],
     [Icon.link('w-5 h-5')],
   )
+}
 
-export const link = (href: string, text: string): Html =>
-  h.a(
+export const link = (href: string, text: string): Html => {
+  const h = html<Message>()
+
+  return h.a(
     [
       h.Href(href),
       h.Class(
@@ -31,9 +34,12 @@ export const link = (href: string, text: string): Html =>
     ],
     [text],
   )
+}
 
-export const pageTitle = (id: string, text: string): Html =>
-  h.h1(
+export const pageTitle = (id: string, text: string): Html => {
+  const h = html<Message>()
+
+  return h.h1(
     [
       h.Class(
         'text-3xl md:text-[2.5rem] leading-normal font-normal text-gray-900 dark:text-white mb-4',
@@ -43,6 +49,7 @@ export const pageTitle = (id: string, text: string): Html =>
     ],
     [text],
   )
+}
 
 const sectionHeadingConfig = {
   h2: {
@@ -70,6 +77,8 @@ export const heading = (
   id: string,
   text: string,
 ): Html => {
+  const h = html<Message>()
+
   const tag = { h2: h.h2, h3: h.h3, h4: h.h4 }
   const config = sectionHeadingConfig[level]
 
@@ -82,44 +91,64 @@ export const heading = (
   )
 }
 
-export const para = (...content: ReadonlyArray<string | Html>): Html =>
-  h.p([h.Class('mb-4 leading-relaxed')], content)
+export const para = (...content: ReadonlyArray<string | Html>): Html => {
+  const h = html<Message>()
 
-export const subPara = (...content: ReadonlyArray<string | Html>): Html =>
-  h.p(
+  return h.p([h.Class('mb-4 leading-relaxed')], content)
+}
+
+export const subPara = (...content: ReadonlyArray<string | Html>): Html => {
+  const h = html<Message>()
+
+  return h.p(
     [h.Class('mb-4 text-sm leading-6 text-gray-800 dark:text-gray-400')],
     content,
   )
+}
 
 export const paragraphs = (
   ...contents: ReadonlyArray<string>
-): ReadonlyArray<Html> =>
-  Array.map(contents, text => h.p([h.Class('mb-4')], [text]))
+): ReadonlyArray<Html> => {
+  const h = html<Message>()
+
+  return Array.map(contents, text => h.p([h.Class('mb-4')], [text]))
+}
 
 export const tableOfContentsEntryToHeader = (
   entry: TableOfContentsEntry,
 ): Html => heading(entry.level, entry.id, entry.text)
 
-export const bullets = (...items: ReadonlyArray<string | Html>): Html =>
-  h.ul(
+export const bullets = (...items: ReadonlyArray<string | Html>): Html => {
+  const h = html<Message>()
+
+  return h.ul(
     [h.Class('list-disc mb-8 space-y-2')],
     Array.map(items, item => h.li([], [item])),
   )
+}
 
-export const bulletPoint = (label: string, description: string): Html =>
-  h.li([], [h.strong([], [`${label}:`]), ` ${description}`])
+export const bulletPoint = (label: string, description: string): Html => {
+  const h = html<Message>()
+
+  return h.li([], [h.strong([], [`${label}:`]), ` ${description}`])
+}
 
 const inlineCodeClassName =
   'bg-gray-200/70 dark:bg-gray-800 px-1 py-px rounded text-sm border border-gray-300/50 dark:border-gray-700/50'
 
-export const inlineCode = (text: string, className?: string): Html =>
-  h.code([h.Class(twMerge(inlineCodeClassName, className))], [text])
+export const inlineCode = (text: string, className?: string): Html => {
+  const h = html<Message>()
+
+  return h.code([h.Class(twMerge(inlineCodeClassName, className))], [text])
+}
 
 export const infoCallout = (
   label: string,
   ...content: ReadonlyArray<string | Html>
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'border border-gray-300 dark:border-gray-700 bg-gray-200/40 dark:bg-gray-800/40 py-3.5 px-5 mb-6 rounded-lg',
@@ -137,9 +166,12 @@ export const infoCallout = (
       h.p([h.Class('text-gray-700 dark:text-gray-300 leading-7')], content),
     ],
   )
+}
 
-export const demoContainer = (...content: ReadonlyArray<Html>): Html =>
-  h.div(
+export const demoContainer = (...content: ReadonlyArray<Html>): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'rounded-xl border border-gray-200 dark:border-gray-700/50 bg-gray-50/50 dark:bg-gray-800/20 p-8 mb-6 flex flex-col items-center',
@@ -147,12 +179,15 @@ export const demoContainer = (...content: ReadonlyArray<Html>): Html =>
     ],
     content,
   )
+}
 
 export const warningCallout = (
   label: string,
   ...content: ReadonlyArray<string | Html>
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'border border-amber-400 dark:border-amber-500/50 py-3.5 px-5 mb-6 rounded-lg',
@@ -170,3 +205,4 @@ export const warningCallout = (
       h.p([h.Class('text-gray-700 dark:text-gray-300 leading-7')], content),
     ],
   )
+}

--- a/packages/website/src/search/view.ts
+++ b/packages/website/src/search/view.ts
@@ -18,8 +18,6 @@ import {
 import type { Model } from './model'
 import { resultsFromState } from './model'
 
-const h = html<ParentMessage>()
-
 type ToMessage = (message: Message) => ParentMessage
 
 const RESULTS_LIST_ID = 'search-results'
@@ -62,6 +60,8 @@ const handleSearchInputKeyDown = (
   )
 
 const searchInputView = (model: Model, toParentMessage: ToMessage): Html => {
+  const h = html<ParentMessage>()
+
   const isListboxVisible =
     model.searchState._tag === 'Ok' || model.searchState._tag === 'Loading'
 
@@ -115,19 +115,24 @@ const resultLabelText = (
     ),
   ])
 
-const resultLabel = (result: typeof SearchResult.Type): ReadonlyArray<Html> =>
-  Option.match(resultLabelText(result), {
+const resultLabel = (result: typeof SearchResult.Type): ReadonlyArray<Html> => {
+  const h = html<ParentMessage>()
+
+  return Option.match(resultLabelText(result), {
     onSome: text => [h.span([h.Class(labelPillClassName)], [text])],
     onNone: () => [],
   })
+}
 
 const resultItemView = (
   result: typeof SearchResult.Type,
   index: number,
   isActive: boolean,
   toParentMessage: ToMessage,
-): Html =>
-  h.a(
+): Html => {
+  const h = html<ParentMessage>()
+
+  return h.a(
     [
       h.Id(resultItemId(index)),
       h.Href(result.url),
@@ -165,29 +170,40 @@ const resultItemView = (
       ),
     ],
   )
+}
 
-const emptyPrompt: Html = h.div(
-  [h.Class('px-4 py-12 text-center')],
-  [
-    h.p(
-      [h.Class('text-sm text-gray-500 dark:text-gray-400')],
-      ['Type to search the documentation...'],
-    ),
-  ],
-)
+const emptyPrompt: Html = (() => {
+  const h = html<ParentMessage>()
 
-const searchingIndicator: Html = h.div(
-  [h.Class('px-4 py-12 text-center'), h.AriaLive('polite')],
-  [
-    h.p(
-      [h.Class('text-sm text-gray-500 dark:text-gray-400')],
-      ['Searching...'],
-    ),
-  ],
-)
+  return h.div(
+    [h.Class('px-4 py-12 text-center')],
+    [
+      h.p(
+        [h.Class('text-sm text-gray-500 dark:text-gray-400')],
+        ['Type to search the documentation...'],
+      ),
+    ],
+  )
+})()
 
-const noResultsView = (query: string): Html =>
-  h.div(
+const searchingIndicator: Html = (() => {
+  const h = html<ParentMessage>()
+
+  return h.div(
+    [h.Class('px-4 py-12 text-center'), h.AriaLive('polite')],
+    [
+      h.p(
+        [h.Class('text-sm text-gray-500 dark:text-gray-400')],
+        ['Searching...'],
+      ),
+    ],
+  )
+})()
+
+const noResultsView = (query: string): Html => {
+  const h = html<ParentMessage>()
+
+  return h.div(
     [h.Class('px-4 py-12 text-center'), h.AriaLive('polite')],
     [
       h.p(
@@ -196,13 +212,16 @@ const noResultsView = (query: string): Html =>
       ),
     ],
   )
+}
 
 const resultListView = (
   results: ReadonlyArray<typeof SearchResult.Type>,
   activeResultIndex: number,
   toParentMessage: ToMessage,
-): Html =>
-  Array.match(results, {
+): Html => {
+  const h = html<ParentMessage>()
+
+  return Array.match(results, {
     onEmpty: () => h.empty,
     onNonEmpty: nonEmptyResults =>
       h.div(
@@ -222,6 +241,7 @@ const resultListView = (
         ),
       ),
   })
+}
 
 const resultsListView = (model: Model, toParentMessage: ToMessage): Html =>
   M.value(model.searchState).pipe(
@@ -245,6 +265,8 @@ const resultsListView = (model: Model, toParentMessage: ToMessage): Html =>
   )
 
 const resultCountAnnouncement = (model: Model): Html => {
+  const h = html<ParentMessage>()
+
   const results = resultsFromState(model.searchState)
   const count = results.length
 
@@ -254,8 +276,10 @@ const resultCountAnnouncement = (model: Model): Html => {
   )
 }
 
-export const view = (model: Model, toParentMessage: ToMessage): Html =>
-  Ui.Dialog.view({
+export const view = (model: Model, toParentMessage: ToMessage): Html => {
+  const h = html<ParentMessage>()
+
+  return Ui.Dialog.view({
     model: model.dialog,
     toParentMessage: message =>
       toParentMessage(GotSearchDialogMessage({ message })),
@@ -284,3 +308,4 @@ export const view = (model: Model, toParentMessage: ToMessage): Html =>
       h.Class('fixed inset-0 z-[59] bg-black/50 dark:bg-black/70'),
     ],
   })
+}

--- a/packages/website/src/snippet/comparisonDslButton.ts
+++ b/packages/website/src/snippet/comparisonDslButton.ts
@@ -7,10 +7,11 @@ const ClickedSave = m('ClickedSave')
 const Message = S.Union([ClickedSave])
 type Message = typeof Message.Type
 
-const h = html<Message>()
+const saveButton = (isSaving: boolean) => {
+  const h = html<Message>()
 
-const saveButton = (isSaving: boolean) =>
-  h.button(
+  return h.button(
     [h.Type('button'), h.Disabled(isSaving), h.OnClick(ClickedSave())],
     ['Save'],
   )
+}

--- a/packages/website/src/snippet/comparisonDslConditional.ts
+++ b/packages/website/src/snippet/comparisonDslConditional.ts
@@ -9,10 +9,10 @@ const Loaded = S.TaggedStruct('Loaded', { greeting: S.String })
 const Status = S.Union([Idle, Loading, Failed, Loaded])
 type Status = typeof Status.Type
 
-const h = html()
+const greetingView = (status: Status) => {
+  const h = html()
 
-const greetingView = (status: Status) =>
-  h.div(
+  return h.div(
     [],
     [
       M.value(status).pipe(
@@ -25,3 +25,4 @@ const greetingView = (status: Status) =>
       ),
     ],
   )
+}

--- a/packages/website/src/snippet/comparisonDslInput.ts
+++ b/packages/website/src/snippet/comparisonDslInput.ts
@@ -7,12 +7,13 @@ const InputtedEmail = m('InputtedEmail', { value: S.String })
 const Message = S.Union([InputtedEmail])
 type Message = typeof Message.Type
 
-const h = html<Message>()
+const emailInput = (email: string) => {
+  const h = html<Message>()
 
-const emailInput = (email: string) =>
-  h.input([
+  return h.input([
     h.Type('email'),
     h.Value(email),
     h.Placeholder('you@example.com'),
     h.OnInput(value => InputtedEmail({ value })),
   ])
+}

--- a/packages/website/src/snippet/counter.ts
+++ b/packages/website/src/snippet/counter.ts
@@ -49,41 +49,43 @@ export const init: Runtime.ProgramInit<Model, Message> = () => [
 
 // VIEW
 
-const h = html<Message>()
+export const view = (model: Model): Document => {
+  const h = html<Message>()
 
-export const view = (model: Model): Document => ({
-  title: `Counter: ${model.count}`,
-  body: h.div(
-    [
-      h.Class(
-        'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
-      ),
-    ],
-    [
-      h.div(
-        [h.Class('text-6xl font-bold text-gray-800')],
-        [model.count.toString()],
-      ),
-      h.div(
-        [h.Class('flex flex-wrap justify-center gap-4')],
-        [
-          h.button(
-            [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
-            ['-'],
-          ),
-          h.button(
-            [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
-            ['Reset'],
-          ),
-          h.button(
-            [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
-            ['+'],
-          ),
-        ],
-      ),
-    ],
-  ),
-})
+  return {
+    title: `Counter: ${model.count}`,
+    body: h.div(
+      [
+        h.Class(
+          'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
+        ),
+      ],
+      [
+        h.div(
+          [h.Class('text-6xl font-bold text-gray-800')],
+          [model.count.toString()],
+        ),
+        h.div(
+          [h.Class('flex flex-wrap justify-center gap-4')],
+          [
+            h.button(
+              [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
+              ['-'],
+            ),
+            h.button(
+              [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
+              ['Reset'],
+            ),
+            h.button(
+              [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
+              ['+'],
+            ),
+          ],
+        ),
+      ],
+    ),
+  }
+}
 
 // STYLE
 

--- a/packages/website/src/snippet/counterView.ts
+++ b/packages/website/src/snippet/counterView.ts
@@ -1,41 +1,43 @@
 import { type Document, html } from 'foldkit/html'
 
-const h = html<Message>()
-
 // VIEW
 
-const view = (model: Model): Document => ({
-  title: `Counter: ${model.count}`,
-  body: h.div(
-    [h.Class(containerStyle)],
-    [
-      h.div(
-        [h.Class('text-6xl font-bold text-gray-800')],
-        [model.count.toString()],
-      ),
-      h.div(
-        [h.Class('flex flex-wrap justify-center gap-4')],
-        [
-          // OnClick takes a Message, not a callback. The Message doesn't
-          // execute anything. It just declares what should happen on click.
-          // Foldkit dispatches it to your update function.
-          h.button(
-            [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
-            ['-'],
-          ),
-          h.button(
-            [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
-            ['Reset'],
-          ),
-          h.button(
-            [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
-            ['+'],
-          ),
-        ],
-      ),
-    ],
-  ),
-})
+const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: `Counter: ${model.count}`,
+    body: h.div(
+      [h.Class(containerStyle)],
+      [
+        h.div(
+          [h.Class('text-6xl font-bold text-gray-800')],
+          [model.count.toString()],
+        ),
+        h.div(
+          [h.Class('flex flex-wrap justify-center gap-4')],
+          [
+            // OnClick takes a Message, not a callback. The Message doesn't
+            // execute anything. It just declares what should happen on click.
+            // Foldkit dispatches it to your update function.
+            h.button(
+              [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
+              ['-'],
+            ),
+            h.button(
+              [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
+              ['Reset'],
+            ),
+            h.button(
+              [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
+              ['+'],
+            ),
+          ],
+        ),
+      ],
+    ),
+  }
+}
 
 // STYLE
 

--- a/packages/website/src/snippet/createKeyedLazy.ts
+++ b/packages/website/src/snippet/createKeyedLazy.ts
@@ -1,11 +1,11 @@
 import { Array, Option } from 'effect'
 import { createKeyedLazy, html } from 'foldkit/html'
 
-const h = html<Message>()
-
 // Define the per-item view at module level
-const contactView = (name: string, email: string, isSelected: boolean) =>
-  h.li(
+const contactView = (name: string, email: string, isSelected: boolean) => {
+  const h = html<Message>()
+
+  return h.li(
     [],
     [
       h.span([], [name]),
@@ -13,6 +13,7 @@ const contactView = (name: string, email: string, isSelected: boolean) =>
       ...(isSelected ? [h.span([], ['✓'])] : []),
     ],
   )
+}
 
 // Create the keyed lazy map at module level.
 // Each key gets its own independent cache slot.
@@ -24,8 +25,10 @@ const lazyContact = createKeyedLazy()
 const contactListView = (
   contacts: ReadonlyArray<Contact>,
   maybeSelectedId: Option.Option<string>,
-) =>
-  h.ul(
+) => {
+  const h = html<Message>()
+
+  return h.ul(
     [],
     Array.map(contacts, contact => {
       const isSelected = Option.exists(
@@ -40,3 +43,4 @@ const contactListView = (
       ])
     }),
   )
+}

--- a/packages/website/src/snippet/createLazy.ts
+++ b/packages/website/src/snippet/createLazy.ts
@@ -1,7 +1,5 @@
 import { createLazy, html } from 'foldkit/html'
 
-const h = html<Message>()
-
 // Define the view function at module level for a stable reference.
 // If defined inside the view, a new function is created each render,
 // defeating the cache.
@@ -9,8 +7,10 @@ const statsView = (
   revenue: number,
   orderCount: number,
   topProducts: ReadonlyArray<string>,
-) =>
-  h.div(
+) => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       h.h2([], ['Dashboard']),
@@ -22,6 +22,7 @@ const statsView = (
       ),
     ],
   )
+}
 
 // Create the lazy slot at module level. One slot per view.
 const lazyStats = createLazy()
@@ -30,18 +31,22 @@ const lazyStats = createLazy()
 // If revenue, orderCount, and topProducts are the same references
 // as last render, the cached VNode is returned instantly.
 // both VNode construction and subtree diffing are skipped.
-const view = (model: Model) => ({
-  title: 'Dashboard',
-  body: h.div(
-    [],
-    [
-      headerView(model),
-      lazyStats(statsView, [
-        model.revenue,
-        model.orderCount,
-        model.topProducts,
-      ]),
-      sidebarView(model),
-    ],
-  ),
-})
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return {
+    title: 'Dashboard',
+    body: h.div(
+      [],
+      [
+        headerView(model),
+        lazyStats(statsView, [
+          model.revenue,
+          model.orderCount,
+          model.topProducts,
+        ]),
+        sidebarView(model),
+      ],
+    ),
+  }
+}

--- a/packages/website/src/snippet/customElementDefine.ts
+++ b/packages/website/src/snippet/customElementDefine.ts
@@ -44,7 +44,6 @@ const ChangedFillColor = m('ChangedFillColor', { value: S.String })
 const Message = S.Union([ChangedFillColor])
 type Message = typeof Message.Type
 
-const h = html<Message>()
 const fillPicker = hexColorPicker.withMessage<Message>()
 const qr = qrCode.withMessage<Message>()
 
@@ -56,8 +55,10 @@ const qr = qrCode.withMessage<Message>()
 export const designerView = (model: {
   content: string
   fillColor: string
-}): Html =>
-  h.div(
+}): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('flex gap-6')],
     [
       fillPicker([
@@ -74,3 +75,4 @@ export const designerView = (model: {
       ]),
     ],
   )
+}

--- a/packages/website/src/snippet/eventHandling.ts
+++ b/packages/website/src/snippet/eventHandling.ts
@@ -1,17 +1,23 @@
-const h = html<Message>()
-
 // Event handlers take Messages, not callbacks.
 // When the button is clicked, Foldkit dispatches the Message
 // to your update function.
-h.button(
-  [h.OnClick(ClickedIncrement()), h.Class('button-primary')],
-  ['Click me'],
-)
+const buttonExample = () => {
+  const h = html<Message>()
+
+  return h.button(
+    [h.OnClick(ClickedIncrement()), h.Class('button-primary')],
+    ['Click me'],
+  )
+}
 
 // For input events, Foldkit extracts the value and passes it
 // to your function:
-h.input([
-  h.OnInput(value => ChangedSearch({ text: value })),
-  h.Value(model.searchText),
-  h.Class('input'),
-])
+const inputExample = (model: Model) => {
+  const h = html<Message>()
+
+  return h.input([
+    h.OnInput(value => ChangedSearch({ text: value })),
+    h.Value(model.searchText),
+    h.Class('input'),
+  ])
+}

--- a/packages/website/src/snippet/fileFormEvents.ts
+++ b/packages/website/src/snippet/fileFormEvents.ts
@@ -1,18 +1,21 @@
 import { File } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const resumePicker = (model: Model) => {
+  const h = html<Message>()
 
-const resumePicker = (model: Model) =>
-  h.input([
+  return h.input([
     h.Key('resume-input'),
     h.Type('file'),
     h.Accept('application/pdf'),
     h.OnFileChange(files => SelectedResume({ files })),
   ])
+}
 
-const attachmentsDropZone = (model: Model) =>
-  h.div(
+const attachmentsDropZone = (model: Model) => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Key('attachments-drop-zone'),
       h.Class(
@@ -27,3 +30,4 @@ const attachmentsDropZone = (model: Model) =>
     ],
     ['Drop files here, or use the Browse button below.'],
   )
+}

--- a/packages/website/src/snippet/foldkitCounter.ts
+++ b/packages/website/src/snippet/foldkitCounter.ts
@@ -30,15 +30,17 @@ const update = (model: Model, message: Message): UpdateReturn =>
 
 // VIEW - A pure function from Model to a Document
 
-const h = html<Message>()
+const view = (model: Model): Document => {
+  const h = html<Message>()
 
-const view = (model: Model): Document => ({
-  title: `Count: ${model}`,
-  body: h.div(
-    [],
-    [
-      h.p([], [`Count: ${model}`]),
-      h.button([h.OnClick(ClickedIncrement())], ['Increment']),
-    ],
-  ),
-})
+  return {
+    title: `Count: ${model}`,
+    body: h.div(
+      [],
+      [
+        h.p([], [`Count: ${model}`]),
+        h.button([h.OnClick(ClickedIncrement())], ['Increment']),
+      ],
+    ),
+  }
+}

--- a/packages/website/src/snippet/foldkitCounterAutoPlay.ts
+++ b/packages/website/src/snippet/foldkitCounterAutoPlay.ts
@@ -78,26 +78,28 @@ const update = (model: Model, message: Message): UpdateReturn =>
 
 // VIEW
 
-const h = html<Message>()
+const view = (model: Model): Document => {
+  const h = html<Message>()
 
-const view = (model: Model): Document => ({
-  title: `Count: ${model.count}`,
-  body: h.div(
-    [],
-    [
-      h.p([], [`Count: ${model.count}`]),
-      h.label(
-        [],
-        [
-          'Step: ',
-          h.input([h.OnInput(value => ChangedStep({ step: Number(value) }))]),
-        ],
-      ),
-      h.button([h.OnClick(ClickedIncrement())], ['Increment']),
-      h.button(
-        [h.OnClick(ClickedToggleAutoCount())],
-        [model.isAutoCounting ? 'Stop' : 'Auto-Count'],
-      ),
-    ],
-  ),
-})
+  return {
+    title: `Count: ${model.count}`,
+    body: h.div(
+      [],
+      [
+        h.p([], [`Count: ${model.count}`]),
+        h.label(
+          [],
+          [
+            'Step: ',
+            h.input([h.OnInput(value => ChangedStep({ step: Number(value) }))]),
+          ],
+        ),
+        h.button([h.OnClick(ClickedIncrement())], ['Increment']),
+        h.button(
+          [h.OnClick(ClickedToggleAutoCount())],
+          [model.isAutoCounting ? 'Stop' : 'Auto-Count'],
+        ),
+      ],
+    ),
+  }
+}

--- a/packages/website/src/snippet/foldkitCounterReset.ts
+++ b/packages/website/src/snippet/foldkitCounterReset.ts
@@ -67,19 +67,21 @@ const update = (model: Model, message: Message): UpdateReturn =>
 
 // VIEW
 
-const h = html<Message>()
+const view = (model: Model): Document => {
+  const h = html<Message>()
 
-const view = (model: Model): Document => ({
-  title: `Count: ${model.count}`,
-  body: h.div(
-    [],
-    [
-      h.p([], [`Count: ${model.count}`]),
-      h.button([h.OnClick(ClickedIncrement())], ['Increment']),
-      h.button(
-        [h.OnClick(ClickedToggleAutoCount())],
-        [model.isAutoCounting ? 'Stop' : 'Auto-Count'],
-      ),
-    ],
-  ),
-})
+  return {
+    title: `Count: ${model.count}`,
+    body: h.div(
+      [],
+      [
+        h.p([], [`Count: ${model.count}`]),
+        h.button([h.OnClick(ClickedIncrement())], ['Increment']),
+        h.button(
+          [h.OnClick(ClickedToggleAutoCount())],
+          [model.isAutoCounting ? 'Stop' : 'Auto-Count'],
+        ),
+      ],
+    ),
+  }
+}

--- a/packages/website/src/snippet/htmlHelpers.ts
+++ b/packages/website/src/snippet/htmlHelpers.ts
@@ -1,15 +1,17 @@
 import { html } from 'foldkit/html'
 
-// Bind the html factory to your Message type once. Reach for `h.` to access
-// elements, attributes, and event handlers. Every callback is typed against
-// your Message union, so `h.OnClick(...)` only accepts your variants.
-const h = html<Message>()
+// Bind the html factory to your Message type once at the top of each view
+// function. Reach for `h.` to access elements, attributes, and event handlers.
+// Every callback is typed against your Message union, so `h.OnClick(...)` only
+// accepts your variants.
+const greeting = (name: string) => {
+  const h = html<Message>()
 
-const greeting = (name: string) =>
-  h.div(
+  return h.div(
     [h.Class('flex flex-col gap-2')],
     [
       h.h1([h.Class('text-2xl font-bold')], [`Hello, ${name}`]),
       h.button([h.OnClick(ClickedRefresh())], ['Refresh']),
     ],
   )
+}

--- a/packages/website/src/snippet/keyingBranchingViews.ts
+++ b/packages/website/src/snippet/keyingBranchingViews.ts
@@ -1,9 +1,9 @@
 import { Match as M } from 'effect'
 import { Document, html } from 'foldkit/html'
 
-const h = html<Message>()
-
 const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const routeContent = M.value(model.route).pipe(
     M.tagsExhaustive({
       Products: () => productsView(model),

--- a/packages/website/src/snippet/keyingConditionalInserts.ts
+++ b/packages/website/src/snippet/keyingConditionalInserts.ts
@@ -1,9 +1,9 @@
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const cartView = (model: Model): Html => {
+  const h = html<Message>()
 
-const cartView = (model: Model): Html =>
-  h.div(
+  return h.div(
     [],
     [
       h.keyed('div')('summary', [], [summaryView(model)]),
@@ -13,3 +13,4 @@ const cartView = (model: Model): Html =>
       h.keyed('div')('checkout', [], [checkoutView(model)]),
     ],
   )
+}

--- a/packages/website/src/snippet/keyingListItems.ts
+++ b/packages/website/src/snippet/keyingListItems.ts
@@ -1,9 +1,9 @@
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const entryListView = (entries: ReadonlyArray<Entry>): Html => {
+  const h = html<Message>()
 
-const entryListView = (entries: ReadonlyArray<Entry>): Html =>
-  h.ul(
+  return h.ul(
     [],
     entries.map(entry =>
       h.keyed('li')(
@@ -18,3 +18,4 @@ const entryListView = (entries: ReadonlyArray<Entry>): Html =>
       ),
     ),
   )
+}

--- a/packages/website/src/snippet/mountPortalToBody.ts
+++ b/packages/website/src/snippet/mountPortalToBody.ts
@@ -3,8 +3,6 @@ import { Mount } from 'foldkit'
 import { type Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 
-const h = html<Message>()
-
 const CompletedPortalToBody = m('CompletedPortalToBody')
 
 // Portal-to-body is a per-instance lifecycle effect that uses the element
@@ -26,5 +24,11 @@ const PortalToBody = Mount.define(
   }),
 )
 
-const overlayView = (): Html =>
-  h.div([h.Class('fixed inset-0 bg-black/50'), h.OnMount(PortalToBody())])
+const overlayView = (): Html => {
+  const h = html<Message>()
+
+  return h.div([
+    h.Class('fixed inset-0 bg-black/50'),
+    h.OnMount(PortalToBody()),
+  ])
+}

--- a/packages/website/src/snippet/mountThirdPartyChart.ts
+++ b/packages/website/src/snippet/mountThirdPartyChart.ts
@@ -3,8 +3,6 @@ import { Mount } from 'foldkit'
 import { type Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 
-const h = html<Message>()
-
 const SucceededMountChart = m('SucceededMountChart')
 const FailedMountChart = m('FailedMountChart', { reason: S.String })
 
@@ -44,5 +42,11 @@ const MountChart = Mount.define(
       ),
 )
 
-const chartView = (data: ChartData): Html =>
-  h.div([h.Class('w-[480px] h-[320px]'), h.OnMount(MountChart({ data }))], [])
+const chartView = (data: ChartData): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class('w-[480px] h-[320px]'), h.OnMount(MountChart({ data }))],
+    [],
+  )
+}

--- a/packages/website/src/snippet/routingKeyed.ts
+++ b/packages/website/src/snippet/routingKeyed.ts
@@ -1,9 +1,9 @@
 import { Match as M } from 'effect'
 import { Document, html } from 'foldkit/html'
 
-const h = html<Message>()
-
 const view = (model: Model): Document => {
+  const h = html<Message>()
+
   const routeContent = M.value(model.route).pipe(
     M.tagsExhaustive({
       Products: () => productsView(model),

--- a/packages/website/src/snippet/submodelParentView.ts
+++ b/packages/website/src/snippet/submodelParentView.ts
@@ -5,21 +5,23 @@ import { GotSettingsMessage, type Message } from './message'
 import type { Model } from './model'
 import * as Settings from './page/settings'
 
-const h = html<Message>()
-
 // The parent calls the child's view with its own Message type as the
 // type argument, plus a toParentMessage callback that wraps every
 // child Message in the parent's GotSettingsMessage envelope. The child
 // stays decoupled from this parent; the same Settings.view could be
 // embedded under any parent that supplies the same wrapping.
-export const view = (model: Model): Document => ({
-  title: 'My App',
-  body: h.div(
-    [h.Class('min-h-screen bg-gray-50')],
-    [
-      Settings.view<Message>(model.settings, message =>
-        GotSettingsMessage({ message }),
-      ),
-    ],
-  ),
-})
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: 'My App',
+    body: h.div(
+      [h.Class('min-h-screen bg-gray-50')],
+      [
+        Settings.view<Message>(model.settings, message =>
+          GotSettingsMessage({ message }),
+        ),
+      ],
+    ),
+  }
+}

--- a/packages/website/src/snippet/uiAnimationBasic.ts
+++ b/packages/website/src/snippet/uiAnimationBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Animation Submodel. Animation tracks
 // its own visibility and lifecycle state. No need for a separate flag:
 const Model = S.Struct({
@@ -85,26 +83,34 @@ GotAnimationMessage: ({ message }) => {
 
 // Inside your view function, toggle visibility by dispatching Ui.Animation.Showed()
 // or Hid() wrapped in your parent Message. model.animation.isShowing is your
-// source of truth for whether content is currently visible:
-h.button(
-  [
-    h.OnClick(
-      GotAnimationMessage({
-        message: model.animation.isShowing
-          ? Ui.Animation.Hid()
-          : Ui.Animation.Showed(),
-      }),
-    ),
-  ],
-  [model.animation.isShowing ? 'Hide' : 'Show'],
-)
+// source of truth for whether content is currently visible. The Animation
+// view wraps your content. Data attributes drive the CSS transitions or
+// keyframe animations defined in className:
+const view = () => {
+  const h = html<Message>()
 
-// The Animation view wraps your content. Data attributes drive the CSS
-// transitions or keyframe animations defined in className:
-Ui.Animation.view({
-  model: model.animation,
-  animateSize: true,
-  className:
-    'transition duration-200 ease-out data-[closed]:opacity-0 data-[closed]:scale-95',
-  content: h.p([], ['This content animates in and out.']),
-})
+  return h.div(
+    [],
+    [
+      h.button(
+        [
+          h.OnClick(
+            GotAnimationMessage({
+              message: model.animation.isShowing
+                ? Ui.Animation.Hid()
+                : Ui.Animation.Showed(),
+            }),
+          ),
+        ],
+        [model.animation.isShowing ? 'Hide' : 'Show'],
+      ),
+      Ui.Animation.view({
+        model: model.animation,
+        animateSize: true,
+        className:
+          'transition duration-200 ease-out data-[closed]:opacity-0 data-[closed]:scale-95',
+        content: h.p([], ['This content animates in and out.']),
+      }),
+    ],
+  )
+}

--- a/packages/website/src/snippet/uiButtonBasic.ts
+++ b/packages/website/src/snippet/uiButtonBasic.ts
@@ -3,16 +3,18 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = () => {
+  const h = html<Message>()
 
-Ui.Button.view({
-  onClick: ClickedSave(), // your Message
-  toView: attributes =>
-    h.button(
-      [
-        ...attributes.button,
-        h.Class('px-4 py-2 rounded-lg bg-blue-600 text-white'),
-      ],
-      ['Save'],
-    ),
-})
+  return Ui.Button.view({
+    onClick: ClickedSave(), // your Message
+    toView: attributes =>
+      h.button(
+        [
+          ...attributes.button,
+          h.Class('px-4 py-2 rounded-lg bg-blue-600 text-white'),
+        ],
+        ['Save'],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiButtonDisabled.ts
+++ b/packages/website/src/snippet/uiButtonDisabled.ts
@@ -3,16 +3,18 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = () => {
+  const h = html<Message>()
 
-Ui.Button.view({
-  isDisabled: true,
-  toView: attributes =>
-    h.button(
-      [
-        ...attributes.button,
-        h.Class('px-4 py-2 rounded-lg bg-gray-300 text-gray-500'),
-      ],
-      ['Disabled'],
-    ),
-})
+  return Ui.Button.view({
+    isDisabled: true,
+    toView: attributes =>
+      h.button(
+        [
+          ...attributes.button,
+          h.Class('px-4 py-2 rounded-lg bg-gray-300 text-gray-500'),
+        ],
+        ['Disabled'],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiCalendarBasic.ts
+++ b/packages/website/src/snippet/uiCalendarBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Calendar Submodel:
 const Model = S.Struct({
   calendarDemo: Ui.Calendar.Model,
@@ -98,194 +96,204 @@ SelectedCalendarDate: ({ date }) => {
 // callback receives a discriminated `CalendarAttributes` whose variant
 // matches the calendar's current `viewMode` — pattern-match on `_tag` to
 // render the day grid, the months grid, or the years grid:
-Ui.Calendar.view({
-  model: model.calendarDemo,
-  toParentMessage: message => GotCalendarMessage({ message }),
-  onSelectedDate: date => SelectedCalendarDate({ date }),
-  toView: attributes =>
-    M.value(attributes).pipe(
-      M.tagsExhaustive({
-        Days: days =>
-          h.div(
-            [
-              ...days.root,
-              h.Class('flex flex-col gap-3 rounded-xl border p-4'),
-            ],
-            [
-              h.div(
-                [h.Class('flex items-center justify-between')],
-                [
-                  h.button(
-                    [...days.previousMonthButton, h.Class('rounded px-2')],
-                    ['‹'],
-                  ),
-                  // The heading is a button: clicking it switches to the
-                  // months grid for fast navigation. Pair the text with a
-                  // chevron so the button reads as interactive at rest.
-                  h.button(
-                    [
-                      h.Id(days.heading.id),
-                      ...days.headingButton,
-                      h.Class(
-                        'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                      ),
-                    ],
-                    [days.heading.text, ' ▾'],
-                  ),
-                  h.button(
-                    [...days.nextMonthButton, h.Class('rounded px-2')],
-                    ['›'],
-                  ),
-                ],
-              ),
-              h.div(
-                [...days.grid, h.Class('flex flex-col gap-1 outline-none')],
-                [
-                  h.div(
-                    [...days.headerRow, h.Class('grid grid-cols-7 gap-1')],
-                    days.columnHeaders.map(header =>
-                      h.div(
-                        [
-                          ...header.attributes,
-                          h.Class('text-center text-xs uppercase'),
-                        ],
-                        [header.name],
-                      ),
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Calendar.view({
+    model: model.calendarDemo,
+    toParentMessage: message => GotCalendarMessage({ message }),
+    onSelectedDate: date => SelectedCalendarDate({ date }),
+    toView: attributes =>
+      M.value(attributes).pipe(
+        M.tagsExhaustive({
+          Days: days =>
+            h.div(
+              [
+                ...days.root,
+                h.Class('flex flex-col gap-3 rounded-xl border p-4'),
+              ],
+              [
+                h.div(
+                  [h.Class('flex items-center justify-between')],
+                  [
+                    h.button(
+                      [...days.previousMonthButton, h.Class('rounded px-2')],
+                      ['‹'],
                     ),
-                  ),
-                  ...days.weeks.map(week =>
+                    // The heading is a button: clicking it switches to the
+                    // months grid for fast navigation. Pair the text with a
+                    // chevron so the button reads as interactive at rest.
+                    h.button(
+                      [
+                        h.Id(days.heading.id),
+                        ...days.headingButton,
+                        h.Class(
+                          'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
+                        ),
+                      ],
+                      [days.heading.text, ' ▾'],
+                    ),
+                    h.button(
+                      [...days.nextMonthButton, h.Class('rounded px-2')],
+                      ['›'],
+                    ),
+                  ],
+                ),
+                h.div(
+                  [...days.grid, h.Class('flex flex-col gap-1 outline-none')],
+                  [
                     h.div(
-                      [...week.attributes, h.Class('grid grid-cols-7 gap-1')],
-                      week.cells.map(cell =>
+                      [...days.headerRow, h.Class('grid grid-cols-7 gap-1')],
+                      days.columnHeaders.map(header =>
                         h.div(
-                          // `group` lets day buttons react to parent state
-                          // via group-data-[today], group-data-[selected],
-                          // etc.
                           [
-                            ...cell.cellAttributes,
-                            h.Class('group flex items-center justify-center'),
+                            ...header.attributes,
+                            h.Class('text-center text-xs uppercase'),
                           ],
-                          [
-                            h.button(
-                              [
-                                ...cell.buttonAttributes,
-                                h.Class(
-                                  'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40',
-                                ),
-                              ],
-                              [cell.label],
-                            ),
-                          ],
+                          [header.name],
                         ),
                       ),
                     ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        // The months grid renders 12 cells (one per month). Clicking the
-        // heading again drills further into the years grid.
-        Months: months =>
-          h.div(
-            [
-              ...months.root,
-              h.Class('flex flex-col gap-3 rounded-xl border p-4'),
-            ],
-            [
-              h.div(
-                [h.Class('flex items-center justify-center')],
-                [
-                  h.button(
-                    [
-                      h.Id(months.heading.id),
-                      ...months.headingButton,
-                      h.Class(
-                        'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                      ),
-                    ],
-                    [months.heading.text, ' ▾'],
-                  ),
-                ],
-              ),
-              h.div(
-                [
-                  ...months.grid,
-                  h.Class('grid grid-cols-3 gap-1 outline-none'),
-                ],
-                months.cells.map(cell =>
-                  h.div(
-                    [
-                      ...cell.cellAttributes,
-                      h.Class('group flex items-center justify-center'),
-                    ],
-                    [
-                      h.button(
-                        [
-                          ...cell.buttonAttributes,
-                          h.Class(
-                            'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                    ...days.weeks.map(week =>
+                      h.div(
+                        [...week.attributes, h.Class('grid grid-cols-7 gap-1')],
+                        week.cells.map(cell =>
+                          h.div(
+                            // `group` lets day buttons react to parent state
+                            // via group-data-[today], group-data-[selected],
+                            // etc.
+                            [
+                              ...cell.cellAttributes,
+                              h.Class('group flex items-center justify-center'),
+                            ],
+                            [
+                              h.button(
+                                [
+                                  ...cell.buttonAttributes,
+                                  h.Class(
+                                    'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40',
+                                  ),
+                                ],
+                                [cell.label],
+                              ),
+                            ],
                           ),
-                        ],
-                        [cell.shortLabel],
+                        ),
                       ),
-                    ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          // The months grid renders 12 cells (one per month). Clicking the
+          // heading again drills further into the years grid.
+          Months: months =>
+            h.div(
+              [
+                ...months.root,
+                h.Class('flex flex-col gap-3 rounded-xl border p-4'),
+              ],
+              [
+                h.div(
+                  [h.Class('flex items-center justify-center')],
+                  [
+                    h.button(
+                      [
+                        h.Id(months.heading.id),
+                        ...months.headingButton,
+                        h.Class(
+                          'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
+                        ),
+                      ],
+                      [months.heading.text, ' ▾'],
+                    ),
+                  ],
+                ),
+                h.div(
+                  [
+                    ...months.grid,
+                    h.Class('grid grid-cols-3 gap-1 outline-none'),
+                  ],
+                  months.cells.map(cell =>
+                    h.div(
+                      [
+                        ...cell.cellAttributes,
+                        h.Class('group flex items-center justify-center'),
+                      ],
+                      [
+                        h.button(
+                          [
+                            ...cell.buttonAttributes,
+                            h.Class(
+                              'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                            ),
+                          ],
+                          [cell.shortLabel],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
-        // The years grid renders 12 cells (one paged window). Prev/next
-        // page through 12-year windows; clicking a year drills back to
-        // the months grid for that year.
-        Years: years =>
-          h.div(
-            [
-              ...years.root,
-              h.Class('flex flex-col gap-3 rounded-xl border p-4'),
-            ],
-            [
-              h.div(
-                [h.Class('flex items-center justify-between')],
-                [
-                  h.button(
-                    [...years.previousPageButton, h.Class('rounded px-2')],
-                    ['‹'],
-                  ),
-                  h.h2(
-                    [h.Id(years.heading.id), h.Class('text-sm font-semibold')],
-                    [years.heading.text],
-                  ),
-                  h.button(
-                    [...years.nextPageButton, h.Class('rounded px-2')],
-                    ['›'],
-                  ),
-                ],
-              ),
-              h.div(
-                [...years.grid, h.Class('grid grid-cols-3 gap-1 outline-none')],
-                years.cells.map(cell =>
-                  h.div(
-                    [
-                      ...cell.cellAttributes,
-                      h.Class('group flex items-center justify-center'),
-                    ],
-                    [
-                      h.button(
-                        [
-                          ...cell.buttonAttributes,
-                          h.Class(
-                            'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
-                          ),
-                        ],
-                        [cell.label],
-                      ),
-                    ],
+              ],
+            ),
+          // The years grid renders 12 cells (one paged window). Prev/next
+          // page through 12-year windows; clicking a year drills back to
+          // the months grid for that year.
+          Years: years =>
+            h.div(
+              [
+                ...years.root,
+                h.Class('flex flex-col gap-3 rounded-xl border p-4'),
+              ],
+              [
+                h.div(
+                  [h.Class('flex items-center justify-between')],
+                  [
+                    h.button(
+                      [...years.previousPageButton, h.Class('rounded px-2')],
+                      ['‹'],
+                    ),
+                    h.h2(
+                      [
+                        h.Id(years.heading.id),
+                        h.Class('text-sm font-semibold'),
+                      ],
+                      [years.heading.text],
+                    ),
+                    h.button(
+                      [...years.nextPageButton, h.Class('rounded px-2')],
+                      ['›'],
+                    ),
+                  ],
+                ),
+                h.div(
+                  [
+                    ...years.grid,
+                    h.Class('grid grid-cols-3 gap-1 outline-none'),
+                  ],
+                  years.cells.map(cell =>
+                    h.div(
+                      [
+                        ...cell.cellAttributes,
+                        h.Class('group flex items-center justify-center'),
+                      ],
+                      [
+                        h.button(
+                          [
+                            ...cell.buttonAttributes,
+                            h.Class(
+                              'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                            ),
+                          ],
+                          [cell.label],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
-      }),
-    ),
-})
+              ],
+            ),
+        }),
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiCheckboxBasic.ts
+++ b/packages/website/src/snippet/uiCheckboxBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Checkbox Submodel:
 const Model = S.Struct({
   checkboxDemo: Ui.Checkbox.Model,
@@ -47,30 +45,34 @@ GotCheckboxMessage: ({ message }) => {
 }
 
 // Inside your view function, render the checkbox:
-Ui.Checkbox.view({
-  model: model.checkboxDemo,
-  toParentMessage: message => GotCheckboxMessage({ message }),
-  toView: attributes =>
-    h.div(
-      [h.Class('flex flex-col gap-1')],
-      [
-        h.div(
-          [h.Class('flex items-center gap-2')],
-          [
-            h.button(
-              [...attributes.checkbox, h.Class('h-5 w-5 rounded border')],
-              model.checkboxDemo.isChecked ? ['✓'] : [],
-            ),
-            h.label(
-              [...attributes.label, h.Class('text-sm')],
-              ['Accept terms and conditions'],
-            ),
-          ],
-        ),
-        h.p(
-          [...attributes.description, h.Class('text-sm text-gray-500')],
-          ['You agree to our Terms of Service.'],
-        ),
-      ],
-    ),
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Checkbox.view({
+    model: model.checkboxDemo,
+    toParentMessage: message => GotCheckboxMessage({ message }),
+    toView: attributes =>
+      h.div(
+        [h.Class('flex flex-col gap-1')],
+        [
+          h.div(
+            [h.Class('flex items-center gap-2')],
+            [
+              h.button(
+                [...attributes.checkbox, h.Class('h-5 w-5 rounded border')],
+                model.checkboxDemo.isChecked ? ['✓'] : [],
+              ),
+              h.label(
+                [...attributes.label, h.Class('text-sm')],
+                ['Accept terms and conditions'],
+              ),
+            ],
+          ),
+          h.p(
+            [...attributes.description, h.Class('text-sm text-gray-500')],
+            ['You agree to our Terms of Service.'],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiCheckboxIndeterminate.ts
+++ b/packages/website/src/snippet/uiCheckboxIndeterminate.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add multiple Checkbox Submodels to your Model for the parent and children:
 const Model = S.Struct({
   optionA: Ui.Checkbox.Model,
@@ -62,22 +60,26 @@ const isIndeterminate =
   !isAllChecked && Array.some(checkboxes, ({ isChecked }) => isChecked)
 
 // Inside your view function, pass isIndeterminate to the parent checkbox:
-Ui.Checkbox.view({
-  model: { id: 'select-all', isChecked: isAllChecked },
-  isIndeterminate,
-  toParentMessage: message => GotSelectAllMessage({ message }),
-  toView: attributes =>
-    h.div(
-      [h.Class('flex items-center gap-2')],
-      [
-        h.button(
-          [...attributes.checkbox, h.Class('h-5 w-5 rounded border')],
-          isIndeterminate ? ['—'] : isAllChecked ? ['✓'] : [],
-        ),
-        h.label(
-          [...attributes.label, h.Class('text-sm')],
-          ['All notifications'],
-        ),
-      ],
-    ),
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Checkbox.view({
+    model: { id: 'select-all', isChecked: isAllChecked },
+    isIndeterminate,
+    toParentMessage: message => GotSelectAllMessage({ message }),
+    toView: attributes =>
+      h.div(
+        [h.Class('flex items-center gap-2')],
+        [
+          h.button(
+            [...attributes.checkbox, h.Class('h-5 w-5 rounded border')],
+            isIndeterminate ? ['—'] : isAllChecked ? ['✓'] : [],
+          ),
+          h.label(
+            [...attributes.label, h.Class('text-sm')],
+            ['All notifications'],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiComboboxBasic.ts
+++ b/packages/website/src/snippet/uiComboboxBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Combobox Submodel, plus a field for
 // the selected value your app actually cares about:
 const Model = S.Struct({
@@ -91,28 +89,32 @@ const filteredCities =
 
 // Inside your view function, pass onSelectedItem to fire your SelectedCity
 // Message on selection:
-Ui.Combobox.view({
-  model: model.combobox,
-  toParentMessage: message => GotComboboxMessage({ message }),
-  onSelectedItem: value => SelectedCity({ value }),
-  items: filteredCities,
-  itemToValue: city => city,
-  itemToDisplayText: city => city,
-  itemToConfig: (city, { isSelected }) => ({
-    className: 'px-3 py-2 cursor-pointer data-[active]:bg-blue-100',
-    content: h.div(
-      [h.Class('flex items-center gap-2')],
-      [
-        isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
-        h.span([], [city]),
-      ],
-    ),
-  }),
-  inputAttributes: [
-    h.Class('w-full rounded-lg border px-3 py-2'),
-    h.Placeholder('Search cities...'),
-  ],
-  itemsAttributes: [h.Class('rounded-lg border shadow-lg')],
-  backdropAttributes: [h.Class('fixed inset-0')],
-  anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Combobox.view({
+    model: model.combobox,
+    toParentMessage: message => GotComboboxMessage({ message }),
+    onSelectedItem: value => SelectedCity({ value }),
+    items: filteredCities,
+    itemToValue: city => city,
+    itemToDisplayText: city => city,
+    itemToConfig: (city, { isSelected }) => ({
+      className: 'px-3 py-2 cursor-pointer data-[active]:bg-blue-100',
+      content: h.div(
+        [h.Class('flex items-center gap-2')],
+        [
+          isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
+          h.span([], [city]),
+        ],
+      ),
+    }),
+    inputAttributes: [
+      h.Class('w-full rounded-lg border px-3 py-2'),
+      h.Placeholder('Search cities...'),
+    ],
+    itemsAttributes: [h.Class('rounded-lg border shadow-lg')],
+    backdropAttributes: [h.Class('fixed inset-0')],
+    anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
+  })
+}

--- a/packages/website/src/snippet/uiComboboxMulti.ts
+++ b/packages/website/src/snippet/uiComboboxMulti.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Combobox.Multi Submodel, plus a field
 // for the selected values your app actually cares about:
 const Model = S.Struct({
@@ -97,28 +95,32 @@ const filteredCities =
 
 // Inside your view function, pass onSelectedItem to fire your ToggledCity
 // Message on selection:
-Ui.Combobox.Multi.view({
-  model: model.comboboxMulti,
-  toParentMessage: message => GotComboboxMultiMessage({ message }),
-  onSelectedItem: value => ToggledCity({ value }),
-  items: filteredCities,
-  itemToValue: city => city,
-  itemToDisplayText: city => city,
-  itemToConfig: (city, { isSelected }) => ({
-    className: 'px-3 py-2 cursor-pointer data-[active]:bg-blue-100',
-    content: h.div(
-      [h.Class('flex items-center gap-2')],
-      [
-        isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
-        h.span([], [city]),
-      ],
-    ),
-  }),
-  inputAttributes: [
-    h.Class('w-full rounded-lg border px-3 py-2'),
-    h.Placeholder('Search cities...'),
-  ],
-  itemsAttributes: [h.Class('rounded-lg border shadow-lg')],
-  backdropAttributes: [h.Class('fixed inset-0')],
-  anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Combobox.Multi.view({
+    model: model.comboboxMulti,
+    toParentMessage: message => GotComboboxMultiMessage({ message }),
+    onSelectedItem: value => ToggledCity({ value }),
+    items: filteredCities,
+    itemToValue: city => city,
+    itemToDisplayText: city => city,
+    itemToConfig: (city, { isSelected }) => ({
+      className: 'px-3 py-2 cursor-pointer data-[active]:bg-blue-100',
+      content: h.div(
+        [h.Class('flex items-center gap-2')],
+        [
+          isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
+          h.span([], [city]),
+        ],
+      ),
+    }),
+    inputAttributes: [
+      h.Class('w-full rounded-lg border px-3 py-2'),
+      h.Placeholder('Search cities...'),
+    ],
+    itemsAttributes: [h.Class('rounded-lg border shadow-lg')],
+    backdropAttributes: [h.Class('fixed inset-0')],
+    anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
+  })
+}

--- a/packages/website/src/snippet/uiDatePickerBasic.ts
+++ b/packages/website/src/snippet/uiDatePickerBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the DatePicker Submodel:
 const Model = S.Struct({
   datePickerDemo: Ui.DatePicker.Model,
@@ -98,187 +96,197 @@ SelectedDate: ({ date }) => {
 // `toCalendarView` callback receives the same discriminated
 // `CalendarAttributes` as Calendar.view's `toView`. Pattern-match on
 // `_tag` to render the day grid, the months grid, or the years grid:
-Ui.DatePicker.view({
-  model: model.datePickerDemo,
-  toParentMessage: message => GotDatePickerMessage({ message }),
-  onSelectedDate: date => SelectedDate({ date }),
-  anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-  triggerContent: maybeDate =>
-    Option.match(maybeDate, {
-      onNone: () => h.span([], ['Pick a date']),
-      onSome: date => h.span([], [`${date.year}-${date.month}-${date.day}`]),
-    }),
-  toCalendarView: attributes =>
-    M.value(attributes).pipe(
-      M.tagsExhaustive({
-        Days: days =>
-          h.div(
-            [...days.root, h.Class('flex flex-col gap-3 p-4')],
-            [
-              h.div(
-                [h.Class('flex items-center justify-between')],
-                [
-                  h.button(
-                    [...days.previousMonthButton, h.Class('rounded px-2')],
-                    ['‹'],
-                  ),
-                  h.button(
-                    [
-                      h.Id(days.heading.id),
-                      ...days.headingButton,
-                      h.Class(
-                        'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                      ),
-                    ],
-                    [days.heading.text, ' ▾'],
-                  ),
-                  h.button(
-                    [...days.nextMonthButton, h.Class('rounded px-2')],
-                    ['›'],
-                  ),
-                ],
-              ),
-              h.div(
-                [...days.grid, h.Class('flex flex-col gap-1 outline-none')],
-                [
-                  h.div(
-                    [...days.headerRow, h.Class('grid grid-cols-7 gap-1')],
-                    days.columnHeaders.map(header =>
-                      h.div(
-                        [
-                          ...header.attributes,
-                          h.Class('text-center text-xs uppercase'),
-                        ],
-                        [header.name],
-                      ),
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.DatePicker.view({
+    model: model.datePickerDemo,
+    toParentMessage: message => GotDatePickerMessage({ message }),
+    onSelectedDate: date => SelectedDate({ date }),
+    anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+    triggerContent: maybeDate =>
+      Option.match(maybeDate, {
+        onNone: () => h.span([], ['Pick a date']),
+        onSome: date => h.span([], [`${date.year}-${date.month}-${date.day}`]),
+      }),
+    toCalendarView: attributes =>
+      M.value(attributes).pipe(
+        M.tagsExhaustive({
+          Days: days =>
+            h.div(
+              [...days.root, h.Class('flex flex-col gap-3 p-4')],
+              [
+                h.div(
+                  [h.Class('flex items-center justify-between')],
+                  [
+                    h.button(
+                      [...days.previousMonthButton, h.Class('rounded px-2')],
+                      ['‹'],
                     ),
-                  ),
-                  ...days.weeks.map(week =>
+                    h.button(
+                      [
+                        h.Id(days.heading.id),
+                        ...days.headingButton,
+                        h.Class(
+                          'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
+                        ),
+                      ],
+                      [days.heading.text, ' ▾'],
+                    ),
+                    h.button(
+                      [...days.nextMonthButton, h.Class('rounded px-2')],
+                      ['›'],
+                    ),
+                  ],
+                ),
+                h.div(
+                  [...days.grid, h.Class('flex flex-col gap-1 outline-none')],
+                  [
                     h.div(
-                      [...week.attributes, h.Class('grid grid-cols-7 gap-1')],
-                      week.cells.map(cell =>
+                      [...days.headerRow, h.Class('grid grid-cols-7 gap-1')],
+                      days.columnHeaders.map(header =>
                         h.div(
                           [
-                            ...cell.cellAttributes,
-                            h.Class('group flex items-center justify-center'),
+                            ...header.attributes,
+                            h.Class('text-center text-xs uppercase'),
                           ],
-                          [
-                            h.button(
-                              [
-                                ...cell.buttonAttributes,
-                                h.Class(
-                                  'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40',
-                                ),
-                              ],
-                              [cell.label],
-                            ),
-                          ],
+                          [header.name],
                         ),
                       ),
                     ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        // The months grid renders 12 cells (one per month). Clicking the
-        // heading again drills further into the years grid.
-        Months: months =>
-          h.div(
-            [...months.root, h.Class('flex flex-col gap-3 p-4')],
-            [
-              h.div(
-                [h.Class('flex items-center justify-center')],
-                [
-                  h.button(
-                    [
-                      h.Id(months.heading.id),
-                      ...months.headingButton,
-                      h.Class(
-                        'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                      ),
-                    ],
-                    [months.heading.text, ' ▾'],
-                  ),
-                ],
-              ),
-              h.div(
-                [
-                  ...months.grid,
-                  h.Class('grid grid-cols-3 gap-1 outline-none'),
-                ],
-                months.cells.map(cell =>
-                  h.div(
-                    [
-                      ...cell.cellAttributes,
-                      h.Class('group flex items-center justify-center'),
-                    ],
-                    [
-                      h.button(
-                        [
-                          ...cell.buttonAttributes,
-                          h.Class(
-                            'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                    ...days.weeks.map(week =>
+                      h.div(
+                        [...week.attributes, h.Class('grid grid-cols-7 gap-1')],
+                        week.cells.map(cell =>
+                          h.div(
+                            [
+                              ...cell.cellAttributes,
+                              h.Class('group flex items-center justify-center'),
+                            ],
+                            [
+                              h.button(
+                                [
+                                  ...cell.buttonAttributes,
+                                  h.Class(
+                                    'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40',
+                                  ),
+                                ],
+                                [cell.label],
+                              ),
+                            ],
                           ),
-                        ],
-                        [cell.shortLabel],
+                        ),
                       ),
-                    ],
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          // The months grid renders 12 cells (one per month). Clicking the
+          // heading again drills further into the years grid.
+          Months: months =>
+            h.div(
+              [...months.root, h.Class('flex flex-col gap-3 p-4')],
+              [
+                h.div(
+                  [h.Class('flex items-center justify-center')],
+                  [
+                    h.button(
+                      [
+                        h.Id(months.heading.id),
+                        ...months.headingButton,
+                        h.Class(
+                          'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
+                        ),
+                      ],
+                      [months.heading.text, ' ▾'],
+                    ),
+                  ],
+                ),
+                h.div(
+                  [
+                    ...months.grid,
+                    h.Class('grid grid-cols-3 gap-1 outline-none'),
+                  ],
+                  months.cells.map(cell =>
+                    h.div(
+                      [
+                        ...cell.cellAttributes,
+                        h.Class('group flex items-center justify-center'),
+                      ],
+                      [
+                        h.button(
+                          [
+                            ...cell.buttonAttributes,
+                            h.Class(
+                              'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                            ),
+                          ],
+                          [cell.shortLabel],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
-        // The years grid renders 12 cells (one paged window). Prev/next
-        // page through 12-year windows; clicking a year drills back to
-        // the months grid for that year.
-        Years: years =>
-          h.div(
-            [...years.root, h.Class('flex flex-col gap-3 p-4')],
-            [
-              h.div(
-                [h.Class('flex items-center justify-between')],
-                [
-                  h.button(
-                    [...years.previousPageButton, h.Class('rounded px-2')],
-                    ['‹'],
-                  ),
-                  h.h2(
-                    [h.Id(years.heading.id), h.Class('text-sm font-semibold')],
-                    [years.heading.text],
-                  ),
-                  h.button(
-                    [...years.nextPageButton, h.Class('rounded px-2')],
-                    ['›'],
-                  ),
-                ],
-              ),
-              h.div(
-                [...years.grid, h.Class('grid grid-cols-3 gap-1 outline-none')],
-                years.cells.map(cell =>
-                  h.div(
-                    [
-                      ...cell.cellAttributes,
-                      h.Class('group flex items-center justify-center'),
-                    ],
-                    [
-                      h.button(
-                        [
-                          ...cell.buttonAttributes,
-                          h.Class(
-                            'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
-                          ),
-                        ],
-                        [cell.label],
-                      ),
-                    ],
+              ],
+            ),
+          // The years grid renders 12 cells (one paged window). Prev/next
+          // page through 12-year windows; clicking a year drills back to
+          // the months grid for that year.
+          Years: years =>
+            h.div(
+              [...years.root, h.Class('flex flex-col gap-3 p-4')],
+              [
+                h.div(
+                  [h.Class('flex items-center justify-between')],
+                  [
+                    h.button(
+                      [...years.previousPageButton, h.Class('rounded px-2')],
+                      ['‹'],
+                    ),
+                    h.h2(
+                      [
+                        h.Id(years.heading.id),
+                        h.Class('text-sm font-semibold'),
+                      ],
+                      [years.heading.text],
+                    ),
+                    h.button(
+                      [...years.nextPageButton, h.Class('rounded px-2')],
+                      ['›'],
+                    ),
+                  ],
+                ),
+                h.div(
+                  [
+                    ...years.grid,
+                    h.Class('grid grid-cols-3 gap-1 outline-none'),
+                  ],
+                  years.cells.map(cell =>
+                    h.div(
+                      [
+                        ...cell.cellAttributes,
+                        h.Class('group flex items-center justify-center'),
+                      ],
+                      [
+                        h.button(
+                          [
+                            ...cell.buttonAttributes,
+                            h.Class(
+                              'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                            ),
+                          ],
+                          [cell.label],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
-      }),
-    ),
-  // Optional: enable hidden form input for native <form> submission:
-  name: 'appointment-date',
-})
+              ],
+            ),
+        }),
+      ),
+    // Optional: enable hidden form input for native <form> submission:
+    name: 'appointment-date',
+  })
+}

--- a/packages/website/src/snippet/uiDialogAnimated.ts
+++ b/packages/website/src/snippet/uiDialogAnimated.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Dialog Submodel:
 const Model = S.Struct({
   dialog: Ui.Dialog.Model,
@@ -48,48 +46,52 @@ const dialogToParentMessage = (message: Ui.Dialog.Message): Message =>
   GotDialogMessage({ message })
 
 // Inside your view function, use data-[closed] for enter/leave transitions:
-Ui.Dialog.view({
-  model: model.dialog,
-  toParentMessage: dialogToParentMessage,
-  backdropAttributes: [
-    h.Class(
-      'fixed inset-0 bg-black/50 transition duration-150 ease-out data-[closed]:opacity-0',
-    ),
-  ],
-  panelContent: h.div(
-    [],
-    [
-      h.h2([h.Id(Ui.Dialog.titleId(model.dialog))], ['Confirm Action']),
-      h.p([], ['Are you sure you want to proceed?']),
-      h.div(
-        [h.Class('flex gap-2 justify-end mt-4')],
-        [
-          h.button(
-            [
-              h.OnClick(dialogToParentMessage(Ui.Dialog.Closed())),
-              h.Class('px-4 py-2 rounded-lg border'),
-            ],
-            ['Cancel'],
-          ),
-          h.button(
-            [
-              h.OnClick(dialogToParentMessage(Ui.Dialog.Closed())),
-              h.Class('px-4 py-2 rounded-lg bg-blue-600 text-white'),
-            ],
-            ['Confirm'],
-          ),
-        ],
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.Dialog.view({
+    model: model.dialog,
+    toParentMessage: dialogToParentMessage,
+    backdropAttributes: [
+      h.Class(
+        'fixed inset-0 bg-black/50 transition duration-150 ease-out data-[closed]:opacity-0',
       ),
     ],
-  ),
-  panelAttributes: [
-    h.Class(
-      'rounded-lg p-6 max-w-md mx-auto shadow-xl transition duration-150 ease-out data-[closed]:opacity-0 data-[closed]:scale-95',
+    panelContent: h.div(
+      [],
+      [
+        h.h2([h.Id(Ui.Dialog.titleId(model.dialog))], ['Confirm Action']),
+        h.p([], ['Are you sure you want to proceed?']),
+        h.div(
+          [h.Class('flex gap-2 justify-end mt-4')],
+          [
+            h.button(
+              [
+                h.OnClick(dialogToParentMessage(Ui.Dialog.Closed())),
+                h.Class('px-4 py-2 rounded-lg border'),
+              ],
+              ['Cancel'],
+            ),
+            h.button(
+              [
+                h.OnClick(dialogToParentMessage(Ui.Dialog.Closed())),
+                h.Class('px-4 py-2 rounded-lg bg-blue-600 text-white'),
+              ],
+              ['Confirm'],
+            ),
+          ],
+        ),
+      ],
     ),
-  ],
-  attributes: [
-    h.Class(
-      'backdrop:bg-transparent bg-transparent p-0 open:flex items-center justify-center',
-    ),
-  ],
-})
+    panelAttributes: [
+      h.Class(
+        'rounded-lg p-6 max-w-md mx-auto shadow-xl transition duration-150 ease-out data-[closed]:opacity-0 data-[closed]:scale-95',
+      ),
+    ],
+    attributes: [
+      h.Class(
+        'backdrop:bg-transparent bg-transparent p-0 open:flex items-center justify-center',
+      ),
+    ],
+  })
+}

--- a/packages/website/src/snippet/uiDialogBasic.ts
+++ b/packages/website/src/snippet/uiDialogBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Dialog Submodel:
 const Model = S.Struct({
   dialog: Ui.Dialog.Model,
@@ -47,30 +45,38 @@ GotDialogMessage: ({ message }) => {
 const dialogToParentMessage = (message: Ui.Dialog.Message): Message =>
   GotDialogMessage({ message })
 
-// Inside your view function, open the dialog by dispatching Ui.Dialog.Opened():
-h.button(
-  [h.OnClick(dialogToParentMessage(Ui.Dialog.Opened()))],
-  ['Open Dialog'],
-)
+// Inside your view function, open the dialog by dispatching Ui.Dialog.Opened()
+// and render the dialog — backed by native <dialog> with showModal():
+const view = () => {
+  const h = html<Message>()
 
-// And render the dialog — backed by native <dialog> with showModal():
-Ui.Dialog.view({
-  model: model.dialog,
-  toParentMessage: dialogToParentMessage,
-  backdropAttributes: [h.Class('fixed inset-0 bg-black/50')],
-  panelContent: h.div(
+  return h.div(
     [],
     [
-      h.h2([h.Id(Ui.Dialog.titleId(model.dialog))], ['Confirm Action']),
-      h.p([], ['Are you sure you want to proceed?']),
       h.button(
-        [
-          h.OnClick(dialogToParentMessage(Ui.Dialog.Closed())),
-          h.Class('px-4 py-2 rounded-lg border'),
-        ],
-        ['Close'],
+        [h.OnClick(dialogToParentMessage(Ui.Dialog.Opened()))],
+        ['Open Dialog'],
       ),
+      Ui.Dialog.view({
+        model: model.dialog,
+        toParentMessage: dialogToParentMessage,
+        backdropAttributes: [h.Class('fixed inset-0 bg-black/50')],
+        panelContent: h.div(
+          [],
+          [
+            h.h2([h.Id(Ui.Dialog.titleId(model.dialog))], ['Confirm Action']),
+            h.p([], ['Are you sure you want to proceed?']),
+            h.button(
+              [
+                h.OnClick(dialogToParentMessage(Ui.Dialog.Closed())),
+                h.Class('px-4 py-2 rounded-lg border'),
+              ],
+              ['Close'],
+            ),
+          ],
+        ),
+        panelAttributes: [h.Class('rounded-lg p-6 max-w-md mx-auto shadow-xl')],
+      }),
     ],
-  ),
-  panelAttributes: [h.Class('rounded-lg p-6 max-w-md mx-auto shadow-xl')],
-})
+  )
+}

--- a/packages/website/src/snippet/uiDisclosureBasic.ts
+++ b/packages/website/src/snippet/uiDisclosureBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Disclosure Submodel:
 const Model = S.Struct({
   disclosure: Ui.Disclosure.Model,
@@ -49,12 +47,16 @@ GotDisclosureMessage: ({ message }) => {
 }
 
 // Inside your view function, render the disclosure:
-Ui.Disclosure.view({
-  model: model.disclosure,
-  toParentMessage: message => GotDisclosureMessage({ message }),
-  buttonContent: h.span([], ['What is Foldkit?']),
-  panelContent: h.p([], ['A functional UI framework built on Effect-TS.']),
-  buttonClassName:
-    'flex items-center justify-between w-full p-4 border rounded-lg data-[open]:rounded-b-none',
-  panelClassName: 'p-4 border-x border-b rounded-b-lg',
-})
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.Disclosure.view({
+    model: model.disclosure,
+    toParentMessage: message => GotDisclosureMessage({ message }),
+    buttonContent: h.span([], ['What is Foldkit?']),
+    panelContent: h.p([], ['A functional UI framework built on Effect-TS.']),
+    buttonClassName:
+      'flex items-center justify-between w-full p-4 border rounded-lg data-[open]:rounded-b-none',
+    panelClassName: 'p-4 border-x border-b rounded-b-lg',
+  })
+}

--- a/packages/website/src/snippet/uiDragAndDropBasic.ts
+++ b/packages/website/src/snippet/uiDragAndDropBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the DragAndDrop Submodel plus the items being sorted:
 const Model = S.Struct({
   items: S.Array(S.Struct({ id: S.String, label: S.String })),
@@ -131,24 +129,28 @@ const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)({
 
 // Inside your view function, spread draggable() onto items and droppable()
 // onto containers:
-h.ul(
-  [
-    ...Ui.DragAndDrop.droppable('list', 'Sortable items'),
-    h.Class('flex flex-col gap-2'),
-  ],
-  model.items.map((item, index) =>
-    h.li(
-      [
-        ...Ui.DragAndDrop.draggable({
-          model: model.dragAndDrop,
-          toParentMessage: message => GotDragAndDropMessage({ message }),
-          itemId: item.id,
-          containerId: 'list',
-          index,
-        }),
-        h.Class('p-3 rounded-lg border cursor-grab'),
-      ],
-      [h.span([], [item.label])],
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return h.ul(
+    [
+      ...Ui.DragAndDrop.droppable('list', 'Sortable items'),
+      h.Class('flex flex-col gap-2'),
+    ],
+    model.items.map((item, index) =>
+      h.li(
+        [
+          ...Ui.DragAndDrop.draggable({
+            model: model.dragAndDrop,
+            toParentMessage: message => GotDragAndDropMessage({ message }),
+            itemId: item.id,
+            containerId: 'list',
+            index,
+          }),
+          h.Class('p-3 rounded-lg border cursor-grab'),
+        ],
+        [h.span([], [item.label])],
+      ),
     ),
-  ),
-)
+  )
+}

--- a/packages/website/src/snippet/uiFieldsetBasic.ts
+++ b/packages/website/src/snippet/uiFieldsetBasic.ts
@@ -3,28 +3,30 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = () => {
+  const h = html<Message>()
 
-Ui.Fieldset.view({
-  id: 'personal-info',
-  toView: attributes =>
-    h.fieldset(
-      [...attributes.fieldset, h.Class('rounded-lg border p-6')],
-      [
-        h.legend(
-          [...attributes.legend, h.Class('text-base font-semibold')],
-          ['Personal Information'],
-        ),
-        h.span(
-          [...attributes.description, h.Class('text-sm text-gray-500 mt-1')],
-          ['We just need a few details.'],
-        ),
-        h.div(
-          [h.Class('mt-4 flex flex-col gap-4')],
-          [
-            // Nest Input, Textarea, Checkbox, etc. here
-          ],
-        ),
-      ],
-    ),
-})
+  return Ui.Fieldset.view({
+    id: 'personal-info',
+    toView: attributes =>
+      h.fieldset(
+        [...attributes.fieldset, h.Class('rounded-lg border p-6')],
+        [
+          h.legend(
+            [...attributes.legend, h.Class('text-base font-semibold')],
+            ['Personal Information'],
+          ),
+          h.span(
+            [...attributes.description, h.Class('text-sm text-gray-500 mt-1')],
+            ['We just need a few details.'],
+          ),
+          h.div(
+            [h.Class('mt-4 flex flex-col gap-4')],
+            [
+              // Nest Input, Textarea, Checkbox, etc. here
+            ],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiFieldsetDisabled.ts
+++ b/packages/website/src/snippet/uiFieldsetDisabled.ts
@@ -4,24 +4,26 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = () => {
+  const h = html<Message>()
 
-Ui.Fieldset.view({
-  id: 'personal-info-disabled',
-  isDisabled: true,
-  toView: attributes =>
-    h.fieldset(
-      [...attributes.fieldset, h.Class('rounded-lg border p-6')],
-      [
-        h.legend(
-          [...attributes.legend, h.Class('text-base font-semibold')],
-          ['Personal Information'],
-        ),
-        h.span(
-          [...attributes.description, h.Class('text-sm text-gray-500 mt-1')],
-          ['This section is disabled.'],
-        ),
-        // All nested form controls inherit the disabled state
-      ],
-    ),
-})
+  return Ui.Fieldset.view({
+    id: 'personal-info-disabled',
+    isDisabled: true,
+    toView: attributes =>
+      h.fieldset(
+        [...attributes.fieldset, h.Class('rounded-lg border p-6')],
+        [
+          h.legend(
+            [...attributes.legend, h.Class('text-base font-semibold')],
+            ['Personal Information'],
+          ),
+          h.span(
+            [...attributes.description, h.Class('text-sm text-gray-500 mt-1')],
+            ['This section is disabled.'],
+          ),
+          // All nested form controls inherit the disabled state
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiFileDropBasic.ts
+++ b/packages/website/src/snippet/uiFileDropBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add the FileDrop Submodel to your Model, plus a list of accepted files:
 const Model = S.Struct({
   uploader: Ui.FileDrop.Model,
@@ -67,23 +65,27 @@ GotFileDropMessage: ({ message }) => {
 // Spread `root` onto a <label> so clicking opens the picker, and spread
 // `input` onto a hidden <input type="file"> nested inside. Style the
 // drag-over state via `data-drag-over`.
-Ui.FileDrop.view({
-  model: model.uploader,
-  toParentMessage: message => GotFileDropMessage({ message }),
-  multiple: true,
-  accept: ['application/pdf', '.doc', '.docx'],
-  toView: attributes =>
-    h.label(
-      [
-        ...attributes.root,
-        h.Class(
-          'flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed border-gray-300 p-8 text-center hover:border-accent-400 data-[drag-over]:border-accent-500 data-[drag-over]:bg-accent-50',
-        ),
-      ],
-      [
-        h.p([], ['Drop files or click to browse']),
-        h.span([h.Class('text-sm text-gray-500')], ['PDF, DOC, or DOCX']),
-        h.input(attributes.input),
-      ],
-    ),
-})
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.FileDrop.view({
+    model: model.uploader,
+    toParentMessage: message => GotFileDropMessage({ message }),
+    multiple: true,
+    accept: ['application/pdf', '.doc', '.docx'],
+    toView: attributes =>
+      h.label(
+        [
+          ...attributes.root,
+          h.Class(
+            'flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed border-gray-300 p-8 text-center hover:border-accent-400 data-[drag-over]:border-accent-500 data-[drag-over]:bg-accent-50',
+          ),
+        ],
+        [
+          h.p([], ['Drop files or click to browse']),
+          h.span([h.Class('text-sm text-gray-500')], ['PDF, DOC, or DOCX']),
+          h.input(attributes.input),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiInputBasic.ts
+++ b/packages/website/src/snippet/uiInputBasic.ts
@@ -3,29 +3,31 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = (model: Model) => {
+  const h = html<Message>()
 
-Ui.Input.view({
-  id: 'full-name',
-  value: model.name, // your Model field
-  onInput: value => UpdatedName({ value }), // your Message
-  placeholder: 'Enter your full name',
-  toView: attributes =>
-    h.div(
-      [h.Class('flex flex-col gap-1.5')],
-      [
-        h.label(
-          [...attributes.label, h.Class('text-sm font-medium')],
-          ['Name'],
-        ),
-        h.input([
-          ...attributes.input,
-          h.Class('w-full rounded-lg border border-gray-300 px-3 py-2'),
-        ]),
-        h.span(
-          [...attributes.description, h.Class('text-sm text-gray-500')],
-          ['As it appears on your government-issued ID.'],
-        ),
-      ],
-    ),
-})
+  return Ui.Input.view({
+    id: 'full-name',
+    value: model.name, // your Model field
+    onInput: value => UpdatedName({ value }), // your Message
+    placeholder: 'Enter your full name',
+    toView: attributes =>
+      h.div(
+        [h.Class('flex flex-col gap-1.5')],
+        [
+          h.label(
+            [...attributes.label, h.Class('text-sm font-medium')],
+            ['Name'],
+          ),
+          h.input([
+            ...attributes.input,
+            h.Class('w-full rounded-lg border border-gray-300 px-3 py-2'),
+          ]),
+          h.span(
+            [...attributes.description, h.Class('text-sm text-gray-500')],
+            ['As it appears on your government-issued ID.'],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiInputDisabled.ts
+++ b/packages/website/src/snippet/uiInputDisabled.ts
@@ -3,30 +3,32 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = () => {
+  const h = html<Message>()
 
-Ui.Input.view({
-  id: 'email-disabled',
-  isDisabled: true,
-  value: 'ada@lovelace.dev',
-  toView: attributes =>
-    h.div(
-      [h.Class('flex flex-col gap-1.5')],
-      [
-        h.label(
-          [...attributes.label, h.Class('text-sm font-medium')],
-          ['Email'],
-        ),
-        h.input([
-          ...attributes.input,
-          h.Class(
-            'w-full rounded-lg border px-3 py-2 data-[disabled]:opacity-50',
+  return Ui.Input.view({
+    id: 'email-disabled',
+    isDisabled: true,
+    value: 'ada@lovelace.dev',
+    toView: attributes =>
+      h.div(
+        [h.Class('flex flex-col gap-1.5')],
+        [
+          h.label(
+            [...attributes.label, h.Class('text-sm font-medium')],
+            ['Email'],
           ),
-        ]),
-        h.span(
-          [...attributes.description, h.Class('text-sm text-gray-500')],
-          ['Contact your admin to update.'],
-        ),
-      ],
-    ),
-})
+          h.input([
+            ...attributes.input,
+            h.Class(
+              'w-full rounded-lg border px-3 py-2 data-[disabled]:opacity-50',
+            ),
+          ]),
+          h.span(
+            [...attributes.description, h.Class('text-sm text-gray-500')],
+            ['Contact your admin to update.'],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiListboxBasic.ts
+++ b/packages/website/src/snippet/uiListboxBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Listbox Submodel, plus a field for
 // the selected value your app actually cares about:
 const Model = S.Struct({
@@ -72,27 +70,31 @@ const people = ['Michael Bluth', 'Lindsay Funke', 'Tobias Funke']
 
 // Inside your view function, pass onSelectedItem to fire your SelectedPerson
 // Message on selection:
-Ui.Listbox.view({
-  model: model.listbox,
-  toParentMessage: message => GotListboxMessage({ message }),
-  onSelectedItem: value => SelectedPerson({ value }),
-  items: people,
-  buttonContent: h.span(
-    [],
-    [Option.getOrElse(model.maybePerson, () => 'Select a person')],
-  ),
-  buttonClassName: 'w-full rounded-lg border px-3 py-2 text-left',
-  itemsClassName: 'rounded-lg border shadow-lg',
-  itemToConfig: (person, { isSelected, isActive }) => ({
-    className: isActive ? 'bg-blue-100' : '',
-    content: h.div(
-      [h.Class('flex items-center gap-2 px-3 py-2')],
-      [
-        isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
-        h.span([], [person]),
-      ],
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.Listbox.view({
+    model: model.listbox,
+    toParentMessage: message => GotListboxMessage({ message }),
+    onSelectedItem: value => SelectedPerson({ value }),
+    items: people,
+    buttonContent: h.span(
+      [],
+      [Option.getOrElse(model.maybePerson, () => 'Select a person')],
     ),
-  }),
-  backdropClassName: 'fixed inset-0',
-  anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-})
+    buttonClassName: 'w-full rounded-lg border px-3 py-2 text-left',
+    itemsClassName: 'rounded-lg border shadow-lg',
+    itemToConfig: (person, { isSelected, isActive }) => ({
+      className: isActive ? 'bg-blue-100' : '',
+      content: h.div(
+        [h.Class('flex items-center gap-2 px-3 py-2')],
+        [
+          isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
+          h.span([], [person]),
+        ],
+      ),
+    }),
+    backdropClassName: 'fixed inset-0',
+    anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+  })
+}

--- a/packages/website/src/snippet/uiListboxGrouped.ts
+++ b/packages/website/src/snippet/uiListboxGrouped.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Listbox Submodel, plus a field for
 // the selected value your app actually cares about:
 const Model = S.Struct({
@@ -88,35 +86,39 @@ const characters: ReadonlyArray<Character> = [
 // Inside your view function, group items by a key and render a heading for
 // each group. Items are grouped in the order they appear — make sure items
 // with the same key are contiguous in the items array:
-Ui.Listbox.view({
-  model: model.listbox,
-  toParentMessage: message => GotListboxMessage({ message }),
-  onSelectedItem: value => SelectedCharacter({ value }),
-  items: characters,
-  itemToValue: characterName,
-  // Group contiguous items by a shared key:
-  itemGroupKey: character => character.lastName,
-  // Render a heading for each group:
-  groupToHeading: lastName => ({
-    content: h.span([], [`${lastName}s`]),
-    className: 'px-3 py-1 text-xs font-semibold uppercase text-gray-500',
-  }),
-  // Optional separator between groups:
-  separatorAttributes: [h.Class('my-1 border-t')],
-  itemToConfig: character => ({
-    className:
-      'px-3 py-2 cursor-pointer data-[active]:bg-blue-100 data-[selected]:font-semibold',
-    content: h.div(
-      [h.Class('flex items-center gap-2')],
-      [h.span([], [characterName(character)])],
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.Listbox.view({
+    model: model.listbox,
+    toParentMessage: message => GotListboxMessage({ message }),
+    onSelectedItem: value => SelectedCharacter({ value }),
+    items: characters,
+    itemToValue: characterName,
+    // Group contiguous items by a shared key:
+    itemGroupKey: character => character.lastName,
+    // Render a heading for each group:
+    groupToHeading: lastName => ({
+      content: h.span([], [`${lastName}s`]),
+      className: 'px-3 py-1 text-xs font-semibold uppercase text-gray-500',
+    }),
+    // Optional separator between groups:
+    separatorAttributes: [h.Class('my-1 border-t')],
+    itemToConfig: character => ({
+      className:
+        'px-3 py-2 cursor-pointer data-[active]:bg-blue-100 data-[selected]:font-semibold',
+      content: h.div(
+        [h.Class('flex items-center gap-2')],
+        [h.span([], [characterName(character)])],
+      ),
+    }),
+    buttonContent: h.span(
+      [],
+      [Option.getOrElse(model.maybeCharacter, () => 'Select a character')],
     ),
-  }),
-  buttonContent: h.span(
-    [],
-    [Option.getOrElse(model.maybeCharacter, () => 'Select a character')],
-  ),
-  buttonClassName: 'w-full rounded-lg border px-3 py-2 text-left',
-  itemsClassName: 'rounded-lg border shadow-lg',
-  backdropClassName: 'fixed inset-0',
-  anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-})
+    buttonClassName: 'w-full rounded-lg border px-3 py-2 text-left',
+    itemsClassName: 'rounded-lg border shadow-lg',
+    backdropClassName: 'fixed inset-0',
+    anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+  })
+}

--- a/packages/website/src/snippet/uiListboxMulti.ts
+++ b/packages/website/src/snippet/uiListboxMulti.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Listbox.Multi Submodel, plus a field
 // for the selected values your app actually cares about:
 const Model = S.Struct({
@@ -78,31 +76,35 @@ const people = ['Michael Bluth', 'Lindsay Funke', 'Tobias Funke']
 
 // Inside your view function, pass onSelectedItem to fire your ToggledPerson
 // Message on selection — selectedItems is an array:
-Ui.Listbox.Multi.view({
-  model: model.listboxMulti,
-  toParentMessage: message => GotListboxMultiMessage({ message }),
-  onSelectedItem: value => ToggledPerson({ value }),
-  items: people,
-  buttonContent: h.span(
-    [],
-    [
-      Array.isReadonlyArrayNonEmpty(model.selectedPeople)
-        ? `${model.selectedPeople.length} selected`
-        : 'Select people',
-    ],
-  ),
-  buttonClassName: 'w-full rounded-lg border px-3 py-2 text-left',
-  itemsClassName: 'rounded-lg border shadow-lg',
-  itemToConfig: (person, { isSelected, isActive }) => ({
-    className: isActive ? 'bg-blue-100' : '',
-    content: h.div(
-      [h.Class('flex items-center gap-2 px-3 py-2')],
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.Listbox.Multi.view({
+    model: model.listboxMulti,
+    toParentMessage: message => GotListboxMultiMessage({ message }),
+    onSelectedItem: value => ToggledPerson({ value }),
+    items: people,
+    buttonContent: h.span(
+      [],
       [
-        isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
-        h.span([], [person]),
+        Array.isReadonlyArrayNonEmpty(model.selectedPeople)
+          ? `${model.selectedPeople.length} selected`
+          : 'Select people',
       ],
     ),
-  }),
-  backdropClassName: 'fixed inset-0',
-  anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-})
+    buttonClassName: 'w-full rounded-lg border px-3 py-2 text-left',
+    itemsClassName: 'rounded-lg border shadow-lg',
+    itemToConfig: (person, { isSelected, isActive }) => ({
+      className: isActive ? 'bg-blue-100' : '',
+      content: h.div(
+        [h.Class('flex items-center gap-2 px-3 py-2')],
+        [
+          isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
+          h.span([], [person]),
+        ],
+      ),
+    }),
+    backdropClassName: 'fixed inset-0',
+    anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+  })
+}

--- a/packages/website/src/snippet/uiMenuAnimated.ts
+++ b/packages/website/src/snippet/uiMenuAnimated.ts
@@ -4,8 +4,6 @@ import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 
-const h = html<Message>()
-
 // Only init and view differ from the basic menu: init adds isAnimated, the
 // view uses data-[closed] selectors for enter/leave transitions.
 
@@ -24,19 +22,23 @@ const GotMenuMessage = m('GotMenuMessage', {
 })
 
 // Inside your view function, use data-[closed] for enter/leave transitions:
-Ui.Menu.view({
-  model: model.menu,
-  toParentMessage: message => GotMenuMessage({ message }),
-  items: actions,
-  onSelectedItem: value => SelectedAction({ value }),
-  buttonContent: h.span([], ['Options']),
-  buttonClassName: 'rounded-lg border px-3 py-2 cursor-pointer',
-  itemsClassName:
-    'rounded-lg border shadow-lg transition duration-150 ease-out data-[closed]:opacity-0 data-[closed]:scale-95',
-  itemToConfig: (action, { isActive }) => ({
-    className: isActive ? 'bg-blue-100' : '',
-    content: h.div([h.Class('px-3 py-2')], [action]),
-  }),
-  backdropClassName: 'fixed inset-0',
-  anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Menu.view({
+    model: model.menu,
+    toParentMessage: message => GotMenuMessage({ message }),
+    items: actions,
+    onSelectedItem: value => SelectedAction({ value }),
+    buttonContent: h.span([], ['Options']),
+    buttonClassName: 'rounded-lg border px-3 py-2 cursor-pointer',
+    itemsClassName:
+      'rounded-lg border shadow-lg transition duration-150 ease-out data-[closed]:opacity-0 data-[closed]:scale-95',
+    itemToConfig: (action, { isActive }) => ({
+      className: isActive ? 'bg-blue-100' : '',
+      content: h.div([h.Class('px-3 py-2')], [action]),
+    }),
+    backdropClassName: 'fixed inset-0',
+    anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+  })
+}

--- a/packages/website/src/snippet/uiMenuBasic.ts
+++ b/packages/website/src/snippet/uiMenuBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Menu Submodel:
 const Model = S.Struct({
   menu: Ui.Menu.Model,
@@ -55,19 +53,23 @@ const actions: ReadonlyArray<Action> = [
 ]
 
 // Inside your view function, render the menu:
-Ui.Menu.view({
-  model: model.menu,
-  toParentMessage: message => GotMenuMessage({ message }),
-  items: actions,
-  onSelectedItem: value => SelectedAction({ value }),
-  buttonContent: h.span([], ['Options']),
-  buttonClassName: 'rounded-lg border px-3 py-2 cursor-pointer',
-  itemsClassName: 'rounded-lg border shadow-lg',
-  itemToConfig: (action, { isActive }) => ({
-    className: isActive ? 'bg-blue-100' : '',
-    content: h.div([h.Class('px-3 py-2')], [action]),
-  }),
-  isItemDisabled: action => action === 'Archive',
-  backdropClassName: 'fixed inset-0',
-  anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Menu.view({
+    model: model.menu,
+    toParentMessage: message => GotMenuMessage({ message }),
+    items: actions,
+    onSelectedItem: value => SelectedAction({ value }),
+    buttonContent: h.span([], ['Options']),
+    buttonClassName: 'rounded-lg border px-3 py-2 cursor-pointer',
+    itemsClassName: 'rounded-lg border shadow-lg',
+    itemToConfig: (action, { isActive }) => ({
+      className: isActive ? 'bg-blue-100' : '',
+      content: h.div([h.Class('px-3 py-2')], [action]),
+    }),
+    isItemDisabled: action => action === 'Archive',
+    backdropClassName: 'fixed inset-0',
+    anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+  })
+}

--- a/packages/website/src/snippet/uiPopoverBasic.ts
+++ b/packages/website/src/snippet/uiPopoverBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Popover Submodel:
 const Model = S.Struct({
   popover: Ui.Popover.Model,
@@ -44,22 +42,26 @@ GotPopoverMessage: ({ message }) => {
 }
 
 // Inside your view function, render the popover:
-Ui.Popover.view({
-  model: model.popover,
-  toParentMessage: message => GotPopoverMessage({ message }),
-  buttonContent: h.span([], ['Solutions']),
-  buttonClassName: 'rounded-lg border px-3 py-2 cursor-pointer',
-  panelContent: h.div(
-    [],
-    [
-      h.h3([h.Class('font-medium')], ['Analytics']),
-      h.p(
-        [h.Class('text-sm text-gray-500')],
-        ['Get a better understanding of where your traffic is coming from.'],
-      ),
-    ],
-  ),
-  panelClassName: 'rounded-lg border shadow-lg p-4 w-80',
-  backdropClassName: 'fixed inset-0',
-  anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Popover.view({
+    model: model.popover,
+    toParentMessage: message => GotPopoverMessage({ message }),
+    buttonContent: h.span([], ['Solutions']),
+    buttonClassName: 'rounded-lg border px-3 py-2 cursor-pointer',
+    panelContent: h.div(
+      [],
+      [
+        h.h3([h.Class('font-medium')], ['Analytics']),
+        h.p(
+          [h.Class('text-sm text-gray-500')],
+          ['Get a better understanding of where your traffic is coming from.'],
+        ),
+      ],
+    ),
+    panelClassName: 'rounded-lg border shadow-lg p-4 w-80',
+    backdropClassName: 'fixed inset-0',
+    anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+  })
+}

--- a/packages/website/src/snippet/uiRadioGroupBasic.ts
+++ b/packages/website/src/snippet/uiRadioGroupBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the RadioGroup Submodel:
 const Model = S.Struct({
   radioGroup: Ui.RadioGroup.Model,
@@ -58,29 +56,36 @@ const descriptions: Record<Plan, string> = {
 }
 
 // Inside your view function, render the radio group:
-Ui.RadioGroup.view<Message, Plan>({
-  model: model.radioGroup,
-  toParentMessage: message => GotRadioGroupMessage({ message }),
-  options: plans,
-  ariaLabel: 'Server plan',
-  optionToConfig: (plan, { isSelected }) => ({
-    value: plan,
-    content: attributes =>
-      h.div(
-        [
-          ...attributes.option,
-          h.Class(
-            'rounded-lg border p-4 cursor-pointer data-[checked]:border-blue-600',
-          ),
-        ],
-        [
-          h.span([...attributes.label, h.Class('text-sm font-medium')], [plan]),
-          h.p(
-            [...attributes.description, h.Class('text-sm text-gray-500')],
-            [descriptions[plan]],
-          ),
-        ],
-      ),
-  }),
-  attributes: [h.Class('flex flex-col gap-3')],
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.RadioGroup.view<Message, Plan>({
+    model: model.radioGroup,
+    toParentMessage: message => GotRadioGroupMessage({ message }),
+    options: plans,
+    ariaLabel: 'Server plan',
+    optionToConfig: (plan, { isSelected }) => ({
+      value: plan,
+      content: attributes =>
+        h.div(
+          [
+            ...attributes.option,
+            h.Class(
+              'rounded-lg border p-4 cursor-pointer data-[checked]:border-blue-600',
+            ),
+          ],
+          [
+            h.span(
+              [...attributes.label, h.Class('text-sm font-medium')],
+              [plan],
+            ),
+            h.p(
+              [...attributes.description, h.Class('text-sm text-gray-500')],
+              [descriptions[plan]],
+            ),
+          ],
+        ),
+    }),
+    attributes: [h.Class('flex flex-col gap-3')],
+  })
+}

--- a/packages/website/src/snippet/uiSelectBasic.ts
+++ b/packages/website/src/snippet/uiSelectBasic.ts
@@ -4,32 +4,37 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = () => {
+  const h = html<Message>()
 
-Ui.Select.view({
-  id: 'country',
-  value: model.country, // your Model field
-  onChange: value => UpdatedCountry({ value }), // your Message
-  toView: attributes =>
-    h.div(
-      [h.Class('flex flex-col gap-1.5')],
-      [
-        h.label(
-          [...attributes.label, h.Class('text-sm font-medium')],
-          ['Country'],
-        ),
-        h.select(
-          [...attributes.select, h.Class('w-full rounded-lg border px-3 py-2')],
-          [
-            h.option([h.Value('us')], ['United States']),
-            h.option([h.Value('ca')], ['Canada']),
-            h.option([h.Value('gb')], ['United Kingdom']),
-          ],
-        ),
-        h.span(
-          [...attributes.description, h.Class('text-sm text-gray-500')],
-          ['Where you currently reside.'],
-        ),
-      ],
-    ),
-})
+  return Ui.Select.view({
+    id: 'country',
+    value: model.country, // your Model field
+    onChange: value => UpdatedCountry({ value }), // your Message
+    toView: attributes =>
+      h.div(
+        [h.Class('flex flex-col gap-1.5')],
+        [
+          h.label(
+            [...attributes.label, h.Class('text-sm font-medium')],
+            ['Country'],
+          ),
+          h.select(
+            [
+              ...attributes.select,
+              h.Class('w-full rounded-lg border px-3 py-2'),
+            ],
+            [
+              h.option([h.Value('us')], ['United States']),
+              h.option([h.Value('ca')], ['Canada']),
+              h.option([h.Value('gb')], ['United Kingdom']),
+            ],
+          ),
+          h.span(
+            [...attributes.description, h.Class('text-sm text-gray-500')],
+            ['Where you currently reside.'],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiSelectDisabled.ts
+++ b/packages/website/src/snippet/uiSelectDisabled.ts
@@ -3,36 +3,38 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = () => {
+  const h = html<Message>()
 
-Ui.Select.view({
-  id: 'country-disabled',
-  isDisabled: true,
-  value: 'us',
-  toView: attributes =>
-    h.div(
-      [h.Class('flex flex-col gap-1.5')],
-      [
-        h.label(
-          [...attributes.label, h.Class('text-sm font-medium')],
-          ['Country'],
-        ),
-        h.select(
-          [
-            ...attributes.select,
-            h.Class(
-              'w-full rounded-lg border px-3 py-2 data-[disabled]:opacity-50',
-            ),
-          ],
-          [
-            h.option([h.Value('us')], ['United States']),
-            h.option([h.Value('ca')], ['Canada']),
-          ],
-        ),
-        h.span(
-          [...attributes.description, h.Class('text-sm text-gray-500')],
-          ['This select is disabled.'],
-        ),
-      ],
-    ),
-})
+  return Ui.Select.view({
+    id: 'country-disabled',
+    isDisabled: true,
+    value: 'us',
+    toView: attributes =>
+      h.div(
+        [h.Class('flex flex-col gap-1.5')],
+        [
+          h.label(
+            [...attributes.label, h.Class('text-sm font-medium')],
+            ['Country'],
+          ),
+          h.select(
+            [
+              ...attributes.select,
+              h.Class(
+                'w-full rounded-lg border px-3 py-2 data-[disabled]:opacity-50',
+              ),
+            ],
+            [
+              h.option([h.Value('us')], ['United States']),
+              h.option([h.Value('ca')], ['Canada']),
+            ],
+          ),
+          h.span(
+            [...attributes.description, h.Class('text-sm text-gray-500')],
+            ['This select is disabled.'],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiSliderBasic.ts
+++ b/packages/website/src/snippet/uiSliderBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Slider Submodel:
 const Model = S.Struct({
   ratingDemo: Ui.Slider.Model,
@@ -88,56 +86,63 @@ const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
 // Inside your view function, render the slider. You control every element's
 // markup and classes through the `toView` callback. The `attributes` groups
 // provide ARIA, pointer, and keyboard wiring:
-Ui.Slider.view({
-  model: model.ratingDemo,
-  toParentMessage: message => GotSliderMessage({ message }),
-  formatValue: value => `${String(value)} of 10`,
-  toView: attributes =>
-    h.div(
-      [h.Class('flex flex-col gap-2 w-full max-w-sm')],
-      [
-        h.div(
-          [h.Class('flex items-center justify-between text-sm')],
-          [
-            h.label([...attributes.label, h.Class('font-medium')], ['Rating']),
-            h.span(
-              [h.Class('tabular-nums text-gray-600')],
-              [`${String(model.ratingDemo.value)} / 10`],
-            ),
-          ],
-        ),
-        h.div(
-          [
-            ...attributes.root,
-            h.Class('relative h-6 w-full flex items-center'),
-          ],
-          [
-            h.div(
-              [
-                ...attributes.track,
-                h.Class('h-1.5 w-full rounded-full bg-gray-200'),
-              ],
-              [
-                h.div(
-                  [
-                    ...attributes.filledTrack,
-                    h.Class('h-full rounded-full bg-blue-600'),
-                  ],
-                  [],
-                ),
-              ],
-            ),
-            h.div(
-              [
-                ...attributes.thumb,
-                h.Class(
-                  'h-5 w-5 rounded-full bg-white border-2 border-blue-600 shadow cursor-grab focus-visible:ring-2 focus-visible:ring-blue-600 data-[dragging]:cursor-grabbing',
-                ),
-              ],
-              [],
-            ),
-          ],
-        ),
-      ],
-    ),
-})
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.Slider.view({
+    model: model.ratingDemo,
+    toParentMessage: message => GotSliderMessage({ message }),
+    formatValue: value => `${String(value)} of 10`,
+    toView: attributes =>
+      h.div(
+        [h.Class('flex flex-col gap-2 w-full max-w-sm')],
+        [
+          h.div(
+            [h.Class('flex items-center justify-between text-sm')],
+            [
+              h.label(
+                [...attributes.label, h.Class('font-medium')],
+                ['Rating'],
+              ),
+              h.span(
+                [h.Class('tabular-nums text-gray-600')],
+                [`${String(model.ratingDemo.value)} / 10`],
+              ),
+            ],
+          ),
+          h.div(
+            [
+              ...attributes.root,
+              h.Class('relative h-6 w-full flex items-center'),
+            ],
+            [
+              h.div(
+                [
+                  ...attributes.track,
+                  h.Class('h-1.5 w-full rounded-full bg-gray-200'),
+                ],
+                [
+                  h.div(
+                    [
+                      ...attributes.filledTrack,
+                      h.Class('h-full rounded-full bg-blue-600'),
+                    ],
+                    [],
+                  ),
+                ],
+              ),
+              h.div(
+                [
+                  ...attributes.thumb,
+                  h.Class(
+                    'h-5 w-5 rounded-full bg-white border-2 border-blue-600 shadow cursor-grab focus-visible:ring-2 focus-visible:ring-blue-600 data-[dragging]:cursor-grabbing',
+                  ),
+                ],
+                [],
+              ),
+            ],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiSwitchBasic.ts
+++ b/packages/website/src/snippet/uiSwitchBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Switch Submodel:
 const Model = S.Struct({
   switchDemo: Ui.Switch.Model,
@@ -44,44 +42,48 @@ GotSwitchMessage: ({ message }) => {
 }
 
 // Inside your view function, render the switch:
-Ui.Switch.view({
-  model: model.switchDemo,
-  toParentMessage: message => GotSwitchMessage({ message }),
-  toView: attributes =>
-    h.div(
-      [h.Class('flex items-center gap-3')],
-      [
-        h.button(
-          [
-            ...attributes.button,
-            h.Class(
-              'relative h-6 w-11 rounded-full transition-colors data-[checked]:bg-blue-600 bg-gray-200',
-            ),
-          ],
-          [
-            h.div(
-              [
-                h.Class(
-                  'absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform',
-                ),
-              ],
-              [],
-            ),
-          ],
-        ),
-        h.div(
-          [],
-          [
-            h.label(
-              [...attributes.label, h.Class('text-sm font-medium')],
-              ['Enable notifications'],
-            ),
-            h.p(
-              [...attributes.description, h.Class('text-sm text-gray-500')],
-              ['Get notified when something important happens.'],
-            ),
-          ],
-        ),
-      ],
-    ),
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Switch.view({
+    model: model.switchDemo,
+    toParentMessage: message => GotSwitchMessage({ message }),
+    toView: attributes =>
+      h.div(
+        [h.Class('flex items-center gap-3')],
+        [
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'relative h-6 w-11 rounded-full transition-colors data-[checked]:bg-blue-600 bg-gray-200',
+              ),
+            ],
+            [
+              h.div(
+                [
+                  h.Class(
+                    'absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform',
+                  ),
+                ],
+                [],
+              ),
+            ],
+          ),
+          h.div(
+            [],
+            [
+              h.label(
+                [...attributes.label, h.Class('text-sm font-medium')],
+                ['Enable notifications'],
+              ),
+              h.p(
+                [...attributes.description, h.Class('text-sm text-gray-500')],
+                ['Get notified when something important happens.'],
+              ),
+            ],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiTabsBasic.ts
+++ b/packages/website/src/snippet/uiTabsBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Tabs Submodel:
 const Model = S.Struct({
   tabs: Ui.Tabs.Model,
@@ -53,17 +51,21 @@ const descriptions: Record<Framework, string> = {
 }
 
 // Inside your view function, render the tabs:
-Ui.Tabs.view<Message, Framework>({
-  model: model.tabs,
-  toParentMessage: message => GotTabsMessage({ message }),
-  tabs: frameworks,
-  tabListAriaLabel: 'Framework comparison',
-  tabToConfig: (tab, { isActive }) => ({
-    buttonClassName:
-      'px-4 py-2 rounded-t-lg border data-[selected]:bg-white data-[selected]:border-b-0',
-    buttonContent: h.span([], [tab]),
-    panelClassName: 'p-6 border rounded-b-lg',
-    panelContent: h.p([], [descriptions[tab]]),
-  }),
-  tabListAttributes: [h.Class('flex')],
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Tabs.view<Message, Framework>({
+    model: model.tabs,
+    toParentMessage: message => GotTabsMessage({ message }),
+    tabs: frameworks,
+    tabListAriaLabel: 'Framework comparison',
+    tabToConfig: (tab, { isActive }) => ({
+      buttonClassName:
+        'px-4 py-2 rounded-t-lg border data-[selected]:bg-white data-[selected]:border-b-0',
+      buttonContent: h.span([], [tab]),
+      panelClassName: 'p-6 border rounded-b-lg',
+      panelContent: h.p([], [descriptions[tab]]),
+    }),
+    tabListAttributes: [h.Class('flex')],
+  })
+}

--- a/packages/website/src/snippet/uiTabsVertical.ts
+++ b/packages/website/src/snippet/uiTabsVertical.ts
@@ -5,8 +5,6 @@ import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 
-const h = html<Message>()
-
 const GotTabsMessage = m('GotTabsMessage', {
   message: Ui.Tabs.Message,
 })
@@ -22,19 +20,23 @@ const descriptions: Record<Framework, string> = {
 
 // Inside your view function, set orientation to 'Vertical' and use flex +
 // flex-col for layout:
-Ui.Tabs.view<Message, Framework>({
-  model: model.tabs,
-  toParentMessage: message => GotTabsMessage({ message }),
-  tabs: frameworks,
-  tabListAriaLabel: 'Framework comparison',
-  orientation: 'Vertical',
-  tabToConfig: (tab, { isActive }) => ({
-    buttonClassName:
-      'px-4 py-2 text-left rounded-l-lg border mr-[-1px] data-[selected]:bg-white data-[selected]:border-r-0',
-    buttonContent: h.span([], [tab]),
-    panelClassName: 'flex-1 p-6 border rounded-r-lg',
-    panelContent: h.p([], [descriptions[tab]]),
-  }),
-  attributes: [h.Class('flex')],
-  tabListAttributes: [h.Class('flex flex-col')],
-})
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.Tabs.view<Message, Framework>({
+    model: model.tabs,
+    toParentMessage: message => GotTabsMessage({ message }),
+    tabs: frameworks,
+    tabListAriaLabel: 'Framework comparison',
+    orientation: 'Vertical',
+    tabToConfig: (tab, { isActive }) => ({
+      buttonClassName:
+        'px-4 py-2 text-left rounded-l-lg border mr-[-1px] data-[selected]:bg-white data-[selected]:border-r-0',
+      buttonContent: h.span([], [tab]),
+      panelClassName: 'flex-1 p-6 border rounded-r-lg',
+      panelContent: h.p([], [descriptions[tab]]),
+    }),
+    attributes: [h.Class('flex')],
+    tabListAttributes: [h.Class('flex flex-col')],
+  })
+}

--- a/packages/website/src/snippet/uiTextareaBasic.ts
+++ b/packages/website/src/snippet/uiTextareaBasic.ts
@@ -3,30 +3,35 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = (model: Model) => {
+  const h = html<Message>()
 
-Ui.Textarea.view({
-  id: 'bio',
-  value: model.bio, // your Model field
-  onInput: value => UpdatedBio({ value }), // your Message
-  placeholder: 'Tell us about yourself...',
-  rows: 4,
-  toView: attributes =>
-    h.div(
-      [h.Class('flex flex-col gap-1.5')],
-      [
-        h.label([...attributes.label, h.Class('text-sm font-medium')], ['Bio']),
-        h.textarea(
-          [
-            ...attributes.textarea,
-            h.Class('w-full rounded-lg border border-gray-300 px-3 py-2'),
-          ],
-          [],
-        ),
-        h.span(
-          [...attributes.description, h.Class('text-sm text-gray-500')],
-          ['A brief introduction about yourself.'],
-        ),
-      ],
-    ),
-})
+  return Ui.Textarea.view({
+    id: 'bio',
+    value: model.bio, // your Model field
+    onInput: value => UpdatedBio({ value }), // your Message
+    placeholder: 'Tell us about yourself...',
+    rows: 4,
+    toView: attributes =>
+      h.div(
+        [h.Class('flex flex-col gap-1.5')],
+        [
+          h.label(
+            [...attributes.label, h.Class('text-sm font-medium')],
+            ['Bio'],
+          ),
+          h.textarea(
+            [
+              ...attributes.textarea,
+              h.Class('w-full rounded-lg border border-gray-300 px-3 py-2'),
+            ],
+            [],
+          ),
+          h.span(
+            [...attributes.description, h.Class('text-sm text-gray-500')],
+            ['A brief introduction about yourself.'],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiTextareaDisabled.ts
+++ b/packages/website/src/snippet/uiTextareaDisabled.ts
@@ -3,31 +3,36 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
+const view = () => {
+  const h = html<Message>()
 
-Ui.Textarea.view({
-  id: 'bio-disabled',
-  isDisabled: true,
-  value: 'Known for work on the Analytical Engine.',
-  rows: 3,
-  toView: attributes =>
-    h.div(
-      [h.Class('flex flex-col gap-1.5')],
-      [
-        h.label([...attributes.label, h.Class('text-sm font-medium')], ['Bio']),
-        h.textarea(
-          [
-            ...attributes.textarea,
-            h.Class(
-              'w-full rounded-lg border px-3 py-2 data-[disabled]:opacity-50',
-            ),
-          ],
-          [],
-        ),
-        h.span(
-          [...attributes.description, h.Class('text-sm text-gray-500')],
-          ['This textarea is disabled.'],
-        ),
-      ],
-    ),
-})
+  return Ui.Textarea.view({
+    id: 'bio-disabled',
+    isDisabled: true,
+    value: 'Known for work on the Analytical Engine.',
+    rows: 3,
+    toView: attributes =>
+      h.div(
+        [h.Class('flex flex-col gap-1.5')],
+        [
+          h.label(
+            [...attributes.label, h.Class('text-sm font-medium')],
+            ['Bio'],
+          ),
+          h.textarea(
+            [
+              ...attributes.textarea,
+              h.Class(
+                'w-full rounded-lg border px-3 py-2 data-[disabled]:opacity-50',
+              ),
+            ],
+            [],
+          ),
+          h.span(
+            [...attributes.description, h.Class('text-sm text-gray-500')],
+            ['This textarea is disabled.'],
+          ),
+        ],
+      ),
+  })
+}

--- a/packages/website/src/snippet/uiToastBasic.ts
+++ b/packages/website/src/snippet/uiToastBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Define the payload shape for your toast. The Toast component owns only
 // lifecycle + a11y fields (id, variant, transition, dismiss timer, hover
 // state). The payload is yours — whatever you can encode in a Schema:
@@ -74,28 +72,36 @@ ClickedSave: () => {
 // renderEntry callback that lays out each entry from its payload — the
 // component handles the <li> wrapper, hover-to-pause, and enter/leave
 // animations.
-Toast.view({
-  model: model.toast,
-  position: 'BottomRight',
-  toParentMessage: message => GotToastMessage({ message }),
-  renderEntry: (entry, handlers) =>
-    h.div(
-      [h.Class('flex items-start gap-3 rounded-lg border bg-white p-3 shadow')],
-      [
-        h.div(
-          [h.Class('flex-1')],
-          [
-            h.p([h.Class('font-semibold text-sm')], [entry.payload.bodyText]),
-            ...Option.match(entry.payload.maybeLink, {
-              onNone: () => [],
-              onSome: ({ href, text }) => [
-                h.a([h.Class('text-sm underline'), h.Href(href)], [text]),
-              ],
-            }),
-          ],
-        ),
-        h.button([h.OnClick(handlers.dismiss)], ['Close']),
-      ],
-    ),
-  entryClassName: 'w-80',
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Toast.view({
+    model: model.toast,
+    position: 'BottomRight',
+    toParentMessage: message => GotToastMessage({ message }),
+    renderEntry: (entry, handlers) =>
+      h.div(
+        [
+          h.Class(
+            'flex items-start gap-3 rounded-lg border bg-white p-3 shadow',
+          ),
+        ],
+        [
+          h.div(
+            [h.Class('flex-1')],
+            [
+              h.p([h.Class('font-semibold text-sm')], [entry.payload.bodyText]),
+              ...Option.match(entry.payload.maybeLink, {
+                onNone: () => [],
+                onSome: ({ href, text }) => [
+                  h.a([h.Class('text-sm underline'), h.Href(href)], [text]),
+                ],
+              }),
+            ],
+          ),
+          h.button([h.OnClick(handlers.dismiss)], ['Close']),
+        ],
+      ),
+    entryClassName: 'w-80',
+  })
+}

--- a/packages/website/src/snippet/uiTooltipBasic.ts
+++ b/packages/website/src/snippet/uiTooltipBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the Tooltip Submodel:
 const Model = S.Struct({
   tooltip: Ui.Tooltip.Model,
@@ -44,13 +42,17 @@ GotTooltipMessage: ({ message }) => {
 }
 
 // Inside your view function, render the tooltip:
-Ui.Tooltip.view({
-  model: model.tooltip,
-  toParentMessage: message => GotTooltipMessage({ message }),
-  anchor: { placement: 'top', gap: 6, padding: 8 },
-  triggerContent: h.span([], ['Save']),
-  triggerClassName: 'rounded-lg border px-3 py-2 cursor-pointer',
-  content: h.span([], ['Save your changes (⌘S)']),
-  panelClassName:
-    'rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white shadow-lg',
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.Tooltip.view({
+    model: model.tooltip,
+    toParentMessage: message => GotTooltipMessage({ message }),
+    anchor: { placement: 'top', gap: 6, padding: 8 },
+    triggerContent: h.span([], ['Save']),
+    triggerClassName: 'rounded-lg border px-3 py-2 cursor-pointer',
+    content: h.span([], ['Save your changes (⌘S)']),
+    panelClassName:
+      'rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white shadow-lg',
+  })
+}

--- a/packages/website/src/snippet/uiVirtualListBasic.ts
+++ b/packages/website/src/snippet/uiVirtualListBasic.ts
@@ -7,8 +7,6 @@ import { html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-const h = html<Message>()
-
 // Add a field to your Model for the VirtualList Submodel. The list items
 // stay in your domain Model (your own `activities`, `messages`, `rows`,
 // whatever you call them); only scroll and measurement state live here:
@@ -87,27 +85,31 @@ const subscriptions = Subscription.makeSubscriptions(SubscriptionDependencies)<
 // fixed height the container grows to fit its children and never scrolls.
 // The component sets only `overflow: auto` inline; everything else is
 // yours:
-Ui.VirtualList.view({
-  model: model.activityList,
-  items: model.activities,
-  itemToKey: activity => String(activity.id),
-  itemToView: activity =>
-    h.div(
-      [h.Class('grid grid-cols-[2rem_1fr_5rem] items-center gap-3 px-4')],
-      [
-        h.div(
-          [h.Class('flex h-7 w-7 items-center justify-center rounded-full')],
-          [activity.initial],
-        ),
-        h.span([h.Class('truncate text-sm')], [activity.label]),
-        h.span(
-          [h.Class('text-right text-xs text-gray-500 tabular-nums')],
-          [activity.timeAgo],
-        ),
-      ],
-    ),
-  className: 'h-96 w-full rounded-lg bg-white ring-1 ring-gray-200',
-})
+const view = (model: Model) => {
+  const h = html<Message>()
+
+  return Ui.VirtualList.view({
+    model: model.activityList,
+    items: model.activities,
+    itemToKey: activity => String(activity.id),
+    itemToView: activity =>
+      h.div(
+        [h.Class('grid grid-cols-[2rem_1fr_5rem] items-center gap-3 px-4')],
+        [
+          h.div(
+            [h.Class('flex h-7 w-7 items-center justify-center rounded-full')],
+            [activity.initial],
+          ),
+          h.span([h.Class('truncate text-sm')], [activity.label]),
+          h.span(
+            [h.Class('text-right text-xs text-gray-500 tabular-nums')],
+            [activity.timeAgo],
+          ),
+        ],
+      ),
+    className: 'h-96 w-full rounded-lg bg-white ring-1 ring-gray-200',
+  })
+}
 
 // Programmatic scrolling. Returns [Model, Commands] in the same shape as
 // update. Stale completions are version-cancelled, so rapid successive

--- a/packages/website/src/snippet/uiVirtualListVariable.ts
+++ b/packages/website/src/snippet/uiVirtualListVariable.ts
@@ -5,8 +5,6 @@
 import { Ui } from 'foldkit'
 import { html } from 'foldkit/html'
 
-const h = html<Message>()
-
 // Model and init are unchanged from the basic example. Pass any
 // `rowHeightPx` to `init`; it remains the uniform default for the
 // `scrollToIndex` initial-apply path on the first measurement, and the
@@ -27,44 +25,48 @@ const init = () => [
 // math walk the items via a prefix-sum to find the visible window. Tests
 // with 10k items at 60Hz scroll well within budget; larger lists may need
 // a prefix-sum cache if you can profile the regression:
-Ui.VirtualList.view({
-  model: model.activityList,
-  items: model.activities,
-  itemToKey: activity => String(activity.id),
-  itemToRowHeightPx: (activity, index) => (activity.hasSummary ? 104 : 56),
-  itemToView: activity =>
-    activity.hasSummary
-      ? h.div(
-          [
-            h.Class(
-              'grid grid-cols-[2rem_1fr_5rem] items-start gap-3 px-4 py-3',
-            ),
-          ],
-          [
-            h.div([h.Class('h-7 w-7 rounded-full')], [activity.initial]),
-            h.div(
-              [],
-              [
-                h.span([], [activity.label]),
-                h.div(
-                  [h.Class('mt-1 text-xs text-gray-500')],
-                  [activity.summary],
-                ),
-              ],
-            ),
-            h.span([h.Class('text-right text-xs')], [activity.timeAgo]),
-          ],
-        )
-      : h.div(
-          [h.Class('grid grid-cols-[2rem_1fr_5rem] items-center gap-3 px-4')],
-          [
-            h.div([h.Class('h-7 w-7 rounded-full')], [activity.initial]),
-            h.span([], [activity.label]),
-            h.span([h.Class('text-right text-xs')], [activity.timeAgo]),
-          ],
-        ),
-  className: 'h-96 w-full rounded-lg bg-white ring-1 ring-gray-200',
-})
+const view = () => {
+  const h = html<Message>()
+
+  return Ui.VirtualList.view({
+    model: model.activityList,
+    items: model.activities,
+    itemToKey: activity => String(activity.id),
+    itemToRowHeightPx: (activity, index) => (activity.hasSummary ? 104 : 56),
+    itemToView: activity =>
+      activity.hasSummary
+        ? h.div(
+            [
+              h.Class(
+                'grid grid-cols-[2rem_1fr_5rem] items-start gap-3 px-4 py-3',
+              ),
+            ],
+            [
+              h.div([h.Class('h-7 w-7 rounded-full')], [activity.initial]),
+              h.div(
+                [],
+                [
+                  h.span([], [activity.label]),
+                  h.div(
+                    [h.Class('mt-1 text-xs text-gray-500')],
+                    [activity.summary],
+                  ),
+                ],
+              ),
+              h.span([h.Class('text-right text-xs')], [activity.timeAgo]),
+            ],
+          )
+        : h.div(
+            [h.Class('grid grid-cols-[2rem_1fr_5rem] items-center gap-3 px-4')],
+            [
+              h.div([h.Class('h-7 w-7 rounded-full')], [activity.initial]),
+              h.span([], [activity.label]),
+              h.span([h.Class('text-right text-xs')], [activity.timeAgo]),
+            ],
+          ),
+    className: 'h-96 w-full rounded-lg bg-white ring-1 ring-gray-200',
+  })
+}
 
 // Programmatic scrolling for variable-height lists uses
 // `scrollToIndexVariable`, which walks the heights to compute the target

--- a/packages/website/src/snippet/viewPureBad.ts
+++ b/packages/website/src/snippet/viewPureBad.ts
@@ -2,10 +2,10 @@ import { type Document, html } from 'foldkit/html'
 
 import { Model } from './model'
 
-const h = html()
-
 // ❌ Don't do this in view
 const view = (model: Model): Document => {
+  const h = html()
+
   // Fetching data in view
   fetch('/api/user').then(res => res.json())
 

--- a/packages/website/src/snippet/viewPureGood.ts
+++ b/packages/website/src/snippet/viewPureGood.ts
@@ -3,17 +3,19 @@ import { Document, html } from 'foldkit/html'
 import { ClickedIncrement, Message } from './message'
 import { Model } from './model'
 
-const h = html<Message>()
-
 // ✅ View is a pure function from Model to a Document describing the page
-const view = (model: Model): Document => ({
-  title: model.title,
-  body: h.div(
-    [h.Class('container')],
-    [
-      h.h1([], [model.title]),
-      h.p([], [`Count: ${model.count}`]),
-      h.button([h.OnClick(ClickedIncrement())], ['+']),
-    ],
-  ),
-})
+const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: model.title,
+    body: h.div(
+      [h.Class('container')],
+      [
+        h.h1([], [model.title]),
+        h.p([], [`Count: ${model.count}`]),
+        h.button([h.OnClick(ClickedIncrement())], ['+']),
+      ],
+    ),
+  }
+}

--- a/packages/website/src/view/codeBlock.ts
+++ b/packages/website/src/view/codeBlock.ts
@@ -5,9 +5,7 @@ import { Html, html } from 'foldkit/html'
 import { Icon } from '../icon'
 import { ClickedCopySnippet, type Message } from '../message'
 
-const h = html<Message>()
-
-const PagefindIgnore = h.DataAttribute('pagefind-ignore', '')
+const PagefindIgnore = html<Message>().DataAttribute('pagefind-ignore', '')
 
 export type CopiedSnippets = HashSet.HashSet<string>
 
@@ -17,6 +15,8 @@ const copyButtonWithIndicator = (
   copiedSnippets: CopiedSnippets,
   positionClass = 'top-2 right-2',
 ) => {
+  const h = html<Message>()
+
   const isCopied = HashSet.has(copiedSnippets, textToCopy)
 
   const copiedIndicator = isCopied
@@ -58,6 +58,8 @@ export const codeBlock = (
   copiedSnippets: CopiedSnippets,
   className?: string,
 ) => {
+  const h = html<Message>()
+
   const content = h.pre(
     [
       h.Class(
@@ -95,8 +97,11 @@ export const highlightedCodeBlock = (
   ariaLabel: string,
   copiedSnippets: CopiedSnippets,
   className?: string,
-) =>
-  h.div(
+) => {
+  const h = html<Message>()
+
+  return h.div(
     [PagefindIgnore, h.Class(clsx('relative min-w-0 mt-8', className))],
     [content, copyButtonWithIndicator(rawCode, ariaLabel, copiedSnippets)],
   )
+}

--- a/packages/website/src/view/docTable.ts
+++ b/packages/website/src/view/docTable.ts
@@ -3,8 +3,6 @@ import { Html, html } from 'foldkit/html'
 
 import { type Message } from '../message'
 
-const h = html<Message>()
-
 // SHARED STYLES
 
 const headerCellClassName =
@@ -24,11 +22,17 @@ const codeClassName =
 const wrappingCodeClassName =
   'bg-gray-200/70 dark:bg-gray-800 px-1 py-px rounded text-sm border border-gray-300/50 dark:border-gray-700/50 whitespace-pre-wrap break-normal'
 
-const inlineCode = (text: string): Html =>
-  h.code([h.Class(codeClassName)], [text])
+const inlineCode = (text: string): Html => {
+  const h = html<Message>()
 
-const wrappingInlineCode = (text: string): Html =>
-  h.code([h.Class(wrappingCodeClassName)], [text])
+  return h.code([h.Class(codeClassName)], [text])
+}
+
+const wrappingInlineCode = (text: string): Html => {
+  const h = html<Message>()
+
+  return h.code([h.Class(wrappingCodeClassName)], [text])
+}
 
 // PROP TABLE
 
@@ -39,8 +43,10 @@ export type PropEntry = Readonly<{
   description: string | Html
 }>
 
-const propRow = (entry: PropEntry): Html =>
-  h.tr(
+const propRow = (entry: PropEntry): Html => {
+  const h = html<Message>()
+
+  return h.tr(
     [h.Class(rowClassName)],
     [
       h.td([h.Class(cellClassName)], [inlineCode(entry.name)]),
@@ -59,9 +65,12 @@ const propRow = (entry: PropEntry): Html =>
       h.td([h.Class(descriptionCellClassName)], [entry.description]),
     ],
   )
+}
 
-export const propTable = (entries: ReadonlyArray<PropEntry>): Html =>
-  h.div(
+export const propTable = (entries: ReadonlyArray<PropEntry>): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('mb-8 overflow-x-auto')],
     [
       h.table(
@@ -86,6 +95,7 @@ export const propTable = (entries: ReadonlyArray<PropEntry>): Html =>
       ),
     ],
   )
+}
 
 // KEYBOARD TABLE
 
@@ -97,8 +107,10 @@ export type KeyboardEntry = Readonly<{
 const keyboardKeyClassName =
   'inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 text-sm font-mono text-gray-700 dark:text-gray-300'
 
-const keyboardRow = (entry: KeyboardEntry): Html =>
-  h.tr(
+const keyboardRow = (entry: KeyboardEntry): Html => {
+  const h = html<Message>()
+
+  return h.tr(
     [h.Class(rowClassName)],
     [
       h.td(
@@ -108,9 +120,12 @@ const keyboardRow = (entry: KeyboardEntry): Html =>
       h.td([h.Class(descriptionCellClassName)], [entry.description]),
     ],
   )
+}
 
-export const keyboardTable = (entries: ReadonlyArray<KeyboardEntry>): Html =>
-  h.div(
+export const keyboardTable = (entries: ReadonlyArray<KeyboardEntry>): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('mb-8 overflow-x-auto')],
     [
       h.table(
@@ -133,6 +148,7 @@ export const keyboardTable = (entries: ReadonlyArray<KeyboardEntry>): Html =>
       ),
     ],
   )
+}
 
 // DATA ATTRIBUTE TABLE
 
@@ -141,19 +157,24 @@ export type DataAttributeEntry = Readonly<{
   condition: string
 }>
 
-const dataAttributeRow = (entry: DataAttributeEntry): Html =>
-  h.tr(
+const dataAttributeRow = (entry: DataAttributeEntry): Html => {
+  const h = html<Message>()
+
+  return h.tr(
     [h.Class(rowClassName)],
     [
       h.td([h.Class(cellClassName)], [inlineCode(entry.attribute)]),
       h.td([h.Class(descriptionCellClassName)], [entry.condition]),
     ],
   )
+}
 
 export const dataAttributeTable = (
   entries: ReadonlyArray<DataAttributeEntry>,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Class('mb-8 overflow-x-auto')],
     [
       h.table(
@@ -176,3 +197,4 @@ export const dataAttributeTable = (
       ),
     ],
   )
+}

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -32,15 +32,15 @@ import {
 } from './tableOfContents'
 import { themeSelector } from './themeSelector'
 
-const h = html<Message>()
-
-const PagefindBody = h.DataAttribute('pagefind-body', '')
-const PagefindIgnore = h.DataAttribute('pagefind-ignore', '')
+const PagefindBody = html<Message>().DataAttribute('pagefind-body', '')
+const PagefindIgnore = html<Message>().DataAttribute('pagefind-ignore', '')
 
 // DOCS HEADER
 
-const docsHeaderView = (model: Model) =>
-  h.header(
+const docsHeaderView = (model: Model) => {
+  const h = html<Message>()
+
+  return h.header(
     [
       h.Class(
         'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream dark:bg-gray-900 border-b border-gray-300 dark:border-gray-800 px-3 md:px-6 flex items-center justify-between transform-gpu',
@@ -153,6 +153,7 @@ const docsHeaderView = (model: Model) =>
       ),
     ],
   )
+}
 
 // DOCS FOOTER
 
@@ -160,8 +161,10 @@ const docsFooterView = (
   emailField: Field,
   emailSubscriptionStatus: EmailSubscriptionStatus,
   currentYear: number,
-): Html =>
-  h.footer(
+): Html => {
+  const h = html<Message>()
+
+  return h.footer(
     [
       h.Class(
         'px-4 py-6 md:px-6 mt-6 border-t border-gray-300 dark:border-gray-800',
@@ -224,6 +227,7 @@ const docsFooterView = (
       ),
     ],
   )
+}
 
 // PAGE NAVIGATION
 
@@ -234,8 +238,10 @@ const neighborLink = (
     page: NavPage
     direction: 'Previous' | 'Next'
   }>,
-) =>
-  h.a(
+) => {
+  const h = html<Message>()
+
+  return h.a(
     [
       h.Href(config.page.href),
       h.Class(
@@ -272,8 +278,11 @@ const neighborLink = (
       ),
     ],
   )
+}
 
 const pageNavigationView = (tag: string) => {
+  const h = html<Message>()
+
   const { maybePrevious, maybeNext } = pageNeighbors(tag)
 
   if (Option.isNone(maybePrevious) && Option.isNone(maybeNext)) {
@@ -368,6 +377,8 @@ const lazyApiReferenceSkeleton = createLazy()
 // VIEW
 
 export const docsView = (model: Model, docsRoute: DocsRoute) => {
+  const h = html<Message>()
+
   const { content, tableOfContents: currentPageTableOfContents } = M.value(
     docsRoute,
   ).pipe(

--- a/packages/website/src/view/landing.ts
+++ b/packages/website/src/view/landing.ts
@@ -25,14 +25,14 @@ import { coreArchitectureRouter, homeRouter } from '../route'
 import { betaTag, emailSignupContentView, skipNavLink } from './shared'
 import { themeSelector } from './themeSelector'
 
-const h = html<Message>()
-
-const PagefindBody = h.DataAttribute('pagefind-body', '')
+const PagefindBody = html<Message>().DataAttribute('pagefind-body', '')
 
 // LANDING HEADER
 
-const landingHeaderView = (model: Model) =>
-  h.header(
+const landingHeaderView = (model: Model) => {
+  const h = html<Message>()
+
+  return h.header(
     [
       h.Class(
         clsx(
@@ -78,11 +78,14 @@ const landingHeaderView = (model: Model) =>
       ),
     ],
   )
+}
 
 // LANDING FOOTER
 
-const landingFooter = (currentYear: number): Html =>
-  h.footer(
+const landingFooter = (currentYear: number): Html => {
+  const h = html<Message>()
+
+  return h.footer(
     [
       h.Class(
         'px-6 py-8 md:px-12 lg:px-20 border-t border-gray-300 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-400',
@@ -108,6 +111,7 @@ const landingFooter = (currentYear: number): Html =>
       h.p([h.Class('mt-1')], [`© ${currentYear} Devin Jameson`]),
     ],
   )
+}
 
 // DEMO TABS
 
@@ -150,21 +154,30 @@ const playgroundItemClassName =
 
 const playgroundBackdropClassName = 'fixed inset-0 z-10'
 
-const chromeRecommendedHint: Html = h.p(
-  [h.Class('text-xs text-gray-500 dark:text-gray-400')],
-  ['Requires a Chromium browser'],
-)
+const chromeRecommendedHint: Html = (() => {
+  const h = html<Message>()
 
-const withChromeRecommendedHint = (menu: Html, isChromium: boolean): Html =>
-  isChromium
+  return h.p(
+    [h.Class('text-xs text-gray-500 dark:text-gray-400')],
+    ['Requires a Chromium browser'],
+  )
+})()
+
+const withChromeRecommendedHint = (menu: Html, isChromium: boolean): Html => {
+  const h = html<Message>()
+
+  return isChromium
     ? menu
     : h.div(
         [h.Class('flex flex-col items-start gap-1')],
         [menu, chromeRecommendedHint],
       )
+}
 
-const playgroundItemContent = (meta: ExampleMeta): Html =>
-  h.div(
+const playgroundItemContent = (meta: ExampleMeta): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [],
     [
       h.div(
@@ -181,12 +194,15 @@ const playgroundItemContent = (meta: ExampleMeta): Html =>
       ),
     ],
   )
+}
 
 const playgroundMenuView = (
   menuModel: Ui.Menu.Model,
   slugs: ReadonlyArray<ExampleSlug>,
-): Html =>
-  Ui.Menu.view<Message, ExampleSlug>({
+): Html => {
+  const h = html<Message>()
+
+  return Ui.Menu.view<Message, ExampleSlug>({
     model: menuModel,
     toParentMessage: message => GotPlaygroundMenuMessage({ message }),
     onSelectedItem: index =>
@@ -226,10 +242,13 @@ const playgroundMenuView = (
     backdropAttributes: [h.Class(playgroundBackdropClassName)],
     attributes: [h.Class('relative inline-block')],
   })
+}
 
 // VIEW
 
 export const landingView = (model: Model) => {
+  const h = html<Message>()
+
   const asyncCounterDemoView = lazyAsyncCounterDemo(
     Page.AsyncCounterDemo.view,
     [model.asyncCounterDemo, toAsyncCounterDemoMessage],
@@ -302,8 +321,10 @@ export const landingView = (model: Model) => {
   )
 }
 
-export const newsletterView = (model: Model) =>
-  h.keyed('div')(
+export const newsletterView = (model: Model) => {
+  const h = html<Message>()
+
+  return h.keyed('div')(
     'newsletter',
     [h.Class('flex flex-col min-h-screen')],
     [
@@ -326,3 +347,4 @@ export const newsletterView = (model: Model) =>
       landingFooter(model.currentYear),
     ],
   )
+}

--- a/packages/website/src/view/shared.ts
+++ b/packages/website/src/view/shared.ts
@@ -6,20 +6,24 @@ import { Html, html } from 'foldkit/html'
 import { type EmailSubscriptionStatus } from '../main'
 import { type Message, SubmittedEmailForm, UpdatedEmailField } from '../message'
 
-const h = html<Message>()
+export const betaTag: Html = (() => {
+  const h = html<Message>()
 
-export const betaTag: Html = h.span(
-  [
-    h.Class(
-      'hidden sm:inline-block -rotate-6 rounded bg-accent-700 dark:bg-accent-500 px-1.5 py-0.5 text-[10px] font-extrabold uppercase leading-none tracking-wider text-white dark:text-accent-900 select-none',
-    ),
-    h.AriaLabel('Beta'),
-  ],
-  ['Beta'],
-)
+  return h.span(
+    [
+      h.Class(
+        'hidden sm:inline-block -rotate-6 rounded bg-accent-700 dark:bg-accent-500 px-1.5 py-0.5 text-[10px] font-extrabold uppercase leading-none tracking-wider text-white dark:text-accent-900 select-none',
+      ),
+      h.AriaLabel('Beta'),
+    ],
+    ['Beta'],
+  )
+})()
 
-export const iconLink = (link: string, ariaLabel: string, icon: Html) =>
-  h.a(
+export const iconLink = (link: string, ariaLabel: string, icon: Html) => {
+  const h = html<Message>()
+
+  return h.a(
     [
       h.Href(link),
       h.Class(
@@ -29,22 +33,29 @@ export const iconLink = (link: string, ariaLabel: string, icon: Html) =>
     ],
     [icon],
   )
+}
 
-export const skipNavLink: Html = h.a(
-  [
-    h.Href('#main-content'),
-    h.Class(
-      'sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-accent-600 dark:focus:bg-accent-500 focus:text-white focus:text-sm focus:font-normal',
-    ),
-  ],
-  ['Skip to main content'],
-)
+export const skipNavLink: Html = (() => {
+  const h = html<Message>()
+
+  return h.a(
+    [
+      h.Href('#main-content'),
+      h.Class(
+        'sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-accent-600 dark:focus:bg-accent-500 focus:text-white focus:text-sm focus:font-normal',
+      ),
+    ],
+    ['Skip to main content'],
+  )
+})()
 
 export const emailFormView = (
   emailField: Field,
   status: 'Idle' | 'Submitting' | 'Failed',
   formClassName: string,
 ): Html => {
+  const h = html<Message>()
+
   const isSubmitting = status === 'Submitting'
 
   return h.div(
@@ -111,8 +122,10 @@ export const emailFormView = (
 export const emailSignupContentView = (
   emailField: Field,
   emailSubscriptionStatus: EmailSubscriptionStatus,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [h.Id('newsletter')],
     [
       h.h2(
@@ -148,3 +161,4 @@ export const emailSignupContentView = (
       ),
     ],
   )
+}

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -36,8 +36,6 @@ import {
 import { ExampleDetailRoute, apiModuleRouter, homeRouter } from '../route'
 import { betaTag, iconLink } from './shared'
 
-const h = html<Message>()
-
 export const DOCS_SIDEBAR_NAV_ID = 'docs-sidebar-nav'
 
 const SCROLL_DEBOUNCE_DURATION = Duration.millis(150)
@@ -81,8 +79,10 @@ const sidebarGroup = (config: {
   readonly model: Ui.Disclosure.Model
   readonly toParentMessage: (message: Ui.Disclosure.Message) => Message
   readonly children: Html
-}): Html =>
-  h.li(
+}): Html => {
+  const h = html<Message>()
+
+  return h.li(
     [],
     [
       Ui.Disclosure.view({
@@ -122,6 +122,7 @@ const sidebarGroup = (config: {
       }),
     ],
   )
+}
 
 const computeNavLinks = (
   route: Model['route'],
@@ -137,6 +138,8 @@ const computeNavLinks = (
   aiGroup: Ui.Disclosure.Model,
   apiReferenceGroup: Ui.Disclosure.Model,
 ): Html => {
+  const h = html<Message>()
+
   const isOnApiModulePage = route._tag === 'ApiModule'
   const maybeExampleSlug = pipe(
     route,
@@ -281,6 +284,8 @@ const lazyDesktopNavLinks = createLazy()
 const lazyMobileNavLinks = createLazy()
 
 export const sidebarView = (model: Model): Html => {
+  const h = html<Message>()
+
   const desktopNavLinks = lazyDesktopNavLinks(computeNavLinks, [
     model.route,
     model.getStartedGroup,

--- a/packages/website/src/view/table.ts
+++ b/packages/website/src/view/table.ts
@@ -4,12 +4,12 @@ import { Html, html } from 'foldkit/html'
 
 import { type Message } from '../message'
 
-const h = html<Message>()
-
 const columnBorder = 'border-r border-gray-300 dark:border-gray-700'
 
-const headerCell = (text: string, isLastColumn: boolean): Html =>
-  h.th(
+const headerCell = (text: string, isLastColumn: boolean): Html => {
+  const h = html<Message>()
+
+  return h.th(
     [
       h.Class(
         clsx(
@@ -20,13 +20,16 @@ const headerCell = (text: string, isLastColumn: boolean): Html =>
     ],
     [text],
   )
+}
 
 const cell = (
   content: ReadonlyArray<string | Html>,
   isFirstColumn: boolean,
   isLastColumn: boolean,
-): Html =>
-  h.td(
+): Html => {
+  const h = html<Message>()
+
+  return h.td(
     [
       h.Class(
         clsx(
@@ -38,12 +41,15 @@ const cell = (
     ],
     content,
   )
+}
 
 export const comparisonTable = (
   headers: ReadonlyArray<string>,
   rows: ReadonlyArray<ReadonlyArray<ReadonlyArray<string | Html>>>,
-): Html =>
-  h.div(
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
     [
       h.Class(
         'overflow-x-auto mb-6 border border-gray-300 dark:border-gray-700 rounded-lg overflow-hidden',
@@ -87,3 +93,4 @@ export const comparisonTable = (
       ),
     ],
   )
+}

--- a/packages/website/src/view/tableOfContents.ts
+++ b/packages/website/src/view/tableOfContents.ts
@@ -11,15 +11,15 @@ import {
   ToggledMobileTableOfContents,
 } from '../message'
 
-const h = html<Message>()
-
 const tableOfContentsEntryView = (
   level: TableOfContentsEntry['level'],
   id: string,
   text: string,
   isActive: boolean,
-): Html =>
-  h.keyed('li')(
+): Html => {
+  const h = html<Message>()
+
+  return h.keyed('li')(
     id,
     [
       h.Class(
@@ -47,14 +47,17 @@ const tableOfContentsEntryView = (
       ),
     ],
   )
+}
 
 const lazyTableOfContentsEntry = createKeyedLazy()
 
 export const tableOfContentsView = (
   entries: ReadonlyArray<TableOfContentsEntry>,
   maybeActiveSectionId: Option.Option<string>,
-) =>
-  h.aside(
+) => {
+  const h = html<Message>()
+
+  return h.aside(
     [
       h.Class(
         'hidden xl:block sticky top-[var(--header-height)] min-w-64 w-fit h-[calc(100vh-var(--header-height))] shrink-0 overflow-y-auto border-l border-gray-300 dark:border-gray-800 p-4',
@@ -93,12 +96,15 @@ export const tableOfContentsView = (
       ),
     ],
   )
+}
 
 export const mobileTableOfContentsView = (
   entries: ReadonlyArray<TableOfContentsEntry>,
   maybeActiveSectionId: Option.Option<string>,
   isOpen: boolean,
 ) => {
+  const h = html<Message>()
+
   const firstEntryText = Array.head(entries).pipe(
     Option.match({
       onNone: () => '',

--- a/packages/website/src/view/themeSelector.ts
+++ b/packages/website/src/view/themeSelector.ts
@@ -8,10 +8,10 @@ import {
   type ThemePreference,
 } from '../message'
 
-const h = html<Message>()
+export const themeSelector = (activePreference: ThemePreference): Html => {
+  const h = html<Message>()
 
-export const themeSelector = (activePreference: ThemePreference): Html =>
-  h.div(
+  return h.div(
     [
       h.Role('group'),
       h.AriaLabel('Theme preference'),
@@ -40,6 +40,7 @@ export const themeSelector = (activePreference: ThemePreference): Html =>
       ),
     ],
   )
+}
 
 const themeSelectorButton = (
   preference: ThemePreference,
@@ -47,6 +48,8 @@ const themeSelectorButton = (
   icon: Html,
   label: string,
 ) => {
+  const h = html<Message>()
+
   const isActive = preference === activePreference
 
   return h.button(

--- a/skills/generate-program/SKILL.md
+++ b/skills/generate-program/SKILL.md
@@ -301,7 +301,7 @@ For each Foldkit module you plan to use, read the `.d.ts` at the paths below. Re
 ```
 # Every app
 <project>/node_modules/foldkit/dist/index.d.ts          # top-level re-exports
-<project>/node_modules/foldkit/dist/html/index.d.ts     # html<M>(), element signatures, Attribute<M>, empty, keyed
+<project>/node_modules/foldkit/dist/html/index.d.ts     # html<Message>(), element signatures, Attribute<Message>, empty, keyed
 <project>/node_modules/foldkit/dist/message/index.d.ts  # m()
 <project>/node_modules/foldkit/dist/schema/index.d.ts   # ts(), r()
 <project>/node_modules/foldkit/dist/struct/index.d.ts   # evo(): check nested-update signature
@@ -341,7 +341,7 @@ For each Foldkit module you plan to use, read the `.d.ts` at the paths below. Re
 For each symbol you'll call, write one line:
 
 ```
-html<M>(): { div, input (VOID), textarea, button, Class, Href, For, Id, Role, OnClick(M), OnInput(value=>M), OnBlur(M), OnSubmit(M), keyed, empty, ... }
+html<Message>(): { div, input (VOID), textarea, button, Class, Href, For, Id, Role, OnClick(Message), OnInput(value=>Message), OnBlur(Message), OnSubmit(Message), keyed, empty, ... }
 Route.mapTo(schema)(parser): curried
 pushUrl(path): Effect<void>  // NOT fallible, no Effect.ignore needed
 urlToString(url: Url): string
@@ -357,7 +357,7 @@ Record these in the crib and keep them visible while generating:
 - **`input` and `br` and other void elements take ONLY attributes**: `input([...])`, never `input([...], [])`. `textarea` and `button` DO take children.
 - **`UrlRequest` tags are `Internal` and `External`**, not `InternalUrl` / `ExternalUrl`.
 - **`OnClick` and `OnSubmit` take a Message directly**, not a `() => Message`. Only `OnInput` takes `(value) => Message` because it needs the input value.
-- **`keyed`, `empty` are properties on the record returned by `html<M>()`**: accessed as `h.keyed` and `h.empty` after `const h = html<M>()`. They are not top-level exports of `foldkit/html`.
+- **`keyed`, `empty` are properties on the record returned by `html<Message>()`**: accessed as `h.keyed` and `h.empty` after `const h = html<Message>()`. They are not top-level exports of `foldkit/html`.
 - **Attribute helpers are specific**: `Value(...)`, `Type(...)`, `Placeholder(...)`, `Href(...)`, `Target(...)`, `Rel(...)`, `Rows(n)`, `Id(...)`, `For(...)`, `Role(...)`, `AriaLabel(...)`. There is no generic `Attr('...', '...')`.
 - **`ProgramInit<Model, Message, Flags>` has no URL parameter.** For routed apps, use `RoutingProgramInit<Model, Message, Flags>`: the second arg is `url: Url`.
 - **`Route.mapTo` takes the route schema, not a factory function.** `pipe(literal('new'), Route.mapTo(NewLinkRoute))`. NOT `Route.mapTo(() => NewLinkRoute())`.
@@ -512,7 +512,7 @@ For file uploads (resumes, images, attachments):
 
 ### View
 
-- Bind the html factory once per module: `const h = html<Message>()`. Reach for elements, attributes, and event handlers off `h`: `h.div`, `h.Class`, `h.OnClick`. For child views generic over a parent's Message, take `<ParentMessage>` as a function generic and bind `const h = html<ParentMessage>()` inside the function body.
+- Bind the html factory inside each view function (never at module level): `const h = html<Message>()` as the first line of the function body. Reach for elements, attributes, and event handlers off `h`: `h.div`, `h.Class`, `h.OnClick`. For child views generic over a parent's Message, take `<ParentMessage>` as a function generic and bind `const h = html<ParentMessage>()` inside the function body.
 - Use `h.Class(...)` for Tailwind classes
 - Use `clsx` from the `clsx` package for conditional class composition: `h.Class(clsx('base-classes', { 'active-class': isActive, 'bg-blue-500': variant === 'Primary' }))`. Use `clsx` whenever classes depend on model state, boolean flags, or discriminated union tags. Never string concatenation, template literals, or `&&` expressions.
 - Pattern match on model state: `M.value(model.state).pipe(M.tagsExhaustive({...}))`

--- a/skills/generate-program/checklist.md
+++ b/skills/generate-program/checklist.md
@@ -71,7 +71,7 @@ grep -rn "label(\[" src/ | grep -v "For("
 grep -rn "maybe[A-Z][a-zA-Z]*: [A-Z][a-zA-Z]* | undefined" src/
 grep -rn "maybe[A-Z][a-zA-Z]*: string\b\|maybe[A-Z][a-zA-Z]*: number\b\|maybe[A-Z][a-zA-Z]*: boolean\b" src/
 
-# h.span([], []): use h.empty (the empty value off h = html<M>())
+# h.span([], []): use h.empty (the empty value off h = html<Message>(), bound inside the view function)
 grep -rn "\.span(\[\], \[\])\|^span(\[\], \[\])" src/
 
 # Effect.ignore on infallible Effects (pushUrl, load, back, forward)

--- a/skills/generate-program/conventions.md
+++ b/skills/generate-program/conventions.md
@@ -441,4 +441,4 @@ Notes:
 - When an Effect module name collides with a global, alias the Effect import with a trailing underscore: `String as String_`, `Array as Array_`, `Number as Number_`.
 - `Match as M` is Effect's Match module. Foldkit re-exports `M.value`, `M.tagsExhaustive`, `M.withReturnType` etc. through Effect's `Match`.
 - `Ui` from `foldkit` gives access to all UI components: `Ui.Dialog`, `Ui.Tabs`, `Ui.Menu`, `Ui.DatePicker`, `Ui.FileDrop`, `Ui.Toast`, `Ui.Tooltip`, etc.
-- `empty` and `keyed` can be imported from `foldkit/html` directly or accessed off `h` after binding `const h = html<Message>()`.
+- `empty` and `keyed` are properties on `h` after binding `const h = html<Message>()` inside the view function. They are not top-level exports of `foldkit/html`.


### PR DESCRIPTION
This change updates the codebase to bind `const h = html<Message>()` at the function scope rather than at module scope. This pattern is more idiomatic and aligns with Foldkit best practices by:

- Keeping the html factory binding close to where it's used
- Making view functions more self-contained and easier to reason about
- Reducing module-level state and improving composability
- Supporting better code organization when multiple view functions exist in a file

## Key Changes

- **View functions**: Moved `const h = html<Message>()` from module scope into the body of view functions (e.g., `view`, `glyph`, `exampleRow`, `plainCode`)
- **Helper functions**: For smaller helper functions that return Html, wrapped them to bind `h` locally before returning the Html value
- **Snippet files**: Updated all UI component snippet examples to follow the new pattern
- **Documentation**: Updated README, template docs, and skill guides to recommend function-level binding
- **Test apps**: Updated test applications to use function-level binding

## Implementation Details

The refactoring maintains identical runtime behavior while improving code organization. Functions that previously relied on module-level `h` now create their own binding, making them more portable and reducing implicit dependencies. This is particularly beneficial for:

- Snippet examples that serve as documentation
- Reusable helper functions that can be moved between files
- Test applications that demonstrate best practices
- Large view files with multiple helper functions

Updated `.changeset/html-binding-function-level.md` to document this pattern change.

https://claude.ai/code/session_016TuUcdkv3sPnvEHU1mp1UA