### PR TITLE
Update Discord invite link

### DIFF
--- a/.changeset/update-discord-invite-link.md
+++ b/.changeset/update-discord-invite-link.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Update Discord invite link.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <h3 align="center">The frontend framework for correctness.</h3>
 
 <p align="center">
-  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/manifesto"><strong>Manifesto</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/AZRTEs2VX"><strong>Discord</strong></a>
+  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/manifesto"><strong>Manifesto</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqG"><strong>Discord</strong></a>
 </p>
 
 ---

--- a/packages/create-foldkit-app/src/commands/create.ts
+++ b/packages/create-foldkit-app/src/commands/create.ts
@@ -160,7 +160,7 @@ const displaySuccessMessage = (name: string, packageManager: PackageManager) =>
       `Incident report: ${chalk.cyan('github.com/foldkit/foldkit/issues')}`,
     )
     yield* Console.log('')
-    yield* Console.log(`Crew channel: ${chalk.cyan('discord.gg/AZRTEs2VX')}`)
+    yield* Console.log(`Crew channel: ${chalk.cyan('discord.gg/kav8VNxqG')}`)
     yield* Console.log('')
     yield* Console.log('Transmissions:')
     yield* Console.log(`  Newsletter:  ${chalk.cyan('foldkit.dev/newsletter')}`)

--- a/packages/website/src/link.ts
+++ b/packages/website/src/link.ts
@@ -37,7 +37,7 @@ export const Link = {
     'https://github.com/foldkit/foldkit/tree/main/packages/create-foldkit-app',
   msw: 'https://mswjs.io',
   github: 'https://github.com/foldkit/foldkit',
-  discord: 'https://discord.gg/AZRTEs2VX',
+  discord: 'https://discord.gg/kav8VNxqG',
   xSocial: 'https://x.com/devinjameson',
   foldkitSource:
     'https://github.com/foldkit/foldkit/tree/main/packages/foldkit',


### PR DESCRIPTION
Updates the Discord server invite link across the codebase to use a new invite URL.

**Changes:**
- Updated Discord invite link in README.md from `discord.gg/AZRTEs2VX` to `discord.gg/kav8VNxqG`
- Updated Discord invite link in the create-foldkit-app success message from `discord.gg/AZRTEs2VX` to `discord.gg/kav8VNxqG`
- Updated Discord invite link in the website link configuration from `discord.gg/AZRTEs2VX` to `discord.gg/kav8VNxqG`

The new invite link is now consistently used across all user-facing documentation and application output.

https://claude.ai/code/session_01SVVkoScyqqNrCknmdtjEeu