### PR TITLE
feat(api-cache): add API Cache example demonstrating TanStack Query patterns

### DIFF
--- a/.changeset/api-cache-scaffold-option.md
+++ b/.changeset/api-cache-scaffold-option.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': minor
+---
+
+Add the api-cache example to the scaffolding choices: query caching in the Model with stale-while-revalidate, request deduplication, invalidation, and interval refetching.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -21,6 +21,7 @@
     "shopping-cart-example",
     "stopwatch-example",
     "weather-example",
+    "api-cache-example",
     "routing-example",
     "counter-example",
     "counters-example",

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -28,6 +28,7 @@ jobs:
           - form
           - job-application
           - weather
+          - api-cache
           - routing
           - query-sync
           - snake

--- a/examples/api-cache/index.html
+++ b/examples/api-cache/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/src/styles.css" rel="stylesheet" />
+    <title>API Cache</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/entry.ts"></script>
+  </body>
+</html>

--- a/examples/api-cache/package.json
+++ b/examples/api-cache/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "api-cache-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@effect/platform-browser": "4.0.0-beta.78",
+    "@tailwindcss/vite": "^4.2.4",
+    "effect": "4.0.0-beta.78",
+    "foldkit": "workspace:*",
+    "tailwindcss": "^4.2.4"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@foldkit/vite-plugin": "workspace:*",
+    "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "@typescript-eslint/eslint-plugin": "^8.59.2",
+    "@typescript-eslint/parser": "^8.59.2",
+    "eslint": "^10.3.0",
+    "happy-dom": "^20.9.0",
+    "prettier": "^3.8.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10",
+    "vitest": "^4.1.5"
+  }
+}

--- a/examples/api-cache/src/data.test.ts
+++ b/examples/api-cache/src/data.test.ts
@@ -1,0 +1,34 @@
+import { Effect, Exit } from 'effect'
+import { expect, test } from 'vitest'
+
+import { FLAKY_POST_ID, fetchPostDetailFromServer } from './data'
+
+test('a regular post resolves with its detail', async () => {
+  const detail = await Effect.runPromise(
+    fetchPostDetailFromServer('model-is-the-cache'),
+  )
+
+  expect(detail.title).toBe('The Model Is the Cache')
+})
+
+test('the flaky post fails on the first fetch and succeeds on retry', async () => {
+  const firstAttempt = await Effect.runPromiseExit(
+    fetchPostDetailFromServer(FLAKY_POST_ID),
+  )
+
+  expect(Exit.isFailure(firstAttempt)).toBe(true)
+
+  const secondAttempt = await Effect.runPromise(
+    fetchPostDetailFromServer(FLAKY_POST_ID),
+  )
+
+  expect(secondAttempt.id).toBe(FLAKY_POST_ID)
+})
+
+test('an unknown post id fails', async () => {
+  const attempt = await Effect.runPromiseExit(
+    fetchPostDetailFromServer('does-not-exist'),
+  )
+
+  expect(Exit.isFailure(attempt)).toBe(true)
+})

--- a/examples/api-cache/src/data.ts
+++ b/examples/api-cache/src/data.ts
@@ -1,0 +1,126 @@
+import { Array, Duration, Effect, Option, Random, Schema as S } from 'effect'
+
+export const Post = S.Struct({
+  id: S.String,
+  title: S.String,
+  excerpt: S.String,
+})
+export type Post = typeof Post.Type
+
+export const PostDetail = S.Struct({
+  id: S.String,
+  title: S.String,
+  author: S.String,
+  body: S.String,
+})
+export type PostDetail = typeof PostDetail.Type
+
+export const Stats = S.Struct({
+  activeUsers: S.Number,
+  requestsPerSecond: S.Number,
+  cacheHitRatePercent: S.Number,
+})
+export type Stats = typeof Stats.Type
+
+export const FLAKY_POST_ID = 'flaky-connection'
+
+const SERVER_LATENCY = Duration.millis(700)
+
+type Article = Readonly<{
+  id: string
+  title: string
+  excerpt: string
+  author: string
+  body: string
+}>
+
+const articles: ReadonlyArray<Article> = [
+  {
+    id: 'model-is-the-cache',
+    title: 'The Model Is the Cache',
+    excerpt: 'Why a single source of truth needs no query client.',
+    author: 'Maya Okafor',
+    body: 'A cache is a place where fetched data lives between requests. In The Elm Architecture that place already exists: the Model. Store each query as a small state machine and every view reads the same truth.',
+  },
+  {
+    id: 'stale-while-revalidate',
+    title: 'Stale-While-Revalidate, Explained',
+    excerpt: 'Show the old data while the new data loads.',
+    author: 'Theo Lindqvist',
+    body: 'Dropping back to a spinner throws away perfectly good data. A Refreshing state carries the previous value while the fetch runs, so the screen never goes blank.',
+  },
+  {
+    id: 'query-keys-are-names',
+    title: 'Query Keys Are Just Names',
+    excerpt: 'A Model field per query replaces stringly-typed keys.',
+    author: 'Priya Raman',
+    body: 'When queries are known statically, the field name is the key. Reach for a HashMap keyed by a domain identifier only when the entries are genuinely dynamic, like these post details.',
+  },
+  {
+    id: 'invalidation-is-a-message',
+    title: 'Invalidation Is a Message',
+    excerpt: 'Marking data stale is a fact, not a framework feature.',
+    author: 'Jonas Weber',
+    body: 'Invalidation means the cached value can no longer be trusted. Dispatch a Message, move the entry to Refreshing, and return the fetch Command. The whole policy is visible in update.',
+  },
+  {
+    id: FLAKY_POST_ID,
+    title: 'This Post Fails Every Other Fetch',
+    excerpt: 'Open it to see the Failure state, then retry.',
+    author: 'Flaky McNetwork',
+    body: 'You made it. The fake server failed your first attempt on purpose and succeeded on the retry, which is exactly the round trip a Failure state plus a retry Message is for.',
+  },
+]
+
+const posts = Array.map(articles, ({ id, title, excerpt }) =>
+  Post.make({ id, title, excerpt }),
+)
+
+const postDetails = Array.map(articles, ({ id, title, author, body }) =>
+  PostDetail.make({ id, title, author, body }),
+)
+
+export const fetchPostsFromServer = Effect.gen(function* () {
+  yield* Effect.sleep(SERVER_LATENCY)
+
+  return posts
+})
+
+// NOTE: Module-level mutation simulates a flaky server so the Failure and
+// retry path is reachable from the UI. The Foldkit app itself never mutates.
+let flakyAttemptCount = 0
+
+export const fetchPostDetailFromServer = (
+  postId: string,
+): Effect.Effect<PostDetail, string> =>
+  Effect.gen(function* () {
+    yield* Effect.sleep(SERVER_LATENCY)
+
+    if (postId === FLAKY_POST_ID) {
+      flakyAttemptCount += 1
+
+      if (flakyAttemptCount % 2 === 1) {
+        return yield* Effect.fail(
+          'The connection dropped. Retry to fetch this post again.',
+        )
+      }
+    }
+
+    return yield* Option.match(
+      Array.findFirst(postDetails, ({ id }) => id === postId),
+      {
+        onNone: () => Effect.fail(`No post found with id ${postId}`),
+        onSome: Effect.succeed,
+      },
+    )
+  })
+
+export const fetchStatsFromServer = Effect.gen(function* () {
+  yield* Effect.sleep(SERVER_LATENCY)
+
+  const activeUsers = yield* Random.nextIntBetween(80, 140)
+  const requestsPerSecond = yield* Random.nextIntBetween(900, 1600)
+  const cacheHitRatePercent = yield* Random.nextIntBetween(86, 99)
+
+  return Stats.make({ activeUsers, requestsPerSecond, cacheHitRatePercent })
+})

