### PR TITLE
feat(website): emit llms.txt, llms-full.txt, and per-route markdown

### DIFF
--- a/packages/website/public/robots.txt
+++ b/packages/website/public/robots.txt
@@ -3,3 +3,8 @@ Allow: /
 Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 Sitemap: https://foldkit.dev/sitemap.xml
+
+# Agent-friendly digests. Every page is also available as Markdown by
+# appending `.md` to its URL (e.g. https://foldkit.dev/getting-started.md).
+# https://foldkit.dev/llms.txt
+# https://foldkit.dev/llms-full.txt

--- a/packages/website/scripts/markdown.test.ts
+++ b/packages/website/scripts/markdown.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  type LlmsFullEntry,
+  type LlmsIndexEntry,
+  buildLlmsFull,
+  buildLlmsIndex,
+  extractMarkdownFromCurrentDocument,
+  shouldExportMarkdown,
+  urlPathToMarkdownPath,
+} from './markdown'
+
+const SITE_URL = 'https://foldkit.dev'
+
+const setBody = (html: string): void => {
+  document.body.innerHTML = `<div data-pagefind-body>${html}</div>`
+}
+
+describe('extractMarkdownFromCurrentDocument', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns the empty string when no pagefind body is present', () => {
+    document.body.innerHTML = '<div>orphaned content</div>'
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe('')
+  })
+
+  it('converts headings, paragraphs, and links', () => {
+    setBody(`
+      <h1>Getting Started</h1>
+      <p>Welcome to <a href="/manifesto">Foldkit</a>.</p>
+      <h2>Install</h2>
+      <p>Run <code>pnpm create foldkit-app</code>.</p>
+    `)
+
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe(
+      `# Getting Started
+
+Welcome to [Foldkit](https://foldkit.dev/manifesto).
+
+## Install
+
+Run \`pnpm create foldkit-app\`.`,
+    )
+  })
+
+  it('preserves external link hrefs verbatim', () => {
+    setBody(`<p>See <a href="https://example.com/x">the docs</a>.</p>`)
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe(
+      'See [the docs](https://example.com/x).',
+    )
+  })
+
+  it('emits fenced code blocks with the detected language', () => {
+    setBody(`
+      <pre><code class="language-typescript">const x = 1
+const y = 2</code></pre>
+    `)
+    const markdown = extractMarkdownFromCurrentDocument(SITE_URL)
+    expect(markdown).toContain('```typescript')
+    expect(markdown).toContain('const x = 1\nconst y = 2')
+    expect(markdown).toContain('```')
+  })
+
+  it('renders unordered lists with hyphen bullets', () => {
+    setBody(`<ul><li>first</li><li>second</li><li>third</li></ul>`)
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe(
+      '- first\n- second\n- third',
+    )
+  })
+
+  it('renders ordered lists with numeric markers', () => {
+    setBody(`<ol><li>one</li><li>two</li></ol>`)
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe('1. one\n2. two')
+  })
+
+  it('skips elements marked data-llm-ignore', () => {
+    setBody(`
+      <p>kept paragraph</p>
+      <div data-llm-ignore>
+        <p>nav junk</p>
+      </div>
+    `)
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe('kept paragraph')
+  })
+
+  it('does not skip elements marked only data-pagefind-ignore', () => {
+    setBody(`
+      <div data-pagefind-ignore>
+        <pre><code class="language-typescript">const x = 1</code></pre>
+      </div>
+    `)
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe(
+      '```typescript\nconst x = 1\n```',
+    )
+  })
+
+  it('extracts source from shiki-tokenized code blocks', () => {
+    setBody(
+      `<pre class="shiki" data-language="typescript"><code><span class="line"><span style="color:#569cd6">const</span><span style="color:#9cdcfe"> x</span><span style="color:#d4d4d4"> =</span><span style="color:#b5cea8"> 1</span></span>\n<span class="line"><span style="color:#569cd6">const</span><span style="color:#9cdcfe"> y</span><span style="color:#d4d4d4"> =</span><span style="color:#b5cea8"> 2</span></span></code></pre>`,
+    )
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe(
+      '```typescript\nconst x = 1\nconst y = 2\n```',
+    )
+  })
+
+  it('skips decorative svgs and buttons', () => {
+    setBody(`
+      <p>visible <svg><path d="M0,0"/></svg> text</p>
+      <button>Copy</button>
+    `)
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe('visible text')
+  })
+
+  it('collapses excess blank lines between blocks', () => {
+    setBody(`
+      <h2>A</h2>
+      <p>one</p>
+      <p>two</p>
+      <h2>B</h2>
+      <p>three</p>
+    `)
+    const markdown = extractMarkdownFromCurrentDocument(SITE_URL)
+    expect(markdown).not.toMatch(/\n\n\n/)
+  })
+})
+
+describe('urlPathToMarkdownPath', () => {
+  it('maps root to index.md', () => {
+    expect(urlPathToMarkdownPath('/')).toBe('index.md')
+  })
+
+  it('maps a top-level path to a sibling .md file', () => {
+    expect(urlPathToMarkdownPath('/getting-started')).toBe('getting-started.md')
+  })
+
+  it('preserves nested paths', () => {
+    expect(urlPathToMarkdownPath('/core/model')).toBe('core/model.md')
+    expect(urlPathToMarkdownPath('/api/foldkit/html')).toBe(
+      'api/foldkit/html.md',
+    )
+  })
+})
+
+describe('shouldExportMarkdown', () => {
+  it('skips Playground, NotFound, and Newsletter routes', () => {
+    expect(
+      shouldExportMarkdown({ _tag: 'Playground', exampleSlug: 'counter' }),
+    ).toBe(false)
+    expect(shouldExportMarkdown({ _tag: 'NotFound', path: '/missing' })).toBe(
+      false,
+    )
+    expect(shouldExportMarkdown({ _tag: 'Newsletter' })).toBe(false)
+  })
+
+  it('exports docs and api routes', () => {
+    expect(shouldExportMarkdown({ _tag: 'GettingStarted' })).toBe(true)
+    expect(shouldExportMarkdown({ _tag: 'CoreModel' })).toBe(true)
+    expect(
+      shouldExportMarkdown({ _tag: 'ApiModule', moduleSlug: 'html' }),
+    ).toBe(true)
+  })
+})
+
+const indexEntry = (
+  urlPath: string,
+  title: string,
+  description: string,
+  section: string,
+): LlmsIndexEntry => ({
+  urlPath,
+  metadata: { title, description, section },
+})
+
+describe('buildLlmsIndex', () => {
+  it('renders the site header and skips entries without a section', () => {
+    const output = buildLlmsIndex([
+      indexEntry('/', 'Foldkit', 'The home page.', ''),
+      indexEntry(
+        '/getting-started',
+        'Getting Started',
+        'Set up your first app.',
+        'Docs',
+      ),
+    ])
+
+    expect(output).toContain('# Foldkit')
+    expect(output).toContain('> Foldkit is a TypeScript frontend framework')
+    expect(output).toContain('## Docs')
+    expect(output).toContain(
+      '- [Getting Started](https://foldkit.dev/getting-started): Set up your first app.',
+    )
+    expect(output).not.toContain('The home page.')
+  })
+
+  it('orders sections by canonical rank and titles alphabetically', () => {
+    const output = buildLlmsIndex([
+      indexEntry('/ui/dialog', 'Dialog', 'Modal dialog.', 'Foldkit UI'),
+      indexEntry('/ui/tabs', 'Tabs', 'Tab interface.', 'Foldkit UI'),
+      indexEntry('/core/model', 'Model', 'Single state tree.', 'Core Concepts'),
+      indexEntry('/manifesto', 'Manifesto', 'Why Foldkit exists.', 'Docs'),
+    ])
+
+    const docsIndex = output.indexOf('## Docs')
+    const coreIndex = output.indexOf('## Core Concepts')
+    const uiIndex = output.indexOf('## Foldkit UI')
+    expect(docsIndex).toBeGreaterThan(-1)
+    expect(coreIndex).toBeGreaterThan(docsIndex)
+    expect(uiIndex).toBeGreaterThan(coreIndex)
+
+    const dialogIndex = output.indexOf('[Dialog]')
+    const tabsIndex = output.indexOf('[Tabs]')
+    expect(dialogIndex).toBeLessThan(tabsIndex)
+  })
+})
+
+const fullEntry = (
+  urlPath: string,
+  title: string,
+  description: string,
+  section: string,
+  markdown: string,
+  orderIndex: number,
+): LlmsFullEntry => ({
+  urlPath,
+  metadata: { title, description, section },
+  markdown,
+  orderIndex,
+})
+
+describe('buildLlmsFull', () => {
+  it('concatenates pages with source headers and separators', () => {
+    const output = buildLlmsFull(
+      [
+        fullEntry(
+          '/getting-started',
+          'Getting Started',
+          'Set up your first app.',
+          'Docs',
+          '# Getting Started\n\nWelcome.',
+          0,
+        ),
+        fullEntry(
+          '/core/model',
+          'Model',
+          'Single state tree.',
+          'Core Concepts',
+          '# Model\n\nOne tree.',
+          1,
+        ),
+      ],
+      '2026-05-16',
+    )
+
+    expect(output).toContain('# Foldkit Documentation')
+    expect(output).toContain('Generated 2026-05-16 from https://foldkit.dev')
+    expect(output).toContain('Source: https://foldkit.dev/getting-started')
+    expect(output).toContain('Source: https://foldkit.dev/core/model')
+    expect(output).toContain('Section: Docs')
+    expect(output).toContain('Section: Core Concepts')
+    expect(output).toContain('# Getting Started')
+    expect(output).toContain('# Model')
+    expect(output.split('\n---\n').length).toBeGreaterThan(1)
+  })
+
+  it('preserves orderIndex within a section instead of sorting alphabetically', () => {
+    const output = buildLlmsFull(
+      [
+        fullEntry(
+          '/core/update',
+          'Update',
+          'Pure transitions.',
+          'Core Concepts',
+          '# Update\n\nUpdate body.',
+          2,
+        ),
+        fullEntry(
+          '/core/architecture',
+          'Architecture',
+          'The shape of a Foldkit app.',
+          'Core Concepts',
+          '# Architecture\n\nArchitecture body.',
+          0,
+        ),
+        fullEntry(
+          '/core/model',
+          'Model',
+          'Single state tree.',
+          'Core Concepts',
+          '# Model\n\nModel body.',
+          1,
+        ),
+      ],
+      '2026-05-16',
+    )
+
+    const architectureAt = output.indexOf('# Architecture')
+    const modelAt = output.indexOf('# Model')
+    const updateAt = output.indexOf('# Update')
+    expect(architectureAt).toBeLessThan(modelAt)
+    expect(modelAt).toBeLessThan(updateAt)
+  })
+})

