### PR TITLE
feat(website): auto-expand and lock active sidebar section

### DIFF
--- a/packages/website/src/docsNav.test.ts
+++ b/packages/website/src/docsNav.test.ts
@@ -1,0 +1,43 @@
+import { Option } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { findActiveSectionKey } from './docsNav'
+
+describe('findActiveSectionKey', () => {
+  test.each([
+    ['Manifesto', 'getStarted'],
+    ['CoreModel', 'coreConcepts'],
+    ['ComingFromReact', 'forReactDevelopers'],
+    ['ProjectOrganization', 'patterns'],
+    ['WhyNoJsx', 'faq'],
+    ['UiButton', 'foldkitUi'],
+    ['AiOverview', 'ai'],
+    ['Testing', 'testing'],
+    ['BestPracticesKeying', 'bestPractices'],
+    ['Examples', 'examples'],
+  ])('route %s resolves to the %s section', (routeTag, expectedKey) => {
+    expect(
+      Option.getOrNull(findActiveSectionKey(routeTag, Option.none())),
+    ).toBe(expectedKey)
+  })
+
+  test('ApiModule routes resolve to the apiReference section', () => {
+    expect(
+      Option.getOrNull(findActiveSectionKey('ApiModule', Option.none())),
+    ).toBe('apiReference')
+  })
+
+  test('an example detail route resolves to the examples section', () => {
+    expect(
+      Option.getOrNull(
+        findActiveSectionKey('ExampleDetail', Option.some('counter')),
+      ),
+    ).toBe('examples')
+  })
+
+  test('a route in no section resolves to none', () => {
+    expect(
+      Option.getOrNull(findActiveSectionKey('Home', Option.none())),
+    ).toBeNull()
+  })
+})

--- a/packages/website/src/docsNav.ts
+++ b/packages/website/src/docsNav.ts
@@ -76,6 +76,9 @@ import {
   whatAboutSsrRouter,
   whyNoJsxRouter,
 } from './route'
+import { type GroupKey } from './sidebarStorage'
+
+export const DOCS_SIDEBAR_NAV_ID = 'docs-sidebar-nav'
 
 // NAV PAGE
 