--- a/examples/api-cache/src/entry.ts
+++ b/examples/api-cache/src/entry.ts
@@ -1,0 +1,17 @@
+import { Runtime } from 'foldkit'
+
+import { Message, Model, init, subscriptions, update, view } from './main'
+
+const application = Runtime.makeApplication({
+  Model,
+  init,
+  update,
+  view,
+  subscriptions,
+  container: document.getElementById('root'),
+  devTools: {
+    Message,
+  },
+})
+
+Runtime.run(application)

--- a/examples/api-cache/src/main.fixtures.ts
+++ b/examples/api-cache/src/main.fixtures.ts
@@ -1,0 +1,64 @@
+import { HashMap, Option } from 'effect'
+import { Ui } from 'foldkit'
+
+import type { Post, PostDetail, Stats } from './data'
+import type { Model } from './main'
+import { PostDetailData, PostsData, StatsData, TABS_ID } from './main'
+
+export const FETCHED_AT = 1_750_000_000_000
+
+export const fixturePosts: ReadonlyArray<Post> = [
+  {
+    id: 'first-post',
+    title: 'First Post',
+    excerpt: 'The first fixture post.',
+  },
+  {
+    id: 'second-post',
+    title: 'Second Post',
+    excerpt: 'The second fixture post.',
+  },
+]
+
+export const firstPostDetail: PostDetail = {
+  id: 'first-post',
+  title: 'First Post',
+  author: 'Grace Hopper',
+  body: 'The whole body of the first fixture post.',
+}
+
+export const fixtureStats: Stats = {
+  activeUsers: 120,
+  requestsPerSecond: 1234,
+  cacheHitRatePercent: 97,
+}
+
+export const loadingPostsModel: Model = {
+  tabs: Ui.Tabs.init({ id: TABS_ID }),
+  activeTab: 'Posts',
+  posts: PostsData.Loading(),
+  postDetailById: HashMap.empty(),
+  maybeSelectedPostId: Option.none(),
+  stats: StatsData.NotAsked(),
+}
+
+export const loadedPostsModel: Model = {
+  ...loadingPostsModel,
+  posts: PostsData.Ok({ data: fixturePosts, fetchedAt: FETCHED_AT }),
+}
+
+export const cachedFirstPostModel: Model = {
+  ...loadedPostsModel,
+  postDetailById: HashMap.set(
+    HashMap.empty(),
+    'first-post',
+    PostDetailData.Ok({ data: firstPostDetail, fetchedAt: FETCHED_AT }),
+  ),
+}
+
+export const loadedStatsModel: Model = {
+  ...loadedPostsModel,
+  tabs: Ui.Tabs.init({ id: TABS_ID, activeIndex: 1 }),
+  activeTab: 'Stats',
+  stats: StatsData.Ok({ data: fixtureStats, fetchedAt: FETCHED_AT }),
+}

--- a/examples/api-cache/src/main.scene.test.ts
+++ b/examples/api-cache/src/main.scene.test.ts
@@ -1,0 +1,112 @@
+import { Scene, Ui } from 'foldkit'
+import { describe, test } from 'vitest'
+
+import {
+  FailedFetchPostDetail,
+  FetchPostDetail,
+  FetchStats,
+  GotTabsMessage,
+  SucceededFetchPostDetail,
+  SucceededFetchStats,
+  update,
+  view,
+} from './main'
+import {
+  FETCHED_AT,
+  cachedFirstPostModel,
+  firstPostDetail,
+  fixtureStats,
+  loadedPostsModel,
+  loadingPostsModel,
+} from './main.fixtures'
+
+const resolveFocusTab = Scene.Command.resolve(
+  Ui.Tabs.FocusTab,
+  Ui.Tabs.CompletedFocusTab(),
+  message => GotTabsMessage({ message }),
+)
+
+describe('scene', () => {
+  test('posts load into clickable rows with an Invalidate button', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(loadingPostsModel),
+      Scene.expect(Scene.text('Loading posts...')).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Invalidate' })).toExist(),
+      Scene.expect(Scene.role('tab', { name: 'Posts' })).toExist(),
+      Scene.expect(Scene.role('tab', { name: 'Stats' })).toExist(),
+    )
+  })
+
+  test('clicking a post fetches its detail and renders it', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(loadedPostsModel),
+      Scene.click(Scene.role('button', { name: /First Post/ })),
+      Scene.expect(Scene.text('Loading post...')).toExist(),
+      Scene.Command.expectExact(FetchPostDetail({ postId: 'first-post' })),
+      Scene.Command.resolve(
+        FetchPostDetail,
+        SucceededFetchPostDetail({
+          postId: 'first-post',
+          detail: firstPostDetail,
+          fetchedAt: FETCHED_AT,
+        }),
+      ),
+      Scene.inside(
+        Scene.role('article'),
+        Scene.expect(Scene.text('By Grace Hopper')).toExist(),
+        Scene.expect(
+          Scene.text('The whole body of the first fixture post.'),
+        ).toExist(),
+      ),
+      Scene.expect(Scene.role('button', { name: 'Back to posts' })).toExist(),
+    )
+  })
+
+  test('a cached post shows the Cached badge and revisits skip the fetch', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(cachedFirstPostModel),
+      Scene.expect(Scene.text('Cached')).toExist(),
+      Scene.click(Scene.role('button', { name: /First Post/ })),
+      Scene.Command.expectNone(),
+      Scene.expect(Scene.text('By Grace Hopper')).toExist(),
+    )
+  })
+
+  test('a failed detail fetch shows the error with a Retry button', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(loadedPostsModel),
+      Scene.click(Scene.role('button', { name: /First Post/ })),
+      Scene.Command.resolve(
+        FetchPostDetail,
+        FailedFetchPostDetail({
+          postId: 'first-post',
+          error: 'The connection dropped.',
+        }),
+      ),
+      Scene.expect(Scene.text('The connection dropped.')).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Retry' })).toExist(),
+    )
+  })
+
+  test('switching to the Stats tab fetches and renders stats', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(loadedPostsModel),
+      Scene.click(Scene.role('tab', { name: 'Stats' })),
+      Scene.expect(Scene.text('Loading stats...')).toExist(),
+      resolveFocusTab,
+      Scene.Command.expectExact(FetchStats()),
+      Scene.Command.resolve(
+        FetchStats,
+        SucceededFetchStats({ stats: fixtureStats, fetchedAt: FETCHED_AT }),
+      ),
+      Scene.expect(Scene.text('Active users')).toExist(),
+      Scene.expect(Scene.text('97%')).toExist(),
+      Scene.expect(Scene.text('Updated at', { exact: false })).toExist(),
+    )
+  })
+})

