### PR TITLE
Add terminal UI runtime built on effect-boxes

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -25,6 +25,7 @@
     "counter-example",
     "websocket-chat-example",
     "snake-example",
+    "snake-terminal-example",
     "crash-view-example",
     "query-sync-example",
     "ui-showcase",

--- a/.changeset/terminal-layer.md
+++ b/.changeset/terminal-layer.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `foldkit/terminal` subpath: a Foldkit runtime for terminal UI apps built on [effect-boxes](https://github.com/lloydrichards/effect-boxes). The same Elm Architecture (`Model`, `Message`, `update`, `view`) with a terminal-native view layer. Views return an `effect-boxes` `Box<AnsiStyle>` so layout, color, padding, borders, flex, and grids all come from the wider Effect ecosystem rather than a Foldkit-specific renderer. Includes `makeTerminalProgram`, `runTerminal`, and `keyPressStream` for raw stdin input. `@effect/platform-node` and `effect-boxes` are optional peer dependencies — only required by apps that import `foldkit/terminal`.

--- a/examples/snake-terminal/package.json
+++ b/examples/snake-terminal/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "snake-terminal-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/main.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@effect/platform-node": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.64",
+    "effect-boxes": "^0.15.0",
+    "foldkit": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/snake-terminal/src/constants.ts
+++ b/examples/snake-terminal/src/constants.ts
@@ -1,0 +1,24 @@
+export const GAME = {
+  GRID_SIZE: 20,
+  INITIAL_POSITION: { x: 10, y: 10 },
+  INITIAL_DIRECTION: 'Right',
+  POINTS_PER_APPLE: 10,
+} as const
+
+export const GAME_SPEED = {
+  MIN_INTERVAL: 80,
+  BASE_INTERVAL: 150,
+} as const
+
+export const CONTROLS = {
+  SPACE: ' ',
+  RESTART: 'r',
+  ARROW_UP: 'ArrowUp',
+  ARROW_DOWN: 'ArrowDown',
+  ARROW_LEFT: 'ArrowLeft',
+  ARROW_RIGHT: 'ArrowRight',
+  W: 'w',
+  A: 'a',
+  S: 's',
+  D: 'd',
+} as const

--- a/examples/snake-terminal/src/domain/apple.ts
+++ b/examples/snake-terminal/src/domain/apple.ts
@@ -1,0 +1,22 @@
+import { Effect, Random, Schedule } from 'effect'
+
+import { GAME } from '../constants'
+import { Position } from './position'
+import * as Snake from './snake'
+
+export const generatePosition = (snake: Snake.Snake) =>
+  Effect.gen(function* () {
+    const x = yield* Random.nextIntBetween(0, GAME.GRID_SIZE, {
+      halfOpen: true,
+    })
+    const y = yield* Random.nextIntBetween(0, GAME.GRID_SIZE, {
+      halfOpen: true,
+    })
+    const pos: Position = { x, y }
+
+    if (Snake.contains(snake, pos)) {
+      return yield* Effect.fail('PositionCollision' as const)
+    } else {
+      return pos
+    }
+  }).pipe(Effect.retry(Schedule.forever), Effect.orDie)

--- a/examples/snake-terminal/src/domain/direction.ts
+++ b/examples/snake-terminal/src/domain/direction.ts
@@ -1,0 +1,17 @@
+import { Match, Schema } from 'effect'
+
+export const Direction = Schema.Literals(['Up', 'Down', 'Left', 'Right'])
+export type Direction = typeof Direction.Type
+
+export const opposite = (direction: Direction): Direction =>
+  Match.value(direction).pipe(
+    Match.withReturnType<Direction>(),
+    Match.when('Up', () => 'Down'),
+    Match.when('Down', () => 'Up'),
+    Match.when('Left', () => 'Right'),
+    Match.when('Right', () => 'Left'),
+    Match.exhaustive,
+  )
+
+export const isOpposite = (a: Direction, b: Direction): boolean =>
+  opposite(a) === b

--- a/examples/snake-terminal/src/domain/index.ts
+++ b/examples/snake-terminal/src/domain/index.ts
@@ -1,0 +1,4 @@
+export * as Position from './position'
+export * as Direction from './direction'
+export * as Snake from './snake'
+export * as Apple from './apple'

--- a/examples/snake-terminal/src/domain/position.ts
+++ b/examples/snake-terminal/src/domain/position.ts
@@ -1,0 +1,32 @@
+import { Match, Schema } from 'effect'
+
+import { GAME } from '../constants'
+import * as Direction from './direction'
+
+export const Position = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+})
+
+export const equivalence = Schema.toEquivalence(Position)
+
+export type Position = typeof Position.Type
+
+export const wrap = ({ x, y }: Position): Position => ({
+  x: x < 0 ? GAME.GRID_SIZE - 1 : x >= GAME.GRID_SIZE ? 0 : x,
+  y: y < 0 ? GAME.GRID_SIZE - 1 : y >= GAME.GRID_SIZE ? 0 : y,
+})
+
+export const move = (
+  pos: Position,
+  direction: Direction.Direction,
+): Position => {
+  const next = Match.value(direction).pipe(
+    Match.when('Up', () => ({ x: pos.x, y: pos.y - 1 })),
+    Match.when('Down', () => ({ x: pos.x, y: pos.y + 1 })),
+    Match.when('Left', () => ({ x: pos.x - 1, y: pos.y })),
+    Match.when('Right', () => ({ x: pos.x + 1, y: pos.y })),
+    Match.exhaustive,
+  )
+  return wrap(next)
+}