@@ -109,12 +112,14 @@ export const isNavPageActive = (
 // DOCS SECTIONS
 
 export type DocsSection = Readonly<{
+  key: GroupKey
   label: string
   pageGroups: ReadonlyArray<ReadonlyArray<NavPage>>
 }>
 
 export const docsSections: ReadonlyArray<DocsSection> = [
   {
+    key: 'getStarted',
     label: 'Get Started',
     pageGroups: [
       [
@@ -132,6 +137,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'coreConcepts',
     label: 'Core Concepts',
     pageGroups: [
       [
@@ -281,6 +287,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'forReactDevelopers',
     label: 'For React Developers',
     pageGroups: [
       [
@@ -298,6 +305,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'patterns',
     label: 'Patterns',
     pageGroups: [
       [
@@ -315,6 +323,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'faq',
     label: 'FAQ',
     pageGroups: [
       [
@@ -332,6 +341,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'foldkitUi',
     label: 'Foldkit UI',
     pageGroups: [
       [
@@ -477,6 +487,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'ai',
     label: 'AI',
     pageGroups: [
       [
@@ -499,6 +510,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'testing',
     label: 'Testing',
     pageGroups: [
       [
@@ -521,6 +533,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'bestPractices',
     label: 'Best Practices',
     pageGroups: [
       [
@@ -548,6 +561,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
     ],
   },
   {
+    key: 'examples',
     label: 'Examples',
     pageGroups: [
       [
@@ -600,3 +614,27 @@ export const pageNeighbors = (_tag: string): PageNeighbors =>
       }),
     }),
   )
+
+export const findActiveSectionKey = (
+  routeTag: string,
+  maybeExampleSlug: Option.Option<string>,
+): Option.Option<GroupKey> => {
+  // NOTE: ApiModule pages aren't in docsSections; their apiReference group is
+  // rendered separately, so map them explicitly.
+  if (routeTag === 'ApiModule') {
+    return Option.some('apiReference')
+  }
+  return pipe(
+    docsSections,
+    Array.findFirst(section =>
+      pipe(
+        section.pageGroups,
+        Array.flatten,
+        Array.some(page =>
+          isNavPageActive(routeTag, maybeExampleSlug, page._tag),
+        ),
+      ),
+    ),
+    Option.map(section => section.key),
+  )
+}

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -5,6 +5,7 @@ import {
   Array,
   DateTime,
   Effect,
+  Equal,
   HashSet,
   Layer,
   Match as M,
@@ -34,7 +35,7 @@ import { load, pushUrl } from 'foldkit/navigation'
 import { evo } from 'foldkit/struct'
 import { Url, toString as urlToString } from 'foldkit/url'
 
-import { allPages } from './docsNav'
+import { DOCS_SIDEBAR_NAV_ID, allPages, findActiveSectionKey } from './docsNav'
 import {
   CompletedApplyTheme,
   CompletedInjectAnalytics,
@@ -43,6 +44,7 @@ import {
   CompletedNavigateInternal,
   CompletedSaveSidebarState,
   CompletedSaveThemePreference,
+  CompletedScrollSidebarActiveLinkIntoView,
   CompletedScrollToAnchor,
   CompletedScrollToTop,
   FailedCopyLink,
@@ -58,10 +60,10 @@ import {
   GotDemoTabsMessage,
   GotExampleDetailMessage,
   GotExamplesGroupMessage,
+  GotFaqGroupMessage,
   GotFoldkitUiGroupMessage,
   GotForReactDevelopersGroupMessage,
   GotGetStartedGroupMessage,
-  GotGuidesGroupMessage,
   GotMobileMenuDialogMessage,
   GotNotePlayerDemoMessage,
   GotPatternsGroupMessage,
@@ -92,7 +94,6 @@ import * as Search from './search'
 import {
   DEFAULT_OPEN_GROUPS,
   type GroupKey,
-  INITIAL_SIDEBAR_SCROLL,
   SIDEBAR_STORAGE_KEY,
   SidebarState,
   SidebarStateJsonString,
@@ -244,7 +245,7 @@ export const Model = S.Struct({
   getStartedGroup: Ui.Disclosure.Model,
   coreConceptsGroup: Ui.Disclosure.Model,
   forReactDevelopersGroup: Ui.Disclosure.Model,
-  guidesGroup: Ui.Disclosure.Model,
+  faqGroup: Ui.Disclosure.Model,
   testingGroup: Ui.Disclosure.Model,
   bestPracticesGroup: Ui.Disclosure.Model,
   patternsGroup: Ui.Disclosure.Model,
@@ -253,7 +254,6 @@ export const Model = S.Struct({
   examplesGroup: Ui.Disclosure.Model,
   apiReferenceGroup: Ui.Disclosure.Model,
   submodelMapMessagesDisclosure: Ui.Disclosure.Model,
-  sidebarScroll: S.Number,
   aiHeadingToggleCount: S.Number,
   themePreference: ThemePreference,
   systemTheme: ResolvedTheme,
@@ -285,12 +285,21 @@ export type AppManagedResources = ManagedResource.ServicesOf<
 
 const isGroupOpenOnBoot = (
   maybeSidebarState: Option.Option<SidebarState>,
+  maybeActiveSectionKey: Option.Option<GroupKey>,
   key: GroupKey,
-): boolean =>
-  Option.match(maybeSidebarState, {
+): boolean => {
+  const isActiveSection = Option.exists(
+    maybeActiveSectionKey,
+    Equal.equals(key),
+  )
+  if (isActiveSection) {
+    return true
+  }
+  return Option.match(maybeSidebarState, {
     onNone: () => Array.contains(DEFAULT_OPEN_GROUPS, key),
     onSome: ({ open }) => open[key] ?? false,
   })
+}
 
 export const init: Runtime.RoutingProgramInit<
   Model,
@@ -331,6 +340,11 @@ export const init: Runtime.RoutingProgramInit<
   )
   const [exampleDetail, exampleDetailCommands] =
     Page.Example.ExampleDetail.boot(maybeInitialExampleSlug)
+
+  const maybeInitialActiveSectionKey = findActiveSectionKey(
+    initialRoute._tag,
+    maybeInitialExampleSlug,
+  )
 
   const mappedAsyncCounterDemoCommands = Command.mapMessages(
     asyncCounterDemoCommands,
@@ -383,58 +397,95 @@ export const init: Runtime.RoutingProgramInit<
       ),
       getStartedGroup: Ui.Disclosure.init({
         id: 'get-started-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'getStarted'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'getStarted',
+        ),
       }),
       coreConceptsGroup: Ui.Disclosure.init({
         id: 'core-concepts-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'coreConcepts'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'coreConcepts',
+        ),
       }),
       forReactDevelopersGroup: Ui.Disclosure.init({
         id: 'for-react-developers-group',
         isOpen: isGroupOpenOnBoot(
           flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
           'forReactDevelopers',
         ),
       }),
-      guidesGroup: Ui.Disclosure.init({
-        id: 'guides-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'guides'),
+      faqGroup: Ui.Disclosure.init({
+        id: 'faq-group',
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'faq',
+        ),
       }),
       testingGroup: Ui.Disclosure.init({
         id: 'testing-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'testing'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'testing',
+        ),
       }),
       bestPracticesGroup: Ui.Disclosure.init({
         id: 'best-practices-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'bestPractices'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'bestPractices',
+        ),
       }),
       patternsGroup: Ui.Disclosure.init({
         id: 'patterns-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'patterns'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'patterns',
+        ),
       }),
       foldkitUiGroup: Ui.Disclosure.init({
         id: 'foldkit-ui-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'foldkitUi'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'foldkitUi',
+        ),
       }),
       aiGroup: Ui.Disclosure.init({
         id: 'ai-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'ai'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'ai',
+        ),
       }),
       examplesGroup: Ui.Disclosure.init({
         id: 'examples-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'examples'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'examples',
+        ),
       }),
       apiReferenceGroup: Ui.Disclosure.init({
         id: 'api-reference-group',
-        isOpen: isGroupOpenOnBoot(flags.maybeSidebarState, 'apiReference'),
+        isOpen: isGroupOpenOnBoot(
+          flags.maybeSidebarState,
+          maybeInitialActiveSectionKey,
+          'apiReference',
+        ),
       }),
       submodelMapMessagesDisclosure: Ui.Disclosure.init({
         id: 'submodel-map-messages-disclosure',
         isOpen: false,
-      }),
-      sidebarScroll: Option.match(flags.maybeSidebarState, {
-        onNone: () => INITIAL_SIDEBAR_SCROLL,
-        onSome: ({ scroll }) => scroll,
       }),
       themePreference,
       systemTheme,
@@ -459,6 +510,7 @@ export const init: Runtime.RoutingProgramInit<
       ...mappedComingFromReactCommands,
       ...mappedApiReferenceCommands,
       ...mappedExampleDetailCommands,
+      ScrollSidebarActiveLinkIntoView(),
       ...Option.match(url.hash, {
         onNone: () => [],
         onSome: hash => [ScrollToAnchor({ hash })],
@@ -546,6 +598,21 @@ export const update = (
 
       ChangedUrl: ({ url }) => {
         const nextRoute = urlToAppRoute(url)
+        const maybeNextExampleSlug = pipe(
+          nextRoute,
+          Option.liftPredicate(route => route._tag === 'ExampleDetail'),
+          Option.map(({ exampleSlug }) => exampleSlug),
+        )
+        const maybeNextActiveSectionKey = findActiveSectionKey(
+          nextRoute._tag,
+          maybeNextExampleSlug,
+        )
+        const expandIfActive =
+          (key: GroupKey) =>
+          (group: Ui.Disclosure.Model): Ui.Disclosure.Model =>
+            Option.exists(maybeNextActiveSectionKey, Equal.equals(key))
+              ? Ui.Disclosure.reflectOpenState(group, true)
+              : group
         const [closedMobileMenu, closeMobileMenuCommands] = Ui.Dialog.close(
           model.mobileMenuDialog,
         )
@@ -605,10 +672,17 @@ export const update = (
             }),
             isLandingHeaderVisible: () =>
               isLandingHeaderAlwaysVisible(nextRoute),
-            apiReferenceGroup: apiReferenceGroup =>
-              nextRoute._tag === 'ApiModule'
-                ? { ...apiReferenceGroup, isOpen: true }
-                : apiReferenceGroup,
+            getStartedGroup: expandIfActive('getStarted'),
+            coreConceptsGroup: expandIfActive('coreConcepts'),
+            forReactDevelopersGroup: expandIfActive('forReactDevelopers'),
+            faqGroup: expandIfActive('faq'),
+            testingGroup: expandIfActive('testing'),
+            bestPracticesGroup: expandIfActive('bestPractices'),
+            patternsGroup: expandIfActive('patterns'),
+            foldkitUiGroup: expandIfActive('foldkitUi'),
+            aiGroup: expandIfActive('ai'),
+            examplesGroup: expandIfActive('examples'),
+            apiReferenceGroup: expandIfActive('apiReference'),
           }),
           [
             ...Command.mapMessages(closeMobileMenuCommands, message =>
@@ -923,12 +997,12 @@ export const update = (
           message => GotForReactDevelopersGroupMessage({ message }),
         ),
 
-      GotGuidesGroupMessage: ({ message }) =>
+      GotFaqGroupMessage: ({ message }) =>
         handleSidebarGroup(
-          model.guidesGroup,
+          model.faqGroup,
           message,
-          next => evo(model, { guidesGroup: () => next }),
-          message => GotGuidesGroupMessage({ message }),
+          next => evo(model, { faqGroup: () => next }),
+          message => GotFaqGroupMessage({ message }),
         ),
 
       GotTestingGroupMessage: ({ message }) =>
@@ -1000,11 +1074,6 @@ export const update = (
         ]
       },
 
-      ScrolledSidebar: ({ scroll }) => {
-        const nextModel = evo(model, { sidebarScroll: () => scroll })
-        return [nextModel, [saveSidebarState(nextModel)]]
-      },
-
       GotExampleDetailMessage: ({ message }) => {
         const [nextExampleDetail, exampleDetailCommands] =
           Page.Example.ExampleDetail.update(model.exampleDetail, message)
@@ -1057,6 +1126,7 @@ export const update = (
       'CompletedInjectSpeedInsights',
       'CompletedScrollToTop',
       'CompletedScrollToAnchor',
+      'CompletedScrollSidebarActiveLinkIntoView',
       'CompletedApplyTheme',
       'CompletedSaveThemePreference',
       'CompletedSaveSidebarState',
@@ -1148,6 +1218,16 @@ const ScrollToAnchor = Command.define(
   }).pipe(Effect.ignore, Effect.as(CompletedScrollToAnchor())),
 )
 
+const ScrollSidebarActiveLinkIntoView = Command.define(
+  'ScrollSidebarActiveLinkIntoView',
+  CompletedScrollSidebarActiveLinkIntoView,
+)(
+  Dom.scrollIntoViewAfterPaint(
+    `#${DOCS_SIDEBAR_NAV_ID} [aria-current="page"]`,
+    { block: 'center' },
+  ).pipe(Effect.ignore, Effect.as(CompletedScrollSidebarActiveLinkIntoView())),
+)
+
 const ApplyTheme = Command.define(
   'ApplyTheme',
   { theme: ResolvedTheme },
@@ -1229,7 +1309,7 @@ const modelToSidebarState = (model: Model): SidebarState => ({
     getStarted: model.getStartedGroup.isOpen,
     coreConcepts: model.coreConceptsGroup.isOpen,
     forReactDevelopers: model.forReactDevelopersGroup.isOpen,
-    guides: model.guidesGroup.isOpen,
+    faq: model.faqGroup.isOpen,
     testing: model.testingGroup.isOpen,
     bestPractices: model.bestPracticesGroup.isOpen,
     patterns: model.patternsGroup.isOpen,
@@ -1238,7 +1318,6 @@ const modelToSidebarState = (model: Model): SidebarState => ({
     examples: model.examplesGroup.isOpen,
     apiReference: model.apiReferenceGroup.isOpen,
   } satisfies Record<GroupKey, boolean>,
-  scroll: model.sidebarScroll,
 })
 
 const saveSidebarState = (model: Model) =>

--- a/packages/website/src/message.ts
+++ b/packages/website/src/message.ts
@@ -26,7 +26,9 @@ export const CompletedScrollToAnchor = m('CompletedScrollToAnchor')
 export const CompletedApplyTheme = m('CompletedApplyTheme')
 export const CompletedSaveThemePreference = m('CompletedSaveThemePreference')
 export const CompletedSaveSidebarState = m('CompletedSaveSidebarState')
-export const ScrolledSidebar = m('ScrolledSidebar', { scroll: S.Number })
+export const CompletedScrollSidebarActiveLinkIntoView = m(
+  'CompletedScrollSidebarActiveLinkIntoView',
+)
 export const SucceededCopyLink = m('SucceededCopyLink')
 export const FailedCopyLink = m('FailedCopyLink')
 export const ClickedLink = m('ClickedLink', {
@@ -114,7 +116,7 @@ export const GotForReactDevelopersGroupMessage = m(
     message: Ui.Disclosure.Message,
   },
 )
-export const GotGuidesGroupMessage = m('GotGuidesGroupMessage', {
+export const GotFaqGroupMessage = m('GotFaqGroupMessage', {
   message: Ui.Disclosure.Message,
 })
 export const GotTestingGroupMessage = m('GotTestingGroupMessage', {
@@ -161,7 +163,7 @@ export const Message = S.Union([
   CompletedApplyTheme,
   CompletedSaveThemePreference,
   CompletedSaveSidebarState,
-  ScrolledSidebar,
+  CompletedScrollSidebarActiveLinkIntoView,
   SucceededCopyLink,
   FailedCopyLink,
   ClickedLink,
@@ -195,7 +197,7 @@ export const Message = S.Union([
   GotGetStartedGroupMessage,
   GotCoreConceptsGroupMessage,
   GotForReactDevelopersGroupMessage,
-  GotGuidesGroupMessage,
+  GotFaqGroupMessage,
   GotTestingGroupMessage,
   GotBestPracticesGroupMessage,
   GotPatternsGroupMessage,

--- a/packages/website/src/sidebarStorage.ts
+++ b/packages/website/src/sidebarStorage.ts
@@ -4,7 +4,6 @@ export const SIDEBAR_STORAGE_KEY = 'foldkit-sidebar-state'
 
 export const SidebarState = S.Struct({
   open: S.Record(S.String, S.Boolean),
-  scroll: S.Number,
 })
 export type SidebarState = typeof SidebarState.Type
 
@@ -14,7 +13,7 @@ export const GroupKey = S.Literals([
   'getStarted',
   'coreConcepts',
   'forReactDevelopers',
-  'guides',
+  'faq',
   'testing',
   'bestPractices',
   'patterns',
@@ -29,5 +28,3 @@ export const DEFAULT_OPEN_GROUPS: ReadonlyArray<GroupKey> = [
   'getStarted',
   'coreConcepts',
 ]
-
-export const INITIAL_SIDEBAR_SCROLL = 0

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -1,19 +1,16 @@
 import { clsx } from 'clsx'
-import {
-  Array,
-  Duration,
-  Effect,
-  Option,
-  Queue,
-  Schema as S,
-  Stream,
-  pipe,
-} from 'effect'
-import { Mount, Ui } from 'foldkit'
+import { Array, Equal, Option, pipe } from 'effect'
+import { Ui } from 'foldkit'
 import { Html, createLazy, html } from 'foldkit/html'
 import apiModuleIndex from 'virtual:api-module-index'
 
-import { type NavPage, docsSections, isNavPageActive } from '../docsNav'
+import {
+  DOCS_SIDEBAR_NAV_ID,
+  type NavPage,
+  docsSections,
+  findActiveSectionKey,
+  isNavPageActive,
+} from '../docsNav'
 import { Icon } from '../icon'
 import { Link } from '../link'
 import { type Model } from '../main'
@@ -23,56 +20,18 @@ import {
   GotBestPracticesGroupMessage,
   GotCoreConceptsGroupMessage,
   GotExamplesGroupMessage,
+  GotFaqGroupMessage,
   GotFoldkitUiGroupMessage,
   GotForReactDevelopersGroupMessage,
   GotGetStartedGroupMessage,
-  GotGuidesGroupMessage,
   GotMobileMenuDialogMessage,
   GotPatternsGroupMessage,
   GotTestingGroupMessage,
   type Message,
-  ScrolledSidebar,
 } from '../message'
 import { ExampleDetailRoute, apiModuleRouter, homeRouter } from '../route'
+import { type GroupKey } from '../sidebarStorage'
 import { betaTag, iconLink } from './shared'
-
-export const DOCS_SIDEBAR_NAV_ID = 'docs-sidebar-nav'
-
-const SCROLL_DEBOUNCE_DURATION = Duration.millis(150)
-
-/** Combined Mount that restores the sidebar's scroll position on first mount
- *  and emits debounced `ScrolledSidebar` Messages over the element's lifetime.
- *  Bundling restore + listen into one Mount is forced by snabbdom's one-Mount-
- *  per-element constraint; the scroll restore is a side effect of `acquire`,
- *  and the scroll listener is the persistent work the Mount performs over the
- *  element's lifetime. */
-const SyncSidebarScroll = Mount.defineStream(
-  'SyncSidebarScroll',
-  { initialScroll: S.Number },
-  ScrolledSidebar,
-)(
-  ({ initialScroll }) =>
-    element =>
-      Stream.callback<typeof ScrolledSidebar.Type>(queue =>
-        Effect.gen(function* () {
-          yield* Effect.acquireRelease(
-            Effect.sync(() => {
-              element.scrollTop = initialScroll
-              const handler = () =>
-                Queue.offerUnsafe(
-                  queue,
-                  ScrolledSidebar({ scroll: element.scrollTop }),
-                )
-              element.addEventListener('scroll', handler, { passive: true })
-              return handler
-            }),
-            handler =>
-              Effect.sync(() => element.removeEventListener('scroll', handler)),
-          )
-          return yield* Effect.never
-        }),
-      ).pipe(Stream.debounce(SCROLL_DEBOUNCE_DURATION)),
-)
 
 const sidebarGroup = (config: {
   readonly id: string
@@ -80,17 +39,21 @@ const sidebarGroup = (config: {
   readonly model: Ui.Disclosure.Model
   readonly toParentMessage: (message: Ui.Disclosure.Message) => Message
   readonly children: Html
+  readonly isLocked: boolean
 }): Html => {
   const h = html<Message>()
 
   const buttonClassName = clsx(
-    'w-full flex items-center justify-between cursor-pointer transition',
+    'w-full flex items-center justify-between transition',
     'px-4 py-2.5 md:py-2',
     'text-xs font-semibold uppercase tracking-wider',
     'text-gray-600 dark:text-gray-400',
     'bg-gray-200 dark:bg-gray-800',
-    'hover:bg-gray-300/60 dark:hover:bg-gray-700/60',
-    'hover:text-gray-700 dark:hover:text-gray-300',
+    {
+      'cursor-default': config.isLocked,
+      'cursor-pointer hover:bg-gray-300/60 dark:hover:bg-gray-700/60 hover:text-gray-700 dark:hover:text-gray-300':
+        !config.isLocked,
+    },
   )
 
   return h.li(
@@ -101,6 +64,7 @@ const sidebarGroup = (config: {
         model: config.model,
         view: Ui.Disclosure.view,
         viewInputs: {
+          isDisabled: config.isLocked,
           toView: attributes =>
             h.div(
               [],
@@ -110,19 +74,21 @@ const sidebarGroup = (config: {
                   [
                     h.div(
                       [h.Class('flex items-center justify-between w-full')],
-                      [
-                        h.span([], [config.label]),
-                        h.span(
-                          [
-                            h.Class(
-                              clsx({
-                                'rotate-180': config.model.isOpen,
-                              }),
+                      config.isLocked
+                        ? [h.span([], [config.label])]
+                        : [
+                            h.span([], [config.label]),
+                            h.span(
+                              [
+                                h.Class(
+                                  clsx({
+                                    'rotate-180': config.model.isOpen,
+                                  }),
+                                ),
+                              ],
+                              [Icon.chevronDown('w-3 h-3')],
                             ),
                           ],
-                          [Icon.chevronDown('w-3 h-3')],
-                        ),
-                      ],
                     ),
                   ],
                 ),
@@ -135,11 +101,16 @@ const sidebarGroup = (config: {
               ],
             ),
         },
-        toParentMessage: message => config.toParentMessage(message),
+        toParentMessage: config.toParentMessage,
       }),
     ],
   )
 }
+
+type DisclosureBinding = Readonly<{
+  model: Ui.Disclosure.Model
+  toParentMessage: (message: Ui.Disclosure.Message) => Message
+}>
 
 const computeNavLinks = (
   idPrefix: string,
@@ -147,7 +118,7 @@ const computeNavLinks = (
   getStartedGroup: Ui.Disclosure.Model,
   coreConceptsGroup: Ui.Disclosure.Model,
   forReactDevelopersGroup: Ui.Disclosure.Model,
-  guidesGroup: Ui.Disclosure.Model,
+  faqGroup: Ui.Disclosure.Model,
   testingGroup: Ui.Disclosure.Model,
   bestPracticesGroup: Ui.Disclosure.Model,
   patternsGroup: Ui.Disclosure.Model,
@@ -167,6 +138,60 @@ const computeNavLinks = (
     ),
     Option.map(route => route.exampleSlug),
   )
+  const maybeActiveSectionKey = findActiveSectionKey(
+    route._tag,
+    maybeExampleSlug,
+  )
+  const isLocked = (key: GroupKey): boolean =>
+    Option.exists(maybeActiveSectionKey, Equal.equals(key))
+
+  const disclosureByKey: Record<GroupKey, DisclosureBinding> = {
+    getStarted: {
+      model: getStartedGroup,
+      toParentMessage: message => GotGetStartedGroupMessage({ message }),
+    },
+    coreConcepts: {
+      model: coreConceptsGroup,
+      toParentMessage: message => GotCoreConceptsGroupMessage({ message }),
+    },
+    forReactDevelopers: {
+      model: forReactDevelopersGroup,
+      toParentMessage: message =>
+        GotForReactDevelopersGroupMessage({ message }),
+    },
+    faq: {
+      model: faqGroup,
+      toParentMessage: message => GotFaqGroupMessage({ message }),
+    },
+    testing: {
+      model: testingGroup,
+      toParentMessage: message => GotTestingGroupMessage({ message }),
+    },
+    bestPractices: {
+      model: bestPracticesGroup,
+      toParentMessage: message => GotBestPracticesGroupMessage({ message }),
+    },
+    patterns: {
+      model: patternsGroup,
+      toParentMessage: message => GotPatternsGroupMessage({ message }),
+    },
+    examples: {
+      model: examplesGroup,
+      toParentMessage: message => GotExamplesGroupMessage({ message }),
+    },
+    foldkitUi: {
+      model: foldkitUiGroup,
+      toParentMessage: message => GotFoldkitUiGroupMessage({ message }),
+    },
+    ai: {
+      model: aiGroup,
+      toParentMessage: message => GotAiGroupMessage({ message }),
+    },
+    apiReference: {
+      model: apiReferenceGroup,
+      toParentMessage: message => GotApiReferenceGroupMessage({ message }),
+    },
+  }
 
   const linkClass = (isActive: boolean) =>
     clsx(
@@ -194,55 +219,6 @@ const computeNavLinks = (
       ],
     )
 
-  const sectionDisclosures: ReadonlyArray<
-    Readonly<{
-      model: Ui.Disclosure.Model
-      toParentMessage: (message: Ui.Disclosure.Message) => Message
-    }>
-  > = [
-    {
-      model: getStartedGroup,
-      toParentMessage: message => GotGetStartedGroupMessage({ message }),
-    },
-    {
-      model: coreConceptsGroup,
-      toParentMessage: message => GotCoreConceptsGroupMessage({ message }),
-    },
-    {
-      model: forReactDevelopersGroup,
-      toParentMessage: message =>
-        GotForReactDevelopersGroupMessage({ message }),
-    },
-    {
-      model: guidesGroup,
-      toParentMessage: message => GotGuidesGroupMessage({ message }),
-    },
-    {
-      model: testingGroup,
-      toParentMessage: message => GotTestingGroupMessage({ message }),
-    },
-    {
-      model: bestPracticesGroup,
-      toParentMessage: message => GotBestPracticesGroupMessage({ message }),
-    },
-    {
-      model: patternsGroup,
-      toParentMessage: message => GotPatternsGroupMessage({ message }),
-    },
-    {
-      model: examplesGroup,
-      toParentMessage: message => GotExamplesGroupMessage({ message }),
-    },
-    {
-      model: foldkitUiGroup,
-      toParentMessage: message => GotFoldkitUiGroupMessage({ message }),
-    },
-    {
-      model: aiGroup,
-      toParentMessage: message => GotAiGroupMessage({ message }),
-    },
-  ]
-
   const pageGroupList = (pages: ReadonlyArray<NavPage>): Html =>
     h.ul(
       [h.Class('space-y-0.5')],
@@ -258,31 +234,31 @@ const computeNavLinks = (
   return h.ul(
     [h.Class('space-y-0.5')],
     [
-      ...Array.zipWith(
-        docsSections,
-        sectionDisclosures,
-        (section, disclosure) =>
-          sidebarGroup({
-            id: `${idPrefix}-${disclosure.model.id}`,
-            label: section.label,
-            model: disclosure.model,
-            toParentMessage: disclosure.toParentMessage,
-            children: h.div(
-              [h.Class('divide-y divide-gray-200 dark:divide-gray-800')],
-              Array.map(section.pageGroups, group =>
-                h.div(
-                  [h.Class('py-2 first:pt-0 last:pb-0')],
-                  [pageGroupList(group)],
-                ),
+      ...Array.map(docsSections, section => {
+        const binding = disclosureByKey[section.key]
+        return sidebarGroup({
+          id: `${idPrefix}-${binding.model.id}`,
+          label: section.label,
+          model: binding.model,
+          toParentMessage: binding.toParentMessage,
+          isLocked: isLocked(section.key),
+          children: h.div(
+            [h.Class('divide-y divide-gray-200 dark:divide-gray-800')],
+            Array.map(section.pageGroups, group =>
+              h.div(
+                [h.Class('py-2 first:pt-0 last:pb-0')],
+                [pageGroupList(group)],
               ),
             ),
-          }),
-      ),
+          ),
+        })
+      }),
       sidebarGroup({
         id: `${idPrefix}-${apiReferenceGroup.id}`,
         label: 'API Reference',
-        model: apiReferenceGroup,
-        toParentMessage: message => GotApiReferenceGroupMessage({ message }),
+        model: disclosureByKey.apiReference.model,
+        toParentMessage: disclosureByKey.apiReference.toParentMessage,
+        isLocked: isLocked('apiReference'),
         children: h.ul(
           [h.Class('space-y-0.5')],
           Array.map(apiModuleIndex, ({ slug, name }) =>
@@ -312,7 +288,7 @@ export const sidebarView = (model: Model): Html => {
     model.getStartedGroup,
     model.coreConceptsGroup,
     model.forReactDevelopersGroup,
-    model.guidesGroup,
+    model.faqGroup,
     model.testingGroup,
     model.bestPracticesGroup,
     model.patternsGroup,
@@ -327,7 +303,7 @@ export const sidebarView = (model: Model): Html => {
     model.getStartedGroup,
     model.coreConceptsGroup,
     model.forReactDevelopersGroup,
-    model.guidesGroup,
+    model.faqGroup,
     model.testingGroup,
     model.bestPracticesGroup,
     model.patternsGroup,
@@ -350,7 +326,6 @@ export const sidebarView = (model: Model): Html => {
           h.AriaLabel('Documentation'),
           h.Id(DOCS_SIDEBAR_NAV_ID),
           h.Class('flex-1 overflow-y-auto pb-4'),
-          h.OnMount(SyncSidebarScroll({ initialScroll: model.sidebarScroll })),
         ],
         [desktopNavLinks],
       ),


### PR DESCRIPTION
Force the section containing the current docs page to be open on init
and on every navigation, and prevent the user from closing it (chevron
hidden, button disabled). Also scroll the active link into view in the
sidebar on init and on navigation. Replaces persisted sidebar scroll
with active-link-driven scroll, and fixes a position-based mismatch
between sections and disclosure models by switching to key-based
lookup.