### PR TITLE
Rename ClickedReset to ClickedResetAfterDelay

### DIFF
--- a/packages/website/src/page/asyncCounterDemo.ts
+++ b/packages/website/src/page/asyncCounterDemo.ts
@@ -144,7 +144,7 @@ export const update = (model: Model, message: Message): UpdateReturn =>
             isResetting: () => true,
             phase: () => 'ResetMessage',
             generation: () => nextGeneration,
-            messageLog: prependToLog('ClickedReset'),
+            messageLog: prependToLog('ClickedResetAfterDelay'),
           }),
           [
             DelayAdvancePhase({

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -466,7 +466,7 @@ const ClickedIncrement = m('ClickedIncrement')
 const ChangedResetDuration = m('ChangedResetDuration', {
   seconds: S.Number,
 })
-const ClickedReset = m('ClickedReset')
+const ClickedResetAfterDelay = m('ClickedResetAfterDelay')
 const CompletedDelayReset = m('CompletedDelayReset')
 
 // COMMAND
@@ -492,7 +492,7 @@ M.tagsExhaustive({
     evo(model, { resetDuration: () => seconds }),
     [],
   ],
-  ClickedReset: () => [
+  ClickedResetAfterDelay: () => [
     evo(model, { isResetting: () => true }),
     [DelayReset({ seconds: model.resetDuration })],
   ],


### PR DESCRIPTION
Clarifies the semantics of the reset Message by renaming it to better reflect that the reset action is delayed rather than immediate.

**Changes:**
- Renamed `ClickedReset` Message to `ClickedResetAfterDelay` in `vite.config.ts`
- Updated the corresponding Message handler in the exhaustive match to use the new name
- Updated the message log entry in `asyncCounterDemo.ts` to reflect the renamed Message

**Rationale:**
The new name `ClickedResetAfterDelay` more accurately describes the Message's semantics: it represents a user click that triggers a delayed reset operation (via the `DelayReset` Command), not an immediate reset. This follows the naming convention of verb-first, past-tense facts that describe what happened.

https://claude.ai/code/session_01ATpLvGQTB2XNp9C4S8sn5g