--- a/packages/website/scripts/markdown.ts
+++ b/packages/website/scripts/markdown.ts
@@ -1,0 +1,393 @@
+import {
+  Array as Array_,
+  Effect,
+  Option,
+  Order,
+  String as Str,
+  pipe,
+} from 'effect'
+import { type Page } from 'playwright'
+
+import { type AppRoute } from '../src/route'
+import { type PageMetadata } from './metadata'
+
+// EXTRACTION
+
+const SITE_URL = 'https://foldkit.dev'
+
+export const extractMarkdownFromCurrentDocument = (siteUrl: string): string => {
+  const root = document.querySelector('[data-pagefind-body]')
+  if (root === null) {
+    return ''
+  }
+
+  const SKIP_TAGS = new Set([
+    'SCRIPT',
+    'STYLE',
+    'SVG',
+    'NOSCRIPT',
+    'BUTTON',
+    'INPUT',
+    'IFRAME',
+  ])
+
+  const isSkippedElement = (element: Element): boolean =>
+    SKIP_TAGS.has(element.tagName) ||
+    element.getAttribute('aria-hidden') === 'true' ||
+    element.hasAttribute('data-llm-ignore')
+
+  const collapseWhitespace = (text: string): string =>
+    text.replace(/[\t\n\r ]+/g, ' ')
+
+  const resolveHref = (href: string): string => {
+    if (href.length === 0) {
+      return ''
+    }
+    if (href.startsWith('/')) {
+      return `${siteUrl}${href}`
+    }
+    return href
+  }
+
+  const collectInline = (node: Node): string => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return collapseWhitespace(node.textContent ?? '')
+    }
+    if (!(node instanceof Element)) {
+      return ''
+    }
+    if (isSkippedElement(node)) {
+      return ''
+    }
+    const tag = node.tagName.toLowerCase()
+    const inner = Array.from(node.childNodes)
+      .map(collectInline)
+      .join('')
+      .replace(/ {2,}/g, ' ')
+
+    switch (tag) {
+      case 'a': {
+        const href = node.getAttribute('href') ?? ''
+        const trimmed = inner.trim()
+        if (trimmed.length === 0) {
+          return ''
+        }
+        return `[${trimmed}](${resolveHref(href)})`
+      }
+      case 'code': {
+        const trimmed = inner.trim()
+        return trimmed.length === 0 ? '' : `\`${trimmed}\``
+      }
+      case 'strong':
+      case 'b': {
+        const trimmed = inner.trim()
+        return trimmed.length === 0 ? '' : `**${trimmed}**`
+      }
+      case 'em':
+      case 'i': {
+        const trimmed = inner.trim()
+        return trimmed.length === 0 ? '' : `_${trimmed}_`
+      }
+      case 'br': {
+        return ' '
+      }
+      default: {
+        return inner
+      }
+    }
+  }
+
+  const detectLanguage = (element: Element): string => {
+    const candidates = [element, ...Array.from(element.querySelectorAll('*'))]
+    for (const candidate of candidates) {
+      const className = candidate.getAttribute('class') ?? ''
+      const match = className.match(/language-([\w+-]+)/)
+      if (match !== null && match[1] !== undefined) {
+        return match[1] === 'plaintext' ? '' : match[1]
+      }
+      const dataLang = candidate.getAttribute('data-language')
+      if (dataLang !== null && dataLang.length > 0) {
+        return dataLang === 'plaintext' ? '' : dataLang
+      }
+    }
+    return ''
+  }
+
+  const extractCodeBlock = (element: Element): string => {
+    const codeElement = element.querySelector('code')
+    const source = codeElement ?? element
+    const text = (source.textContent ?? '').replace(/\n+$/, '')
+    const language = detectLanguage(element)
+    return `\`\`\`${language}\n${text}\n\`\`\``
+  }
+
+  const indentBlock = (text: string, indent: string): string =>
+    text
+      .split('\n')
+      .map(line => (line.length === 0 ? line : `${indent}${line}`))
+      .join('\n')
+
+  const extractList = (element: Element, ordered: boolean): string => {
+    const lines: Array<string> = []
+    let index = 1
+    for (const child of Array.from(element.children)) {
+      if (child.tagName !== 'LI') {
+        continue
+      }
+      if (isSkippedElement(child)) {
+        continue
+      }
+      const marker = ordered ? `${index}. ` : '- '
+      const body = extractBlocks(child).trim()
+      const indent = ' '.repeat(marker.length)
+      const indented = body
+        .split('\n')
+        .map((line, lineIndex) =>
+          lineIndex === 0 || line.length === 0 ? line : `${indent}${line}`,
+        )
+        .join('\n')
+      lines.push(`${marker}${indented}`)
+      if (ordered) {
+        index += 1
+      }
+    }
+    return lines.join('\n')
+  }
+
+  const extractBlocks = (parent: Element): string => {
+    const parts: Array<string> = []
+    for (const node of Array.from(parent.childNodes)) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const text = collapseWhitespace(node.textContent ?? '').trim()
+        if (text.length > 0) {
+          parts.push(text)
+        }
+        continue
+      }
+      if (!(node instanceof Element)) {
+        continue
+      }
+      if (isSkippedElement(node)) {
+        continue
+      }
+      const tag = node.tagName.toLowerCase()
+
+      switch (tag) {
+        case 'h1':
+        case 'h2':
+        case 'h3':
+        case 'h4':
+        case 'h5':
+        case 'h6': {
+          const level = Number(tag.slice(1))
+          const inline = collectInline(node).trim()
+          if (inline.length > 0) {
+            parts.push(`${'#'.repeat(level)} ${inline}`)
+          }
+          break
+        }
+        case 'p': {
+          const inline = collectInline(node).trim()
+          if (inline.length > 0) {
+            parts.push(inline)
+          }
+          break
+        }
+        case 'pre': {
+          parts.push(extractCodeBlock(node))
+          break
+        }
+        case 'ul': {
+          const list = extractList(node, false)
+          if (list.length > 0) {
+            parts.push(list)
+          }
+          break
+        }
+        case 'ol': {
+          const list = extractList(node, true)
+          if (list.length > 0) {
+            parts.push(list)
+          }
+          break
+        }
+        case 'blockquote': {
+          const inner = extractBlocks(node).trim()
+          if (inner.length > 0) {
+            parts.push(indentBlock(inner, '> '))
+          }
+          break
+        }
+        case 'hr': {
+          parts.push('---')
+          break
+        }
+        case 'br': {
+          break
+        }
+        case 'span':
+        case 'em':
+        case 'strong':
+        case 'a':
+        case 'code': {
+          const inline = collectInline(node).trim()
+          if (inline.length > 0) {
+            parts.push(inline)
+          }
+          break
+        }
+        default: {
+          const nested = extractBlocks(node)
+          if (nested.length > 0) {
+            parts.push(nested)
+          }
+          break
+        }
+      }
+    }
+    return parts.join('\n\n')
+  }
+
+  return extractBlocks(root)
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+export const extractPageMarkdown = (page: Page): Effect.Effect<string, Error> =>
+  Effect.tryPromise({
+    try: () => page.evaluate(extractMarkdownFromCurrentDocument, SITE_URL),
+    catch: error => new Error(`Failed to extract markdown: ${String(error)}`),
+  })
+
+// PATHS
+
+export const urlPathToMarkdownPath = (urlPath: string): string =>
+  urlPath === '/' ? 'index.md' : `${urlPath.slice(1)}.md`
+
+// SKIP
+
+const SKIPPED_ROUTE_TAGS: ReadonlySet<AppRoute['_tag']> = new Set([
+  'Playground',
+  'NotFound',
+  'Newsletter',
+])
+
+export const shouldExportMarkdown = (route: AppRoute): boolean =>
+  !SKIPPED_ROUTE_TAGS.has(route._tag)
+
+// INDEX
+
+export type LlmsIndexEntry = Readonly<{
+  urlPath: string
+  metadata: PageMetadata
+}>
+
+const SECTION_ORDER: ReadonlyArray<string> = [
+  'Docs',
+  'Guides',
+  'Core Concepts',
+  'Best Practices',
+  'Patterns',
+  'Foldkit UI',
+  'Testing',
+  'Examples',
+  'AI',
+  'API Reference',
+]
+
+const sectionRank = (section: string): number =>
+  pipe(
+    SECTION_ORDER,
+    Array_.findFirstIndex(candidate => candidate === section),
+    Option.getOrElse(() => SECTION_ORDER.length),
+  )
+
+const sectionOrder: Order.Order<string> = Order.mapInput(
+  Order.Number,
+  sectionRank,
+)
+
+const SITE_BLURB =
+  'Foldkit is a TypeScript frontend framework built on Effect-TS that uses The Elm Architecture: a single Model, pure update, and side effects confined to Commands.'
+
+const renderIndexEntry = (entry: LlmsIndexEntry): string =>
+  `- [${entry.metadata.title}](${SITE_URL}${entry.urlPath}): ${entry.metadata.description}`
+
+const titleOrder: Order.Order<LlmsIndexEntry> = Order.mapInput(
+  Order.String,
+  (entry: LlmsIndexEntry) => entry.metadata.title,
+)
+
+const renderIndexSection = (
+  section: string,
+  entries: ReadonlyArray<LlmsIndexEntry>,
+): string => {
+  const lines = pipe(
+    entries,
+    Array_.sortBy(titleOrder),
+    Array_.map(renderIndexEntry),
+  )
+  return `## ${section}\n\n${Array_.join(lines, '\n')}`
+}
+
+export const buildLlmsIndex = (
+  entries: ReadonlyArray<LlmsIndexEntry>,
+): string => {
+  const sectioned = pipe(
+    entries,
+    Array_.filter(entry => entry.metadata.section.length > 0),
+    Array_.groupBy(entry => entry.metadata.section),
+  )
+
+  const sectionBlocks = pipe(
+    Object.entries(sectioned),
+    Array_.sortBy(Order.mapInput(sectionOrder, ([section]) => section)),
+    Array_.map(([section, sectionEntries]) =>
+      renderIndexSection(section, sectionEntries),
+    ),
+  )
+
+  const header = `# Foldkit\n\n> ${SITE_BLURB}\n\nThis index lists every page on the Foldkit documentation site with a short description. Every page is also available as Markdown by appending \`.md\` to its URL (e.g. ${SITE_URL}/getting-started.md). A single-file concatenation of every page is available at ${SITE_URL}/llms-full.txt.`
+
+  return `${header}\n\n${Array_.join(sectionBlocks, '\n\n')}\n`
+}
+
+// FULL
+
+export type LlmsFullEntry = Readonly<{
+  urlPath: string
+  metadata: PageMetadata
+  markdown: string
+  orderIndex: number
+}>
+
+const sectionRankForEntry = (entry: LlmsFullEntry): number =>
+  entry.metadata.section.length === 0 ? -1 : sectionRank(entry.metadata.section)
+
+const fullEntryOrder: Order.Order<LlmsFullEntry> = Order.combine(
+  Order.mapInput(Order.Number, sectionRankForEntry),
+  Order.mapInput(Order.Number, (entry: LlmsFullEntry) => entry.orderIndex),
+)
+
+const renderFullEntry = (entry: LlmsFullEntry): string => {
+  const sourceLine = `Source: ${SITE_URL}${entry.urlPath}`
+  const sectionLine =
+    entry.metadata.section.length === 0
+      ? ''
+      : `Section: ${entry.metadata.section}\n`
+  const trimmed = Str.trim(entry.markdown)
+  return `${sourceLine}\n${sectionLine}\n${trimmed}`
+}
+
+export const buildLlmsFull = (
+  entries: ReadonlyArray<LlmsFullEntry>,
+  generatedDate: string,
+): string => {
+  const sections = pipe(
+    entries,
+    Array_.sortBy(fullEntryOrder),
+    Array_.map(renderFullEntry),
+  )
+  const header = `# Foldkit Documentation\n\nGenerated ${generatedDate} from ${SITE_URL}\n\n${SITE_BLURB}`
+  return `${header}\n\n---\n\n${Array_.join(sections, '\n\n---\n\n')}\n`
+}