--- a/examples/snake-terminal/src/domain/snake.ts
+++ b/examples/snake-terminal/src/domain/snake.ts
@@ -1,0 +1,43 @@
+import { Array, Schema as S } from 'effect'
+
+import type { Direction } from './direction'
+import * as Position from './position'
+
+export const INITIAL_LENGTH = 3
+
+export const Snake = S.NonEmptyArray(Position.Position)
+export type Snake = typeof Snake.Type
+
+export const create = (startPos: Position.Position): Snake =>
+  Array.makeBy(INITIAL_LENGTH, i => ({
+    x: startPos.x - i,
+    y: startPos.y,
+  }))
+
+export const move = (snake: Snake, direction: Direction): Snake =>
+  Array.matchLeft(snake, {
+    onEmpty: () => snake,
+    onNonEmpty: (head, tail) => {
+      const newHead = Position.move(head, direction)
+      return [newHead, head, ...Array.dropRight(tail, 1)]
+    },
+  })
+
+export const grow = (snake: Snake, direction: Direction): Snake =>
+  Array.matchLeft(snake, {
+    onEmpty: () => snake,
+    onNonEmpty: (head, tail) => {
+      const newHead = Position.move(head, direction)
+      return [newHead, head, ...tail]
+    },
+  })
+
+export const hasCollision = (snake: Snake): boolean =>
+  Array.matchLeft(snake, {
+    onEmpty: () => false,
+    onNonEmpty: (head, tail) =>
+      Array.some(tail, segment => Position.equivalence(head, segment)),
+  })
+
+export const contains = (snake: Snake, pos: Position.Position): boolean =>
+  Array.some(snake, segment => Position.equivalence(segment, pos))

