### PR TITLE
fix(website): isolate StackBlitz playground embed

### DIFF
--- a/packages/website/scripts/playgroundIsolation.test.ts
+++ b/packages/website/scripts/playgroundIsolation.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { stackBlitzPlaygroundEmbedOptions } from '../src/page/playgroundConfig'
+
+const PLAYGROUND_ROUTE_SOURCE = '/playground/(.*)'
+
+type VercelConfig = {
+  headers?: ReadonlyArray<{
+    source: string
+    headers: ReadonlyArray<{
+      key: string
+      value: string
+    }>
+  }>
+}
+
+describe('playground StackBlitz isolation', () => {
+  it('keeps the WebContainer embed opt-in and Vercel headers together', () => {
+    const vercelConfig: VercelConfig = JSON.parse(
+      readFileSync(resolve(process.cwd(), '../../vercel.json'), 'utf8'),
+    )
+    const playgroundHeaders =
+      vercelConfig.headers?.find(
+        rule => rule.source === PLAYGROUND_ROUTE_SOURCE,
+      )?.headers ?? []
+
+    expect(stackBlitzPlaygroundEmbedOptions.crossOriginIsolated).toBe(true)
+    expect(playgroundHeaders).toContainEqual({
+      key: 'Cross-Origin-Embedder-Policy',
+      value: 'require-corp',
+    })
+    expect(playgroundHeaders).toContainEqual({
+      key: 'Cross-Origin-Opener-Policy',
+      value: 'same-origin',
+    })
+  })
+})

--- a/packages/website/src/page/playground.ts
+++ b/packages/website/src/page/playground.ts
@@ -8,6 +8,7 @@ import { Icon } from '../icon'
 import type { Message } from '../message'
 import { exampleDetailRouter, examplesRouter } from '../route'
 import { type ExampleMeta, findBySlug } from './example/meta'
+import { stackBlitzPlaygroundEmbedOptions } from './playgroundConfig'
 
 export const SucceededPlaygroundEmbed = m('SucceededPlaygroundEmbed')
 export const FailedPlaygroundEmbed = m('FailedPlaygroundEmbed', {
@@ -42,13 +43,7 @@ const PlaygroundEmbed = Mount.define(
                 template: 'node',
                 files,
               },
-              {
-                height: '100%',
-                hideNavigation: true,
-                openFile: 'src/main.ts',
-                showSidebar: true,
-                view: 'default',
-              },
+              stackBlitzPlaygroundEmbedOptions,
             ),
           ),
         )

--- a/packages/website/src/page/playgroundConfig.ts
+++ b/packages/website/src/page/playgroundConfig.ts
@@ -1,0 +1,10 @@
+import type { EmbedOptions } from '@stackblitz/sdk'
+
+export const stackBlitzPlaygroundEmbedOptions = {
+  height: '100%',
+  crossOriginIsolated: true,
+  hideNavigation: true,
+  openFile: 'src/main.ts',
+  showSidebar: true,
+  view: 'default',
+} as const satisfies EmbedOptions

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,13 @@
           "value": "</sitemap.xml>; rel=\"sitemap\", </manifesto>; rel=\"about\", </getting-started>; rel=\"help\", </example-apps>; rel=\"related\", </ai/overview>; rel=\"related\""
         }
       ]
+    },
+    {
+      "source": "/playground/(.*)",
+      "headers": [
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
+      ]
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Current issue:

<img width="3456" height="2114" alt="image" src="https://github.com/user-attachments/assets/ad1f10ae-139f-41e2-a187-a3bbc7f68461" />

This PR fixes it by enabling the cross-origin isolation required by WebContainers on the playground route and the StackBlitz iframe.