### PR TITLE
Document Embedding and Managed Resources features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Built on [Effect](https://effect.website/). Architected like [Elm](https://guide
 
 Foldkit is for developers who want to build their product with confidence instead of fighting their architecture. If you want a single pattern that scales from a counter to a multiplayer game without complexity creep, this is it.
 
-It's not incremental. There's no React interop, no escape hatch from Effect, no way to "just use hooks for this one part." You're all in or you're not.
+It's not incremental. Inside a Foldkit program there's no escape hatch from Effect, no way to "just use hooks for this one part." You're all in or you're not. The program doesn't have to own the whole page, though: [`Runtime.embed`](https://foldkit.dev/core/embedding) runs a Foldkit widget inside any existing app (React included), with Schema-typed Ports as the boundary.
 
 ## Built on Effect
 
@@ -173,8 +173,9 @@ Foldkit is a complete system, not a collection of libraries you stitch together.
 - **Routing**: Type-safe bidirectional routing built from parser combinators. URLs parse into typed Routes and Routes build back into URLs. No string matching, no mismatches between parsing and building.
 - **Subscriptions**: Declare which streams your app needs as a function of the Model. The runtime diffs and switches them as the Model changes.
 - **Managed Resources**: Model-driven lifecycle for long-lived browser resources like WebSockets, AudioContext, and RTCPeerConnection. Acquire on state change, release on cleanup.
-- **Submodels**: A pattern for composing nested modules. A child owns its own Model, Messages, update function, and view; the parent embeds it and wraps child Messages in a `Got*Message` envelope. The pattern scales unchanged from a login form to a multi-page app.
+- **Submodels**: A self-contained Model, Messages, update function, and view that a parent embeds in its own, wrapping child Messages in a `Got*Message` envelope. Reach for one to encapsulate a unit the parent shouldn't see inside, or to split a grown app into feature areas like Settings and Dashboard.
 - **OutMessage**: A typed channel for a child Submodel to emit domain events up to its parent, so the parent reacts to meaningful facts instead of internal child Messages.
+- **Embedding**: Run a Foldkit program inside a host application with `Runtime.embed`. The host starts the runtime, pushes data in and receives values out through Schema-typed Ports, and calls `dispose` for a complete teardown. The handle is the whole boundary; the host never reads the Model or dispatches Messages.
 - **UI Components**: Accessible, keyboard-friendly primitives — Button, Checkbox, Combobox, Dialog, Disclosure, DragAndDrop, Fieldset, Input, Listbox, Menu, Popover, RadioGroup, Select, Switch, Tabs, Textarea, and Transition. Every component is a Submodel you embed and style through a typed `ViewConfig`.
 - **Field Validation**: Per-field validation state modeled as a discriminated union. Define rules as data, apply them in update, and the Model tracks the result.
 - **Virtual DOM**: Declarative views powered by [Snabbdom](https://github.com/snabbdom/snabbdom), with lazy memoization and fast, keyed diffing. Views are plain functions of your Model.

--- a/packages/website/src/page/landing.ts
+++ b/packages/website/src/page/landing.ts
@@ -23,6 +23,9 @@ import {
   comingFromReactRouter,
   coreArchitectureRouter,
   coreDevToolsRouter,
+  coreEmbeddingRouter,
+  coreManagedResourcesRouter,
+  coreSubmodelRouter,
   coreSubscriptionsRouter,
   examplesRouter,
   fieldValidationRouter,
@@ -588,6 +591,17 @@ const includedSection = (): Html => {
                 ],
               ),
               includedFeature(
+                Icon.squareStack('w-6 h-6'),
+                'Submodels',
+                [
+                  'A self-contained Model, Messages, update, and view, embedded inside a larger program. Children surface domain facts as typed OutMessages and parents handle them in update. Every stateful Foldkit UI component ships as a Submodel.',
+                ],
+                {
+                  href: coreSubmodelRouter(),
+                  label: 'Explore Submodels',
+                },
+              ),
+              includedFeature(
                 Icon.signal('w-6 h-6'),
                 'Subscriptions',
                 [
@@ -596,6 +610,17 @@ const includedSection = (): Html => {
                 {
                   href: coreSubscriptionsRouter(),
                   label: 'Explore Subscriptions',
+                },
+              ),
+              includedFeature(
+                Icon.circleStack('w-6 h-6'),
+                'Managed Resources',
+                [
+                  'Model-driven lifecycles for long-lived browser resources like WebSockets, AudioContext, and RTCPeerConnection. The runtime acquires when the Model calls for the resource and releases when it no longer does.',
+                ],
+                {
+                  href: coreManagedResourcesRouter(),
+                  label: 'Explore Managed Resources',
                 },
               ),
               includedFeature(
@@ -629,6 +654,17 @@ const includedSection = (): Html => {
                 {
                   href: coreDevToolsRouter(),
                   label: 'Explore DevTools',
+                },
+              ),
+              includedFeature(
+                Icon.codeBracket('w-6 h-6'),
+                'Embedding',
+                [
+                  'Run a Foldkit widget inside any host application with Runtime.embed. The host pushes data in and receives values out through Schema-typed Ports, and tears the widget down with dispose.',
+                ],
+                {
+                  href: coreEmbeddingRouter(),
+                  label: 'Explore embedding',
                 },
               ),
             ],
@@ -940,7 +976,7 @@ const audienceSection = (): Html => {
                     [
                       audienceNotItem(
                         'Large existing React codebases',
-                        'Foldkit isn’t an incremental adoption. It’s a different architecture. Migration means a rewrite.',
+                        'Foldkit isn’t an incremental adoption. It’s a different architecture, and migrating means a rewrite. The middle path is embedding: Runtime.embed runs a Foldkit widget inside an existing app.',
                       ),
                       audienceNotItem(
                         'Teams not ready to invest in Effect',


### PR DESCRIPTION
This PR adds documentation and landing page content for two core Foldkit features: Embedding and Managed Resources.

## Summary

Updates the website landing page and README to highlight `Runtime.embed` for running Foldkit widgets inside existing applications, and clarifies the Managed Resources pattern for model-driven lifecycle management of browser resources.

## Changes

- **Landing page**: Added three new feature cards to the "Included" section:
  - Submodels: Composing nested modules with owned Model, Messages, update, and view
  - Managed Resources: Model-driven lifecycles for WebSockets, AudioContext, RTCPeerConnection
  - Embedding: Running Foldkit widgets inside host applications via `Runtime.embed`

- **README**: 
  - Clarified that Foldkit's "all-in" requirement applies within a Foldkit program, not necessarily the entire page
  - Added `Runtime.embed` as the middle path for teams with large existing React codebases
  - Added Embedding to the feature list with description of Schema-typed Ports as the boundary
  - Reworded the audience section to explain embedding as an alternative to full migration

- **Imports**: Added router imports for the three new feature documentation pages (`coreEmbeddingRouter`, `coreManagedResourcesRouter`, `coreSubmodelRouter`)

## Implementation Details

Each feature card follows the existing `includedFeature` pattern with an icon, title, description, and link to detailed documentation. The embedding feature is positioned as a pragmatic solution for incremental adoption in existing applications, with the host and Foldkit program communicating only through Schema-typed Ports.

https://claude.ai/code/session_016vASFCBeoRC8Ftym7gSMN4