--- a/examples/snake-terminal/src/main.ts
+++ b/examples/snake-terminal/src/main.ts
@@ -1,0 +1,348 @@
+import {
+  Array,
+  Duration,
+  Effect,
+  Match as M,
+  Schema as S,
+  Stream,
+  pipe,
+} from 'effect'
+import * as Ansi from 'effect-boxes/Ansi'
+import * as Box from 'effect-boxes/Box'
+import * as Command from 'foldkit/command'
+import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
+import * as Subscription from 'foldkit/subscription'
+import {
+  type KeyPress,
+  type TerminalView,
+  keyPressStream,
+  makeTerminalProgram,
+  runTerminal,
+} from 'foldkit/terminal'
+
+import { GAME, GAME_SPEED } from './constants'
+import { Apple, Direction, Position, Snake } from './domain'
+
+// MODEL
+
+const GameState = S.Literals(['NotStarted', 'Playing', 'Paused', 'GameOver'])
+type GameState = typeof GameState.Type
+
+const Model = S.Struct({
+  snake: Snake.Snake,
+  apple: Position.Position,
+  direction: Direction.Direction,
+  nextDirection: Direction.Direction,
+  gameState: GameState,
+  points: S.Number,
+  highScore: S.Number,
+})
+type Model = typeof Model.Type
+
+// MESSAGE
+
+const TickedClock = m('TickedClock')
+const PressedKey = m('PressedKey', { key: S.String })
+const GeneratedApplePosition = m('GeneratedApplePosition', {
+  position: Position.Position,
+})
+
+const Message = S.Union([TickedClock, PressedKey, GeneratedApplePosition])
+type Message = typeof Message.Type
+
+// COMMAND
+
+const GenerateApplePosition = Command.define(
+  'GenerateApplePosition',
+  { snake: Snake.Snake },
+  GeneratedApplePosition,
+)(({ snake }) =>
+  Apple.generatePosition(snake).pipe(
+    Effect.map(position => GeneratedApplePosition({ position })),
+  ),
+)
+
+// INIT
+
+const init = (): readonly [Model, ReadonlyArray<Command.Command<Message>>] => {
+  const snake = Snake.create(GAME.INITIAL_POSITION)
+  return [
+    {
+      snake,
+      apple: { x: 15, y: 15 },
+      direction: GAME.INITIAL_DIRECTION,
+      nextDirection: GAME.INITIAL_DIRECTION,
+      gameState: 'NotStarted',
+      points: 0,
+      highScore: 0,
+    },
+    [GenerateApplePosition({ snake })],
+  ]
+}
+
+// UPDATE
+
+const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    M.tagsExhaustive({
+      PressedKey: ({ key }) =>
+        M.value(key).pipe(
+          M.withReturnType<
+            readonly [Model, ReadonlyArray<Command.Command<Message>>]
+          >(),
+          M.whenOr(
+            'ArrowUp',
+            'ArrowDown',
+            'ArrowLeft',
+            'ArrowRight',
+            'w',
+            'a',
+            's',
+            'd',
+            moveKey => {
+              const nextDirection = M.value(moveKey).pipe(
+                M.withReturnType<Direction.Direction>(),
+                M.whenOr('ArrowUp', 'w', () => 'Up'),
+                M.whenOr('ArrowDown', 's', () => 'Down'),
+                M.whenOr('ArrowLeft', 'a', () => 'Left'),
+                M.whenOr('ArrowRight', 'd', () => 'Right'),
+                M.exhaustive,
+              )
+
+              if (model.gameState === 'Playing') {
+                return [evo(model, { nextDirection: () => nextDirection }), []]
+              }
+              return [model, []]
+            },
+          ),
+          M.when(' ', () => {
+            const nextGameState = M.value(model.gameState).pipe(
+              M.withReturnType<GameState>(),
+              M.when('NotStarted', () => 'Playing'),
+              M.when('Playing', () => 'Paused'),
+              M.when('Paused', () => 'Playing'),
+              M.when('GameOver', () => 'GameOver'),
+              M.exhaustive,
+            )
+            return [evo(model, { gameState: () => nextGameState }), []]
+          }),
+          M.when('r', () => {
+            const nextSnake = Snake.create(GAME.INITIAL_POSITION)
+            return [
+              evo(model, {
+                snake: () => nextSnake,
+                direction: () => GAME.INITIAL_DIRECTION,
+                nextDirection: () => GAME.INITIAL_DIRECTION,
+                gameState: () => 'NotStarted',
+                points: () => 0,
+              }),
+              [GenerateApplePosition({ snake: nextSnake })],
+            ]
+          }),
+          M.orElse(() => [model, []]),
+        ),
+
+      TickedClock: () => {
+        if (model.gameState !== 'Playing') {
+          return [model, []]
+        }
+
+        const currentDirection = Direction.isOpposite(
+          model.direction,
+          model.nextDirection,
+        )
+          ? model.direction
+          : model.nextDirection
+
+        const newHead = Position.move(model.snake[0], currentDirection)
+        const willEatApple = Position.equivalence(newHead, model.apple)
+
+        const nextSnake = willEatApple
+          ? Snake.grow(model.snake, currentDirection)
+          : Snake.move(model.snake, currentDirection)
+
+        if (Snake.hasCollision(nextSnake)) {
+          return [
+            evo(model, {
+              gameState: () => 'GameOver',
+              highScore: highScore => Math.max(model.points, highScore),
+            }),
+            [],
+          ]
+        }
+
+        const commands = willEatApple
+          ? [GenerateApplePosition({ snake: nextSnake })]
+          : []
+
+        return [
+          evo(model, {
+            snake: () => nextSnake,
+            direction: () => currentDirection,
+            points: points =>
+              willEatApple ? points + GAME.POINTS_PER_APPLE : points,
+          }),
+          commands,
+        ]
+      },
+
+      GeneratedApplePosition: ({ position }) => [
+        evo(model, { apple: () => position }),
+        [],
+      ],
+    }),
+  )
+
+// SUBSCRIPTION
+
+const SubscriptionDeps = S.Struct({
+  gameClock: S.Struct({
+    isPlaying: S.Boolean,
+    interval: S.Number,
+  }),
+  keyboard: S.Null,
+})
+
+const subscriptions = Subscription.makeSubscriptions(SubscriptionDeps)<
+  Model,
+  Message
+>({
+  gameClock: {
+    modelToDependencies: model => ({
+      isPlaying: model.gameState === 'Playing',
+      interval: Math.max(
+        GAME_SPEED.MIN_INTERVAL,
+        GAME_SPEED.BASE_INTERVAL - model.points,
+      ),
+    }),
+    dependenciesToStream: deps =>
+      Stream.when(
+        Stream.tick(Duration.millis(deps.interval)).pipe(
+          Stream.map(TickedClock),
+        ),
+        Effect.sync(() => deps.isPlaying),
+      ),
+  },
+
+  keyboard: {
+    modelToDependencies: () => null,
+    dependenciesToStream: () =>
+      keyPressStream().pipe(
+        Stream.map((keyPress: KeyPress) => PressedKey({ key: keyPress.key })),
+      ),
+  },
+})
+
+// VIEW
+
+const CELL = '  '
+const emptyCellStyle = Ansi.bgBrightBlack
+const snakeHeadStyle = Ansi.bgGreen
+const snakeBodyStyle = Ansi.bgBrightGreen
+const appleStyle = Ansi.bgRed
+
+const cellStyle = (x: number, y: number, model: Model): Ansi.AnsiAnnotation => {
+  if (Position.equivalence({ x, y }, model.snake[0])) {
+    return snakeHeadStyle
+  }
+  const isBody = pipe(
+    model.snake,
+    Array.tailNonEmpty,
+    Array.some(segment => Position.equivalence({ x, y }, segment)),
+  )
+  if (isBody) {
+    return snakeBodyStyle
+  }
+  if (Position.equivalence({ x, y }, model.apple)) {
+    return appleStyle
+  }
+  return emptyCellStyle
+}
+
+const cellView = (x: number, y: number, model: Model): TerminalView =>
+  Box.annotate(Box.text(CELL), cellStyle(x, y, model))
+
+const gridView = (model: Model): TerminalView =>
+  pipe(
+    Array.makeBy(GAME.GRID_SIZE, y =>
+      Box.hcat(
+        Array.makeBy(GAME.GRID_SIZE, x => cellView(x, y, model)),
+        Box.top,
+      ),
+    ),
+    rows => Box.vcat(rows, Box.left),
+    Box.border<never>('rounded'),
+  )
+
+const gameStateText = (gameState: GameState): string =>
+  M.value(gameState).pipe(
+    M.when('NotStarted', () => 'Press SPACE to start'),
+    M.when('Playing', () => 'Playing. SPACE to pause'),
+    M.when('Paused', () => 'Paused. SPACE to continue'),
+    M.when('GameOver', () => 'Game Over. R to restart'),
+    M.exhaustive,
+  )
+
+const headerView = (model: Model): TerminalView =>
+  Box.vcat(
+    [
+      Box.annotate(
+        Box.text(' Snake Game'),
+        Ansi.combine(Ansi.bold, Ansi.green),
+      ),
+      Box.emptyBox(1, 0),
+      Box.hcat(
+        [
+          Box.annotate(Box.text(` Score: ${model.points}`), Ansi.yellow),
+          Box.text('   '),
+          Box.annotate(Box.text(`High Score: ${model.highScore}`), Ansi.cyan),
+        ],
+        Box.top,
+      ),
+      Box.annotate(
+        Box.text(` ${gameStateText(model.gameState)}`),
+        Ansi.brightBlack,
+      ),
+      Box.emptyBox(1, 0),
+    ],
+    Box.left,
+  )
+
+const footerView = (): TerminalView =>
+  Box.vcat(
+    [
+      Box.annotate(Box.text(' Arrow keys or WASD to move'), Ansi.brightBlack),
+      Box.annotate(Box.text(' SPACE to pause / start'), Ansi.brightBlack),
+      Box.annotate(
+        Box.text(' R to restart    Ctrl+C to quit'),
+        Ansi.brightBlack,
+      ),
+    ],
+    Box.left,
+  )
+
+const view = (model: Model): TerminalView =>
+  Box.vcat(
+    [headerView(model), gridView(model), Box.emptyBox(1, 0), footerView()],
+    Box.left,
+  )
+
+// RUN
+
+const program = makeTerminalProgram({
+  Model,
+  init,
+  update,
+  view,
+  subscriptions,
+  title: model => `Snake (${model.points} pts)`,
+})
+
+runTerminal(program)

