### PR TITLE
fix(foldkit)!: surface render failures as the crash view

### DIFF
--- a/.changeset/crash-on-render-failure.md
+++ b/.changeset/crash-on-render-failure.md
@@ -1,0 +1,9 @@
+---
+'foldkit': minor
+---
+
+Surface render failures as the crash view instead of silently freezing the DOM.
+
+A view that throws (for example a Schema constructor rejecting its input while building a VNode) ran inside the render loop fiber, which had no error path. The fiber died and the DOM stayed at the last successful render, so the failure was swallowed: no crash screen, and the app appeared stuck on its last good frame. Update failures already routed to the crash view. Render failures now do too, as do failures during the initial render.
+
+**Breaking:** `CrashContext.message` is now `Option<Message>` instead of `Message`, because a crash during the initial render has no triggering Message. Update `crash.view` / `crash.report` handlers that read `message` to unwrap the `Option` (for example `Option.getOrUndefined(message)`).

--- a/examples/crash-view/src/entry.ts
+++ b/examples/crash-view/src/entry.ts
@@ -1,3 +1,4 @@
+import { Option } from 'effect'
 import { Runtime } from 'foldkit'
 
 import { Message, Model, crashView, init, update, view } from './main'
@@ -11,7 +12,11 @@ const program = Runtime.makeProgram({
   crash: {
     view: crashView,
     report: ({ error, model, message }) => {
-      console.log('Crash report:', { error, model, message })
+      console.log('Crash report:', {
+        error,
+        model,
+        message: Option.getOrUndefined(message),
+      })
     },
   },
   container: document.getElementById('root'),

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -215,11 +215,14 @@ export type RoutingConfig<Message> = Readonly<{
   onUrlChange: (url: Url) => Message
 }>
 
-/** Context provided to crash.view and crash.report when the runtime encounters an unrecoverable error. */
+/** Context provided to crash.view and crash.report when the runtime encounters
+ *  an unrecoverable error. `message` is the Message being processed when the
+ *  crash occurred, present as an `Option` because a crash during the initial
+ *  render has no triggering Message. */
 export type CrashContext<Model, Message> = Readonly<{
   error: Error
   model: Model
-  message: Message
+  message: Option.Option<Message>
 }>
 
 /** Configuration for crash handling, with custom crash UI and/or crash reporting. */
@@ -792,6 +795,27 @@ const makeRuntime = <
           Option.none(),
         )
 
+        // NOTE: shared by every perpetual fiber's crash path (init render,
+        // render loop, message drain). Each fiber catches its own cause so a
+        // failure surfaces as the crash view instead of dying silently and
+        // leaving the DOM frozen at the last successful render.
+        const crashWith = (
+          cause: Cause.Cause<never>,
+          maybeMessage: Option.Option<Message>,
+        ): Effect.Effect<void> =>
+          Effect.gen(function* () {
+            const model = yield* Ref.get(modelRef)
+            const squashed = Cause.squash(cause)
+            const error =
+              squashed instanceof Error ? squashed : new Error(String(squashed))
+            renderCrashView(
+              { error, model, message: maybeMessage },
+              crash,
+              container,
+              maybeCurrentVNodeRef,
+            )
+          })
+
         // NOTE: queue-drain-fiber-local state. Kept as plain closure
         // variables instead of `Ref`s because nothing else reads or writes
         // them concurrently, and JS's single-threaded model already orders
@@ -819,9 +843,9 @@ const makeRuntime = <
         const dispatch = { dispatchAsync, dispatchSync }
 
         const isRenderPendingRef = yield* SubscriptionRef.make(false)
-        const lastDirtyMessageRef = yield* Ref.make<Option.Option<Message>>(
-          Option.none(),
-        )
+        const maybeLastDirtyMessageRef = yield* Ref.make<
+          Option.Option<Message>
+        >(Option.none())
 
         const isPausedEffect: Effect.Effect<boolean> = Effect.suspend(() =>
           Option.match(maybeDevToolsStore, {
@@ -866,7 +890,7 @@ const makeRuntime = <
             if (currentModel !== nextModel) {
               yield* Ref.set(modelRef, nextModel)
               yield* SubscriptionRef.set(isRenderPendingRef, true)
-              yield* Ref.set(lastDirtyMessageRef, Option.some(message))
+              yield* Ref.set(maybeLastDirtyMessageRef, Option.some(message))
 
               PubSub.publishUnsafe(modelPubSub, nextModel)
               yield* schedulePreserveModel(nextModel)
@@ -1073,7 +1097,13 @@ const makeRuntime = <
           }
         }
 
-        yield* render(initModel, Option.none())
+        const initRenderExit = yield* Effect.exit(
+          render(initModel, Option.none()),
+        )
+        if (Exit.isFailure(initRenderExit)) {
+          yield* crashWith(initRenderExit.cause, Option.none())
+          return
+        }
 
         const initMountEvents = drainMountEvents()
         yield* Option.match(maybeDevToolsStore, {
@@ -1086,12 +1116,12 @@ const makeRuntime = <
             ),
         })
 
-        // NOTE: lastDirtyMessageRef holds the most recent dirtying Message, so
-        // slow-view callbacks during high-rate bursts attribute to the last
-        // Message in the frame batch, not the specific one that pushed the
-        // view past threshold. Acceptable for a debug callback; full
-        // attribution would require correlating each message with its render
-        // contribution, which isn't worth the complexity.
+        // NOTE: maybeLastDirtyMessageRef holds the most recent dirtying
+        // Message, so slow-view callbacks during high-rate bursts attribute
+        // to the last Message in the frame batch, not the specific one that
+        // pushed the view past threshold. Acceptable for a debug callback;
+        // full attribution would require correlating each message with its
+        // render contribution, which isn't worth the complexity.
 
         const renderLoop = makeRenderLoop({
           pendingRef: isRenderPendingRef,
@@ -1099,7 +1129,7 @@ const makeRuntime = <
           isPaused: isPausedEffect,
           render: Effect.gen(function* () {
             const model = yield* Ref.get(modelRef)
-            const maybeMessage = yield* Ref.get(lastDirtyMessageRef)
+            const maybeMessage = yield* Ref.get(maybeLastDirtyMessageRef)
             yield* render(model, maybeMessage)
 
             const mountEvents = drainMountEvents()
@@ -1114,7 +1144,16 @@ const makeRuntime = <
           }),
         })
 
-        yield* Effect.forkDetach(renderLoop)
+        yield* Effect.forkDetach(
+          renderLoop.pipe(
+            Effect.catchCause(cause =>
+              Effect.gen(function* () {
+                const maybeMessage = yield* Ref.get(maybeLastDirtyMessageRef)
+                yield* crashWith(cause, maybeMessage)
+              }),
+            ),
+          ),
+        )
 
         addBfcacheRestoreListener()
 
@@ -1339,24 +1378,7 @@ const makeRuntime = <
               yield* drainQueue
             }),
           ),
