### PR TITLE
Clarify Mount documentation with more precise language

### DIFF
--- a/packages/website/src/page/core/mount.ts
+++ b/packages/website/src/page/core/mount.ts
@@ -72,9 +72,9 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ' is a function from Model to Html. It doesn’t reach into the DOM, it doesn’t hold references, it doesn’t run side effects. That purity is what makes Foldkit programs predictable.',
       ),
       para(
-        'Mount is the moment an element enters the live DOM, when the virtual DOM becomes real. ',
+        'Mount binds an imperative, element-scoped side effect to a view element for as long as that element lives in the DOM. It sets up when the element enters and tears down when the element leaves. ',
         inlineCode('OnMount'),
-        ' is the seam where view code can drop down to imperative work at that moment. The common shape, ',
+        ' is the seam where view code drops down to imperative work on the live element. The common shape, ',
         inlineCode('Mount.define'),
         ', runs an ',
         inlineCode('Effect<Message>'),


### PR DESCRIPTION
## Summary
Updated the Mount documentation in the website to more accurately describe what Mount does and how it relates to imperative side effects in Foldkit applications.

## Changes
- Replaced vague "moment an element enters the live DOM" language with a precise definition: Mount binds imperative, element-scoped side effects to view elements for their lifetime in the DOM
- Clarified the setup/teardown lifecycle: "sets up when the element enters and tears down when the element leaves"
- Changed "can drop down" to "drops down" to reflect that Mount is the standard seam for imperative work, not an optional capability
- Changed "at that moment" to "on the live element" to emphasize the element-scoped nature of Mount effects

## Details
These changes improve clarity for developers learning about Mount by:
1. Leading with the core concept (binding side effects to element lifecycle)
2. Explicitly naming the setup/teardown pattern
3. Emphasizing that Mount is the idiomatic way to handle imperative work in Foldkit, consistent with the framework's architecture principles

https://claude.ai/code/session_01LaC3DEb15w31GYVAHbj2hr