--- a/packages/website/scripts/prerender.ts
+++ b/packages/website/scripts/prerender.ts
@@ -6,6 +6,7 @@ import {
   Deferred,
   Effect,
   Match as M,
+  Option,
   Schema as S,
   String as Str,
   Stream,
@@ -177,6 +178,16 @@ import {
   uiVirtualListRouter,
   whyNoJsxRouter,
 } from '../src/route'
+import {
+  type LlmsFullEntry,
+  type LlmsIndexEntry,
+  buildLlmsFull,
+  buildLlmsIndex,
+  extractPageMarkdown,
+  shouldExportMarkdown,
+  urlPathToMarkdownPath,
+} from './markdown'
+import { routeToMetadata } from './metadata'
 import { generateOgImages, injectMetaTags } from './og-image'
 
 // ROUTES
@@ -415,16 +426,29 @@ const playwrightBrowserResource = Effect.acquireRelease(
   browser => Effect.promise(() => browser.close()),
 )
 
-const captureRouteHtml = (browser: Browser, url: string, route: AppRoute) =>
+type CapturedPage = Readonly<{ html: string; markdown: string }>
+
+// NOTE: tsx/esbuild wraps named arrow functions with a `__name(fn, "name")`
+// helper to preserve debug names. When Playwright ships our extraction
+// function to the page via `fn.toString()`, the body still references
+// `__name`, which doesn't exist in browser scope. The no-op polyfill keeps
+// `page.evaluate` calls from crashing without touching the foldkit bundle
+// (Vite scopes its own `__name` per module, so the global shim is never
+// reached by app code).
+const PAGE_INIT_SCRIPT = `
+  Object.defineProperty(window, "__FOLDKIT_PRERENDER__", {
+    value: true,
+    writable: false,
+  });
+  window.__name = (target) => target;
+`
+
+const captureRoutePage = (browser: Browser, url: string, route: AppRoute) =>
   Effect.acquireUseRelease(
     Effect.tryPromise(() => browser.newPage()),
     page =>
       Effect.gen(function* () {
-        yield* Effect.tryPromise(() =>
-          page.addInitScript(
-            'Object.defineProperty(window, "__FOLDKIT_PRERENDER__", { value: true, writable: false })',
-          ),
-        )
+        yield* Effect.tryPromise(() => page.addInitScript(PAGE_INIT_SCRIPT))
         yield* Effect.tryPromise(() => page.goto(url))
         yield* Effect.tryPromise(() =>
           page.waitForFunction(() => {
@@ -441,9 +465,14 @@ const captureRouteHtml = (browser: Browser, url: string, route: AppRoute) =>
             page.waitForSelector('h1[data-pagefind-meta="section"]'),
           )
         }
-        return yield* Effect.tryPromise(() =>
+        const html = yield* Effect.tryPromise(() =>
           page.evaluate(() => document.body.firstElementChild?.outerHTML ?? ''),
         )
+        const markdown = shouldExportMarkdown(route)
+          ? yield* extractPageMarkdown(page)
+          : ''
+        const captured: CapturedPage = { html, markdown }
+        return captured
       }),
     page => Effect.promise(() => page.close()),
   )
@@ -461,6 +490,12 @@ const readApiModuleSlugs = Effect.gen(function* () {
   )
 })
 
+type PrerenderResult = Readonly<{
+  route: AppRoute
+  urlPath: string
+  markdown: string
+}>
+
 const prerenderRoute =
   (browser: Browser, baseHtml: string) => (route: AppRoute) =>
     Effect.gen(function* () {
@@ -469,8 +504,8 @@ const prerenderRoute =
       const url = `${PREVIEW_BASE_URL}${urlPath}`
       const outputFilePath = resolve(DIST_DIR, outputPath)
 
-      const renderedHtml = yield* captureRouteHtml(browser, url, route)
-      const injectedHtml = injectHtml(baseHtml, renderedHtml)
+      const captured = yield* captureRoutePage(browser, url, route)
+      const injectedHtml = injectHtml(baseHtml, captured.html)
       const outputHtml = injectMetaTags(injectedHtml, route, urlPath)
 
       const fs = yield* FileSystem.FileSystem
@@ -478,10 +513,30 @@ const prerenderRoute =
         recursive: true,
       })
       yield* fs.writeFileString(outputFilePath, outputHtml)
+
+      if (shouldExportMarkdown(route) && captured.markdown.length > 0) {
+        const markdownFilePath = resolve(
+          DIST_DIR,
+          urlPathToMarkdownPath(urlPath),
+        )
+        yield* fs.makeDirectory(dirname(markdownFilePath), {
+          recursive: true,
+        })
+        yield* fs.writeFileString(markdownFilePath, captured.markdown)
+      }
+
       yield* Console.log(`  ✓ ${urlPath}`)
+      return Option.some<PrerenderResult>({
+        route,
+        urlPath,
+        markdown: captured.markdown,
+      })
     }).pipe(
       Effect.catch(error =>
-        Console.warn(`  ✗ ${routeToUrlPath(route)}: ${String(error)}`),
+        Effect.as(
+          Console.warn(`  ✗ ${routeToUrlPath(route)}: ${String(error)}`),
+          Option.none<PrerenderResult>(),
+        ),
       ),
     )
 
