### PR TITLE
feat(foldkit)!: always anchor and portal the Listbox items panel

### DIFF
--- a/.changeset/portal-overlay-panels.md
+++ b/.changeset/portal-overlay-panels.md
@@ -1,0 +1,13 @@
+---
+'foldkit': minor
+---
+
+`Ui.Listbox`, `Ui.Menu`, and `Ui.Combobox` now always portal their items panel to the document body, positioned relative to the trigger with Floating UI. Previously this only happened when an `anchor` config was supplied; without one the panel rendered inline, at the mercy of the parent stacking context. Any sibling with an explicit z-index (a sticky section header, a toast, another overlay's wrapper) could occlude the open panel, forcing consumers into an app-wide z-index ladder.
+
+`anchor` remains optional and defaults to `bottom-start` placement with no gap. Migration:
+
+- If you already pass `anchor`, nothing changes.
+- If you rendered without `anchor` and positioned the panel with your own CSS (for example `absolute top-full mt-1`), remove those rules. Floating UI now writes `left` and `top` inline. Express spacing through `anchor: { gap }` and `placement` instead, and size the panel with `width: var(--button-width)` (Tailwind `w-(--button-width)`) rather than `w-full`. Give the panel a z-index above your elevated content; the docs demos use `z-10`.
+- To keep the panel inside the wrapper, pass `anchor: { portal: false }`. The panel is still positioned by Floating UI.
+- Scene tests that open one of these components now have a pending anchor Mount to acknowledge: add `Scene.Mount.resolve(AnchorListbox, CompletedAnchorListbox())`, `Scene.Mount.resolve(AnchorMenu, CompletedAnchorMenu())`, or `Scene.Mount.resolve(AnchorCombobox, CompletedAnchorCombobox())`.
+- Combobox only: the items panel no longer renders the `AttachComboboxPreventBlur` Mount, because `AnchorCombobox` installs the blur-prevention listener itself. Scene tests that resolved `AttachComboboxPreventBlur` on the items panel should resolve `AnchorCombobox` instead. The Mount still renders on the toggle button.

--- a/examples/ui-showcase/src/ui/view/listbox.ts
+++ b/examples/ui-showcase/src/ui/view/listbox.ts
@@ -59,7 +59,7 @@ const triggerClassName =
   'inline-flex items-center justify-between gap-2 min-w-48 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 bg-white text-gray-900 hover:bg-gray-100 select-none'
 
 const itemsClassName =
-  'absolute mt-1 w-56 rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden z-10 outline-none'
+  'w-56 rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden z-10 outline-none'
 
 const itemClassName =
   'group px-3 py-2 text-base text-gray-700 cursor-pointer data-[active]:bg-gray-100'

--- a/examples/ui-showcase/src/ui/view/menu.ts
+++ b/examples/ui-showcase/src/ui/view/menu.ts
@@ -14,10 +14,10 @@ const triggerClassName =
   'inline-flex items-center gap-1.5 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 bg-white text-gray-900 hover:bg-gray-100 select-none'
 
 const basicItemsClassName =
-  'absolute mt-1 w-48 rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden z-10 outline-none'
+  'w-48 rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden z-10 outline-none'
 
 const animatedItemsClassName =
-  'absolute mt-1 w-48 rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden z-10 outline-none transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0'
+  'w-48 rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden z-10 outline-none transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0'
 
 const itemClassName =
   'px-3 py-2 text-base text-gray-700 cursor-pointer data-[active]:bg-gray-100 data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed'

--- a/packages/examples-e2e/e2e/job-application.spec.ts
+++ b/packages/examples-e2e/e2e/job-application.spec.ts
@@ -12,4 +12,13 @@ test.describe('job-application example', () => {
     await page.getByRole('button', { name: 'Select pronouns' }).click()
     await expect(page.getByRole('option').first()).toBeVisible()
   })
+
+  test('opening the Pronouns listbox with the keyboard focuses the items panel', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Select pronouns' }).focus()
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('listbox')).toBeFocused()
+  })
 })