--- a/examples/snake-terminal/tsconfig.json
+++ b/examples/snake-terminal/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "../../packages/foldkit/src"]
+}

--- a/packages/foldkit/package.json
+++ b/packages/foldkit/package.json
@@ -103,6 +103,10 @@
       "types": "./dist/test/vitest.d.ts",
       "import": "./dist/test/vitest.js"
     },
+    "./terminal": {
+      "types": "./dist/terminal/public.d.ts",
+      "import": "./dist/terminal/public.js"
+    },
     "./ui": {
       "types": "./dist/ui/index.d.ts",
       "import": "./dist/ui/index.js"
@@ -214,12 +218,24 @@
   },
   "peerDependencies": {
     "@effect/platform-browser": "4.0.0-beta.64",
-    "effect": "4.0.0-beta.64"
+    "@effect/platform-node": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.64",
+    "effect-boxes": "^0.15.0"
+  },
+  "peerDependenciesMeta": {
+    "@effect/platform-node": {
+      "optional": true
+    },
+    "effect-boxes": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-node": "4.0.0-beta.64",
     "@effect/vitest": "4.0.0-beta.64",
     "effect": "4.0.0-beta.64",
+    "effect-boxes": "^0.15.0",
     "happy-dom": "^20.9.0",
     "rimraf": "^6.1.3",
     "typedoc": "^0.28.19",

--- a/packages/foldkit/src/terminal/input.ts
+++ b/packages/foldkit/src/terminal/input.ts
@@ -1,0 +1,95 @@
+import { Effect, Queue, Stream } from 'effect'
+
+/** A parsed key press from raw terminal input. */
+export type KeyPress = Readonly<{
+  key: string
+  ctrl: boolean
+  shift: boolean
+  alt: boolean
+}>
+
+const noModifiers = { ctrl: false, shift: false, alt: false } as const
+
+const parseKeyPress = (data: Buffer): KeyPress => {
+  const hex = data.toString('hex')
+  const str = data.toString('utf8')
+
+  if (hex === '1b5b41') {
+    return { key: 'ArrowUp', ...noModifiers }
+  }
+  if (hex === '1b5b42') {
+    return { key: 'ArrowDown', ...noModifiers }
+  }
+  if (hex === '1b5b43') {
+    return { key: 'ArrowRight', ...noModifiers }
+  }
+  if (hex === '1b5b44') {
+    return { key: 'ArrowLeft', ...noModifiers }
+  }
+  if (hex === '0d' || hex === '0a') {
+    return { key: 'Enter', ...noModifiers }
+  }
+  if (hex === '1b') {
+    return { key: 'Escape', ...noModifiers }
+  }
+  if (hex === '7f' || hex === '08') {
+    return { key: 'Backspace', ...noModifiers }
+  }
+  if (hex === '09') {
+    return { key: 'Tab', ...noModifiers }
+  }
+  if (hex === '20') {
+    return { key: ' ', ...noModifiers }
+  }
+
+  const firstByte = data[0]
+  if (data.length === 1 && firstByte !== undefined && firstByte < 27) {
+    return {
+      key: String.fromCharCode(firstByte + 96),
+      ctrl: true,
+      shift: false,
+      alt: false,
+    }
+  }
+
+  return { key: str, ...noModifiers }
+}
+
+/**
+ * A `Stream` of key presses read from `process.stdin` in raw mode.
+ *
+ * Acquires raw mode and a `data` listener on subscription, and tears them
+ * down on stream completion. `Ctrl+C` short-circuits to `process.exit(0)`
+ * so users can always abort.
+ */
+export const keyPressStream = (): Stream.Stream<KeyPress> =>
+  Stream.callback<KeyPress>(queue =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        process.stdin.setRawMode(true)
+        process.stdin.resume()
+        process.stdin.setEncoding('utf8')
+
+        const onData = (data: Buffer) => {
+          const keyPress = parseKeyPress(
+            Buffer.isBuffer(data) ? data : Buffer.from(data),
+          )
+
+          if (keyPress.ctrl && keyPress.key === 'c') {
+            process.exit(0)
+          }
+
+          Queue.offerUnsafe(queue, keyPress)
+        }
+
+        process.stdin.on('data', onData)
+        return onData
+      }),
+      onData =>
+        Effect.sync(() => {
+          process.stdin.removeListener('data', onData)
+          process.stdin.setRawMode(false)
+          process.stdin.pause()
+        }),
+    ),
+  )