--- a/examples/api-cache/src/main.story.test.ts
+++ b/examples/api-cache/src/main.story.test.ts
@@ -1,0 +1,265 @@
+import { HashMap, Option } from 'effect'
+import { Story, Ui } from 'foldkit'
+import { expect, test } from 'vitest'
+
+import {
+  ClickedBackToPosts,
+  ClickedInvalidatePosts,
+  ClickedPost,
+  ClickedRefreshStats,
+  ClickedRetryPostDetail,
+  ClickedRetryPosts,
+  FailedFetchPostDetail,
+  FetchPostDetail,
+  FetchPosts,
+  FetchStats,
+  GotTabsMessage,
+  type Model,
+  PostDetailData,
+  PostsData,
+  StatsData,
+  SucceededFetchPostDetail,
+  SucceededFetchPosts,
+  SucceededFetchStats,
+  TickedRevalidateStats,
+  update,
+} from './main'
+import {
+  FETCHED_AT,
+  firstPostDetail,
+  fixturePosts,
+  fixtureStats,
+  loadedPostsModel,
+  loadedStatsModel,
+} from './main.fixtures'
+
+const postDetailTag = (model: Model, postId: string): string =>
+  HashMap.get(model.postDetailById, postId).pipe(
+    Option.map(postDetail => postDetail._tag),
+    Option.getOrElse(() => 'Missing'),
+  )
+
+const selectedPostsTab = GotTabsMessage({
+  message: Ui.Tabs.SelectedTab({ index: 0, value: 'Posts' }),
+})
+
+const selectedStatsTab = GotTabsMessage({
+  message: Ui.Tabs.SelectedTab({ index: 1, value: 'Stats' }),
+})
+
+const resolveFocusTab = Story.Command.resolve(
+  Ui.Tabs.FocusTab,
+  Ui.Tabs.CompletedFocusTab(),
+  message => GotTabsMessage({ message }),
+)
+
+test('first visit to the Stats tab fetches stats', () => {
+  Story.story(
+    update,
+    Story.with(loadedPostsModel),
+    Story.message(selectedStatsTab),
+    Story.model(model => {
+      expect(model.activeTab).toBe('Stats')
+      expect(model.stats._tag).toBe('Loading')
+    }),
+    resolveFocusTab,
+    Story.Command.resolve(
+      FetchStats,
+      SucceededFetchStats({ stats: fixtureStats, fetchedAt: FETCHED_AT }),
+    ),
+    Story.model(model => {
+      expect(model.stats._tag).toBe('Ok')
+    }),
+  )
+})
+
+test('returning to a tab with cached data does not refetch', () => {
+  Story.story(
+    update,
+    Story.with(loadedStatsModel),
+    Story.message(selectedPostsTab),
+    resolveFocusTab,
+    Story.Command.expectNone(),
+    Story.message(selectedStatsTab),
+    resolveFocusTab,
+    Story.Command.expectNone(),
+    Story.model(model => {
+      expect(model.stats._tag).toBe('Ok')
+    }),
+  )
+})
+
+test('a revalidation tick keeps stale stats on screen while refetching', () => {
+  Story.story(
+    update,
+    Story.with(loadedStatsModel),
+    Story.message(TickedRevalidateStats()),
+    Story.model(model => {
+      expect(model.stats._tag).toBe('Refreshing')
+      if (model.stats._tag === 'Refreshing') {
+        expect(model.stats.data).toEqual(fixtureStats)
+      }
+    }),
+    Story.Command.resolve(
+      FetchStats,
+      SucceededFetchStats({
+        stats: { ...fixtureStats, activeUsers: 99 },
+        fetchedAt: FETCHED_AT + 5000,
+      }),
+    ),
+    Story.model(model => {
+      expect(model.stats._tag).toBe('Ok')
+      if (model.stats._tag === 'Ok') {
+        expect(model.stats.data.activeUsers).toBe(99)
+      }
+    }),
+  )
+})
+
+test('refresh clicks during an in-flight fetch are deduplicated', () => {
+  Story.story(
+    update,
+    Story.with({ ...loadedStatsModel, stats: StatsData.Loading() }),
+    Story.message(ClickedRefreshStats()),
+    Story.Command.expectNone(),
+  )
+})
+
+test('a revalidation tick during a refresh is deduplicated', () => {
+  Story.story(
+    update,
+    Story.with({
+      ...loadedStatsModel,
+      stats: StatsData.Refreshing({
+        data: fixtureStats,
+        fetchedAt: FETCHED_AT,
+      }),
+    }),
+    Story.message(TickedRevalidateStats()),
+    Story.Command.expectNone(),
+  )
+})
+
+test('invalidating posts refetches while keeping the current list', () => {
+  Story.story(
+    update,
+    Story.with(loadedPostsModel),
+    Story.message(ClickedInvalidatePosts()),
+    Story.model(model => {
+      expect(model.posts._tag).toBe('Refreshing')
+      if (model.posts._tag === 'Refreshing') {
+        expect(model.posts.data).toEqual(fixturePosts)
+      }
+    }),
+    Story.Command.resolve(
+      FetchPosts,
+      SucceededFetchPosts({
+        posts: fixturePosts,
+        fetchedAt: FETCHED_AT + 1000,
+      }),
+    ),
+    Story.model(model => {
+      expect(model.posts._tag).toBe('Ok')
+    }),
+  )
+})
+
+test('retrying failed posts shows the loading state and refetches', () => {
+  Story.story(
+    update,
+    Story.with({
+      ...loadedPostsModel,
+      posts: PostsData.Failure({ error: 'The server is down.' }),
+    }),
+    Story.message(ClickedRetryPosts()),
+    Story.model(model => {
+      expect(model.posts._tag).toBe('Loading')
+    }),
+    Story.Command.resolve(
+      FetchPosts,
+      SucceededFetchPosts({ posts: fixturePosts, fetchedAt: FETCHED_AT }),
+    ),
+    Story.model(model => {
+      expect(model.posts._tag).toBe('Ok')
+    }),
+  )
+})
+
+test('opening a post fetches it once and serves revisits from the Model', () => {
+  Story.story(
+    update,
+    Story.with(loadedPostsModel),
+    Story.message(ClickedPost({ postId: 'first-post' })),
+    Story.model(model => {
+      expect(postDetailTag(model, 'first-post')).toBe('Loading')
+    }),
+    Story.Command.resolve(
+      FetchPostDetail,
+      SucceededFetchPostDetail({
+        postId: 'first-post',
+        detail: firstPostDetail,
+        fetchedAt: FETCHED_AT,
+      }),
+    ),
+    Story.message(ClickedBackToPosts()),
+    Story.message(ClickedPost({ postId: 'first-post' })),
+    Story.Command.expectNone(),
+    Story.model(model => {
+      expect(postDetailTag(model, 'first-post')).toBe('Ok')
+      expect(model.maybeSelectedPostId).toEqual(Option.some('first-post'))
+    }),
+  )
+})
+
+test('a failed post detail fetch lands in Failure and retry refetches', () => {
+  Story.story(
+    update,
+    Story.with(loadedPostsModel),
+    Story.message(ClickedPost({ postId: 'first-post' })),
+    Story.Command.resolve(
+      FetchPostDetail,
+      FailedFetchPostDetail({
+        postId: 'first-post',
+        error: 'The connection dropped.',
+      }),
+    ),
+    Story.model(model => {
+      expect(postDetailTag(model, 'first-post')).toBe('Failure')
+    }),
+    Story.message(ClickedRetryPostDetail({ postId: 'first-post' })),
+    Story.model(model => {
+      expect(postDetailTag(model, 'first-post')).toBe('Loading')
+    }),
+    Story.Command.resolve(
+      FetchPostDetail,
+      SucceededFetchPostDetail({
+        postId: 'first-post',
+        detail: firstPostDetail,
+        fetchedAt: FETCHED_AT,
+      }),
+    ),
+    Story.model(model => {
+      expect(postDetailTag(model, 'first-post')).toBe('Ok')
+    }),
+  )
+})
+
+test('revisiting a post with a cached failure shows it without refetching', () => {
+  Story.story(
+    update,
+    Story.with({
+      ...loadedPostsModel,
+      postDetailById: HashMap.set(
+        HashMap.empty(),
+        'first-post',
+        PostDetailData.Failure({ error: 'The connection dropped.' }),
+      ),
+    }),
+    Story.message(ClickedPost({ postId: 'first-post' })),
+    Story.Command.expectNone(),
+    Story.model(model => {
+      expect(postDetailTag(model, 'first-post')).toBe('Failure')
+      expect(model.maybeSelectedPostId).toEqual(Option.some('first-post'))
+    }),
+  )
+})

