### PR TITLE
fix(foldkit): clone reused vnode objects before patch

### DIFF
--- a/.changeset/fix-shared-vnode-dom-corruption.md
+++ b/.changeset/fix-shared-vnode-dom-corruption.md
@@ -1,0 +1,7 @@
+---
+'foldkit': patch
+---
+
+Fix DOM corruption when the same vnode value is rendered in more than one position within a single render.
+
+Reusing a view value across positions, for example a `const checkmark = h.span(...)` placed into several slots, previously left those positions sharing a single DOM reference. Removals and text updates then landed on the wrong node, so repeated toggles accumulated stale elements and a moved selection indicator could stick to its old position. The runtime now gives each position its own DOM node before patching. Trees that never reuse a vnode are unaffected, and `createLazy` / `createKeyedLazy` memoized subtrees keep their fast path.

--- a/packages/foldkit/src/runtime/patchVNode.test.ts
+++ b/packages/foldkit/src/runtime/patchVNode.test.ts
@@ -1,0 +1,43 @@
+import { Option } from 'effect'
+import { h } from 'snabbdom'
+import { describe, expect, it } from 'vitest'
+
+import { type VNode } from '../vdom.js'
+import { patchVNode } from './runtime.js'
+
+const spanCountsIn = (root: Node | undefined): ReadonlyArray<number> => {
+  if (!(root instanceof Element)) {
+    return []
+  }
+  return Array.from(root.querySelectorAll('button')).map(
+    button => button.querySelectorAll('span').length,
+  )
+}
+
+describe('patchVNode', () => {
+  // NOTE: guards the dedupeSharedVNodes wiring. The three buttons share ONE
+  // `check` vnode object; without the dedupe pass inside patchVNode, snabbdom
+  // mutates a single `.elm` across all three positions and a hide/show cycle
+  // leaves stale spans behind. Removing the call fails the final assertion.
+  it('does not accumulate DOM nodes when a vnode value is reused across positions', () => {
+    const renderTree = (isShown: boolean): VNode => {
+      const check = h('span', {}, ['✓'])
+      return h('div', {}, [
+        h('button', {}, isShown ? [check] : []),
+        h('button', {}, isShown ? [check] : []),
+        h('button', {}, isShown ? [check] : []),
+      ])
+    }
+
+    const container = document.createElement('div')
+
+    let mounted = patchVNode(Option.none(), renderTree(true), container)
+    expect(spanCountsIn(mounted.elm)).toEqual([1, 1, 1])
+
+    mounted = patchVNode(Option.some(mounted), renderTree(false), container)
+    expect(spanCountsIn(mounted.elm)).toEqual([0, 0, 0])
+
+    mounted = patchVNode(Option.some(mounted), renderTree(true), container)
+    expect(spanCountsIn(mounted.elm)).toEqual([1, 1, 1])
+  })
+})

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -43,7 +43,7 @@ import {
 import { MountTracker } from '../mount/index.js'
 import { UrlRequest } from '../navigation/urlRequest.js'
 import { Url, fromString as urlFromString } from '../url/index.js'
-import { VNode, patch, toVNode } from '../vdom.js'
+import { VNode, dedupeSharedVNodes, patch, toVNode } from '../vdom.js'
 import {
   addBfcacheRestoreListener,
   addNavigationEventListeners,
@@ -1364,18 +1364,20 @@ const makeRuntime = <
   return { runtimeId, start }
 }
 
-const patchVNode = (
+// NOTE: exported for `patchVNode.test.ts` to assert the dedupeSharedVNodes
+// wiring; not part of the public surface (`runtime/public.ts` is curated).
+export const patchVNode = (
   maybeCurrentVNode: Option.Option<VNode>,
-  nullableNextVNode: VNode | null,
+  nextVNode: VNode | null,
   container: HTMLElement,
 ): VNode => {
-  const nextVNode = Predicate.isNotNull(nullableNextVNode)
-    ? nullableNextVNode
+  const dedupedVNode = Predicate.isNotNull(nextVNode)
+    ? dedupeSharedVNodes(nextVNode)
     : h('!')
 
   return Option.match(maybeCurrentVNode, {
-    onNone: () => patch(toVNode(container), nextVNode),
-    onSome: currentVNode => patch(currentVNode, nextVNode),
+    onNone: () => patch(toVNode(container), dedupedVNode),
+    onSome: currentVNode => patch(currentVNode, dedupedVNode),
   })
 }
 

--- a/packages/foldkit/src/vdom.test.ts
+++ b/packages/foldkit/src/vdom.test.ts
@@ -1,0 +1,96 @@
+import { h } from 'snabbdom'
+import { describe, expect, it } from 'vitest'
+
+import { type VNode, dedupeSharedVNodes, patch, toVNode } from './vdom.js'
+
+const asVNode = (child: VNode | string | undefined): VNode => {
+  if (child === undefined || typeof child === 'string') {
+    throw new Error('expected a VNode')
+  }
+  return child
+}
+
+describe('dedupeSharedVNodes', () => {
+  it('returns the tree unchanged when no vnode object is reused', () => {
+    const tree = h('div', {}, [h('span', {}, ['a']), h('span', {}, ['b'])])
+
+    const result = dedupeSharedVNodes(tree)
+
+    expect(result).toBe(tree)
+    expect(result.children?.[0]).toBe(tree.children?.[0])
+    expect(result.children?.[1]).toBe(tree.children?.[1])
+  })
+
+  it('clones a vnode object reused across sibling positions into distinct objects', () => {
+    const shared = h('span', {}, ['✓'])
+    const tree = h('div', {}, [shared, shared])
+
+    const result = dedupeSharedVNodes(tree)
+
+    expect(result.children?.[0]).toBe(shared)
+    expect(result.children?.[1]).not.toBe(shared)
+    expect(asVNode(result.children?.[1]).sel).toBe(shared.sel)
+  })
+
+  it('resets elm on the cloned occurrence so it gets its own DOM node', () => {
+    const shared = h('span', {}, ['✓'])
+    shared.elm = document.createElement('span')
+    const tree = h('div', {}, [shared, shared])
+
+    const result = dedupeSharedVNodes(tree)
+
+    expect(asVNode(result.children?.[0]).elm).toBe(shared.elm)
+    expect(asVNode(result.children?.[1]).elm).toBeUndefined()
+  })
+
+  it('clones the entire shared subtree, not just its root', () => {
+    const sharedChild = h('i', {}, ['x'])
+    const sharedParent = h('span', {}, [sharedChild])
+    const tree = h('div', {}, [sharedParent, sharedParent])
+
+    const result = dedupeSharedVNodes(tree)
+
+    const first = asVNode(result.children?.[0])
+    const second = asVNode(result.children?.[1])
+
+    expect(first).toBe(sharedParent)
+    expect(first.children?.[0]).toBe(sharedChild)
+    expect(second).not.toBe(sharedParent)
+    expect(second.children?.[0]).not.toBe(sharedChild)
+    expect(sharedParent.children?.[0]).toBe(sharedChild)
+  })
+
+  it('renders and removes a reused vnode in every position without accumulation', () => {
+    const renderTree = (isShown: boolean): VNode => {
+      const check = h('span', {}, ['✓'])
+      return h('div', {}, [
+        h('button', {}, isShown ? [check] : []),
+        h('button', {}, isShown ? [check] : []),
+        h('button', {}, isShown ? [check] : []),
+      ])
+    }
+
+    const spanCountsIn = (root: Node | undefined): ReadonlyArray<number> => {
+      if (!(root instanceof Element)) {
+        return []
+      }
+      return Array.from(root.querySelectorAll('button')).map(
+        button => button.querySelectorAll('span').length,
+      )
+    }
+
+    const container = document.createElement('div')
+
+    let mounted = patch(
+      toVNode(container),
+      dedupeSharedVNodes(renderTree(true)),
+    )
+    expect(spanCountsIn(mounted.elm)).toEqual([1, 1, 1])
+
+    mounted = patch(mounted, dedupeSharedVNodes(renderTree(false)))
+    expect(spanCountsIn(mounted.elm)).toEqual([0, 0, 0])
+
+    mounted = patch(mounted, dedupeSharedVNodes(renderTree(true)))
+    expect(spanCountsIn(mounted.elm)).toEqual([1, 1, 1])
+  })
+})

--- a/packages/foldkit/src/vdom.ts
+++ b/packages/foldkit/src/vdom.ts
@@ -1,4 +1,5 @@
 import {
+  type VNode,
   attributesModule,
   classModule,
   datasetModule,
@@ -21,3 +22,48 @@ export const patch = init([
   propsModule,
   styleModule,
 ])
+
+// NOTE: snabbdom records each element's live DOM node on `vnode.elm` by
+// mutating the vnode object during patch. A vnode object placed in more than
+// one tree position would share a single `.elm`, so removals and text updates
+// land on the wrong DOM node. View code legitimately reuses vnode values, e.g.
+// `const checkmark = h.span(...)` dropped into several slots, so before each
+// patch we clone any vnode object reached a second time, giving every position
+// its own object.
+// Detection is keyed off a per-patch Set, so a vnode reused across renders (a
+// memoized `createLazy` subtree, the identical object each render) is reached
+// only once per patch and passes through untouched, leaving snabbdom's
+// same-object subtree short-circuit intact. Allocation happens only along
+// paths where a duplicate is actually found; a tree with no reuse returns
+// unchanged.
+export const dedupeSharedVNodes = (root: VNode): VNode => {
+  const seen = new Set<object>()
+  const visit = (node: VNode): VNode => {
+    const base: VNode = seen.has(node) ? { ...node, elm: undefined } : node
+    seen.add(base)
+    const children = base.children
+    if (children === undefined) {
+      return base
+    }
+    let nextChildren: Array<VNode | string> | undefined
+    for (let index = 0; index < children.length; index++) {
+      const child = children[index]!
+      const deduped = typeof child === 'string' ? child : visit(child)
+      if (deduped !== child) {
+        if (nextChildren === undefined) {
+          nextChildren = children.slice()
+        }
+        nextChildren[index] = deduped
+      }
+    }
+    if (nextChildren === undefined) {
+      return base
+    }
+    if (base === node) {
+      return { ...node, children: nextChildren }
+    }
+    base.children = nextChildren
+    return base
+  }
+  return visit(root)
+}


### PR DESCRIPTION
The 0.102.0 perf overhaul changed `Html` from `Effect<VNode>` to a bare
snabbdom `VNode`. The old pipeline ran each element's Effect at its
position, so a reused view value (`const checkmark = h.span(...)`
dropped into several slots) produced a fresh VNode per use. With bare
VNodes the same object now lands in every slot, and snabbdom records
each element's live DOM node on `vnode.elm` by mutation, so the shared
object's `.elm` is overwritten per position. Removals and text updates
then hit the wrong node: repeated toggles piled up stale elements and a
moved selection indicator stuck to its old spot.

patchVNode now clones any vnode object reached a second time before
handing the tree to snabbdom, so each position gets its own object.
Detection uses a per-patch Set, so a vnode reused across renders (a
memoized createLazy subtree, identical object each render) is reached
once and passes through untouched, leaving the same-object short-circuit
intact. View values are freely shareable again, matching Elm.

The walk is O(tree) per render but does little more than a Set lookup
per node, so the added cost is small.