--- a/packages/foldkit/src/terminal/public.ts
+++ b/packages/foldkit/src/terminal/public.ts
@@ -1,0 +1,10 @@
+export type { KeyPress } from './input.js'
+export { keyPressStream } from './input.js'
+
+export type {
+  TerminalProgram,
+  TerminalProgramConfig,
+  TerminalProgramConfigWithFlags,
+  TerminalView,
+} from './runtime.js'
+export { makeTerminalProgram, runTerminal } from './runtime.js'

--- a/packages/foldkit/src/terminal/runtime.ts
+++ b/packages/foldkit/src/terminal/runtime.ts
@@ -1,0 +1,386 @@
+import { NodeRuntime } from '@effect/platform-node'
+import {
+  Cause,
+  Effect,
+  Layer,
+  PubSub,
+  Queue,
+  Record,
+  Ref,
+  Schema,
+  Stream,
+  pipe,
+} from 'effect'
+import type * as Ansi from 'effect-boxes/Ansi'
+import type * as Box from 'effect-boxes/Box'
+import * as Renderer from 'effect-boxes/Renderer'
+
+import type { Command } from '../command/index.js'
+import type { Subscriptions } from '../runtime/subscription.js'
+
+/**
+ * The view type for terminal programs. An effect-boxes Box annotated with
+ * Ansi styles. Compose with `Box.text`, `Box.vcat`, `Box.annotate`, the
+ * `Layout` combinators, etc.
+ */
+export type TerminalView = Box.Box<Ansi.AnsiStyle>
+
+type AnyCommand<T, E = never, R = never> = Readonly<{
+  name: string
+  args?: Record<string, unknown>
+  effect: Effect.Effect<T, E, R>
+}>
+
+/** Configuration for a terminal program without flags. */
+export type TerminalProgramConfig<
+  Model,
+  Message,
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Resources = never,
+> = Readonly<{
+  Model: Schema.Codec<Model, any, unknown, unknown>
+  init: () => readonly [
+    Model,
+    ReadonlyArray<Command<Message, never, Resources>>,
+  ]
+  update: (
+    model: Model,
+    message: Message,
+  ) => readonly [Model, ReadonlyArray<Command<Message, never, Resources>>]
+  view: (model: Model) => TerminalView
+  subscriptions?: Subscriptions<Model, Message, StreamDepsMap, Resources>
+  title?: (model: Model) => string
+  resources?: Layer.Layer<Resources>
+}>
+
+/** Configuration for a terminal program with flags. */
+export type TerminalProgramConfigWithFlags<
+  Model,
+  Message,
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources = never,
+> = Omit<
+  TerminalProgramConfig<Model, Message, StreamDepsMap, Resources>,
+  'init'
+> &
+  Readonly<{
+    Flags: Schema.Codec<Flags, any, unknown, unknown>
+    flags: Effect.Effect<Flags>
+    init: (
+      flags: Flags,
+    ) => readonly [Model, ReadonlyArray<Command<Message, never, Resources>>]
+  }>
+
+/** A configured terminal program. Pass to `runTerminal` to start it. */
+export type TerminalProgram = Readonly<{
+  start: () => Effect.Effect<void>
+}>
+
+const ESC = '\x1b['
+const eraseScreen = `${ESC}2J`
+const cursorHome = `${ESC}H`
+const cursorHide = `${ESC}?25l`
+const cursorShow = `${ESC}?25h`
+const altScreenEnter = `${ESC}?1049h`
+const altScreenLeave = `${ESC}?1049l`
+
+const renderToString = (view: TerminalView): Effect.Effect<string> =>
+  Renderer.render()(view).pipe(
+    Effect.map(body => eraseScreen + cursorHome + body),
+    Effect.provide(Renderer.AnsiRendererLive),
+  )
+
+type ResolvedConfig<
+  Model,
+  Message,
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources,
+> = Readonly<{
+  Model: Schema.Codec<Model, any, unknown, unknown>
+  flags: Effect.Effect<Flags>
+  init: (
+    flags: Flags,
+  ) => readonly [Model, ReadonlyArray<Command<Message, never, Resources>>]
+  update: (
+    model: Model,
+    message: Message,
+  ) => readonly [Model, ReadonlyArray<Command<Message, never, Resources>>]
+  view: (model: Model) => TerminalView
+  subscriptions:
+    | Subscriptions<Model, Message, StreamDepsMap, Resources>
+    | undefined
+  title: ((model: Model) => string) | undefined
+  resources: Layer.Layer<Resources> | undefined
+}>
+
+const makeRuntime = <
+  Model,
+  Message,
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources,
+>(
+  config: ResolvedConfig<Model, Message, StreamDepsMap, Flags, Resources>,
+): TerminalProgram => ({
+  start: () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const provideResources = <A>(
+          effect: Effect.Effect<A, never, Resources>,
+        ): Effect.Effect<A> =>
+          config.resources
+            ? Effect.provide(effect, config.resources)
+            : /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+              (effect as Effect.Effect<A>)
+
+        const flags = yield* config.flags
+
+        const modelEquivalence = Schema.toEquivalence(config.Model)
+
+        const messageQueue = yield* Queue.unbounded<Message>()
+        const enqueueMessage = (message: Message) =>
+          Queue.offer(messageQueue, message)
+
+        const [initModel, initCommands] = config.init(flags)
+
+        const modelRef = yield* Ref.make<Model>(initModel)
+        const modelPubSub = yield* PubSub.unbounded<Model>()
+
+        const forkCommand = (
+          command: AnyCommand<Message, never, Resources>,
+        ): Effect.Effect<void> =>
+          Effect.forkDetach(
+            command.effect.pipe(
+              Effect.withSpan(command.name),
+              provideResources,
+              Effect.flatMap(enqueueMessage),
+            ),
+          )
+
+        yield* Effect.forEach(
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+          initCommands as ReadonlyArray<AnyCommand<Message, never, Resources>>,
+          forkCommand,
+        )
+
+        const render = (model: Model): Effect.Effect<void> =>
+          Effect.gen(function* () {
+            const view = config.view(model)
+            const frame = yield* renderToString(view)
+            process.stdout.write(frame)
+
+            if (config.title) {
+              process.stdout.write(`\x1b]2;${config.title(model)}\x07`)
+            }
+          })
+
+        yield* render(initModel)
+
+        if (config.subscriptions) {
+          yield* pipe(
+            config.subscriptions,
+            Record.toEntries,
+            Effect.forEach(
+              ([
+                _key,
+                {
+                  schema,
+                  modelToDependencies,
+                  equivalence: customEquivalence,
+                  dependenciesToStream,
+                },
+              ]) =>
+                Effect.gen(function* () {
+                  const latestDependenciesRef = yield* Ref.make(
+                    modelToDependencies(initModel),
+                  )
+                  const equivalence =
+                    customEquivalence ?? Schema.toEquivalence(schema)
+
+                  const modelStream = Stream.concat(
+                    Stream.make(initModel),
+                    Stream.fromPubSub(modelPubSub),
+                  )
+
+                  yield* Effect.forkDetach(
+                    modelStream.pipe(
+                      Stream.mapEffect(model =>
+                        Effect.gen(function* () {
+                          const dependencies = modelToDependencies(model)
+                          yield* Ref.set(latestDependenciesRef, dependencies)
+                          return dependencies
+                        }),
+                      ),
+                      Stream.changesWith(equivalence),
+                      Stream.switchMap(dependencies =>
+                        dependenciesToStream(dependencies, () =>
+                          Ref.getUnsafe(latestDependenciesRef),
+                        ),
+                      ),
+                      Stream.runForEach(message =>
+                        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+                        enqueueMessage(message as Message),
+                      ),
+                      provideResources,
+                    ),
+                  )
+                }),
+              { concurrency: 'unbounded', discard: true },
+            ),
+          )
+        }
+
+        yield* Effect.forever(
+          Effect.gen(function* () {
+            const message = yield* Queue.take(messageQueue)
+            const currentModel = yield* Ref.get(modelRef)
+            const [nextModel, commands] = config.update(currentModel, message)
+
+            if (currentModel !== nextModel) {
+              yield* Ref.set(modelRef, nextModel)
+              yield* render(nextModel)
+
+              if (!modelEquivalence(currentModel, nextModel)) {
+                yield* PubSub.publish(modelPubSub, nextModel)
+              }
+            }
+
+            yield* Effect.forEach(
+              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+              commands as ReadonlyArray<AnyCommand<Message, never, Resources>>,
+              forkCommand,
+            )
+          }),
+        ).pipe(
+          Effect.catchCause(cause =>
+            Effect.sync(() => {
+              const squashed = Cause.squash(cause)
+              const appError =
+                squashed instanceof Error
+                  ? squashed
+                  : new Error(String(squashed))
+              process.stdout.write(altScreenLeave + cursorShow)
+              console.error('[foldkit] Application crash:', appError)
+            }),
+          ),
+        )
+      }),
+    ),
+})
+
+/**
+ * Builds a Foldkit terminal program. Provide a `Model` schema, `init`,
+ * `update`, and `view: (model) => Box<AnsiStyle>`. The returned program is
+ * passed to `runTerminal`.
+ *
+ * Views are pure effect-boxes `Box` values: compose with `Box.text`,
+ * `Box.vcat`, `Box.annotate`, the `Layout` module, and ANSI annotations.
+ */
+export function makeTerminalProgram<
+  Model,
+  Message extends { _tag: string },
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources = never,
+>(
+  config: TerminalProgramConfigWithFlags<
+    Model,
+    Message,
+    StreamDepsMap,
+    Flags,
+    Resources
+  >,
+): TerminalProgram
+
+export function makeTerminalProgram<
+  Model,
+  Message extends { _tag: string },
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Resources = never,
+>(
+  config: TerminalProgramConfig<Model, Message, StreamDepsMap, Resources>,
+): TerminalProgram
+
+export function makeTerminalProgram<
+  Model,
+  Message extends { _tag: string },
+  StreamDepsMap extends Schema.Struct<Schema.Struct.Fields>,
+  Flags,
+  Resources = never,
+>(
+  config:
+    | TerminalProgramConfigWithFlags<
+        Model,
+        Message,
+        StreamDepsMap,
+        Flags,
+        Resources
+      >
+    | TerminalProgramConfig<Model, Message, StreamDepsMap, Resources>,
+): TerminalProgram {
+  /* eslint-disable @typescript-eslint/consistent-type-assertions */
+  if ('Flags' in config) {
+    const withFlags = config as TerminalProgramConfigWithFlags<
+      Model,
+      Message,
+      StreamDepsMap,
+      Flags,
+      Resources
+    >
+    return makeRuntime({
+      Model: withFlags.Model,
+      flags: withFlags.flags,
+      init: withFlags.init,
+      update: withFlags.update,
+      view: withFlags.view,
+      subscriptions: withFlags.subscriptions,
+      title: withFlags.title,
+      resources: withFlags.resources,
+    })
+  }
+
+  const noFlags = config as TerminalProgramConfig<
+    Model,
+    Message,
+    StreamDepsMap,
+    Resources
+  >
+  return makeRuntime({
+    Model: noFlags.Model,
+    flags: Effect.succeed(undefined as Flags),
+    init: () => noFlags.init(),
+    update: noFlags.update,
+    view: noFlags.view,
+    subscriptions: noFlags.subscriptions,
+    title: noFlags.title,
+    resources: noFlags.resources,
+  })
+  /* eslint-enable @typescript-eslint/consistent-type-assertions */
+}
+
+/**
+ * Starts a Foldkit terminal program. Enters the alternate screen buffer,
+ * hides the cursor, and installs SIGINT/SIGTERM/exit handlers that restore
+ * the original screen before the process exits.
+ */
+export const runTerminal = (program: TerminalProgram): void => {
+  process.stdout.write(altScreenEnter + cursorHide)
+
+  const cleanup = () => {
+    process.stdout.write(cursorShow + altScreenLeave)
+  }
+
+  process.on('SIGINT', () => {
+    cleanup()
+    process.exit(0)
+  })
+  process.on('SIGTERM', () => {
+    cleanup()
+    process.exit(0)
+  })
+  process.on('exit', cleanup)
+
+  NodeRuntime.runMain(program.start())
+}