@@ -524,6 +579,21 @@ ${entries}
 
 // PROGRAM
 
+const resultToIndexEntry = (result: PrerenderResult): LlmsIndexEntry => ({
+  urlPath: result.urlPath,
+  metadata: routeToMetadata(result.route),
+})
+
+const resultToFullEntry = (
+  result: PrerenderResult,
+  orderIndex: number,
+): LlmsFullEntry => ({
+  urlPath: result.urlPath,
+  metadata: routeToMetadata(result.route),
+  markdown: result.markdown,
+  orderIndex,
+})
+
 const program = Effect.scoped(
   Effect.gen(function* () {
     yield* Console.log('Starting prerender...')
@@ -539,9 +609,17 @@ const program = Effect.scoped(
     const fs = yield* FileSystem.FileSystem
     const baseHtml = yield* fs.readFileString(resolve(DIST_DIR, 'index.html'))
 
-    yield* Effect.forEach(routes, prerenderRoute(browser, baseHtml), {
-      concurrency: 4,
-    })
+    const results = yield* Effect.forEach(
+      routes,
+      prerenderRoute(browser, baseHtml),
+      { concurrency: 4 },
+    )
+
+    const successfulResults = Array.getSomes(results)
+    const markdownResults = Array.filter(
+      successfulResults,
+      result => result.markdown.length > 0,
+    )
 
     const lastModification = formatDateIso(yield* DateTime.now)
     yield* fs.writeFileString(
@@ -549,7 +627,21 @@ const program = Effect.scoped(
       buildSitemap(routes, lastModification),
     )
 
-    yield* Console.log(`Prerendered ${routes.length} routes.`)
+    const indexEntries = Array.map(markdownResults, resultToIndexEntry)
+    const fullEntries = Array.map(markdownResults, resultToFullEntry)
+
+    yield* fs.writeFileString(
+      resolve(DIST_DIR, 'llms.txt'),
+      buildLlmsIndex(indexEntries),
+    )
+    yield* fs.writeFileString(
+      resolve(DIST_DIR, 'llms-full.txt'),
+      buildLlmsFull(fullEntries, lastModification),
+    )
+
+    yield* Console.log(
+      `Prerendered ${routes.length} routes; emitted ${markdownResults.length} markdown pages.`,
+    )
   }),
 )
 

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -34,6 +34,7 @@ import { themeSelector } from './themeSelector'
 
 const PagefindBody = html<Message>().DataAttribute('pagefind-body', '')
 const PagefindIgnore = html<Message>().DataAttribute('pagefind-ignore', '')
+const LlmIgnore = html<Message>().DataAttribute('llm-ignore', '')
 
 // DOCS HEADER
 
@@ -955,7 +956,10 @@ export const docsView = (model: Model, docsRoute: DocsRoute) => {
                 ],
                 [
                   content,
-                  h.div([PagefindIgnore], [pageNavigationView(docsRoute._tag)]),
+                  h.div(
+                    [PagefindIgnore, LlmIgnore],
+                    [pageNavigationView(docsRoute._tag)],
+                  ),
                 ],
               ),
               h.div(


### PR DESCRIPTION
Build-time prerender now extracts a Markdown twin of each page from the rendered DOM and writes it next to the .html (e.g. /getting-started.md). A curated /llms.txt index lists every doc page with its description, grouped by section. /llms-full.txt concatenates every page's Markdown for one-shot context loading. The DOM walker runs in the same Playwright page that prerenders the HTML, so there's no second crawl.

Agents pointed at foldkit.dev can now pull the whole site as Markdown without paying HTML overhead per page.