-          Effect.catchCause(cause =>
-            Effect.sync(() => {
-              const squashed = Cause.squash(cause)
-              const appError =
-                squashed instanceof Error
-                  ? squashed
-                  : new Error(String(squashed))
-
-              const model = Effect.runSync(Ref.get(modelRef))
-              const message = Option.getOrThrow(currentMessage)
-              renderCrashView(
-                { error: appError, model, message },
-                crash,
-                container,
-                maybeCurrentVNodeRef,
-              )
-            }),
-          ),
+          Effect.catchCause(cause => crashWith(cause, currentMessage)),
         )
       }),
     )

--- a/packages/foldkit/src/test/apps/crashOnRender.test.ts
+++ b/packages/foldkit/src/test/apps/crashOnRender.test.ts
@@ -1,0 +1,93 @@
+import { Effect, Fiber } from 'effect'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { Command } from '../../command/index.js'
+import { makeProgram } from '../../runtime/index.js'
+import * as App from './crashOnRender.js'
+
+let runningFiber: Fiber.Fiber<void> | null = null
+
+const boot = (
+  initialModel: App.Model,
+  commands: ReadonlyArray<Command<App.Message>> = [],
+): void => {
+  const container = document.createElement('div')
+  container.id = 'app'
+  document.body.appendChild(container)
+
+  const program = makeProgram<App.Model, App.Message>({
+    Model: App.Model,
+    init: () => [initialModel, commands],
+    update: App.update,
+    view: App.view,
+    container,
+    devTools: false,
+  })
+
+  runningFiber = Effect.runFork(program.start())
+}
+
+const waitForBodyText = async (
+  text: string,
+  timeoutMs = 2000,
+): Promise<void> => {
+  const start = Date.now()
+  while (!(document.body.textContent ?? '').includes(text)) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(
+        `Timed out waiting for "${text}". Last content: ${document.body.textContent}`,
+      )
+    }
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+const clickButton = (text: string): void => {
+  const button = Array.from(document.querySelectorAll('button')).find(
+    candidate => (candidate.textContent ?? '').includes(text),
+  )
+  if (button === undefined) {
+    throw new Error(
+      `No button labelled "${text}". Body: ${document.body.innerHTML}`,
+    )
+  }
+  button.click()
+}
+
+describe('crash view on unrecoverable errors', () => {
+  afterEach(async () => {
+    if (runningFiber !== null) {
+      await Effect.runPromise(Fiber.interrupt(runningFiber))
+      runningFiber = null
+    }
+    document.body.innerHTML = ''
+  })
+
+  it('shows the crash view when a later render throws instead of freezing on the last frame', async () => {
+    boot(App.initialModel)
+    await waitForBodyText('Select 1')
+
+    // NOTE: Reload loads a malformed source; the empty id throws on the next
+    // frame, when the view rebuilds its SelectedSource handler.
+    clickButton('Reload')
+
+    await waitForBodyText('Application Crash')
+    expect(document.body.textContent).not.toContain('Select 1')
+  })
+
+  it('shows the crash view when the initial render throws', async () => {
+    boot({ sources: App.malformedSources })
+
+    await waitForBodyText('Application Crash')
+  })
+
+  it('shows the crash view when update throws', async () => {
+    boot(App.initialModel)
+    await waitForBodyText('Select 1')
+
+    // NOTE: an empty id makes update construct a Source, which throws.
+    clickButton('Add source')
+
+    await waitForBodyText('Application Crash')
+  })
+})