--- a/packages/foldkit/tsconfig.base.json
+++ b/packages/foldkit/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "rootDir": "src",
     "noEmit": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,6 +852,28 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
 
+  examples/snake-terminal:
+    dependencies:
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
+      effect:
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64
+      effect-boxes:
+        specifier: ^0.15.0
+        version: 0.15.0(effect@4.0.0-beta.64)
+      foldkit:
+        specifier: workspace:*
+        version: link:../../packages/foldkit
+    devDependencies:
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   examples/stopwatch:
     dependencies:
       '@effect/platform-browser':
@@ -1301,12 +1323,18 @@ importers:
       '@effect/platform-browser':
         specifier: 4.0.0-beta.64
         version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.64
+        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.64
         version: 4.0.0-beta.64(effect@4.0.0-beta.64)(vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))
       effect:
         specifier: 4.0.0-beta.64
         version: 4.0.0-beta.64
+      effect-boxes:
+        specifier: ^0.15.0
+        version: 0.15.0(effect@4.0.0-beta.64)
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -2245,24 +2273,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -2321,36 +2353,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -2486,24 +2524,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -3215,6 +3257,11 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect-boxes@0.15.0:
+    resolution: {integrity: sha512-3Z5q9vp4M/Zo/R6ILi+5quky1toPhXpcaPH/f6gMepv/CwLB0SuamEM/RjpqQoVOuNiBxENCgwVkP/c/lu0fyg==}
+    peerDependencies:
+      effect: 4.0.0-beta.64
+
   effect@4.0.0-beta.64:
     resolution: {integrity: sha512-xI332I9guVLsqvLg7aO62IuWq9LiCMs+u5dhr4JDyND2ndYXAk5eaR8KMqtYLoJg1Ie28VQToYPM+xBLEBU3pQ==}
 
