### PR TITLE
Refactor tabs OutMessage handling with exhaustive pattern match

### DIFF
--- a/examples/api-cache/src/main.ts
+++ b/examples/api-cache/src/main.ts
@@ -200,7 +200,7 @@ export const update = (model: Model, message: Message): UpdateReturn =>
     M.withReturnType<UpdateReturn>(),
     M.tagsExhaustive({
       GotTabsMessage: ({ message }) => {
-        const [nextTabs, tabsCommands, maybeSelected] = AppTabs.update(
+        const [nextTabs, tabsCommands, maybeOutMessage] = AppTabs.update(
           model.tabs,
           message,
         )
@@ -210,19 +210,24 @@ export const update = (model: Model, message: Message): UpdateReturn =>
           GotTabsMessage({ message }),
         )
 
-        return Option.match(maybeSelected, {
+        return Option.match(maybeOutMessage, {
           onNone: () => [tabsModel, mappedCommands],
-          onSome: ({ value }) => {
-            const [activatedModel, activationCommands] = activateTab(
-              tabsModel,
-              value,
-            )
+          onSome: M.type<Ui.Tabs.OutMessage<Tab>>().pipe(
+            M.withReturnType<UpdateReturn>(),
+            M.tagsExhaustive({
+              Selected: ({ value }) => {
+                const [activatedModel, activationCommands] = activateTab(
+                  tabsModel,
+                  value,
+                )
 
-            return [
-              activatedModel,
-              Array.appendAll(mappedCommands, activationCommands),
-            ]
-          },
+                return [
+                  activatedModel,
+                  Array.appendAll(mappedCommands, activationCommands),
+                ]
+              },
+            }),
+          ),
         })
       },
 


### PR DESCRIPTION
## Summary

Refactored the tabs update handler to properly pattern-match on the `OutMessage` type returned by `AppTabs.update`, replacing a generic `Option` match with an exhaustive match on the `Ui.Tabs.OutMessage<Tab>` discriminated union.

## Changes

- Renamed `maybeSelected` to `maybeOutMessage` to better reflect that it's an `Option` of an `OutMessage`, not just a selected tab value
- Replaced the generic `Option.match` with a Schema-based exhaustive match using `M.tagsExhaustive` on `Ui.Tabs.OutMessage<Tab>`
- Extracted the `Selected` case handler from the `onSome` callback, making the message type explicit and ensuring all OutMessage variants are handled exhaustively
- Maintained the same activation logic within the `Selected` case

## Implementation Details

This change follows Foldkit conventions by:
- Using `M.tagsExhaustive` for exhaustive pattern matching on tagged unions instead of generic `Option` matching
- Making the OutMessage type explicit in the match expression with `M.type<Ui.Tabs.OutMessage<Tab>>()`
- Applying `withReturnType<UpdateReturn>()` to ensure type safety in the nested match context
- Improving code clarity by naming the intermediate value to reflect its actual type

https://claude.ai/code/session_01EPG4j17db5BzzDmhGWskgi