--- a/packages/foldkit/src/ui/combobox/multi.story.test.ts
+++ b/packages/foldkit/src/ui/combobox/multi.story.test.ts
@@ -9,9 +9,9 @@ import { create, init, update } from './multi.js'
 import type { Model, ViewInputs } from './multi.js'
 import {
   ActivatedItem,
-  AttachComboboxPreventBlur,
+  AnchorCombobox,
   Closed,
-  CompletedAttachComboboxPreventBlur,
+  CompletedAnchorCombobox,
   CompletedFocusInput,
   CompletedPortalComboboxBackdrop,
   CompletedScrollIntoView,
@@ -25,9 +25,9 @@ import {
 const TestCombobox = create<string>()
 const view = TestCombobox.view
 
-const acknowledgePreventBlur = Scene.Mount.resolve(
-  AttachComboboxPreventBlur,
-  CompletedAttachComboboxPreventBlur(),
+const acknowledgeAnchor = Scene.Mount.resolve(
+  AnchorCombobox,
+  CompletedAnchorCombobox(),
 )
 const acknowledgeBackdrop = Scene.Mount.resolve(
   PortalComboboxBackdrop,
@@ -245,7 +245,7 @@ describe('Combobox.Multi', () => {
               'true',
             )
           }),
-          acknowledgePreventBlur,
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -270,7 +270,7 @@ describe('Combobox.Multi', () => {
               '',
             )
           }),
-          acknowledgePreventBlur,
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })

--- a/packages/foldkit/src/ui/combobox/shared.ts
+++ b/packages/foldkit/src/ui/combobox/shared.ts
@@ -660,8 +660,13 @@ export const makeUpdate = <Model extends BaseModel>(
   return internalUpdate
 }
 
