### PR TITLE
Escape hash in ScrollToAnchor to handle special CSS characters

### DIFF
--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -1100,7 +1100,7 @@ const ScrollToAnchor = Command.define(
   CompletedScrollToAnchor,
 )(({ hash }) =>
   Effect.gen(function* () {
-    const target = `#${hash}`
+    const target = `#${CSS.escape(hash)}`
     yield* Dom.scrollIntoViewAfterPaint(target, { block: 'start' })
     yield* Dom.focus(target, { preventScroll: true, makeFocusable: true })
   }).pipe(Effect.ignore, Effect.as(CompletedScrollToAnchor())),


### PR DESCRIPTION
## Summary
Fixes a bug in the `ScrollToAnchor` Command where hash fragments containing special CSS characters would fail to select the target element.

## Changes
- Wrapped the hash parameter with `CSS.escape()` when constructing the selector in `ScrollToAnchor`
- This ensures that hash values with special characters (e.g., `#section:1`, `#item[0]`) are properly escaped for CSS selector queries

## Details
The `ScrollToAnchor` Command constructs a CSS selector by concatenating `#` with the hash value. Without escaping, hashes containing special CSS characters would produce invalid selectors, causing `Dom.scrollIntoViewAfterPaint` and `Dom.focus` to fail silently. The `CSS.escape()` function properly escapes these characters so the selector matches the intended element.

https://claude.ai/code/session_01Wc7XfVb3AqY8hBL98fmLN5