### PR TITLE
Clarify portal overlay panel migration guide with section header

### DIFF
--- a/.changeset/portal-overlay-panels.md
+++ b/.changeset/portal-overlay-panels.md
@@ -4,7 +4,9 @@
 
 `Ui.Listbox`, `Ui.Menu`, and `Ui.Combobox` now always portal their items panel to the document body, positioned relative to the trigger with Floating UI. Previously this only happened when an `anchor` config was supplied; without one the panel rendered inline, at the mercy of the parent stacking context. Any sibling with an explicit z-index (a sticky section header, a toast, another overlay's wrapper) could occlude the open panel, forcing consumers into an app-wide z-index ladder.
 
-`anchor` remains optional and defaults to `bottom-start` placement with no gap. Migration:
+`anchor` remains optional and defaults to `bottom-start` placement with no gap.
+
+### Migration
 
 - If you already pass `anchor`, nothing changes.
 - If you rendered without `anchor` and positioned the panel with your own CSS (for example `absolute top-full mt-1`), remove those rules. Floating UI now writes `left` and `top` inline. Express spacing through `anchor: { gap }` and `placement` instead, and size the panel with `width: var(--button-width)` (Tailwind `w-(--button-width)`) rather than `w-full`. Give the panel a z-index above your elevated content; the docs demos use `z-10`.


### PR DESCRIPTION
This change improves the documentation for the portal overlay panels feature by adding a clear section header to the migration guide.

## Summary

The changeset documentation for `Ui.Listbox`, `Ui.Menu`, and `Ui.Combobox` portal behavior now uses a proper `### Migration` section header to visually separate the migration guidance from the feature description.

## Changes

- Added `### Migration` section header before the migration steps
- Improved document structure and readability by clearly delineating the feature explanation from the migration instructions

This is a documentation-only change that makes the changeset easier to scan and understand.

https://claude.ai/code/session_016A3kEbzrfeFhLDERdmfgyg