### PR TITLE
docs(website): correct side-effect and Subscription claims in manifesto

### DIFF
--- a/packages/website/src/page/manifesto.ts
+++ b/packages/website/src/page/manifesto.ts
@@ -62,7 +62,7 @@ export const view = (): Html => {
         'Every Foldkit app has the same architecture. Not by convention. By design.',
       ),
       para(
-        'State lives in the Model. Events are Messages. Every state change flows through update. Side effects are managed by Commands. View code reaches the DOM through Mount. Ongoing streams are Subscriptions. These aren’t conventions. This is the only path. You can’t scatter state across components because there are no component-local state hooks. You can’t hide side effects in the view because the view is a pure function.',
+        'State lives in the Model. Events are Messages. Every state change flows through update. Side effects are described as data and executed by the runtime: Commands for one-shot effects, Mount for imperative DOM work bound to a live element, Subscriptions for Streams gated by a slice of your Model, ManagedResources for stateful handles gated by a slice of your Model. These aren’t conventions. This is the only path. You can’t scatter state across components because there are no component-local state hooks. You can’t hide side effects in the view because the view is a pure function.',
       ),
       para(
         'This might sound limiting. It’s the opposite. When architectural decisions are off the table, development gets more interesting. The questions shift from implementation to behavior. Not “How should we manage side effects in this component?” but “How should this feature behave?” Not “What tool should we use for streams and how should we wire them up to our components?” but “What Model state does this Subscription depend on?”',
@@ -72,7 +72,7 @@ export const view = (): Html => {
       ),
       tableOfContentsEntryToHeader(readableByDesignHeader),
       para(
-        'Any developer can walk into any Foldkit app and immediately know where to look. All state is in the Model. All events are Messages. All transitions are in update. All side effects are managed by Commands. This isn’t a claim about team discipline or code review. It’s a structural guarantee. The architecture makes it impossible to organize your app in a way that is opaque to a new reader.',
+        'Any developer can walk into any Foldkit app and immediately know where to look. All state is in the Model. All events are Messages. All transitions are in update. All side effects are described as data and executed by the runtime. This isn’t a claim about team discipline or code review. It’s a structural guarantee. The architecture makes it impossible to organize your app in a way that is opaque to a new reader.',
       ),
       para(
         'No other TypeScript framework can make this claim. Most frameworks are readable if the team is disciplined. Foldkit apps are readable by construction.',


### PR DESCRIPTION
## Summary

Sweep of the manifesto page for inaccuracies against the core concepts pages (which are the source of truth).

Two passages overstated Commands and undersold the other side-effect primitives:

- **"Side effects are managed by Commands"** (twice) is false. Per `core/architecture.ts`, side effects come from four primitives: Commands (one-shot), Mount (per-element DOM work), Subscriptions (Streams gated by Model state), and ManagedResources (stateful handles gated by Model state). Also, Commands describe side effects, the runtime executes them.
- **"View code reaches the DOM through Mount"** is imprecise. Per `core/mount.ts`, Mount is the seam where view code can drop into imperative DOM work on a live element, not the general path by which the view reaches the DOM.
- **"Ongoing streams are Subscriptions"** is imprecise. Per `core/subscriptions.ts`, you are subscribed to a slice of the Model, not to an event source. Some Subscriptions emit no Messages and just maintain DOM state. And `Mount.defineStream` also produces ongoing streams.
- The enumeration omitted **ManagedResources** entirely.

The fixes reframe both passages around the structural guarantee that side effects are described as data and executed by the runtime, with each primitive named for the cause it serves.

## Test plan

- [x] `pnpm --filter website typecheck` clean
- [x] Pre-push hook (format, lint, build, typecheck, tests) green
- [ ] Spot-check rendered manifesto page after merge


---
_Generated by [Claude Code](https://claude.ai/code/session_013EDJ7i4DY2W9j8XzwToHCw)_