--- a/examples/api-cache/src/main.ts
+++ b/examples/api-cache/src/main.ts
@@ -1,0 +1,818 @@
+import {
+  Array,
+  Clock,
+  Duration,
+  Effect,
+  HashMap,
+  Match as M,
+  Option,
+  Schema as S,
+  Stream,
+  pipe,
+} from 'effect'
+import { Command, Runtime, Subscription, Ui } from 'foldkit'
+import { Document, Html, html } from 'foldkit/html'
+import { m } from 'foldkit/message'
+import { ts } from 'foldkit/schema'
+import { evo } from 'foldkit/struct'
+
+import {
+  Post,
+  PostDetail,
+  Stats,
+  fetchPostDetailFromServer,
+  fetchPostsFromServer,
+  fetchStatsFromServer,
+} from './data'
+
+const STATS_REFETCH_INTERVAL = Duration.seconds(5)
+
+export const TABS_ID = 'api-cache-tabs'
+
+// MODEL
+
+const makeRemoteData = <DA, DI>(dataSchema: S.Codec<DA, DI>) => {
+  const NotAsked = ts('NotAsked')
+  const Loading = ts('Loading')
+  const Refreshing = ts('Refreshing', { data: dataSchema, fetchedAt: S.Number })
+  const Failure = ts('Failure', { error: S.String })
+  const Ok = ts('Ok', { data: dataSchema, fetchedAt: S.Number })
+
+  const Union = S.Union([NotAsked, Loading, Refreshing, Failure, Ok])
+
+  const refetch = (
+    current: typeof Union.Type,
+  ): Option.Option<typeof Union.Type> =>
+    M.value(current).pipe(
+      M.withReturnType<Option.Option<typeof Union.Type>>(),
+      M.tagsExhaustive({
+        NotAsked: () => Option.some(Loading()),
+        Loading: () => Option.none(),
+        Refreshing: () => Option.none(),
+        Failure: () => Option.some(Loading()),
+        Ok: ({ data, fetchedAt }) =>
+          Option.some(Refreshing({ data, fetchedAt })),
+      }),
+    )
+
+  return {
+    NotAsked,
+    Loading,
+    Refreshing,
+    Failure,
+    Ok,
+    Union,
+    refetch,
+  }
+}
+
+export const PostsData = makeRemoteData(S.Array(Post))
+export const PostDetailData = makeRemoteData(PostDetail)
+export const StatsData = makeRemoteData(Stats)
+
+type PostDetailData = typeof PostDetailData.Union.Type
+
+const Tab = S.Literals(['Posts', 'Stats'])
+type Tab = typeof Tab.Type
+
+const tabValues: ReadonlyArray<Tab> = Tab.literals
+
+export const AppTabs = Ui.Tabs.create<Tab>()
+
+export const Model = S.Struct({
+  tabs: Ui.Tabs.Model,
+  activeTab: Tab,
+  posts: PostsData.Union,
+  postDetailById: S.HashMap(S.String, PostDetailData.Union),
+  maybeSelectedPostId: S.Option(S.String),
+  stats: StatsData.Union,
+})
+export type Model = typeof Model.Type
+
+// MESSAGE
+
+export const GotTabsMessage = m('GotTabsMessage', { message: Ui.Tabs.Message })
+export const ClickedPost = m('ClickedPost', { postId: S.String })
+export const ClickedBackToPosts = m('ClickedBackToPosts')
+export const ClickedInvalidatePosts = m('ClickedInvalidatePosts')
+export const ClickedRetryPosts = m('ClickedRetryPosts')
+export const ClickedRetryPostDetail = m('ClickedRetryPostDetail', {
+  postId: S.String,
+})
+export const ClickedRefreshStats = m('ClickedRefreshStats')
+export const ClickedRetryStats = m('ClickedRetryStats')
+export const TickedRevalidateStats = m('TickedRevalidateStats')
+export const SucceededFetchPosts = m('SucceededFetchPosts', {
+  posts: S.Array(Post),
+  fetchedAt: S.Number,
+})
+export const FailedFetchPosts = m('FailedFetchPosts', { error: S.String })
+export const SucceededFetchPostDetail = m('SucceededFetchPostDetail', {
+  postId: S.String,
+  detail: PostDetail,
+  fetchedAt: S.Number,
+})
+export const FailedFetchPostDetail = m('FailedFetchPostDetail', {
+  postId: S.String,
+  error: S.String,
+})
+export const SucceededFetchStats = m('SucceededFetchStats', {
+  stats: Stats,
+  fetchedAt: S.Number,
+})
+export const FailedFetchStats = m('FailedFetchStats', { error: S.String })
+
+export const Message = S.Union([
+  GotTabsMessage,
+  ClickedPost,
+  ClickedBackToPosts,
+  ClickedInvalidatePosts,
+  ClickedRetryPosts,
+  ClickedRetryPostDetail,
+  ClickedRefreshStats,
+  ClickedRetryStats,
+  TickedRevalidateStats,
+  SucceededFetchPosts,
+  FailedFetchPosts,
+  SucceededFetchPostDetail,
+  FailedFetchPostDetail,
+  SucceededFetchStats,
+  FailedFetchStats,
+])
+export type Message = typeof Message.Type
+
+// UPDATE
+
+type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>]
+
+const refetchPosts = (model: Model): UpdateReturn =>
+  Option.match(PostsData.refetch(model.posts), {
+    onNone: () => [model, []],
+    onSome: nextPosts => [
+      evo(model, { posts: () => nextPosts }),
+      [FetchPosts()],
+    ],
+  })
+
+const refetchStats = (model: Model): UpdateReturn =>
+  Option.match(StatsData.refetch(model.stats), {
+    onNone: () => [model, []],
+    onSome: nextStats => [
+      evo(model, { stats: () => nextStats }),
+      [FetchStats()],
+    ],
+  })
+
+const setPostDetail = (postId: string, postDetail: PostDetailData) =>
+  HashMap.set(postId, postDetail)
+
+const activateTab = (model: Model, tab: Tab): UpdateReturn => {
+  const modelWithActiveTab = evo(model, { activeTab: () => tab })
+
+  return M.value(tab).pipe(
+    M.withReturnType<UpdateReturn>(),
+    M.when('Posts', () =>
+      M.value(modelWithActiveTab.posts).pipe(
+        M.withReturnType<UpdateReturn>(),
+        M.tag('NotAsked', () => [
+          evo(modelWithActiveTab, { posts: () => PostsData.Loading() }),
+          [FetchPosts()],
+        ]),
+        M.orElse(() => [modelWithActiveTab, []]),
+      ),
+    ),
+    M.when('Stats', () =>
+      M.value(modelWithActiveTab.stats).pipe(
+        M.withReturnType<UpdateReturn>(),
+        M.tag('NotAsked', () => [
+          evo(modelWithActiveTab, { stats: () => StatsData.Loading() }),
+          [FetchStats()],
+        ]),
+        M.orElse(() => [modelWithActiveTab, []]),
+      ),
+    ),
+    M.exhaustive,
+  )
+}
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    M.withReturnType<UpdateReturn>(),
+    M.tagsExhaustive({
+      GotTabsMessage: ({ message }) => {
+        const [nextTabs, tabsCommands, maybeSelected] = AppTabs.update(
+          model.tabs,
+          message,
+        )
+
+        const tabsModel = evo(model, { tabs: () => nextTabs })
+        const mappedCommands = Command.mapMessages(tabsCommands, message =>
+          GotTabsMessage({ message }),
+        )
+
+        return Option.match(maybeSelected, {
+          onNone: () => [tabsModel, mappedCommands],
+          onSome: ({ value }) => {
+            const [activatedModel, activationCommands] = activateTab(
+              tabsModel,
+              value,
+            )
+
+            return [
+              activatedModel,
+              Array.appendAll(mappedCommands, activationCommands),
+            ]
+          },
+        })
+      },
+
+      ClickedPost: ({ postId }) => {
+        const selectedModel = evo(model, {
+          maybeSelectedPostId: () => Option.some(postId),
+        })
+
+        return Option.match(HashMap.get(model.postDetailById, postId), {
+          onNone: () => [
+            evo(selectedModel, {
+              postDetailById: setPostDetail(postId, PostDetailData.Loading()),
+            }),
+            [FetchPostDetail({ postId })],
+          ],
+          onSome: () => [selectedModel, []],
+        })
+      },
+
+      ClickedBackToPosts: () => [
+        evo(model, { maybeSelectedPostId: () => Option.none() }),
+        [],
+      ],
+
+      ClickedInvalidatePosts: () => refetchPosts(model),
+
+      ClickedRetryPosts: () => refetchPosts(model),
+
+      ClickedRetryPostDetail: ({ postId }) => [
+        evo(model, {
+          postDetailById: setPostDetail(postId, PostDetailData.Loading()),
+        }),
+        [FetchPostDetail({ postId })],
+      ],
+
+      ClickedRefreshStats: () => refetchStats(model),
+
+      ClickedRetryStats: () => refetchStats(model),
+
+      TickedRevalidateStats: () => refetchStats(model),
+
+      SucceededFetchPosts: ({ posts, fetchedAt }) => [
+        evo(model, { posts: () => PostsData.Ok({ data: posts, fetchedAt }) }),
+        [],
+      ],
+
+      FailedFetchPosts: ({ error }) => [
+        evo(model, { posts: () => PostsData.Failure({ error }) }),
+        [],
+      ],
+
+      SucceededFetchPostDetail: ({ postId, detail, fetchedAt }) => [
+        evo(model, {
+          postDetailById: setPostDetail(
+            postId,
+            PostDetailData.Ok({ data: detail, fetchedAt }),
+          ),
+        }),
+        [],
+      ],
+
+      FailedFetchPostDetail: ({ postId, error }) => [
+        evo(model, {
+          postDetailById: setPostDetail(
+            postId,
+            PostDetailData.Failure({ error }),
+          ),
+        }),
+        [],
+      ],
+
+      SucceededFetchStats: ({ stats, fetchedAt }) => [
+        evo(model, { stats: () => StatsData.Ok({ data: stats, fetchedAt }) }),
+        [],
+      ],
+
+      FailedFetchStats: ({ error }) => [
+        evo(model, { stats: () => StatsData.Failure({ error }) }),
+        [],
+      ],
+    }),
+  )
+
+// INIT
+
+export const init: Runtime.ApplicationInit<Model, Message> = () => [
+  {
+    tabs: Ui.Tabs.init({ id: TABS_ID }),
+    activeTab: 'Posts',
+    posts: PostsData.Loading(),
+    postDetailById: HashMap.empty(),
+    maybeSelectedPostId: Option.none(),
+    stats: StatsData.NotAsked(),
+  },
+  [FetchPosts()],
+]
+
+// COMMAND
+
+export const FetchPosts = Command.define(
+  'FetchPosts',
+  SucceededFetchPosts,
+  FailedFetchPosts,
+)(
+  Effect.gen(function* () {
+    const posts = yield* fetchPostsFromServer
+    const fetchedAt = yield* Clock.currentTimeMillis
+    return SucceededFetchPosts({ posts, fetchedAt })
+  }),
+)
+
+export const FetchPostDetail = Command.define(
+  'FetchPostDetail',
+  { postId: S.String },
+  SucceededFetchPostDetail,
+  FailedFetchPostDetail,
+)(({ postId }) =>
+  Effect.gen(function* () {
+    const detail = yield* fetchPostDetailFromServer(postId)
+    const fetchedAt = yield* Clock.currentTimeMillis
+    return SucceededFetchPostDetail({ postId, detail, fetchedAt })
+  }).pipe(
+    Effect.catch(error =>
+      Effect.succeed(FailedFetchPostDetail({ postId, error })),
+    ),
+  ),
+)
+
+export const FetchStats = Command.define(
+  'FetchStats',
+  SucceededFetchStats,
+  FailedFetchStats,
+)(
+  Effect.gen(function* () {
+    const stats = yield* fetchStatsFromServer
+    const fetchedAt = yield* Clock.currentTimeMillis
+    return SucceededFetchStats({ stats, fetchedAt })
+  }),
+)
+
+// SUBSCRIPTION
+
+export const subscriptions = Subscription.make<Model, Message>()(entry => ({
+  revalidateStats: entry(
+    { isObservingStats: S.Boolean },
+    {
+      modelToDependencies: model => ({
+        isObservingStats:
+          model.activeTab === 'Stats' &&
+          (model.stats._tag === 'Ok' || model.stats._tag === 'Refreshing'),
+      }),
+      dependenciesToStream: ({ isObservingStats }) =>
+        Stream.when(
+          // NOTE: Stream.tick emits once immediately. Drop that first
+          // emission so freshly loaded stats are not refetched instantly.
+          Stream.tick(STATS_REFETCH_INTERVAL).pipe(
+            Stream.drop(1),
+            Stream.map(TickedRevalidateStats),
+          ),
+          Effect.sync(() => isObservingStats),
+        ),
+    },
+  ),
+}))
+
+// VIEW
+
+const formatFetchedAt = (fetchedAt: number): string =>
+  new Date(fetchedAt).toLocaleTimeString()
+
+const remoteDataKey = (remoteDataTag: string): string =>
+  M.value(remoteDataTag).pipe(
+    M.whenOr('Ok', 'Refreshing', () => 'Loaded'),
+    M.orElse(() => remoteDataTag),
+  )
+
+const tabButtonClassName =
+  'px-4 py-2 rounded-lg bg-white text-slate-600 font-semibold hover:bg-slate-50 transition cursor-pointer data-[selected]:bg-indigo-600 data-[selected]:text-white data-[selected]:hover:bg-indigo-600'
+
+const toolbarButtonClassName =
+  'px-3 py-1.5 bg-white text-slate-700 text-sm font-semibold rounded-md shadow hover:bg-slate-50 transition cursor-pointer data-[disabled]:opacity-50 data-[disabled]:cursor-default data-[disabled]:hover:bg-white'
+
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: 'API Cache',
+    body: h.div(
+      [h.Class('min-h-screen bg-slate-100 flex justify-center p-6')],
+      [
+        h.div(
+          [h.Class('w-full max-w-2xl flex flex-col gap-6')],
+          [
+            headerView(),
+            h.submodel({
+              slotId: TABS_ID,
+              model: model.tabs,
+              view: AppTabs.view,
+              viewInputs: {
+                tabs: tabValues,
+                ariaLabel: 'API cache sections',
+                toView: ({ tablist, tabs }) =>
+                  h.div(
+                    [h.Class('flex flex-col gap-6')],
+                    [
+                      h.div(
+                        [...tablist, h.Class('flex gap-2')],
+                        Array.map(tabs, tabInfo =>
+                          h.keyed('button')(
+                            tabInfo.value,
+                            [...tabInfo.tab, h.Class(tabButtonClassName)],
+                            [tabInfo.value],
+                          ),
+                        ),
+                      ),
+                      ...pipe(
+                        tabs,
+                        Array.filter(tabInfo => tabInfo.isActive),
+                        Array.map(tabInfo =>
+                          h.keyed('div')(
+                            tabInfo.value,
+                            [...tabInfo.panel, h.Class('flex flex-col gap-4')],
+                            [
+                              M.value(tabInfo.value).pipe(
+                                M.when('Posts', () => postsTabView(model)),
+                                M.when('Stats', () => statsTabView(model)),
+                                M.exhaustive,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+              },
+              toParentMessage: message => GotTabsMessage({ message }),
+            }),
+          ],
+        ),
+      ],
+    ),
+  }
+}
+
+const headerView = (): Html => {
+  const h = html<Message>()
+
+  return h.header(
+    [h.Class('flex flex-col gap-1')],
+    [
+      h.h1([h.Class('text-3xl font-bold text-slate-900')], ['API Cache']),
+      h.p(
+        [h.Class('text-slate-600')],
+        [
+          'Query client patterns written as ordinary Model state, update logic, and one Subscription.',
+        ],
+      ),
+    ],
+  )
+}
+
+const postsTabView = (model: Model): Html => {
+  const h = html<Message>()
+
+  return Option.match(model.maybeSelectedPostId, {
+    onNone: () =>
+      h.keyed('section')(
+        'PostsList',
+        [h.Class('flex flex-col gap-4')],
+        [postsListView(model)],
+      ),
+    onSome: postId =>
+      h.keyed('section')(
+        postId,
+        [h.Class('flex flex-col gap-4')],
+        [postDetailView(model, postId)],
+      ),
+  })
+}
+
+const postsListView = (model: Model): Html => {
+  const h = html<Message>()
+
+  const isFetchInFlight =
+    model.posts._tag === 'Loading' || model.posts._tag === 'Refreshing'
+
+  return h.div(
+    [h.Class('flex flex-col gap-4')],
+    [
+      h.div(
+        [h.Class('flex items-center justify-between')],
+        [
+          h.h2([h.Class('text-xl font-bold text-slate-800')], ['Posts']),
+          Ui.Button.view({
+            onClick: ClickedInvalidatePosts(),
+            isDisabled: isFetchInFlight,
+            toView: attributes =>
+              h.button(
+                [...attributes.button, h.Class(toolbarButtonClassName)],
+                [
+                  M.value(model.posts).pipe(
+                    M.tag('Refreshing', () => 'Refreshing...'),
+                    M.orElse(() => 'Invalidate'),
+                  ),
+                ],
+              ),
+          }),
+        ],
+      ),
+      h.p(
+        [h.Class('text-sm text-slate-500')],
+        [
+          'Open a post, go back, and open it again. The second visit renders instantly from the Model. Invalidate marks the list stale and refetches it while the current list stays on screen.',
+        ],
+      ),
+      h.keyed('div')(
+        remoteDataKey(model.posts._tag),
+        [],
+        [
+          M.value(model.posts).pipe(
+            M.tagsExhaustive({
+              NotAsked: () => loadingPanel('Loading posts...'),
+              Loading: () => loadingPanel('Loading posts...'),
+              Failure: ({ error }) => errorPanel(error, ClickedRetryPosts()),
+              Refreshing: ({ data }) =>
+                postListItems(data, model.postDetailById),
+              Ok: ({ data }) => postListItems(data, model.postDetailById),
+            }),
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+const isPostDetailCached = (
+  postDetailById: HashMap.HashMap<string, PostDetailData>,
+  postId: string,
+): boolean =>
+  Option.exists(
+    HashMap.get(postDetailById, postId),
+    postDetail => postDetail._tag === 'Ok',
+  )
+
+const postListItems = (
+  posts: ReadonlyArray<Post>,
+  postDetailById: HashMap.HashMap<string, PostDetailData>,
+): Html => {
+  const h = html<Message>()
+
+  return h.ul(
+    [h.Class('flex flex-col gap-2')],
+    Array.map(posts, post =>
+      h.keyed('li')(
+        post.id,
+        [],
+        [
+          Ui.Button.view({
+            onClick: ClickedPost({ postId: post.id }),
+            toView: attributes =>
+              h.button(
+                [
+                  ...attributes.button,
+                  h.Class(
+                    'w-full text-left bg-white rounded-lg shadow px-4 py-3 hover:bg-slate-50 transition cursor-pointer flex items-center justify-between gap-4',
+                  ),
+                ],
+                [
+                  h.div(
+                    [],
+                    [
+                      h.div(
+                        [h.Class('font-semibold text-slate-800')],
+                        [post.title],
+                      ),
+                      h.div(
+                        [h.Class('text-sm text-slate-500')],
+                        [post.excerpt],
+                      ),
+                    ],
+                  ),
+                  isPostDetailCached(postDetailById, post.id)
+                    ? h.span(
+                        [
+                          h.Class(
+                            'shrink-0 text-xs font-semibold text-emerald-700 bg-emerald-100 rounded-full px-2 py-1',
+                          ),
+                        ],
+                        ['Cached'],
+                      )
+                    : h.empty,
+                ],
+              ),
+          }),
+        ],
+      ),
+    ),
+  )
+}
+
+const postDetailView = (model: Model, postId: string): Html => {
+  const h = html<Message>()
+
+  const postDetailData = Option.getOrElse(
+    HashMap.get(model.postDetailById, postId),
+    () => PostDetailData.NotAsked(),
+  )
+
+  return h.div(
+    [h.Class('flex flex-col gap-4')],
+    [
+      Ui.Button.view({
+        onClick: ClickedBackToPosts(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'self-start text-sm font-semibold text-indigo-600 hover:underline cursor-pointer',
+              ),
+            ],
+            ['Back to posts'],
+          ),
+      }),
+      h.keyed('div')(
+        remoteDataKey(postDetailData._tag),
+        [],
+        [
+          M.value(postDetailData).pipe(
+            M.tagsExhaustive({
+              NotAsked: () => loadingPanel('Loading post...'),
+              Loading: () => loadingPanel('Loading post...'),
+              Failure: ({ error }) =>
+                errorPanel(error, ClickedRetryPostDetail({ postId })),
+              Refreshing: ({ data, fetchedAt }) =>
+                postDetailCard(data, fetchedAt),
+              Ok: ({ data, fetchedAt }) => postDetailCard(data, fetchedAt),
+            }),
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+const postDetailCard = (detail: PostDetail, fetchedAt: number): Html => {
+  const h = html<Message>()
+
+  return h.article(
+    [h.Class('bg-white rounded-xl shadow p-6 flex flex-col gap-3')],
+    [
+      h.h2([h.Class('text-2xl font-bold text-slate-900')], [detail.title]),
+      h.p([h.Class('text-sm text-slate-500')], [`By ${detail.author}`]),
+      h.p([h.Class('text-slate-700 leading-relaxed')], [detail.body]),
+      h.p(
+        [h.Class('text-xs text-slate-400')],
+        [
+          `Fetched at ${formatFetchedAt(fetchedAt)}. Future visits render instantly from the Model.`,
+        ],
+      ),
+    ],
+  )
+}
+
+const statsTabView = (model: Model): Html => {
+  const h = html<Message>()
+
+  const isFetchInFlight =
+    model.stats._tag === 'Loading' || model.stats._tag === 'Refreshing'
+
+  return h.div(
+    [h.Class('flex flex-col gap-4')],
+    [
+      h.div(
+        [h.Class('flex items-center justify-between')],
+        [
+          h.h2([h.Class('text-xl font-bold text-slate-800')], ['Stats']),
+          Ui.Button.view({
+            onClick: ClickedRefreshStats(),
+            isDisabled: isFetchInFlight,
+            toView: attributes =>
+              h.button(
+                [...attributes.button, h.Class(toolbarButtonClassName)],
+                [isFetchInFlight ? 'Refreshing...' : 'Refresh'],
+              ),
+          }),
+        ],
+      ),
+      h.p(
+        [h.Class('text-sm text-slate-500')],
+        [
+          'Stats refetch every 5 seconds while this tab is open. The old numbers stay on screen while the new ones load.',
+        ],
+      ),
+      h.keyed('div')(
+        remoteDataKey(model.stats._tag),
+        [],
+        [
+          M.value(model.stats).pipe(
+            M.tagsExhaustive({
+              NotAsked: () => loadingPanel('Loading stats...'),
+              Loading: () => loadingPanel('Loading stats...'),
+              Failure: ({ error }) => errorPanel(error, ClickedRetryStats()),
+              Refreshing: ({ data, fetchedAt }) =>
+                statsCards(data, fetchedAt, true),
+              Ok: ({ data, fetchedAt }) => statsCards(data, fetchedAt, false),
+            }),
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+const statsCards = (
+  stats: Stats,
+  fetchedAt: number,
+  isRefreshing: boolean,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class('flex flex-col gap-3')],
+    [
+      h.div(
+        [h.Class('grid grid-cols-3 gap-4')],
+        [
+          statCard('Active users', `${stats.activeUsers}`),
+          statCard('Requests per second', `${stats.requestsPerSecond}`),
+          statCard('Cache hit rate', `${stats.cacheHitRatePercent}%`),
+        ],
+      ),
+      h.div(
+        [h.Class('flex items-center gap-3 text-sm text-slate-500')],
+        [
+          h.span([], [`Updated at ${formatFetchedAt(fetchedAt)}`]),
+          isRefreshing
+            ? h.span([h.Class('text-indigo-600 font-semibold')], ['Refreshing'])
+            : h.empty,
+        ],
+      ),
+    ],
+  )
+}
+
+const statCard = (label: string, value: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class('bg-white rounded-xl shadow p-4 flex flex-col gap-1')],
+    [
+      h.div([h.Class('text-sm text-slate-500')], [label]),
+      h.div([h.Class('text-2xl font-bold text-slate-900')], [value]),
+    ],
+  )
+}
+
+const loadingPanel = (text: string): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class('bg-white rounded-lg shadow p-6 text-center text-slate-500')],
+    [text],
+  )
+}
+
+const errorPanel = (error: string, retryMessage: Message): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      h.Class(
+        'bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 flex items-center justify-between gap-4',
+      ),
+    ],
+    [
+      h.p([], [error]),
+      Ui.Button.view({
+        onClick: retryMessage,
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'shrink-0 px-3 py-1.5 bg-red-600 text-white text-sm font-semibold rounded-md hover:bg-red-700 transition cursor-pointer',
+              ),
+            ],
+            ['Retry'],
+          ),
+      }),
+    ],
+  )
+}

--- a/examples/api-cache/src/styles.css
+++ b/examples/api-cache/src/styles.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/examples/api-cache/src/vitest-setup.ts
+++ b/examples/api-cache/src/vitest-setup.ts
@@ -1,0 +1,3 @@
+import { setup } from 'foldkit/test/vitest'
+
+setup()

--- a/examples/api-cache/tsconfig.json
+++ b/examples/api-cache/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"],
+  "exclude": ["node_modules", "dist", "../../packages/foldkit/src"]
+}

--- a/examples/api-cache/vite.config.ts
+++ b/examples/api-cache/vite.config.ts
@@ -1,0 +1,17 @@
+import { foldkit } from '@foldkit/vite-plugin'
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite'
+
+import { foldkitAliases } from '../vite.aliases'
+
+export default defineConfig({
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
+  resolve: {
+    alias: foldkitAliases(__dirname),
+  },
+  server: {
+    fs: {
+      allow: ['../../'],
+    },
+  },
+})

--- a/examples/api-cache/vitest.config.ts
+++ b/examples/api-cache/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['./src/vitest-setup.ts'],
+    server: {
+      deps: {
+        inline: ['foldkit'],
+      },
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dev:example:counters": "pnpm --filter counters-example dev",
     "dev:example:stopwatch": "pnpm --filter stopwatch-example dev",
     "dev:example:weather": "pnpm --filter weather-example dev",
+    "dev:example:api-cache": "pnpm --filter api-cache-example dev",
     "dev:example:todo": "pnpm --filter todo-example dev",
     "dev:example:form": "pnpm --filter form-example dev",
     "dev:example:routing": "pnpm --filter routing-example dev",

--- a/packages/create-foldkit-app/src/examples.ts
+++ b/packages/create-foldkit-app/src/examples.ts
@@ -7,6 +7,7 @@ export const EXAMPLE_VALUES = [
   'form',
   'job-application',
   'weather',
+  'api-cache',
   'routing',
   'query-sync',
   'snake',
@@ -70,6 +71,12 @@ export const examples: ReadonlyArray<{
     value: 'weather',
     title: 'weather',
     description: 'HTTP requests with async state handling',
+  },
+  {
+    value: 'api-cache',
+    title: 'api-cache',
+    description:
+      'Query caching in the Model with stale-while-revalidate, request deduplication, invalidation, and interval refetching',
   },
   {
     value: 'routing',

--- a/packages/examples-e2e/e2e/api-cache.spec.ts
+++ b/packages/examples-e2e/e2e/api-cache.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('api-cache example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('fetches posts, caches details, and renders stats', async ({ page }) => {
+    await page.goto('/')
+
+    const firstPost = page.getByRole('button', {
+      name: 'The Model Is the Cache',
+    })
+    await expect(firstPost).toBeVisible()
+
+    await firstPost.click()
+    await expect(page.getByText('Fetched at')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Back to posts' }).click()
+    await expect(page.getByText('Cached')).toBeVisible()
+
+    await firstPost.click()
+    await expect(page.getByText('Fetched at')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Back to posts' }).click()
+    await page.getByRole('tab', { name: 'Stats' }).click()
+    await expect(page.getByText('Active users')).toBeVisible()
+    await expect(page.getByText('Updated at')).toBeVisible()
+  })
+
+  test('the flaky post fails on the first fetch and succeeds on retry', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    await page
+      .getByRole('button', { name: 'This Post Fails Every Other Fetch' })
+      .click()
+    await expect(page.getByText('The connection dropped.')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Retry' }).click()
+    await expect(page.getByText('You made it.')).toBeVisible()
+  })
+})

--- a/packages/website/src/page/example/meta.ts
+++ b/packages/website/src/page/example/meta.ts
@@ -11,6 +11,7 @@ export const ExampleSlug = S.Literals([
   'form',
   'job-application',
   'weather',
+  'api-cache',
   'routing',
   'query-sync',
   'snake',
@@ -99,6 +100,15 @@ export const examples: ReadonlyArray<ExampleMeta> = [
       'Look up weather by zip code. Demonstrates HTTP requests and loading states.',
     difficulty: 'Intermediate',
     tags: ['HTTP'],
+    hasRouting: false,
+  },
+  {
+    slug: 'api-cache',
+    title: 'API Cache',
+    description:
+      'Query caching without a query client. Demonstrates stale-while-revalidate, request deduplication, invalidation, and interval refetching.',
+    difficulty: 'Intermediate',
+    tags: ['Caching', 'Subscriptions', 'UI Components'],
     hasRouting: false,
   },
   {

--- a/packages/website/src/page/example/sources.ts
+++ b/packages/website/src/page/example/sources.ts
@@ -23,6 +23,7 @@ const loadersBySlug: Readonly<Record<string, SourceLoader | undefined>> = {
   'job-application': () => import('virtual:example-sources/job-application'),
   kanban: () => import('virtual:example-sources/kanban'),
   weather: () => import('virtual:example-sources/weather'),
+  'api-cache': () => import('virtual:example-sources/api-cache'),
   routing: () => import('virtual:example-sources/routing'),
   'query-sync': () => import('virtual:example-sources/query-sync'),
   'shopping-cart': () => import('virtual:example-sources/shopping-cart'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,58 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  examples/api-cache:
+    dependencies:
+      '@effect/platform-browser':
+        specifier: 4.0.0-beta.78
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      effect:
+        specifier: 4.0.0-beta.78
+        version: 4.0.0-beta.78
+      foldkit:
+        specifier: workspace:*
+        version: link:../../packages/foldkit
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+    devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.3.0(jiti@2.7.0))
+      '@foldkit/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-foldkit
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^6.0.2
+        version: 6.0.2(@vue/compiler-sfc@3.5.34)(prettier@3.8.3)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.59.2
+        version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.59.2
+        version: 8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint:
+        specifier: ^10.3.0
+        version: 10.3.0(jiti@2.7.0)
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
   examples/auth:
     dependencies:
       '@effect/platform-browser':
@@ -2540,24 +2592,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -2616,36 +2672,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -2778,24 +2840,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -4100,24 +4166,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
A two-tab app showing how query caching maps onto plain Foldkit: queries
cached in the Model as RemoteData unions, request deduplication and cache
hits in update, stale-while-revalidate via a Refreshing state, invalidation
as a Message, interval refetching through a Model-gated Subscription, and a
HashMap detail cache keyed by domain id. A simulated server with latency and
a deliberately flaky post makes every state reachable from the UI.

https://claude.ai/code/session_01FcAs5Yuox5u5uSuK128y7j