### PR TITLE
refactor(foldkit): rename ManagedResourceDeps to ManagedResourceRequirements

### DIFF
--- a/.changeset/rename-managed-resource-deps-to-managed-resource-requirements.md
+++ b/.changeset/rename-managed-resource-deps-to-managed-resource-requirements.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Rename the `ManagedResourceDeps` generic type parameter on `ManagedResource.makeManagedResources` to `ManagedResourceRequirements`. Spells out the abbreviated `Deps` and aligns with the existing `modelToMaybeRequirements` callback name. The rename is positional, so application code that named its local schema `ManagedResourceDeps` continues to compile unchanged. By convention, rename local schemas to `ManagedResourceRequirements` to match.

--- a/examples/websocket-chat/src/main.ts
+++ b/examples/websocket-chat/src/main.ts
@@ -241,12 +241,12 @@ export const SendMessage = Command.define(
 
 // MANAGED RESOURCE
 
-const ManagedResourceDeps = S.Struct({
+const ManagedResourceRequirements = S.Struct({
   chatSocket: S.Option(S.Null),
 })
 
 export const managedResources = ManagedResource.makeManagedResources(
-  ManagedResourceDeps,
+  ManagedResourceRequirements,
 )<Model, Message>({
   chatSocket: {
     resource: ChatSocket,

--- a/packages/foldkit/src/runtime/managedResource.ts
+++ b/packages/foldkit/src/runtime/managedResource.ts
@@ -74,12 +74,12 @@ export type ManagedResourceServicesOf<MR> =
  * ```ts
  * const CameraStream = ManagedResource.tag<MediaStream>()('CameraStream')
  *
- * const ManagedResourceDeps = S.Struct({
+ * const ManagedResourceRequirements = S.Struct({
  *   camera: S.Option(S.Struct({ facingMode: S.String })),
  * })
  *
  * const managedResources = ManagedResource.makeManagedResources(
- *   ManagedResourceDeps,
+ *   ManagedResourceRequirements,
  * )<Model, Message>({
  *   camera: {
  *     resource: CameraStream,
@@ -105,28 +105,28 @@ export type ManagedResourceServicesOf<MR> =
  * })
  * ```
  *
- * @param ManagedResourceDeps - An Effect Schema struct where each field's type
+ * @param ManagedResourceRequirements - An Effect Schema struct where each field's type
  * drives the requirements for one managed resource. Wrap in `S.Option(...)` for
  * resources that can be released (most cases).
  *
  * @see {@link ManagedResource.tag} for creating the resource identity.
  */
 export const makeManagedResources =
-  <ManagedResourceDeps extends Schema.Struct<any>>(
-    ManagedResourceDeps: ManagedResourceDeps,
+  <ManagedResourceRequirements extends Schema.Struct<any>>(
+    ManagedResourceRequirements: ManagedResourceRequirements,
   ) =>
   <Model, Message>(configs: {
-    [K in keyof Schema.Schema.Type<ManagedResourceDeps>]: {
+    [K in keyof Schema.Schema.Type<ManagedResourceRequirements>]: {
       readonly resource: ManagedResource<any, any>
       readonly modelToMaybeRequirements: (
         model: Model,
-      ) => Schema.Schema.Type<ManagedResourceDeps>[K]
+      ) => Schema.Schema.Type<ManagedResourceRequirements>[K]
       readonly acquire: (
-        params: Schema.Schema.Type<ManagedResourceDeps>[K] extends Option.Option<
+        params: Schema.Schema.Type<ManagedResourceRequirements>[K] extends Option.Option<
           infer P
         >
           ? P
-          : Schema.Schema.Type<ManagedResourceDeps>[K],
+          : Schema.Schema.Type<ManagedResourceRequirements>[K],
       ) => Effect.Effect<any, unknown>
       readonly release: (value: any) => Effect.Effect<void>
       readonly onAcquired: (value: any) => Message
@@ -140,7 +140,7 @@ export const makeManagedResources =
       (config, key) =>
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
         ({
-          schema: ManagedResourceDeps.fields[key],
+          schema: ManagedResourceRequirements.fields[key],
           ...config,
         }) as ManagedResourceConfig<Model, Message>,
     ) as ManagedResources<Model, Message>

--- a/packages/website/src/snippet/managedResources.ts
+++ b/packages/website/src/snippet/managedResources.ts
@@ -5,13 +5,13 @@ import { ManagedResource, Runtime } from 'foldkit'
 const CameraStream = ManagedResource.tag<MediaStream>()('CameraStream')
 
 // 2. Define a requirements schema. Option.some = active, Option.none = inactive
-const ManagedResourceDeps = S.Struct({
+const ManagedResourceRequirements = S.Struct({
   camera: S.Option(S.Struct({ facingMode: S.String })),
 })
 
 // 3. Wire lifecycle with makeManagedResources
 const managedResources = ManagedResource.makeManagedResources(
-  ManagedResourceDeps,
+  ManagedResourceRequirements,
 )<Model, Message>({
   camera: {
     resource: CameraStream,


### PR DESCRIPTION
Spells out the abbreviated `Deps` per the project's no-abbreviation
convention and aligns with the existing `modelToMaybeRequirements`
callback name. The renamed identifier is a positional generic type
parameter, not an export, so the rename of local
`ManagedResourceDeps` constants across the snippet and websocket-chat
example is a convention update rather than a type-enforced change.