### PR TITLE
perf(foldkit): mark package as side-effect-free for tree-shaking

### DIFF
--- a/.changeset/foldkit-side-effects-false.md
+++ b/.changeset/foldkit-side-effects-false.md
@@ -1,0 +1,9 @@
+---
+'foldkit': patch
+---
+
+Mark the `foldkit` package as side-effect-free (`"sideEffects": false`) so bundlers can tree-shake unused modules from production builds.
+
+Foldkit has no module-level side effects (no CSS imports, no top-level `customElements.define`, no global mutations), but without this field bundlers conservatively retain every module they touch. In practice that meant the dev-only DevTools overlay, HMR model-preservation, and WebSocket bridge code, all gated behind `import.meta.hot` and dead-code-eliminated in production, could not be dropped from the module graph and shipped in every app.
+
+Impact: a minimal counter app drops from 314.9 KB to 268.4 KB raw (102.8 KB to 87.9 KB gzip), roughly a 15% reduction, with no source changes required by consumers.

--- a/.changeset/foldkit-side-effects-false.md
+++ b/.changeset/foldkit-side-effects-false.md
@@ -4,6 +4,6 @@
 
 Mark the `foldkit` package as side-effect-free (`"sideEffects": false`) so bundlers can tree-shake unused modules from production builds.
 
-Foldkit has no module-level side effects (no CSS imports, no top-level `customElements.define`, no global mutations), but without this field bundlers conservatively retain every module they touch. In practice that meant the dev-only DevTools overlay, HMR model-preservation, and WebSocket bridge code, all gated behind `import.meta.hot` and dead-code-eliminated in production, could not be dropped from the module graph and shipped in every app.
+Foldkit has no module-level side effects (no CSS imports, no top-level `customElements.define`, no global mutations), but without this field bundlers conservatively retain every module they touch. In practice that meant the dev-only DevTools overlay, HMR Model-preservation, and WebSocket bridge code, all gated behind `import.meta.hot` and dead-code-eliminated in production, could not be dropped from the module graph and shipped in every app.
 
-Impact: a minimal counter app drops from 314.9 KB to 268.4 KB raw (102.8 KB to 87.9 KB gzip), roughly a 15% reduction, with no source changes required by consumers.
+A minimal counter app drops from 314.9 KB to 268.4 KB raw (102.8 KB to 87.9 KB gzip), roughly a 15% reduction, with no source changes required by consumers.

--- a/packages/foldkit/package.json
+++ b/packages/foldkit/package.json
@@ -200,6 +200,7 @@
       "import": "./dist/devTools/public.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## What

Adds `"sideEffects": false` to `foldkit`'s `package.json`.

## Why

A minimal counter app built with Foldkit was ~315 KB raw / ~103 KB gzip. Splitting the bundle apart showed ~15 KB gzip of dev-only code (the DevTools overlay, HMR model-preservation, and the WebSocket bridge) shipping in production.

That code is statically imported by `runtime/runtime.ts` and gated behind `import.meta.hot`. In a production build the *calls* are dead-code-eliminated, but the *modules* could not be dropped from the graph, because the package declared no `sideEffects` field. Without it, bundlers conservatively assume every module has side effects and keep them all.

## Result

| | raw | gzip |
|---|---|---|
| Before | 314.9 KB | 102.8 KB |
| After | 268.4 KB | 87.9 KB |

Roughly a 15% reduction, one line, no source changes required by users.

## Safety

Verified `foldkit` has no module-level side effects before flipping the flag:

- No CSS imports (`import './x.css'`)
- No top-level `customElements.define`
- No bare side-effect imports (`import 'x'`)
- No top-level `window.`/`document.`/`globalThis.` mutations
