### PR TITLE
fix(website): isolate StackBlitz playground embed

### DIFF
--- a/packages/website/src/page/playground.ts
+++ b/packages/website/src/page/playground.ts
@@ -42,8 +42,13 @@ const PlaygroundEmbed = Mount.define(
                 template: 'node',
                 files,
               },
+              // NOTE: crossOriginIsolated requires the COOP/COEP headers
+              // set on /playground/(.*) in vercel.json. Without those
+              // headers the host page is not cross-origin isolated and
+              // the WebContainer embed fails to bootstrap.
               {
                 height: '100%',
+                crossOriginIsolated: true,
                 hideNavigation: true,
                 openFile: 'src/main.ts',
                 showSidebar: true,

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,13 @@
           "value": "</sitemap.xml>; rel=\"sitemap\", </manifesto>; rel=\"about\", </getting-started>; rel=\"help\", </example-apps>; rel=\"related\", </ai/overview>; rel=\"related\""
         }
       ]
+    },
+    {
+      "source": "/playground/(.*)",
+      "headers": [
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
+      ]
     }
   ],
   "rewrites": [


### PR DESCRIPTION
StackBlitz WebContainers depend on SharedArrayBuffer, which browsers
only expose to cross-origin isolated pages. Set the COOP/COEP headers
on the playground route in vercel.json and pass crossOriginIsolated:
true to the embed so the SDK hosts the WebContainer in this page's
isolation context instead of routing through the stackblitz.com
service worker fallback.

Co-authored-by: Devin Jameson <39350030+devinjameson@users.noreply.github.com>