### PR TITLE
chore(foldkit): bump Effect to beta.66

### DIFF
--- a/.changeset/effect-beta-66-upgrade.md
+++ b/.changeset/effect-beta-66-upgrade.md
@@ -1,0 +1,17 @@
+---
+'foldkit': patch
+'@foldkit/vite-plugin': patch
+'@foldkit/devtools-mcp': patch
+'create-foldkit-app': patch
+---
+
+Bump Effect to `4.0.0-beta.66` across the workspace. This keeps Foldkit aligned with the current Effect v4 beta and updates the exact pins for `effect`, `@effect/platform-browser`, `@effect/platform-node`, `@effect/platform-node-shared`, and `@effect/vitest`.
+
+The upgrade also replaces direct `Option` yields in `Effect.gen` with `Effect.fromOption`, matching the beta.66 generator typing. Behavior is unchanged.
+
+Consumers should align their Effect packages to `4.0.0-beta.66` exactly during the v4 beta window.
+
+```bash
+pnpm add effect@4.0.0-beta.66 @effect/platform-browser@4.0.0-beta.66
+pnpm add -D @effect/platform-node@4.0.0-beta.66 @effect/vitest@4.0.0-beta.66
+```

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/canvas-art/package.json
+++ b/examples/canvas-art/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/crash-view/package.json
+++ b/examples/crash-view/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/form/package.json
+++ b/examples/form/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/generative-art/package.json
+++ b/examples/generative-art/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/job-application/package.json
+++ b/examples/job-application/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "fractional-indexing": "^3.2.0",
     "tailwindcss": "^4.2.4"

--- a/examples/map/package.json
+++ b/examples/map/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "maplibre-gl": "^5.24.0",
     "tailwindcss": "^4.2.4"

--- a/examples/pixel-art/package.json
+++ b/examples/pixel-art/package.json
@@ -10,10 +10,10 @@
     "bench": "vitest run --config vitest.bench.config.ts"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/query-sync/package.json
+++ b/examples/query-sync/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/routing/package.json
+++ b/examples/routing/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/shopping-cart/package.json
+++ b/examples/shopping-cart/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/snake/package.json
+++ b/examples/snake/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/stopwatch/package.json
+++ b/examples/stopwatch/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/ui-showcase/package.json
+++ b/examples/ui-showcase/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/weather/package.json
+++ b/examples/weather/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/examples/web-components/package.json
+++ b/examples/web-components/package.json
@@ -9,11 +9,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@shoelace-style/shoelace": "^2.20.1",
     "@tailwindcss/vite": "^4.2.4",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4",
     "vanilla-colorful": "^0.7.2"

--- a/examples/websocket-chat/package.json
+++ b/examples/websocket-chat/package.json
@@ -9,9 +9,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/internal/performance-harness/package.json
+++ b/internal/performance-harness/package.json
@@ -8,9 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.59",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
       "simple-git-hooks"
     ],
     "overrides": {
-      "effect": "4.0.0-beta.64",
-      "@effect/platform-browser": "4.0.0-beta.64",
-      "@effect/platform-node": "4.0.0-beta.64",
-      "@effect/vitest": "4.0.0-beta.64"
+      "effect": "4.0.0-beta.66",
+      "@effect/platform-browser": "4.0.0-beta.66",
+      "@effect/platform-node": "4.0.0-beta.66",
+      "@effect/vitest": "4.0.0-beta.66"
     }
   },
   "engines": {

--- a/packages/create-foldkit-app/package.json
+++ b/packages/create-foldkit-app/package.json
@@ -18,10 +18,10 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.64",
-    "@effect/platform-node-shared": "4.0.0-beta.64",
+    "@effect/platform-node": "4.0.0-beta.66",
+    "@effect/platform-node-shared": "4.0.0-beta.66",
     "chalk": "^5.6.2",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3"
   },

--- a/packages/devtools-mcp/package.json
+++ b/packages/devtools-mcp/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc -b --noEmit"
   },
   "peerDependencies": {
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:^0"
   },
   "dependencies": {
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "@types/ws": "^8.18.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3"

--- a/packages/foldkit/package.json
+++ b/packages/foldkit/package.json
@@ -213,13 +213,13 @@
     "docs": "typedoc"
   },
   "peerDependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
-    "effect": "4.0.0-beta.64"
+    "@effect/platform-browser": "4.0.0-beta.66",
+    "effect": "4.0.0-beta.66"
   },
   "devDependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