--- a/packages/foldkit/src/test/apps/crashOnRender.ts
+++ b/packages/foldkit/src/test/apps/crashOnRender.ts
@@ -1,0 +1,127 @@
+import { Array, Effect, Match as M, Schema as S } from 'effect'
+
+import * as Command from '../../command/index.js'
+import { type Document, html } from '../../html/index.js'
+import { m } from '../../message/index.js'
+import { evo } from '../../struct/index.js'
+
+// MODEL
+
+export const RawSource = S.Struct({
+  kind: S.Literal('Book'),
+  id: S.String,
+})
+export type RawSource = typeof RawSource.Type
+
+// NOTE: the strict counterpart of RawSource, requiring a non-empty id.
+// Constructing one (or a SelectedSource Message carrying one) from an empty id
+// throws at construction time, which is what drives the render and update crash.
+export const Source = S.Struct({
+  kind: S.Literal('Book'),
+  id: S.String.check(S.isNonEmpty()),
+})
+export type Source = typeof Source.Type
+
+export const Model = S.Struct({
+  sources: S.Array(RawSource),
+})
+export type Model = typeof Model.Type
+
+// MESSAGE
+
+export const ClickedReload = m('ClickedReload')
+export const LoadedSources = m('LoadedSources', { sources: S.Array(RawSource) })
+export const SelectedSource = m('SelectedSource', { source: Source })
+export const SubmittedNewSourceId = m('SubmittedNewSourceId', { id: S.String })
+
+export const Message = S.Union([
+  ClickedReload,
+  LoadedSources,
+  SelectedSource,
+  SubmittedNewSourceId,
+])
+export type Message = typeof Message.Type
+
+// COMMAND
+
+// NOTE: the malformed entry (empty id) sits inertly as a RawSource until the
+// view rebuilds its SelectedSource handler, which constructs a Source and throws.
+export const reloadedSources: ReadonlyArray<RawSource> = [
+  { kind: 'Book', id: '1' },
+  { kind: 'Book', id: '' },
+]
+
+export const ReloadSources = Command.define(
+  'ReloadSources',
+  LoadedSources,
+)(Effect.succeed(LoadedSources({ sources: reloadedSources })))
+
+// INIT
+
+export const validSources: ReadonlyArray<RawSource> = [
+  { kind: 'Book', id: '1' },
+]
+
+export const malformedSources: ReadonlyArray<RawSource> = [
+  { kind: 'Book', id: '' },
+]
+
+export const initialModel: Model = { sources: validSources }
+
+// UPDATE
+
+export const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    M.tagsExhaustive({
+      ClickedReload: () => [model, [ReloadSources()]],
+      LoadedSources: ({ sources }) => [
+        evo(model, { sources: () => sources }),
+        [],
+      ],
+      SelectedSource: () => [model, []],
+      SubmittedNewSourceId: ({ id }) => {
+        const source = Source.make({ kind: 'Book', id })
+        return [evo(model, { sources: Array.append(source) }), []]
+      },
+    }),
+  )
+
+// VIEW
+
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  const body = h.div(
+    [],
+    [
+      h.button([h.OnClick(ClickedReload()), h.Role('button')], ['Reload']),
+      h.button(
+        [h.OnClick(SubmittedNewSourceId({ id: '' })), h.Role('button')],
+        ['Add source'],
+      ),
+      h.ul(
+        [h.Role('list')],
+        Array.map(model.sources, source =>
+          h.keyed('li')(
+            source.id,
+            [],
+            [
+              h.button(
+                [h.OnClick(SelectedSource({ source })), h.Role('button')],
+                [`Select ${source.id}`],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+  return { title: 'Sources', body }
+}

--- a/packages/website/src/page/core/crashView.ts
+++ b/packages/website/src/page/core/crashView.ts
@@ -58,7 +58,9 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('model'),
         ' at the time of the crash, and the ',
         inlineCode('message'),
-        ' being processed:',
+        ' being processed as an ',
+        inlineCode('Option'),
+        ' (it is absent when the crash happens during the initial render):',
       ),
       highlightedCodeBlock(
         h.div(

--- a/packages/website/src/snippet/crashReport.ts
+++ b/packages/website/src/snippet/crashReport.ts
@@ -1,3 +1,4 @@
+import { Option } from 'effect'
 import { Runtime } from 'foldkit'
 
 const program = Runtime.makeProgram({
@@ -8,7 +9,7 @@ const program = Runtime.makeProgram({
   crash: {
     report: ({ error, model, message }) => {
       Sentry.captureException(error, {
-        extra: { model, message },
+        extra: { model, message: Option.getOrUndefined(message) },
       })
     },
   },


### PR DESCRIPTION
The render loop ran in a fork-detached fiber with no error path, so a
view that threw killed the fiber silently and left the DOM frozen at the
last successful render. Route render-loop and initial-render failures
through the same crash-view handler the message drain already used, via
a shared crashWith helper.

CrashContext.message becomes Option<Message> since the initial render has
no triggering Message.

https://claude.ai/code/session_01G42y3ftiXxFxhwwvkejMrS