### PR TITLE
Simplify cross-field validation logic with imperative control flow

### DIFF
--- a/packages/website/src/snippet/fieldValidationCrossField.ts
+++ b/packages/website/src/snippet/fieldValidationCrossField.ts
@@ -2,7 +2,6 @@ import { Match as M } from 'effect'
 import {
   type Field,
   Invalid,
-  Valid,
   makeRules,
   minLength,
   validate,
@@ -19,18 +18,16 @@ const validatePassword = validate(passwordRules)
 const validateConfirmPassword = (
   password: string,
   confirmPassword: string,
-): Field =>
-  M.value(validatePassword(confirmPassword)).pipe(
-    M.tag('Valid', () =>
-      confirmPassword === password
-        ? Valid({ value: confirmPassword })
-        : Invalid({
-            value: confirmPassword,
-            errors: ['Passwords must match'],
-          }),
-    ),
-    M.orElse(invalidResult => invalidResult),
-  )
+): Field => {
+  const result = validatePassword(confirmPassword)
+  if (result._tag === 'Valid' && result.value !== password) {
+    return Invalid({
+      value: confirmPassword,
+      errors: ['Passwords must match'],
+    })
+  }
+  return result
+}
 
 const update = (model: Model, message: Message) =>
   M.value(message).pipe(
@@ -39,12 +36,9 @@ const update = (model: Model, message: Message) =>
         evo(model, {
           password: () => validatePassword(value),
           confirmPassword: confirmPassword =>
-            M.value(confirmPassword).pipe(
-              M.tag('NotValidated', () => confirmPassword),
-              M.orElse(() =>
-                validateConfirmPassword(value, confirmPassword.value),
-              ),
-            ),
+            confirmPassword._tag === 'NotValidated'
+              ? confirmPassword
+              : validateConfirmPassword(value, confirmPassword.value),
         }),
         [],
       ],


### PR DESCRIPTION
Replace Effect-TS `Match` chains with imperative `if`/`else` logic in the cross-field password validation function, improving readability and reducing unnecessary abstraction.

## Summary

Refactored `validateConfirmPassword` and the password field update logic to use straightforward imperative code instead of Effect `Match` combinators. The validation behavior remains identical, but the code is now more direct and easier to follow.

## Key Changes

- **Simplified `validateConfirmPassword`**: Replaced `M.value().pipe(M.tag(...), M.orElse(...))` with a direct `if` check on the validation result. If the password passes basic validation but doesn't match the confirmation, return `Invalid`; otherwise return the validation result as-is.
- **Simplified password field update**: Replaced `M.value(confirmPassword).pipe(M.tag('NotValidated', ...), M.orElse(...))` with a ternary that checks the `_tag` directly. If the field is `NotValidated`, return it unchanged; otherwise re-validate against the new password.
- **Removed unused import**: Deleted the `Valid` import, which is no longer needed after the refactor.

## Implementation Details

The refactored code maintains the same validation semantics:
- Basic password rules (minLength, etc.) are still applied via `validatePassword`
- Cross-field matching is still enforced only after basic validation passes
- The `NotValidated` state is still preserved until the field is first touched

This change follows the project convention to use explicit `if`/`else` when both branches return, reserving `Match` for more complex discriminated union handling.

https://claude.ai/code/session_016BiA7kxxiDihDRu16imHvm