-/** The anchor-positioning Mount this Combobox renders when an anchor is
- *  configured. Exposed so Scene tests can call
+/** The anchor-positioning Mount this Combobox renders on its items panel.
+ *  The panel is always anchored to the input wrapper via Floating UI and
+ *  portaled to the document body (opt out of portaling with
+ *  `anchor.portal: false`), so it escapes ancestor stacking contexts and
+ *  overflow clipping. The Mount also installs the `pointerdown`-cancelling
+ *  capture listener that prevents input blur on item presses. Exposed so
+ *  Scene tests can call
  *  `Scene.Mount.resolve(AnchorCombobox, CompletedAnchorCombobox())`. */
 export const AnchorCombobox = Mount.define(
   'AnchorCombobox',
@@ -883,7 +888,7 @@ export const makeView = <Model extends BaseModel>(
         groupAttributes = [],
         separatorClassName,
         separatorAttributes = [],
-        anchor,
+        anchor = {},
       } = viewInputs
 
       const isLeaving =
@@ -1063,21 +1068,19 @@ export const makeView = <Model extends BaseModel>(
         ...inputAttributes,
       ]
 
-      const anchorAttributes = anchor
-        ? [
-            h.Style({
-              position: 'absolute',
-              margin: '0',
-              visibility: 'hidden',
-            }),
-            h.OnMount(
-              AnchorCombobox({
-                buttonId: `${id}-input-wrapper`,
-                anchor,
-              }),
-            ),
-          ]
-        : [h.OnMount(AttachComboboxPreventBlur())]
+      const anchorAttributes = [
+        h.Style({
+          position: 'absolute',
+          margin: '0',
+          visibility: 'hidden',
+        }),
+        h.OnMount(
+          AnchorCombobox({
+            buttonId: `${id}-input-wrapper`,
+            anchor,
+          }),
+        ),
+      ]
 
       const itemsContainerAttributes = [
         h.Id(`${id}-items`),

--- a/packages/foldkit/src/ui/combobox/single.story.test.ts
+++ b/packages/foldkit/src/ui/combobox/single.story.test.ts
@@ -8,12 +8,10 @@ import * as Animation from '../animation/index.js'
 import {
   ActivatedItem,
   AnchorCombobox,
-  AttachComboboxPreventBlur,
   BlurredInput,
   ClickItem,
   Closed,
   CompletedAnchorCombobox,
-  CompletedAttachComboboxPreventBlur,
   CompletedClickItem,
   CompletedFocusInput,
   CompletedInertOthers,
@@ -48,10 +46,6 @@ const view = TestCombobox.view
 const animationToComboboxMessage = (message: Animation.Message) =>
   GotAnimationMessage({ message })
 
-const acknowledgePreventBlur = Scene.Mount.resolve(
-  AttachComboboxPreventBlur,
-  CompletedAttachComboboxPreventBlur(),
-)
 const acknowledgeAnchor = Scene.Mount.resolve(
   AnchorCombobox,
   CompletedAnchorCombobox(),
@@ -1068,7 +1062,7 @@ describe('Combobox', () => {
             'listbox',
           )
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1081,7 +1075,7 @@ describe('Combobox', () => {
           expect(Scene.find(html, '[key="test-items-container"]')).toExist()
           expect(Scene.findAll(html, '[key^="test-item-"]')).toHaveLength(2)
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1112,7 +1106,7 @@ describe('Combobox', () => {
             '',
           )
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1133,7 +1127,7 @@ describe('Combobox', () => {
             '',
           )
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1176,7 +1170,7 @@ describe('Combobox', () => {
             expect(Option.some(item)).toHaveAttr('role', 'option')
           })
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1194,7 +1188,7 @@ describe('Combobox', () => {
             'true',
           )
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1212,7 +1206,7 @@ describe('Combobox', () => {
             'false',
           )
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1226,7 +1220,7 @@ describe('Combobox', () => {
             Scene.find(html, '[key="test-items-container"]'),
           ).not.toHaveAttr('aria-multiselectable')
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1238,7 +1232,7 @@ describe('Combobox', () => {
         Scene.tap(({ html }) => {
           expect(Scene.find(html, 'input')).toHaveAttr('aria-expanded', 'true')
         }),
-        acknowledgePreventBlur,
+        acknowledgeAnchor,
         acknowledgeBackdrop,
       )
     })
@@ -1329,16 +1323,22 @@ describe('Combobox', () => {
         )
       })
 
-      it('does not add positioning styles when anchor is absent', () => {
+      it('applies anchor positioning by default when anchor is absent', () => {
         Scene.scene(
           { update, view: sceneView() },
           Scene.with(openModel()),
           Scene.tap(({ html }) => {
-            expect(
-              Scene.find(html, '[key="test-items-container"]'),
-            ).not.toHaveStyle('position')
+            const itemsContainer = Scene.find(
+              html,
+              '[key="test-items-container"]',
+            )
+            expect(itemsContainer).toHaveStyle('position', 'absolute')
+            expect(itemsContainer).toHaveStyle('margin', '0')
+            expect(itemsContainer).toHaveStyle('visibility', 'hidden')
+            expect(itemsContainer).toHaveHook('insert')
+            expect(itemsContainer).toHaveHook('destroy')
           }),
-          acknowledgePreventBlur,
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1377,7 +1377,7 @@ describe('Combobox', () => {
           Scene.tap(() => {
             expect(contexts[0]?.isSelected).toBe(true)
           }),
-          acknowledgePreventBlur,
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1414,7 +1414,7 @@ describe('Combobox', () => {
           Scene.tap(() => {
             expect(contexts[1]?.isSelected).toBe(false)
           }),
-          acknowledgePreventBlur,
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })

--- a/packages/foldkit/src/ui/listbox/multi.story.test.ts
+++ b/packages/foldkit/src/ui/listbox/multi.story.test.ts
@@ -9,6 +9,8 @@ import { create, init, update } from './multi.js'
 import type { Model, ViewInputs } from './multi.js'
 import {
   ActivatedItem,
+  AnchorListbox,
+  CompletedAnchorListbox,
   CompletedFocusItems,
   CompletedPortalListboxBackdrop,
   CompletedScrollIntoView,
@@ -22,6 +24,10 @@ import {
 const TestListbox = create<string>()
 const view = TestListbox.view
 
+const acknowledgeAnchor = Scene.Mount.resolve(
+  AnchorListbox,
+  CompletedAnchorListbox(),
+)
 const acknowledgeBackdrop = Scene.Mount.resolve(
   PortalListboxBackdrop,
   CompletedPortalListboxBackdrop(),
@@ -177,6 +183,7 @@ describe('Listbox.Multi', () => {
               'true',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -201,6 +208,7 @@ describe('Listbox.Multi', () => {
               '',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })

--- a/packages/foldkit/src/ui/listbox/shared.ts
+++ b/packages/foldkit/src/ui/listbox/shared.ts
@@ -725,8 +725,11 @@ export const makeUpdate = <Model extends BaseModel>(
   return internalUpdate
 }
 
-/** The anchor-positioning Mount this Listbox renders when an anchor is
- *  configured. Exposed so Scene tests can call
+/** The anchor-positioning Mount this Listbox renders on its items panel.
+ *  The panel is always anchored to the button via Floating UI and portaled
+ *  to the document body (opt out of portaling with `anchor.portal: false`),
+ *  so it escapes ancestor stacking contexts and overflow clipping. Exposed
+ *  so Scene tests can call
  *  `Scene.Mount.resolve(AnchorListbox, CompletedAnchorListbox())`. */
 export const AnchorListbox = Mount.define(
   'AnchorListbox',
@@ -879,7 +882,7 @@ export const makeView = <Model extends BaseModel>(
         groupAttributes = [],
         separatorClassName,
         separatorAttributes = [],
-        anchor,
+        anchor = {},
         name,
         form,
         isDisabled,
@@ -1100,16 +1103,14 @@ export const makeView = <Model extends BaseModel>(
         onSome: index => [h.AriaActiveDescendant(itemId(id, index))],
       })
 
-      const anchorAttributes = anchor
-        ? [
-            h.Style({
-              position: 'absolute',
-              margin: '0',
-              visibility: 'hidden',
-            }),
-            h.OnMount(AnchorListbox({ buttonId: `${id}-button`, anchor })),
-          ]
-        : []
+      const anchorAttributes = [
+        h.Style({
+          position: 'absolute',
+          margin: '0',
+          visibility: 'hidden',
+        }),
+        h.OnMount(AnchorListbox({ buttonId: `${id}-button`, anchor })),
+      ]
 
       const itemsContainerAttributes = [
         h.Id(`${id}-items`),

--- a/packages/foldkit/src/ui/listbox/single.story.test.ts
+++ b/packages/foldkit/src/ui/listbox/single.story.test.ts
@@ -1302,6 +1302,7 @@ describe('Listbox', () => {
               'listbox',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1316,6 +1317,7 @@ describe('Listbox', () => {
               'listbox',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1334,6 +1336,7 @@ describe('Listbox', () => {
               'option',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1352,6 +1355,7 @@ describe('Listbox', () => {
               'true',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1370,6 +1374,7 @@ describe('Listbox', () => {
               'false',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1391,6 +1396,7 @@ describe('Listbox', () => {
               '',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1404,6 +1410,7 @@ describe('Listbox', () => {
               Scene.find(html, '[key="test-items-container"]'),
             ).not.toHaveAttr('aria-multiselectable')
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1496,6 +1503,7 @@ describe('Listbox', () => {
           Scene.tap(() => {
             expect(contexts[0]?.isSelected).toBe(true)
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1533,6 +1541,7 @@ describe('Listbox', () => {
           Scene.tap(() => {
             expect(contexts[1]?.isSelected).toBe(false)
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1564,7 +1573,7 @@ describe('Listbox', () => {
         )
       })
 
-      it('does not add positioning styles when anchor is absent', () => {
+      it('applies anchor positioning by default when anchor is absent', () => {
         Scene.scene(
           { update, view: sceneView() },
           Scene.with(openModel()),
@@ -1573,8 +1582,13 @@ describe('Listbox', () => {
               html,
               '[key="test-items-container"]',
             )
-            expect(itemsContainer).not.toHaveStyle('position')
+            expect(itemsContainer).toHaveStyle('position', 'absolute')
+            expect(itemsContainer).toHaveStyle('margin', '0')
+            expect(itemsContainer).toHaveStyle('visibility', 'hidden')
+            expect(itemsContainer).toHaveHook('insert')
+            expect(itemsContainer).toHaveHook('destroy')
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1591,6 +1605,7 @@ describe('Listbox', () => {
               'vertical',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1606,6 +1621,7 @@ describe('Listbox', () => {
               'horizontal',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1762,6 +1778,7 @@ describe('Listbox', () => {
               'click',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1781,6 +1798,7 @@ describe('Listbox', () => {
               '',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })
@@ -1799,6 +1817,7 @@ describe('Listbox', () => {
               'data-selected',
             )
           }),
+          acknowledgeAnchor,
           acknowledgeBackdrop,
         )
       })

--- a/packages/foldkit/src/ui/menu/index.ts
+++ b/packages/foldkit/src/ui/menu/index.ts
@@ -721,9 +721,11 @@ export const update = (model: Model, message: Message): UpdateReturn => {
   )
 }
 
-/** The anchor-positioning Mount this Menu renders on its panel. Exposed so
- *  Scene tests can call `Scene.Mount.resolve(AnchorMenu, CompletedAnchorMenu())`
- *  to acknowledge the mount produced by the rendered panel. */
+/** The anchor-positioning Mount this Menu renders on its panel. The panel is
+ *  always anchored to the button via Floating UI and portaled to the document
+ *  body (opt out of portaling with `anchor.portal: false`), so it escapes
+ *  ancestor stacking contexts and overflow clipping. Exposed so Scene tests
+ *  can call `Scene.Mount.resolve(AnchorMenu, CompletedAnchorMenu())`. */
 export const AnchorMenu = Mount.define(
   'AnchorMenu',
   { buttonId: S.String, anchor: AnchorConfig },
@@ -874,7 +876,7 @@ const menuViewImpl = defineView<Model, Message, ViewInputs<string>>(
       groupAttributes = [],
       separatorClassName,
       separatorAttributes = [],
-      anchor,
+      anchor = {},
     } = viewInputs
 
     const dispatchSelectedItem = (item: string, index: number) =>
@@ -1078,12 +1080,10 @@ const menuViewImpl = defineView<Model, Message, ViewInputs<string>>(
       onSome: index => [h.AriaActiveDescendant(itemId(id, index))],
     })
 
-    const anchorAttributes = anchor
-      ? [
-          h.Style({ position: 'absolute', margin: '0', visibility: 'hidden' }),
-          h.OnMount(AnchorMenu({ buttonId: `${id}-button`, anchor })),
-        ]
-      : []
+    const anchorAttributes = [
+      h.Style({ position: 'absolute', margin: '0', visibility: 'hidden' }),
+      h.OnMount(AnchorMenu({ buttonId: `${id}-button`, anchor })),
+    ]
 
     const itemsContainerAttributes = [
       h.Id(`${id}-items`),

--- a/packages/website/src/page/ui/comboboxPage.ts
+++ b/packages/website/src/page/ui/comboboxPage.ts
@@ -209,7 +209,8 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
   {
     name: 'anchor',
     type: 'AnchorConfig',
-    description: 'Floating positioning config: placement, gap, and padding.',
+    description:
+      'Floating positioning config: placement, gap, offset, padding, and portal. The items panel is always anchored to the input wrapper; when omitted, the panel uses bottom-start placement. Portaled to the document body by default; pass portal: false to keep the panel inside the wrapper.',
   },
 ]
 
@@ -414,6 +415,13 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           'Combobox is headless. The ',
           inlineCode('itemToConfig'),
           ' callback controls all item markup. Style the input, button, items container, and backdrop through their respective attribute props.',
+        ),
+        para(
+          'The items panel is portaled to the document body and positioned relative to the input wrapper with Floating UI. Ancestor stacking contexts and overflow clipping no longer apply, so a clipped container or a sibling overlay wrapper cannot hide the open panel. The panel still stacks at the document level: give it a z-index above elevated content like sticky headers or toasts, as the demos on this page do with ',
+          inlineCode('z-10'),
+          '. Pass ',
+          inlineCode('anchor: { portal: false }'),
+          ' to keep the panel inside the wrapper instead.',
         ),
         dataAttributeTable(dataAttributes),
         heading(

--- a/packages/website/src/page/ui/listbox.ts
+++ b/packages/website/src/page/ui/listbox.ts
@@ -88,7 +88,7 @@ const triggerClassName =
   'inline-flex items-center justify-between gap-2 min-w-48 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
 
 const itemsClassName =
-  'absolute mt-1 w-(--button-width) rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none'
+  'w-(--button-width) rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none'
 
 const itemClassName =
   'group px-3 py-2 text-base text-gray-700 dark:text-gray-200 cursor-pointer data-[active]:bg-gray-100 dark:data-[active]:bg-gray-700/50'

--- a/packages/website/src/page/ui/listboxPage.ts
+++ b/packages/website/src/page/ui/listboxPage.ts
@@ -187,7 +187,8 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
   {
     name: 'anchor',
     type: 'AnchorConfig',
-    description: 'Floating positioning config: placement, gap, and padding.',
+    description:
+      'Floating positioning config: placement, gap, offset, padding, and portal. The items panel is always anchored to the button; when omitted, the panel uses bottom-start placement. Portaled to the document body by default; pass portal: false to keep the panel inside the wrapper.',
   },
   {
     name: 'name',
@@ -414,6 +415,13 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           ' for the keyboard/pointer highlight and ',
           inlineCode('data-selected'),
           ' for the persistent selection indicator.',
+        ),
+        para(
+          'The items panel is portaled to the document body and positioned relative to the trigger button with Floating UI. Ancestor stacking contexts and overflow clipping no longer apply, so a clipped container or a sibling listbox wrapper cannot hide an open dropdown. The panel still stacks at the document level: give it a z-index above elevated content like sticky headers or toasts, as the demos on this page do with ',
+          inlineCode('z-10'),
+          '. Pass ',
+          inlineCode('anchor: { portal: false }'),
+          ' to keep the panel inside the wrapper instead.',
         ),
         para(
           'To make the items panel match the trigger button width, set ',

--- a/packages/website/src/page/ui/menu.ts
+++ b/packages/website/src/page/ui/menu.ts
@@ -37,10 +37,10 @@ const triggerClassName =
   'inline-flex items-center gap-1.5 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
 
 const basicItemsClassName =
-  'absolute mt-1 w-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none'
+  'w-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none'
 
 const animatedItemsClassName =
-  'absolute mt-1 w-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0'
+  'w-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0'
 
 const itemClassName =
   'px-3 py-2 text-base text-gray-700 dark:text-gray-200 cursor-pointer data-[active]:bg-gray-100 dark:data-[active]:bg-gray-700/50 data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed'

--- a/packages/website/src/page/ui/menuPage.ts
+++ b/packages/website/src/page/ui/menuPage.ts
@@ -178,7 +178,8 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
   {
     name: 'anchor',
     type: 'AnchorConfig | undefined',
-    description: 'Floating positioning config: placement, gap, and padding.',
+    description:
+      'Floating positioning config: placement, gap, offset, padding, and portal. The items panel is always anchored to the button; when omitted, the panel uses bottom-start placement. Portaled to the document body by default; pass portal: false to keep the panel inside the wrapper.',
   },
   {
     name: 'buttonClassName',
@@ -399,6 +400,13 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           ' and ',
           inlineCode('groupToHeading'),
           '.',
+        ),
+        para(
+          'The items panel is portaled to the document body and positioned relative to the trigger button with Floating UI. Ancestor stacking contexts and overflow clipping no longer apply, so a clipped container or a sibling overlay wrapper cannot hide an open menu. The panel still stacks at the document level: give it a z-index above elevated content like sticky headers or toasts, as the demos on this page do with ',
+          inlineCode('z-10'),
+          '. Pass ',
+          inlineCode('anchor: { portal: false }'),
+          ' to keep the panel inside the wrapper instead.',
         ),
         para(
           'When ',

--- a/packages/website/src/view/landing.ts
+++ b/packages/website/src/view/landing.ts
@@ -175,7 +175,7 @@ const PLAYGROUND_MENU_ANCHOR = {
 const playgroundButtonClassName = 'cta-amber cursor-pointer'
 
 const playgroundItemsClassName =
-  'absolute mt-1 w-80 max-h-[28rem] overflow-y-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-900 shadow-xl z-20 outline-none transition duration-150 ease-out data-[closed]:scale-95 data-[closed]:opacity-0'
+  'w-80 max-h-[28rem] overflow-y-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-900 shadow-xl z-20 outline-none transition duration-150 ease-out data-[closed]:scale-95 data-[closed]:opacity-0'
 
 const playgroundItemClassName =
   'block px-4 py-3 cursor-pointer border-b border-gray-100 dark:border-gray-800 last:border-b-0 hover:bg-gray-100 dark:hover:bg-gray-800/60 data-[active]:bg-gray-100 dark:data-[active]:bg-gray-800/60'


### PR DESCRIPTION
The items panel previously rendered inline unless an anchor config was
supplied, leaving the open dropdown at the mercy of the parent stacking
context: sticky headers, toasts, or a sibling listbox's wrapper could
occlude it, forcing consumers into an app-wide z-index ladder. The panel
now always renders through the AnchorListbox Mount: positioned relative
to the button with Floating UI and portaled into foldkit-portal-root,
matching what the backdrop already does. anchor stays optional and
defaults to bottom-start placement; pass anchor: { portal: false } to
keep the panel inside the wrapper.

Closes #351

https://claude.ai/code/session_011TzVFGxhV4ityEBM8kauBw