-    "@effect/vitest": "4.0.0-beta.64",
-    "effect": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
+    "@effect/vitest": "4.0.0-beta.66",
+    "effect": "4.0.0-beta.66",
     "happy-dom": "^20.9.0",
     "rimraf": "^6.1.3",
     "typedoc": "^0.28.19",

--- a/packages/foldkit/src/managedResource/index.ts
+++ b/packages/foldkit/src/managedResource/index.ts
@@ -49,7 +49,7 @@ export const tag =
     const get = Effect.gen(function* () {
       const ref = yield* serviceTag
       const maybeValue = yield* Ref.get(ref)
-      return yield* maybeValue
+      return yield* Effect.fromOption(maybeValue)
     }).pipe(
       Effect.catchTag('NoSuchElementError', () =>
         Effect.fail(new ResourceNotAvailable({ resource: key })),

--- a/packages/typing-game/client/package.json
+++ b/packages/typing-game/client/package.json
@@ -13,11 +13,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@tailwindcss/vite": "^4.2.4",
     "@typing-game/shared": "workspace:*",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.2.4"
   },

--- a/packages/typing-game/server/package.json
+++ b/packages/typing-game/server/package.json
@@ -11,9 +11,9 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.64",
+    "@effect/platform-node": "4.0.0-beta.66",
     "@typing-game/shared": "workspace:*",
-    "effect": "4.0.0-beta.64"
+    "effect": "4.0.0-beta.66"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/typing-game/server/src/scoring.ts
+++ b/packages/typing-game/server/src/scoring.ts
@@ -55,7 +55,7 @@ export const calculateScoreboard = (
   progressByGamePlayer: ProgressByGamePlayer,
 ): Shared.Scoreboard =>
   Effect.gen(function* () {
-    const game = yield* room.maybeGame
+    const game = yield* Effect.fromOption(room.maybeGame)
 
     const scores = Array.map(room.players, player => {
       const gamePlayer = Shared.GamePlayer.make({

--- a/packages/typing-game/shared/package.json
+++ b/packages/typing-game/shared/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.64"
+    "effect": "4.0.0-beta.66"
   },
   "devDependencies": {
     "typescript": "^6.0.3"

--- a/packages/vite-plugin-foldkit/package.json
+++ b/packages/vite-plugin-foldkit/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc -b --noEmit"
   },
   "peerDependencies": {
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:^0",
     "vite": "^8.0.0"
   },
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/ws": "^8.18.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -22,20 +22,20 @@
     "preview:search": "pnpm build && pnpm prerender && vite preview"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.64",
+    "@effect/platform-browser": "4.0.0-beta.66",
     "@stackblitz/sdk": "^1.11.0",
     "@tailwindcss/vite": "^4.2.4",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "clsx": "^2.1.1",
-    "effect": "4.0.0-beta.64",
+    "effect": "4.0.0-beta.66",
     "foldkit": "workspace:*",
     "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
-    "@effect/platform-node": "4.0.0-beta.64",
+    "@effect/platform-node": "4.0.0-beta.66",
     "@eslint/js": "^10.0.1",
     "@foldkit/vite-plugin": "workspace:*",
     "@playwright/test": "^1.59.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  effect: 4.0.0-beta.64
-  '@effect/platform-browser': 4.0.0-beta.64
-  '@effect/platform-node': 4.0.0-beta.64
-  '@effect/vitest': 4.0.0-beta.64
+  effect: 4.0.0-beta.66
+  '@effect/platform-browser': 4.0.0-beta.66
+  '@effect/platform-node': 4.0.0-beta.66
+  '@effect/vitest': 4.0.0-beta.66
 
 importers:
 
@@ -103,8 +103,8 @@ importers:
   examples/auth:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -112,8 +112,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -158,14 +158,14 @@ importers:
   examples/canvas-art:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -210,14 +210,14 @@ importers:
   examples/counter:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -262,14 +262,14 @@ importers:
   examples/crash-view:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -314,8 +314,8 @@ importers:
   examples/form:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -323,8 +323,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -369,14 +369,14 @@ importers:
   examples/generative-art:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -421,8 +421,8 @@ importers:
   examples/job-application:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -430,8 +430,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -476,8 +476,8 @@ importers:
   examples/kanban:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -485,8 +485,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -534,14 +534,14 @@ importers:
   examples/map:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -589,8 +589,8 @@ importers:
   examples/pixel-art:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -598,8 +598,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -644,8 +644,8 @@ importers:
   examples/query-sync:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -653,8 +653,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -699,14 +699,14 @@ importers:
   examples/routing:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -751,14 +751,14 @@ importers:
   examples/shopping-cart:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -803,14 +803,14 @@ importers:
   examples/snake:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -855,14 +855,14 @@ importers:
   examples/stopwatch:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -907,14 +907,14 @@ importers:
   examples/todo:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -959,8 +959,8 @@ importers:
   examples/ui-showcase:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -968,8 +968,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -1014,14 +1014,14 @@ importers:
   examples/weather:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -1066,8 +1066,8 @@ importers:
   examples/web-components:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@shoelace-style/shoelace':
         specifier: ^2.20.1
         version: 2.20.1(@floating-ui/utils@0.2.11)(@types/react@19.2.14)
@@ -1078,8 +1078,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -1127,14 +1127,14 @@ importers:
   examples/websocket-chat:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -1179,14 +1179,14 @@ importers:
   internal/performance-harness:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit
@@ -1207,17 +1207,17 @@ importers:
   packages/create-foldkit-app:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)(ioredis@5.10.1)
       '@effect/platform-node-shared':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1241,8 +1241,8 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../foldkit
@@ -1299,14 +1299,14 @@ importers:
         version: 3.6.3
     devDependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@effect/vitest':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)(vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -1326,8 +1326,8 @@ importers:
   packages/typing-game/client:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -1338,8 +1338,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../../foldkit
@@ -1387,14 +1387,14 @@ importers:
   packages/typing-game/server:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)(ioredis@5.10.1)
       '@typing-game/shared':
         specifier: workspace:*
         version: link:../shared
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1424,8 +1424,8 @@ importers:
   packages/typing-game/shared:
     dependencies:
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -1441,8 +1441,8 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../foldkit
@@ -1459,8 +1459,8 @@ importers:
   packages/website:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)
       '@stackblitz/sdk':
         specifier: ^1.11.0
         version: 1.11.0
@@ -1477,8 +1477,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       effect:
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66
       foldkit:
         specifier: workspace:*
         version: link:../foldkit
@@ -1493,8 +1493,8 @@ importers:
         version: 4.2.4
     devDependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.64
-        version: 4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.66
+        version: 4.0.0-beta.66(effect@4.0.0-beta.66)(ioredis@5.10.1)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.3.0(jiti@2.7.0))
@@ -1708,28 +1708,28 @@ packages:
     resolution: {integrity: sha512-v6oD9Ukp+N7V4n6p5I/+mM5fIohSfkrDSGlFm5w/pYmchvbk+sMIHsLxrFJ5Lnujewj1BzWL0K84d88lwZAMQA==}
     engines: {node: '>=18'}
 
-  '@effect/platform-browser@4.0.0-beta.64':
-    resolution: {integrity: sha512-RTNOMeSxh2Gef1ola+DGsBm9MSEM2+TQLrbNDMLPuBa5ngFk5L5Kphqf8bDGaQh03oSoeojIJJdA+KqTLpF4Ow==}
+  '@effect/platform-browser@4.0.0-beta.66':
+    resolution: {integrity: sha512-UGKKzAXWaVNJSLDNqXdYu5Hfi12A+JWDiiT/YW7SvEmGi9Bi70kdtTGET5Xl9kUqUn2paeMyadijJ3ADjFj+qQ==}
     peerDependencies:
-      effect: 4.0.0-beta.64
+      effect: 4.0.0-beta.66
 
-  '@effect/platform-node-shared@4.0.0-beta.64':
-    resolution: {integrity: sha512-F5hVnPZbgKzxy2TijjhNZKqj7tQi60dx1W/JinnsNxYKGuspvW2gDUeqmNw7sP2bEA5ToeGDPqRCRdpHj3sZxg==}
+  '@effect/platform-node-shared@4.0.0-beta.66':
+    resolution: {integrity: sha512-+ymrhBnESv/hmn5SKTe2//IY9Ox/hGPeoogEWhW47ZGyhFI5eMYFxdEUBa+3IAV05rrBzrxON9lynu68n0DM7w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: 4.0.0-beta.64
+      effect: 4.0.0-beta.66
 
-  '@effect/platform-node@4.0.0-beta.64':
-    resolution: {integrity: sha512-HlY04TBxe1Z2+Jl4dbwG5uHiUpEH6jvasoNtII6oergaHHQbbD8fLgFzHdy09mJTMK5B1O1fSb95Yztu5jwHxw==}
+  '@effect/platform-node@4.0.0-beta.66':
+    resolution: {integrity: sha512-s/0RgaQFuszzdorRnX1PwEQNnSOi+JgMJo3zEe9O2NR3sosMhTr0Uk+1AF6bUOI9uJ2CPT3KpTIIU7q5/TpOkg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: 4.0.0-beta.64
+      effect: 4.0.0-beta.66
       ioredis: ^5.7.0
 
-  '@effect/vitest@4.0.0-beta.64':
-    resolution: {integrity: sha512-BI+ju06iC6adB6evHSIz/HTppp9r8Kg1aaoOR6XVUgquLA9h3DJKmR7NWZLh8EXl5fIBI7VXDGpqJVr7MWBUug==}
+  '@effect/vitest@4.0.0-beta.66':
+    resolution: {integrity: sha512-UHPNtU0xXkKtNgyRQEh2c8jh4nIIm8Mzp3xc4j2ZdFU4nq5ZSySnpovjPMdoWbVClg1ki8UbpNGEZUfxEJo+6Q==}
     peerDependencies:
-      effect: 4.0.0-beta.64
+      effect: 4.0.0-beta.66
       vitest: ^3.0.0 || ^4.0.0
 
   '@emnapi/core@1.10.0':
@@ -3215,8 +3215,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-beta.64:
-    resolution: {integrity: sha512-xI332I9guVLsqvLg7aO62IuWq9LiCMs+u5dhr4JDyND2ndYXAk5eaR8KMqtYLoJg1Ie28VQToYPM+xBLEBU3pQ==}
+  effect@4.0.0-beta.66:
+    resolution: {integrity: sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==}
 
   emoji-regex-xs@2.0.1:
     resolution: {integrity: sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==}
@@ -5148,24 +5148,24 @@ snapshots:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.2
 
-  '@effect/platform-browser@4.0.0-beta.64(effect@4.0.0-beta.64)':
+  '@effect/platform-browser@4.0.0-beta.66(effect@4.0.0-beta.66)':
     dependencies:
-      effect: 4.0.0-beta.64
+      effect: 4.0.0-beta.66
       multipasta: 0.2.7
 
-  '@effect/platform-node-shared@4.0.0-beta.64(effect@4.0.0-beta.64)':
+  '@effect/platform-node-shared@4.0.0-beta.66(effect@4.0.0-beta.66)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.64
+      effect: 4.0.0-beta.66
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.64(effect@4.0.0-beta.64)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.66(effect@4.0.0-beta.66)(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.64(effect@4.0.0-beta.64)
-      effect: 4.0.0-beta.64
+      '@effect/platform-node-shared': 4.0.0-beta.66(effect@4.0.0-beta.66)
+      effect: 4.0.0-beta.66
       ioredis: 5.10.1
       mime: 4.1.0
       undici: 8.2.0
@@ -5173,9 +5173,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.64(effect@4.0.0-beta.64)(vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))':
+  '@effect/vitest@4.0.0-beta.66(effect@4.0.0-beta.66)(vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))':
     dependencies:
-      effect: 4.0.0-beta.64
+      effect: 4.0.0-beta.66
       vitest: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
 
   '@emnapi/core@1.10.0':
@@ -6523,7 +6523,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-beta.64:
+  effect@4.0.0-beta.66:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.7.0


### PR DESCRIPTION
## Summary

Bumps Foldkit's Effect v4 beta pin from `4.0.0-beta.64` to `4.0.0-beta.66` across the workspace.

This also updates the stale `internal/performance-harness` Effect pins from `.59` to `.66`.

## Changes

- Updated exact pins for `effect`, `@effect/platform-browser`, `@effect/platform-node`, `@effect/platform-node-shared`, and `@effect/vitest`
- Updated the root pnpm overrides and lockfile
- Replaced direct `Option` yields inside `Effect.gen` with `Effect.fromOption`, matching beta.66 generator typing
- Added a patch changeset for Foldkit, vite plugin, devtools MCP, and create-foldkit-app

## Testing

- `pnpm pre-push`
