### PR TITLE
Prerender playground shell to avoid landing page flash

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -94,6 +94,7 @@ jobs:
                 "has": [{ "type": "query", "key": "embedded", "value": "(?<slug>[^&]+)" }],
                 "dest": "/example-apps-embed/$slug/index.html"
               },
+              { "src": "/playground/(.*)", "dest": "/playground/index.html" },
               { "src": "/(.*)", "dest": "/index.html" }
             ]
           }

--- a/packages/website/scripts/prerender.test.ts
+++ b/packages/website/scripts/prerender.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { STATIC_ROUTES, enumerateRoutes, injectHtml } from './prerender'
+import {
+  STATIC_ROUTES,
+  buildPlaygroundShellHtml,
+  enumerateRoutes,
+  injectHtml,
+} from './prerender'
 
 describe('injectHtml', () => {
   it('wraps rendered html in the root div', () => {
@@ -15,6 +20,17 @@ describe('injectHtml', () => {
     const base = '<body><div id="other"></div></body>'
     const rendered = '<div class="app"><p>hello</p></div>'
     expect(injectHtml(base, rendered)).toBe(base)
+  })
+})
+
+describe('buildPlaygroundShellHtml', () => {
+  it('injects the neutral spinner shell into the root div', () => {
+    const base = '<body><div id="root"></div></body>'
+    const result = buildPlaygroundShellHtml(base)
+    expect(result.startsWith('<body><div id="root">')).toBe(true)
+    expect(result).toContain('Starting playground')
+    expect(result).toContain('animate-spin')
+    expect(result).not.toContain('<div id="root"></div>')
   })
 })
 

--- a/packages/website/scripts/prerender.ts
+++ b/packages/website/scripts/prerender.ts
@@ -368,6 +368,25 @@ const ROOT_PLACEHOLDER = '<div id="root"></div>'
 export const injectHtml = (baseHtml: string, renderedHtml: string): string =>
   baseHtml.replace(ROOT_PLACEHOLDER, `<div id="root">${renderedHtml}</div>`)
 
+// PLAYGROUND SHELL
+
+// NOTE: Playground routes are deliberately excluded from STATIC_ROUTES: the
+// WebContainer editor can't be statically rendered, and every entry into it is
+// a full document load for cross-origin isolation. With no file of its own,
+// Vercel's SPA catch-all serves the prerendered home page for
+// `/playground/<slug>`, so the landing view flashes before the app boots and
+// swaps in the editor. We prerender this neutral shell once and route
+// `/playground/*` to it instead (see deploy-website.yml and the preview
+// fallback in vite.config.ts). The markup mirrors the booting spinner in
+// `src/page/playground.ts`; every class here must already appear in app source
+// because Tailwind scans source, not this injected string.
+const PLAYGROUND_SHELL_MARKUP = `<div class="flex flex-col h-screen bg-white dark:bg-gray-900"><div class="flex-1 flex items-center justify-center px-6 py-20 text-center"><div class="max-w-sm flex flex-col items-center"><div class="w-8 h-8 mb-6 rounded-full border-2 border-gray-300 dark:border-gray-700 border-t-gray-900 dark:border-t-gray-100 animate-spin" role="status" aria-label="Loading"></div><div class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Starting playground…</div><div class="text-sm text-gray-600 dark:text-gray-400">Hang tight. The preview will appear automatically. First load takes about 30 seconds.</div></div></div></div>`
+
+const PLAYGROUND_SHELL_OUTPUT_PATH = 'playground/index.html'
+
+export const buildPlaygroundShellHtml = (baseHtml: string): string =>
+  injectHtml(baseHtml, PLAYGROUND_SHELL_MARKUP)
+
 export const enumerateRoutes = (
   apiModuleSlugs: ReadonlyArray<string>,
 ): ReadonlyArray<AppRoute> =>
@@ -613,6 +632,14 @@ const program = Effect.scoped(
 
     const fs = yield* FileSystem.FileSystem
     const baseHtml = yield* fs.readFileString(resolve(DIST_DIR, 'index.html'))
+
+    const playgroundShellPath = resolve(DIST_DIR, PLAYGROUND_SHELL_OUTPUT_PATH)
+    yield* fs.makeDirectory(dirname(playgroundShellPath), { recursive: true })
+    yield* fs.writeFileString(
+      playgroundShellPath,
+      buildPlaygroundShellHtml(baseHtml),
+    )
+    yield* Console.log('  ✓ /playground/* shell')
 
     const results = yield* Effect.forEach(
       routes,

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -916,12 +916,37 @@ const playgroundIsolationHeadersPlugin = (): Plugin => ({
   },
 })
 
+// NOTE: Mirrors the `/playground/(.*)` rewrite in
+// .github/workflows/deploy-website.yml so the prerendered build can be
+// verified with `pnpm preview`. Playground routes aren't prerendered, so the
+// SPA fallback would otherwise serve the home page and flash the landing view
+// before the app boots. `pnpm dev` needs nothing: there's no prerender, so
+// `#root` is empty and there's no landing markup to flash.
+const playgroundShellFallbackPlugin = (): Plugin => ({
+  name: 'playground-shell-fallback',
+  configurePreviewServer(server) {
+    server.middlewares.use((req, _res, next) => {
+      if (req.url) {
+        const { pathname, search } = new URL(req.url, 'http://localhost')
+        if (
+          pathname.startsWith('/playground/') &&
+          pathname !== '/playground/index.html'
+        ) {
+          req.url = `/playground/index.html${search}`
+        }
+      }
+      next()
+    })
+  },
+})
+
 export default defineConfig({
   plugins: [
     tailwindcss(),
     foldkit({ devToolsMcpPort: 9988 }),
     embeddedExampleRedirectPlugin(),
     playgroundIsolationHeadersPlugin(),
+    playgroundShellFallbackPlugin(),
     highlightCodePlugin(),
     highlightApiSignaturesPlugin(),
     apiModuleIndexPlugin(),


### PR DESCRIPTION
## Summary

Add a prerendered neutral loading shell for playground routes to prevent the landing page from flashing before the WebContainer editor boots. Playground routes cannot be statically rendered due to cross-origin isolation requirements, so this shell serves as a fallback while the app initializes.

## Changes

- **prerender.ts**: Added `PLAYGROUND_SHELL_MARKUP` containing a spinner and loading message that mirrors the booting state in `src/page/playground.ts`. Exported `buildPlaygroundShellHtml()` to inject this markup into the base HTML template. Added build step to prerender the shell once to `playground/index.html`.

- **vite.config.ts**: Added `playgroundShellFallbackPlugin()` to rewrite `/playground/*` requests to `/playground/index.html` during preview mode, matching the production Vercel rewrite behavior. This allows `pnpm preview` to verify the prerendered build without serving the home page as a fallback.

- **deploy-website.yml**: Added Vercel rewrite rule to route `/playground/(.*)` to `/playground/index.html`, ensuring all playground entry points serve the prerendered shell instead of the SPA fallback.

- **prerender.test.ts**: Added test for `buildPlaygroundShellHtml()` to verify the shell markup is correctly injected and contains expected loading UI elements.

## Implementation Details

The playground shell markup uses only Tailwind classes that already appear in the app source, ensuring Tailwind's static scanning includes them in the production build. The spinner and messaging match the actual loading state users see when the editor boots, providing visual continuity rather than a jarring transition from the landing page.

https://claude.ai/code/session_01MwpNMDtnqeVdTHfRpcCXEG