### PR TITLE
Respect modifier keys and link attributes in SPA link interception

### DIFF
--- a/.changeset/spa-link-click-modifiers.md
+++ b/.changeset/spa-link-click-modifiers.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+SPA link interception now lets the browser handle clicks that aren't a plain primary-button navigation: Cmd/Ctrl/Shift/Alt-click, middle/right-click, links with `target="_blank"` (or any non-`_self` target), `download` links, and clicks whose default has already been prevented by an app-level handler all fall through instead of being captured by the router. Previously the handler called `preventDefault` on every click of an `<a>` with a non-empty href, so opening a link in a new tab silently did nothing.

--- a/packages/foldkit/src/runtime/browserListeners.test.ts
+++ b/packages/foldkit/src/runtime/browserListeners.test.ts
@@ -1,0 +1,187 @@
+import { describe, it } from '@effect/vitest'
+import { afterEach, beforeAll, beforeEach, expect } from 'vitest'
+
+import { type UrlRequest } from '../navigation/urlRequest.js'
+import { type Url } from '../url/index.js'
+import { addLinkClickListener } from './browserListeners.js'
+import { type RoutingConfig } from './runtime.js'
+
+declare global {
+  interface Window {
+    happyDOM?: {
+      settings: {
+        navigation: { disableMainFrameNavigation: boolean }
+      }
+    }
+  }
+}
+
+const dispatched: Array<UrlRequest> = []
+
+const dispatch = (request: UrlRequest) => {
+  dispatched.push(request)
+}
+
+const onUrlChange = (_url: Url): UrlRequest => {
+  throw new Error('onUrlChange should not be called by the link-click handler')
+}
+
+const routingConfig: RoutingConfig<UrlRequest> = {
+  onUrlRequest: request => request,
+  onUrlChange,
+}
+
+const makeLink = (
+  href: string,
+  attributes: Readonly<{ target?: string; download?: boolean }> = {},
+): HTMLAnchorElement => {
+  const link = document.createElement('a')
+  link.href = href
+  if (attributes.target !== undefined) {
+    link.target = attributes.target
+  }
+  if (attributes.download === true) {
+    link.setAttribute('download', '')
+  }
+  document.body.appendChild(link)
+  return link
+}
+
+const click = (
+  link: HTMLAnchorElement,
+  options: MouseEventInit = {},
+): MouseEvent => {
+  const event = new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...options,
+  })
+  link.dispatchEvent(event)
+  return event
+}
+
+describe('addLinkClickListener', () => {
+  beforeAll(() => {
+    // NOTE: happy-dom follows links whose default isn't prevented. Without
+    // this, the fall-through tests would trigger a real fetch to the link's
+    // href and log ECONNREFUSED every time they pass.
+    if (window.happyDOM !== undefined) {
+      window.happyDOM.settings.navigation.disableMainFrameNavigation = true
+    }
+
+    addLinkClickListener(dispatch, routingConfig)
+  })
+
+  beforeEach(() => {
+    dispatched.length = 0
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('preventDefaults and dispatches Internal for a plain left-click on a same-origin link', () => {
+    const link = makeLink(`${window.location.origin}/about`)
+    const event = click(link)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(dispatched).toMatchObject([{ _tag: 'Internal' }])
+  })
+
+  it('preventDefaults and dispatches External for a plain left-click on a cross-origin link', () => {
+    const link = makeLink('https://example.com/news')
+    const event = click(link)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(dispatched).toMatchObject([
+      { _tag: 'External', href: 'https://example.com/news' },
+    ])
+  })
+
+  it('falls through on cmd/meta-click so the browser can open a new tab', () => {
+    const link = makeLink(`${window.location.origin}/about`)
+    const event = click(link, { metaKey: true })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('falls through on ctrl-click', () => {
+    const link = makeLink(`${window.location.origin}/about`)
+    const event = click(link, { ctrlKey: true })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('falls through on shift-click', () => {
+    const link = makeLink(`${window.location.origin}/about`)
+    const event = click(link, { shiftKey: true })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('falls through on alt-click', () => {
+    const link = makeLink(`${window.location.origin}/about`)
+    const event = click(link, { altKey: true })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('falls through on non-primary mouse buttons', () => {
+    const link = makeLink(`${window.location.origin}/about`)
+    const event = click(link, { button: 1 })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('falls through on a link with target="_blank"', () => {
+    const link = makeLink(`${window.location.origin}/about`, {
+      target: '_blank',
+    })
+    const event = click(link)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('captures a link with target="_self" (explicit default)', () => {
+    const link = makeLink(`${window.location.origin}/about`, {
+      target: '_self',
+    })
+    const event = click(link)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(dispatched).toMatchObject([{ _tag: 'Internal' }])
+  })
+
+  it('falls through on a link with a download attribute', () => {
+    const link = makeLink(`${window.location.origin}/file.zip`, {
+      download: true,
+    })
+    const event = click(link)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('falls through when an upstream handler has already called preventDefault', () => {
+    const link = makeLink(`${window.location.origin}/about`)
+    document.body.addEventListener(
+      'click',
+      event => {
+        event.preventDefault()
+      },
+      { capture: true, once: true },
+    )
+
+    const event = click(link)
+
+    expect(dispatched).toHaveLength(0)
+    expect(event.defaultPrevented).toBe(true)
+  })
+})

--- a/packages/foldkit/src/runtime/browserListeners.ts
+++ b/packages/foldkit/src/runtime/browserListeners.ts
@@ -25,23 +25,41 @@ const addPopStateListener = <Message>(
   window.addEventListener('popstate', onPopState)
 }
 
-const addLinkClickListener = <Message>(
+export const addLinkClickListener = <Message>(
   dispatch: (message: Message) => void,
   routingConfig: RoutingConfig<Message>,
 ) => {
-  const onLinkClick = (event: Event) => {
-    const target = event.target
-    if (!(target instanceof Element)) {
+  const onLinkClick = (event: MouseEvent) => {
+    const isNonPrimaryButton = event.button !== 0
+    const isModifierKeyPressed =
+      event.metaKey || event.ctrlKey || event.shiftKey || event.altKey
+    const isDefaultPrevented = event.defaultPrevented
+
+    if (isNonPrimaryButton || isModifierKeyPressed || isDefaultPrevented) {
       return
     }
 
-    const maybeLink = Option.fromNullishOr(target.closest('a'))
+    const eventTarget = event.target
+    if (!(eventTarget instanceof Element)) {
+      return
+    }
+
+    const maybeLink = Option.fromNullishOr(eventTarget.closest('a'))
     if (Option.isNone(maybeLink)) {
       return
     }
 
-    const { href } = maybeLink.value
+    const link = maybeLink.value
+    const { href } = link
     if (String.isEmpty(href)) {
+      return
+    }
+
+    const isNonSelfTarget =
+      !String.isEmpty(link.target) && link.target !== '_self'
+    const isDownloadLink = link.hasAttribute('download')
+
+    if (isNonSelfTarget || isDownloadLink) {
       return
     }
 


### PR DESCRIPTION
## Summary

Enhanced the SPA link click listener to respect standard browser conventions for link handling. Links are now only intercepted by the router when they represent genuine same-origin navigation; modifier keys, alternative mouse buttons, and special link attributes fall through to the browser's default behavior.

## Changes

- **Event filtering**: Added checks for modifier keys (Cmd/Ctrl/Shift/Alt), non-primary mouse buttons, and `defaultPrevented` to exit early before any routing logic
- **Link attribute validation**: Added checks to skip interception for links with `target` attributes other than `_self` and links with the `download` attribute
- **Type refinement**: Changed event parameter from `Event` to `MouseEvent` for better type safety and access to button and modifier key properties
- **Variable naming**: Renamed `target` to `eventTarget` for clarity (distinguishing the DOM element from the link's `target` attribute)

## Implementation Details

The listener now follows the standard browser behavior:
- Cmd/Ctrl/Ctrl/Shift/Alt-click opens in new tab/window
- Middle/right-click shows context menu
- Links with `target="_blank"` or other non-`_self` targets open externally
- Links with `download` attribute trigger file downloads

These checks are performed before `preventDefault()` to ensure the browser handles these cases naturally. Closes #368.

https://claude.ai/code/session_018soatrMm39LdbmzPjRRbze