### PR TITLE
fix(ci): revalidate website HTML so stale caches pick up new asset hashes

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -88,6 +88,20 @@ jobs:
                 },
                 "continue": true
               },
+              {
+                "src": "^/assets/(.*)",
+                "headers": {
+                  "Cache-Control": "public, max-age=31536000, immutable"
+                },
+                "continue": true
+              },
+              {
+                "src": "^/([^.]*)$",
+                "headers": {
+                  "Cache-Control": "public, max-age=0, must-revalidate"
+                },
+                "continue": true
+              },
               { "handle": "filesystem" },
               {
                 "src": "/",


### PR DESCRIPTION
Prerendered pages reference content-hashed bundles. When a deploy
reshuffles those hashes, browsers holding a cached HTML document
(notably iOS Safari, which caches documents aggressively) request a
purged /assets/<oldhash>.js, it 404s, and the Foldkit runtime never
boots. The prerendered HTML stays inert: links fall back to native
full-page navigation and disclosure buttons have no listeners attached.
Private browsing bypasses the disk cache and works, which is the tell.

Serve document navigations with max-age=0, must-revalidate so the HTML
is always revalidated and references the current bundles, and mark the
content-hashed /assets/ files immutable. The two patterns are mutually
exclusive on Cache-Control, so neither depends on header merge order.