@@ -3773,24 +3820,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6522,6 +6573,10 @@ snapshots:
   earcut@3.0.2: {}
 
   ee-first@1.1.1: {}
+
+  effect-boxes@0.15.0(effect@4.0.0-beta.64):
+    dependencies:
+      effect: 4.0.0-beta.64
 
   effect@4.0.0-beta.64:
     dependencies:


### PR DESCRIPTION
## Summary

Introduces `foldkit/terminal`, a new Foldkit runtime for building terminal UI applications using the same Elm Architecture (Model, Message, update, view) as the web runtime. The terminal runtime renders to ANSI-styled boxes via [effect-boxes](https://github.com/lloydrichards/effect-boxes) and includes keyboard input handling, subscriptions, and proper terminal state management.

## Key Changes

- **Terminal runtime** (`packages/foldkit/src/terminal/runtime.ts`): Core orchestration for terminal programs. Implements the Elm Architecture with:
  - `makeTerminalProgram` to configure Model, init, update, view, subscriptions, and optional flags
  - `runTerminal` to start a program with alternate screen buffer, cursor hiding, and signal handlers
  - Message queue and PubSub for state updates and subscription notifications
  - Proper cleanup on SIGINT/SIGTERM/exit

- **Keyboard input** (`packages/foldkit/src/terminal/input.ts`): 
  - `keyPressStream()` — a Stream of parsed KeyPress events from stdin in raw mode
  - Parses arrow keys, special keys (Enter, Escape, Backspace, Tab), and Ctrl+letter combinations
  - Handles Ctrl+C to exit cleanly

- **Public API** (`packages/foldkit/src/terminal/public.ts`): Exports types and functions for terminal programs

- **Snake game example** (`examples/snake-terminal/`): A complete terminal game demonstrating:
  - Model as a discriminated union (GameState: NotStarted | Playing | Paused | GameOver)
  - Messages for clock ticks, key presses, and apple generation
  - Subscriptions for game clock (adaptive speed) and keyboard input
  - View composition with effect-boxes (grid, header, footer, ANSI styling)
  - Commands for procedural apple placement

- **Package configuration**: Added `foldkit/terminal` export path and optional peer dependencies on `@effect/platform-node` and `effect-boxes`

## Implementation Details

- Terminal state is managed via `Ref` for the current Model and `PubSub` for broadcasting model changes to subscriptions
- Subscriptions use `Stream.changesWith` to detect meaningful model changes (via Schema equivalence) before re-running dependent streams
- Commands are forked as detached Effects with span tracing; results are enqueued as Messages
- View rendering clears the screen, renders the box tree to ANSI, and optionally updates the terminal title
- Error handling catches crashes, restores terminal state, and logs to stderr before exit
- TypeScript configuration updated to use ESNext module and Bundler resolution for better interop with effect-boxes

The implementation follows Foldkit conventions: discriminated union state, verb-first Message naming (TickedClock, PressedKey, GeneratedApplePosition), and unidirectional data flow through update and view functions.

https://claude.ai/code/session_01BhjgdYBwEmbDdFxaWwKj4A