### PR TITLE
feat(foldkit): add experimental statechart spike

### DIFF
--- a/.changeset/statechart-spike.md
+++ b/.changeset/statechart-spike.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Add an experimental statechart spike at `src/statechart/`: a declarative transition table that compiles to a plain `transition(state, message) => [nextState, commands]` function. Not exported from the package surface and not part of the public API; findings live in `src/statechart/SPIKE_NOTES.md`.

--- a/packages/foldkit/src/statechart/SPIKE_NOTES.md
+++ b/packages/foldkit/src/statechart/SPIKE_NOTES.md
@@ -1,0 +1,266 @@
+# Statechart Spike Notes
+
+An exploratory prototype of `foldkit/statechart`: a declarative transition
+table that compiles down to a plain `transition(state, message) =>
+[nextState, commands]` function, spliced into `update` with `evo`. The
+machine state lives in the Model. There is no second runtime. This document
+records what survived TypeScript inference, what did not, and whether the
+idea is worth pursuing.
+
+Verification status: `pnpm typecheck` and `pnpm lint` pass. All 17 tests in
+`statechart.test.ts` pass, and every `@ts-expect-error` directive in the
+test file is consumed (checked with `tsc -p tsconfig.json`, which includes
+test files; the build config used by `pnpm typecheck` excludes them).
+
+## The API that shipped
+
+```ts
+const connectionMachine = defineMachine({
+  state: ConnectionState,
+  message: ConnectionMessage,
+})({
+  initial: Disconnected(),
+  states: {
+    Connecting: {
+      on: {
+        SocketOpened: to(
+          'Connected',
+          (state, message) => Connected({ sessionId: message.sessionId }),
+          (state, message) => [LogTransition({ description: '...' })],
+        ),
+        SocketErrored: [
+          when(
+            state => state.attemptCount < MAX_CONNECT_ATTEMPTS,
+            to('Reconnecting', state => Reconnecting({ ... })),
+          ),
+          otherwise(to('Failed', (state, message) => Failed({ ... }))),
+        ],
+      },
+    },
+  },
+})
+```
+
+`machine.transition` has exactly the `update` branch shape.
+`machine.step` returns `Transitioned | Ignored`, so dropped messages are
+observable rather than silently swallowed. `machine.edges`,
+`reachableFrom`, `unreachableStates`, `deadTransitions`, and `toMermaid`
+all read the same runtime edge data.
+
+## What held under inference
+
+These all pass `pnpm typecheck` with zero manual annotations in user code:
+
+- Inside `to('Connected', build)` under `Connecting.on.SocketOpened`, `state`
+  narrows to exactly the `Connecting` variant and `message` to exactly
+  `SocketOpened`. The test proves exact narrowing (not merely "a variant
+  with this field") with `const sourceTag: 'Connecting' = state._tag`.
+- The same narrowing holds inside `when` predicates, inside `to` calls
+  nested under `when` and `otherwise`, and inside the optional `commands`
+  callback.
+- `to('Connected', () => Disconnected())` is rejected: the build return type
+  is checked against the variant named by the target tag. Verified with
+  `@ts-expect-error`.
+- `to('Loadingg', ...)` (unknown target tag), an unknown state key in the
+  table, and an unknown message key under `on` are all rejected. The key
+  checks come from excess property checking against the mapped table type.
+
+## What did not hold, and what it cost
+
+### 1. The single-call `defineMachine({ state, message, initial, states })`
+
+The spec called for one config object. It cannot work with inference, and
+this is structural, not a tuning problem. When TypeScript infers
+`defineMachine`'s type parameters from the `state` and `message` properties,
+the nested `to(...)` calls inside `states` are checked during that same
+inference pass, while `State` and `Message` are still unresolved variables.
+A call expression is not "context sensitive" in TypeScript's sense (only
+function literals with unannotated parameters are), so the `to` calls are
+not deferred to the second inference round. Their results collapse to the
+type parameter constraints and the narrowing is gone.
+
+A micro-probe confirmed the mechanism: the identical `to(...)` call infers
+perfectly when its contextual type is concrete (direct assignment, object
+literal property, even a union context), and fails only when nested inside
+the inferring call.
+
+The fix is the two-stage form, which is also this codebase's existing
+pattern for the same problem (`Subscription.make<Model, Message>()(...)`,
+`ManagedResource.make<Model, Message>()(...)`, both of whose doc comments
+describe exactly this ordering issue):
+
+```ts
+defineMachine({ state, message })({ initial, states })
+```
+
+Stage one fixes the type parameters from the Schemas. Stage two checks the
+table against fully concrete types. Everything downstream works because of
+this split.
+
+### 2. Type-level edge precision
+
+The first design encoded the target tag in the `Edge` type itself
+(`Edge<State, Message, Source, Trigger, TargetTag>`), so the table position
+type was a union of edge types distributed over every possible target tag.
+That union is what broke inference: when TypeScript tries to infer `to`'s
+type parameters from a contextual union whose constituents differ only in
+`TargetTag`, multiple constituents match ambiguously and it bails to the
+constraints.
+
+The resolution: the `target`/`build` correlation is enforced only by `to`'s
+parameter signature (`build` must return `Variant<State, TargetTag>`), and
+the stored `Edge` type keeps `target: TagOf<State>` unspecific. Every
+constituent of the table position type then agrees on the inferable type
+arguments, and inference succeeds.
+
+What this costs: the type system no longer knows which target each edge
+points at, so a type-level reachability analysis is off the table. The
+runtime data still has literal target tags, and all the shipped analysis is
+runtime anyway, so nothing in the prototype's feature set was lost. But
+"the edge set is enumerable at the type level" is not true in the shipped
+design, and I could not find a formulation where it is true and inference
+survives.
+
+### 3. NoInfer placement is load-bearing and subtle
+
+Three separate inference leaks had to be plugged, each found by a failing
+probe:
+
+- `TransitionTable<NoInfer<State>, Message>` breaks entirely: the unreduced
+  `NoInfer` wrapper makes `Extract<NoInfer<State>, { _tag: Tag }>` evaluate
+  to `never`, so every build callback expected `never`. `NoInfer` must wrap
+  whole computed types, never types that feed conditional types.
+- `when`/`otherwise` need `NoInfer` on all parameters. Without it, the
+  nested `to(...)` result (computed without context during the guard
+  helper's own inference) supplies wrong candidates: `State` gets fixed to
+  the target variant alone, the source candidate then violates its
+  constraint, and the source falls back to the wrong variant.
+- `to`'s build return and commands parameter need `NoInfer`. A zero
+  parameter build like `() => Idle()` is not context sensitive, so its
+  return type participates in round one inference, and TypeScript infers
+  into the `Extract` conditional, again fixing `State` to the single target
+  variant.
+
+The result works, but it is a Jenga tower: five `NoInfer`s and a two-stage
+call, each individually necessary, none discoverable except by probing.
+Anyone extending this module needs the probe discipline, not just the types.
+
+### 4. Incidental findings inside the implementation
+
+- Effect's `Array.isArray` declares `(self: unknown)` as its first overload,
+  so it cannot narrow `Edge | ReadonlyArray<GuardedEdge>` (the readonly
+  array survives the negative branch). A named type guard over
+  `globalThis.Array.isArray` was needed.
+- `Match.tagsExhaustive` collapses (handlers expected to be `never`) when
+  the matched union contains unresolved generic type parameters, which is
+  the normal condition inside a generic library function. It is fine in app
+  code with concrete unions. The implementation uses plain conditionals on
+  `_tag` internally instead.
+- Two internal type assertions were unavoidable: widening the precise table
+  to a loose `(state: State, message: Message)` view (safe because `step`
+  dispatches by the same `_tag` keys the table was built from), and typing
+  the tags extracted from the Schema at runtime. Both are single-site and
+  eslint-suppressed in the house style.
+- Extracting state tags from the union Schema at runtime works via
+  `member.fields._tag.schema.literal` (verified by test). `defineMachine`
+  throws at definition time if a member is not a TaggedStruct.
+
+## How guards and reachability turned out
+
+Guards are the strongest part of the design. An ordered list of
+single-target edges (`when` then `otherwise`) keeps every branch's target a
+literal, the first matching guard fires, and a guard list with no match
+(all predicates false, no `otherwise`) produces an observable `Ignored`
+rather than an implicit no-op. Narrowing inside predicates means backoff
+logic reads naturally: `state.attemptCount < MAX_CONNECT_ATTEMPTS` with no
+annotations.
+
+Reachability is almost free once edges are data: `reachableFrom` is a ~15
+line BFS, `unreachableStates` subtracts it from the Schema-derived tag set,
+and `deadTransitions` reports both unreachable-source edges and guards
+listed after an `otherwise`. All three are exercised and sound on the
+connection example (a deliberately orphaned `Suspended` state is reported
+unreachable, and its outgoing edge dead). `toMermaid` is ~20 lines and
+emits a complete `stateDiagram-v2` with guard labels. The claim that "viz
+falls out of the definition" is simply true.
+
+## Honest cost versus a hand-written `update`
+
+For the connection machine (six states, ten edges, one guard pair), the
+table is roughly 80 lines; the equivalent `Match`-based `update` branch
+written in house style is roughly 50 to 60. The table costs more lines but
+each line carries less logic, and the transitions are data you can audit,
+test, and render.
+
+The real costs are not line counts:
+
+- A second vocabulary (`to`, `when`, `otherwise`, two-stage `defineMachine`)
+  for something every Foldkit developer already knows how to write with
+  `Match`.
+- Type errors inside a mistyped table are large structural dumps, far
+  noisier than the equivalent error in a plain `update`. The wrong-variant
+  rejection works, but its error message spans 20 lines.
+- No services channel: edge commands are `Command<Message>` with `R =
+never`. The typing-game's update returns commands with an `RpcClient`
+  requirement, so this would need an `R` type parameter on `defineMachine`
+  before real apps could attach RPC commands to edges. Straightforward, but
+  not done.
+- The Model field must be exactly the machine's state union, and the
+  machine's messages must be a subset of the app's Message union. Both held
+  naturally in the integration example (`M.tag` over the machine's message
+  tags, then `machine.transition`, then `evo`), which came out to about
+  15 lines.
+
+What you get for that cost: ignored messages are explicit and observable
+(`step`), dead edges and unreachable states are detectable at boot or in
+tests, and the diagram is generated rather than hand-drawn and stale.
+
+## The hierarchy gap
+
+Foldkit has no compound or hierarchical state concept, and neither does this
+table. Two honest observations:
+
+- The table shape leaves syntactic room: a state entry could grow `initial`
+  and `states` keys for child machines, or a machine-level `parent` map,
+  without breaking the current flat form. Nothing in the runtime
+  representation (edges as plain records) resists it, and the analysis
+  functions would extend by recursion.
+- But hierarchy is not a syntax extension, it is a semantics project:
+  message bubbling (child handles first, parent as fallback), entering a
+  composite state through its initial child, exit and entry ordering, and
+  what `Ignored` means when a parent could still handle the message. None
+  of that exists in Foldkit today, and the Submodel idiom (parent variant
+  carries a child union field, parent `update` delegates and maps
+  OutMessages) already covers the same ground in plain code. A hierarchical
+  machine would compete with Submodels, not fill a void.
+
+So: no rework needed to add hierarchy later, but also no pressure to. If
+hierarchy ever lands it should be designed against Submodels, not bolted
+onto this table.
+
+## Recommendation
+
+Worth pursuing, narrowly. The type-level results are better than expected
+(exact narrowing with zero annotations, wrong-variant rejection, typo
+rejection), and the analysis and Mermaid output genuinely fall out of the
+data. But as a way to write transitions, the table is only a modest
+improvement over an idiomatic `Match`-based `update` branch, and it adds a
+vocabulary and an inference Jenga tower that someone has to maintain.
+
+The smallest version worth shipping:
+
+- `defineMachine` (two-stage, as here), `to`, `when`, `otherwise`.
+- `transition` and `step` (the `Ignored` observability is a real win and
+  costs nothing).
+- `edges` and `toMermaid` (the cheapest, most demoable payoff).
+- `reachableFrom` / `unreachableStates` / `deadTransitions` (they are ~50
+  lines combined and make the "transitions are data" pitch concrete).
+- Plus one addition before real use: an `R` (services) type parameter so
+  edge commands can require RPC clients.
+- Skip hierarchy entirely.
+
+Ship it as an experimental `foldkit/statechart` subpath, document the
+two-stage call as a hard requirement with a short explanation of why, and
+treat the website docs' state-modeling page as the place to position it:
+reach for a Machine when a Model field has more than three or four states
+with non-obvious legal transitions, and stay with plain `update` otherwise.

--- a/packages/foldkit/src/statechart/SPIKE_NOTES.md
+++ b/packages/foldkit/src/statechart/SPIKE_NOTES.md
@@ -8,9 +8,10 @@ records what survived TypeScript inference, what did not, and whether the
 idea is worth pursuing.
 
 Verification status: `pnpm typecheck` and `pnpm lint` pass. All 17 tests in
-`statechart.test.ts` pass, and every `@ts-expect-error` directive in the
-test file is consumed (checked with `tsc -p tsconfig.json`, which includes
-test files; the build config used by `pnpm typecheck` excludes them).
+`statechart.test.ts` and the 27 tests across `examples/` pass, and every
+`@ts-expect-error` directive in the test file is consumed (checked with
+`tsc -p tsconfig.json`, which includes test files; the build config used by
+`pnpm typecheck` excludes them).
 
 ## The API that shipped
 
@@ -238,14 +239,54 @@ So: no rework needed to add hierarchy later, but also no pressure to. If
 hierarchy ever lands it should be designed against Submodels, not bolted
 onto this table.
 
+## Where it shines: worked examples
+
+The connection machine above is the canonical demo, but it is mid-tier as a
+pitch: a competent developer writes it as a plain `update` branch without
+trouble. The cases that actually justify the module live in `examples/`,
+each a self-contained test file paired with an analysis markdown
+(`examples/README.md` is the index):
+
+- `staleAsyncPruning`: stale completion Messages are dropped by topology
+  (the only state with a `SucceededSave` edge is `Saving`), and the
+  remaining generation check collapses into a single guard. This replaces
+  the scattered request-id checks that are the most reliably forgotten
+  defensive code in Elm-architecture apps.
+- `dragGesture`: adversarial pointer-event orderings (cancel mid-drag,
+  second pointers, release without movement) become a fully decided
+  state-by-event matrix, with one test stepping every cell and asserting
+  which are `Ignored`.
+- `resumableUpload`: protocol legality is the table. Duplicate and racing
+  server acknowledgements are observably `Ignored`, and the Commands
+  attached to edges form an assertable request sequence, an executable
+  stand-in for the protocol's sequence diagram.
+- `rowSync`: one machine amortized over every row of a table, with
+  `Command.mapMessages` routing results back to the originating row and a
+  single analysis pass certifying the lifecycle for all instances. This is
+  where the table's fixed cost flips into a clear win.
+- `checkoutWizard`: the generated Mermaid diagram is the artifact a PM
+  reviews, skip logic is a symmetric guard pair on forward and back
+  navigation, and `unreachableStates` catches the orphaned step a flow
+  change left behind.
+
+The shared traits, in rough order of strength: a (state, message) matrix
+dense with combinations that must be rejected observably; messages arriving
+from sources the app does not control (network, pointer hardware, timers)
+in orders the happy path never exercises; one machine instantiated many
+times; and flows that non-engineers review.
+
 ## Recommendation
 
-Worth pursuing, narrowly. The type-level results are better than expected
-(exact narrowing with zero annotations, wrong-variant rejection, typo
-rejection), and the analysis and Mermaid output genuinely fall out of the
-data. But as a way to write transitions, the table is only a modest
-improvement over an idiomatic `Match`-based `update` branch, and it adds a
-vocabulary and an inference Jenga tower that someone has to maintain.
+Worth pursuing, positioned by scenario rather than by state count. The
+type-level results are better than expected (exact narrowing with zero
+annotations, wrong-variant rejection, typo rejection), and the analysis and
+Mermaid output genuinely fall out of the data. For the median Model field a
+plain `Match`-based `update` branch remains the right call, and the table
+is only a modest improvement there, paid for with a second vocabulary and
+an inference Jenga tower someone has to maintain. For the scenarios in
+`examples/`, the table is a structural improvement rather than a stylistic
+one: it deletes bug classes (stale async results, unhandled event
+orderings, drifting flow diagrams) instead of shortening code.
 
 The smallest version worth shipping:
 
@@ -261,6 +302,12 @@ The smallest version worth shipping:
 
 Ship it as an experimental `foldkit/statechart` subpath, document the
 two-stage call as a hard requirement with a short explanation of why, and
-treat the website docs' state-modeling page as the place to position it:
-reach for a Machine when a Model field has more than three or four states
-with non-obvious legal transitions, and stay with plain `update` otherwise.
+position it in the docs by trait, not by size. Reach for a Machine when
+illegal (state, message) combinations outnumber legal ones and must be
+rejected observably, when messages arrive from sources you do not control,
+when one machine is instantiated per entity, or when the flow itself is a
+review artifact for non-engineers. Stay with plain `update` for toggles,
+forms, and any state where most messages mutate data within a state rather
+than move between states. The per-row save/conflict machine
+(`examples/rowSync.test.ts`) is the motivating example the docs should lead
+with, not a connection machine.

--- a/packages/foldkit/src/statechart/examples/README.md
+++ b/packages/foldkit/src/statechart/examples/README.md
@@ -1,0 +1,29 @@
+# Statechart Examples
+
+Five scenarios where the transition table earns its keep over a hand-written
+`update` branch. The connection machine in `../statechart.test.ts` is the
+canonical demo; these are the cases that motivated the spike's
+recommendation. Each example is a self-contained test file (so it
+typechecks, runs, and stays out of the build output) paired with a short
+analysis.
+
+Run them with `npx vitest run src/statechart/examples`.
+
+| Example                   | Claim                                                                                    | Files                               |
+| ------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------- |
+| Stale async pruning       | Stale completions are dropped by topology, and generation checks collapse into one guard | `staleAsyncPruning.test.ts` / `.md` |
+| Drag gesture recognition  | Adversarial pointer-event orderings become a fully decided state-by-event matrix         | `dragGesture.test.ts` / `.md`       |
+| Resumable upload protocol | Spec legality is the table, and edge Commands form an assertable request sequence        | `resumableUpload.test.ts` / `.md`   |
+| Per-row sync              | One definition amortizes across every instance, with Commands routed back per row        | `rowSync.test.ts` / `.md`           |
+| Checkout wizard           | The generated diagram is the review artifact, and analysis catches orphaned steps        | `checkoutWizard.test.ts` / `.md`    |
+
+The shared traits, in rough order of strength:
+
+1. The (state, message) matrix is dense with combinations that must be
+   rejected, and rejection should be observable (`Ignored`), not accidental.
+2. Messages arrive from sources the app does not control (network, pointer
+   hardware, timers) in orders the happy path never exercises.
+3. One machine is instantiated many times, so the definition's fixed cost
+   amortizes and its analysis certifies every instance.
+4. The flow itself is a communication artifact that non-engineers review,
+   so the generated Mermaid diagram replaces a drifting hand-drawn one.

--- a/packages/foldkit/src/statechart/examples/checkoutWizard.md
+++ b/packages/foldkit/src/statechart/examples/checkoutWizard.md
@@ -1,0 +1,49 @@
+# Checkout Wizard (Flows Other People Review)
+
+Code: `checkoutWizard.test.ts` (`Cart | ShippingAddress | ShippingMethod |
+Payment | Review | Placing | Confirmed`, plus a deliberately orphaned
+`GiftWrap`).
+
+## The problem this solves
+
+Multi-step flows like checkout, onboarding, and KYC are owned as much by
+product as by engineering. The flow logic changes often, the changes are
+expressed as diagrams in design docs, and the diagrams drift from the code
+within weeks. Meanwhile branching rules ("digital carts skip shipping")
+must hold in both directions, and back-navigation is where hand-written
+wizards reliably break.
+
+## What the machine buys
+
+- The Mermaid output is the review artifact. `toMermaid` emits the actual
+  flow, with guard labels on the conditional edges, generated from the same
+  table the app executes. The test pins the diagram, so any PR that changes
+  the flow shows up as a readable diff of the diagram itself. That is the
+  thing a PM can review without reading TypeScript.
+- Skip logic is a symmetric pair of guards. Digital carts skip shipping on
+  `ClickedContinue` (`when(isShippingRequired)` / `otherwise`), and the same
+  pair appears on `Payment.ClickedBack`, sending the user back to where they
+  actually came from. The forward and backward rules sit next to each other
+  in the table, so an asymmetry is visible rather than discovered by a user
+  pressing Back.
+- Defense in depth on terms acceptance: `ClickedPlaceOrder` is a guard list
+  with no `otherwise`, so placing an order before accepting the terms is
+  `Ignored` even if the view forgets to disable the button. The test asserts
+  the observable `Ignored` result.
+- The orphaned step is caught by analysis. `GiftWrap` models the step a flow
+  change left behind: still in the union, still has an outgoing edge, no
+  inbound edges. `unreachableStates()` reports it and `deadTransitions()`
+  flags its edge, the kind of dead flow code that otherwise survives in a
+  hand-written wizard indefinitely.
+
+## Honest limits
+
+- Wizard steps carry data (addresses, payment details), and this example
+  threads only one boolean through the states. A real checkout would thread
+  form data through every build function, which is the table at its most
+  verbose; keeping step data in sibling Model fields and leaving only the
+  position in the machine is the more livable split.
+- Failure handling for order placement is omitted for brevity; `Placing`
+  would need `FailedPlaceOrder` edges in a real flow.
+- Parallel concerns (a promo-code panel usable on several steps) do not fit
+  a flat machine and would stay in ordinary Model fields beside it.

--- a/packages/foldkit/src/statechart/examples/checkoutWizard.test.ts
+++ b/packages/foldkit/src/statechart/examples/checkoutWizard.test.ts
@@ -1,0 +1,240 @@
+import { Schema as S } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { m, ts } from '../../schema/index.js'
+import { defineMachine, otherwise, to, when } from '../statechart.js'
+
+// STATE
+
+const Cart = ts('Cart', { isShippingRequired: S.Boolean })
+const ShippingAddress = ts('ShippingAddress')
+const ShippingMethod = ts('ShippingMethod')
+const Payment = ts('Payment', { isShippingRequired: S.Boolean })
+const Review = ts('Review', {
+  isShippingRequired: S.Boolean,
+  isTermsAccepted: S.Boolean,
+})
+const Placing = ts('Placing')
+const Confirmed = ts('Confirmed', { orderId: S.String })
+const GiftWrap = ts('GiftWrap')
+
+const CheckoutState = S.Union([
+  Cart,
+  ShippingAddress,
+  ShippingMethod,
+  Payment,
+  Review,
+  Placing,
+  Confirmed,
+  GiftWrap,
+])
+type CheckoutState = typeof CheckoutState.Type
+
+// MESSAGE
+
+const ClickedContinue = m('ClickedContinue')
+const ClickedBack = m('ClickedBack')
+const AcceptedTerms = m('AcceptedTerms')
+const ClickedPlaceOrder = m('ClickedPlaceOrder')
+const SucceededPlaceOrder = m('SucceededPlaceOrder', { orderId: S.String })
+
+const CheckoutMessage = S.Union([
+  ClickedContinue,
+  ClickedBack,
+  AcceptedTerms,
+  ClickedPlaceOrder,
+  SucceededPlaceOrder,
+])
+type CheckoutMessage = typeof CheckoutMessage.Type
+
+// MACHINE
+
+const checkoutMachine = defineMachine({
+  state: CheckoutState,
+  message: CheckoutMessage,
+})({
+  initial: Cart({ isShippingRequired: true }),
+  states: {
+    Cart: {
+      on: {
+        ClickedContinue: [
+          when(
+            state => state.isShippingRequired,
+            to('ShippingAddress', () => ShippingAddress()),
+          ),
+          otherwise(
+            to('Payment', state =>
+              Payment({ isShippingRequired: state.isShippingRequired }),
+            ),
+          ),
+        ],
+      },
+    },
+    ShippingAddress: {
+      on: {
+        ClickedContinue: to('ShippingMethod', () => ShippingMethod()),
+        ClickedBack: to('Cart', () => Cart({ isShippingRequired: true })),
+      },
+    },
+    ShippingMethod: {
+      on: {
+        ClickedContinue: to('Payment', () =>
+          Payment({ isShippingRequired: true }),
+        ),
+        ClickedBack: to('ShippingAddress', () => ShippingAddress()),
+      },
+    },
+    Payment: {
+      on: {
+        ClickedContinue: to('Review', state =>
+          Review({
+            isShippingRequired: state.isShippingRequired,
+            isTermsAccepted: false,
+          }),
+        ),
+        ClickedBack: [
+          when(
+            state => state.isShippingRequired,
+            to('ShippingMethod', () => ShippingMethod()),
+          ),
+          otherwise(
+            to('Cart', state =>
+              Cart({ isShippingRequired: state.isShippingRequired }),
+            ),
+          ),
+        ],
+      },
+    },
+    Review: {
+      on: {
+        AcceptedTerms: to('Review', state =>
+          Review({
+            isShippingRequired: state.isShippingRequired,
+            isTermsAccepted: true,
+          }),
+        ),
+        ClickedBack: to('Payment', state =>
+          Payment({ isShippingRequired: state.isShippingRequired }),
+        ),
+        ClickedPlaceOrder: [
+          when(
+            state => state.isTermsAccepted,
+            to('Placing', () => Placing()),
+          ),
+        ],
+      },
+    },
+    Placing: {
+      on: {
+        SucceededPlaceOrder: to('Confirmed', (_state, message) =>
+          Confirmed({ orderId: message.orderId }),
+        ),
+      },
+    },
+    GiftWrap: {
+      on: {
+        ClickedContinue: to('Review', () =>
+          Review({ isShippingRequired: true, isTermsAccepted: false }),
+        ),
+      },
+    },
+  },
+})
+
+// TESTS
+
+describe('checkout wizard machine', () => {
+  it('skips the shipping steps for digital only carts, forward and back', () => {
+    const digitalCart = Cart({ isShippingRequired: false })
+
+    const [payment] = checkoutMachine.transition(digitalCart, ClickedContinue())
+    expect(payment).toStrictEqual(Payment({ isShippingRequired: false }))
+
+    const [backToCart] = checkoutMachine.transition(payment, ClickedBack())
+    expect(backToCart).toStrictEqual(Cart({ isShippingRequired: false }))
+  })
+
+  it('walks the full physical goods path', () => {
+    const [address] = checkoutMachine.transition(
+      Cart({ isShippingRequired: true }),
+      ClickedContinue(),
+    )
+    expect(address).toStrictEqual(ShippingAddress())
+
+    const [method] = checkoutMachine.transition(address, ClickedContinue())
+    const [payment] = checkoutMachine.transition(method, ClickedContinue())
+    expect(payment).toStrictEqual(Payment({ isShippingRequired: true }))
+
+    const [backToMethod] = checkoutMachine.transition(payment, ClickedBack())
+    expect(backToMethod).toStrictEqual(ShippingMethod())
+
+    const [review] = checkoutMachine.transition(payment, ClickedContinue())
+    const [accepted] = checkoutMachine.transition(review, AcceptedTerms())
+    const [placing] = checkoutMachine.transition(accepted, ClickedPlaceOrder())
+    expect(placing).toStrictEqual(Placing())
+
+    const [confirmed] = checkoutMachine.transition(
+      placing,
+      SucceededPlaceOrder({ orderId: 'order-9' }),
+    )
+    expect(confirmed).toStrictEqual(Confirmed({ orderId: 'order-9' }))
+  })
+
+  it('refuses to place an order before the terms are accepted', () => {
+    const review = Review({ isShippingRequired: true, isTermsAccepted: false })
+    const result = checkoutMachine.step(review, ClickedPlaceOrder())
+
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Review',
+      messageTag: 'ClickedPlaceOrder',
+      state: review,
+    })
+  })
+
+  it('catches the orphaned GiftWrap step left behind by a flow change', () => {
+    expect(checkoutMachine.unreachableStates()).toEqual(['GiftWrap'])
+    expect(checkoutMachine.deadTransitions()).toEqual([
+      {
+        edge: {
+          from: 'GiftWrap',
+          messageTag: 'ClickedContinue',
+          target: 'Review',
+          guard: { _tag: 'Unguarded' },
+        },
+        reason: 'UnreachableSource',
+      },
+    ])
+  })
+
+  it('emits the flow diagram reviewers actually look at', () => {
+    expect(checkoutMachine.toMermaid()).toBe(
+      [
+        'stateDiagram-v2',
+        '  Cart',
+        '  ShippingAddress',
+        '  ShippingMethod',
+        '  Payment',
+        '  Review',
+        '  Placing',
+        '  Confirmed',
+        '  GiftWrap',
+        '  [*] --> Cart',
+        '  Cart --> ShippingAddress: ClickedContinue [when 1]',
+        '  Cart --> Payment: ClickedContinue [otherwise]',
+        '  ShippingAddress --> ShippingMethod: ClickedContinue',
+        '  ShippingAddress --> Cart: ClickedBack',
+        '  ShippingMethod --> Payment: ClickedContinue',
+        '  ShippingMethod --> ShippingAddress: ClickedBack',
+        '  Payment --> Review: ClickedContinue',
+        '  Payment --> ShippingMethod: ClickedBack [when 1]',
+        '  Payment --> Cart: ClickedBack [otherwise]',
+        '  Review --> Review: AcceptedTerms',
+        '  Review --> Payment: ClickedBack',
+        '  Review --> Placing: ClickedPlaceOrder [when 1]',
+        '  Placing --> Confirmed: SucceededPlaceOrder',
+        '  GiftWrap --> Review: ClickedContinue',
+      ].join('\n'),
+    )
+  })
+})

--- a/packages/foldkit/src/statechart/examples/dragGesture.md
+++ b/packages/foldkit/src/statechart/examples/dragGesture.md
@@ -1,0 +1,47 @@
+# Drag Gesture Recognition
+
+Code: `dragGesture.test.ts` (`Idle | Pressed | Dragging | Settling`, driven
+by pointer events).
+
+## The problem this solves
+
+Pointer streams are adversarial. Real devices deliver `pointerup` with no
+preceding `pointermove`, `pointercancel` mid-drag, moves from a second
+pointer while the first is dragging, and presses that land during a drop
+animation. Hand-written handlers accumulate implicit holes in the
+state-by-event matrix: each `if` was written with one ordering in mind, and
+the pathological orderings fall through to whichever branch happens to
+match.
+
+## What the machine buys
+
+- Every cell of the matrix is a visible decision. The
+  `decides every cell of the state and message matrix explicitly` test steps
+  every sample state against every message and asserts exactly which pairs
+  transition; everything else is observably `Ignored`. That test is only
+  writable because transitions are enumerable data.
+- Pointer identity is a guard, not an `if` inside a handler. Each guarded
+  list checks `message.pointerId === state.pointerId` first, and because the
+  lists have no `otherwise`, another pointer's events fall through to
+  `Ignored` in every state. One loop in the test proves it for the whole
+  machine.
+- The threshold logic is a two-entry guard list that reads like the spec:
+  cross the threshold and become `Dragging`, same pointer below the
+  threshold stays `Pressed` (an identity self-edge, `state => state`),
+  anything else is ignored.
+- Interruptions are first-class edges: `pointercancel` during a drag settles
+  back to the origin, and a new press during `Settling` cuts the animation
+  short. Both are single table entries rather than special cases threaded
+  through handlers.
+
+## Honest limits
+
+- This is a single-pointer machine. Real multi-touch (pinch, two-finger
+  scroll) is parallel state, which a flat statechart models badly; that is
+  the hierarchy/parallelism gap noted in the spike notes.
+- The machine recognizes the gesture but does not render it. The actual
+  drag visuals still need view code reading `Dragging`'s coordinates, and
+  the settle animation needs a Subscription or Mount gated on the
+  `Settling` tag to dispatch `CompletedSettle`.
+- Foldkit UI already ships a drag-and-drop module; this example is about the
+  recognition pattern, not a replacement for it.

--- a/packages/foldkit/src/statechart/examples/dragGesture.test.ts
+++ b/packages/foldkit/src/statechart/examples/dragGesture.test.ts
@@ -1,0 +1,298 @@
+import { Array, Schema as S, pipe } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { m, ts } from '../../schema/index.js'
+import { defineMachine, to, when } from '../statechart.js'
+
+const DRAG_THRESHOLD_PIXELS = 8
+
+// STATE
+
+const Idle = ts('Idle')
+const Pressed = ts('Pressed', {
+  pointerId: S.Number,
+  startX: S.Number,
+  startY: S.Number,
+})
+const Dragging = ts('Dragging', {
+  pointerId: S.Number,
+  startX: S.Number,
+  startY: S.Number,
+  currentX: S.Number,
+  currentY: S.Number,
+})
+const Settling = ts('Settling', { endX: S.Number, endY: S.Number })
+
+const GestureState = S.Union([Idle, Pressed, Dragging, Settling])
+type GestureState = typeof GestureState.Type
+
+// MESSAGE
+
+const PressedPointer = m('PressedPointer', {
+  pointerId: S.Number,
+  x: S.Number,
+  y: S.Number,
+})
+const MovedPointer = m('MovedPointer', {
+  pointerId: S.Number,
+  x: S.Number,
+  y: S.Number,
+})
+const ReleasedPointer = m('ReleasedPointer', { pointerId: S.Number })
+const CancelledPointer = m('CancelledPointer', { pointerId: S.Number })
+const CompletedSettle = m('CompletedSettle')
+
+const GestureMessage = S.Union([
+  PressedPointer,
+  MovedPointer,
+  ReleasedPointer,
+  CancelledPointer,
+  CompletedSettle,
+])
+type GestureMessage = typeof GestureMessage.Type
+
+// MACHINE
+
+const gestureMachine = defineMachine({
+  state: GestureState,
+  message: GestureMessage,
+})({
+  initial: Idle(),
+  states: {
+    Idle: {
+      on: {
+        PressedPointer: to('Pressed', (_state, message) =>
+          Pressed({
+            pointerId: message.pointerId,
+            startX: message.x,
+            startY: message.y,
+          }),
+        ),
+      },
+    },
+    Pressed: {
+      on: {
+        MovedPointer: [
+          when(
+            (state, message) =>
+              message.pointerId === state.pointerId &&
+              Math.hypot(message.x - state.startX, message.y - state.startY) >=
+                DRAG_THRESHOLD_PIXELS,
+            to('Dragging', (state, message) =>
+              Dragging({
+                pointerId: state.pointerId,
+                startX: state.startX,
+                startY: state.startY,
+                currentX: message.x,
+                currentY: message.y,
+              }),
+            ),
+          ),
+          when(
+            (state, message) => message.pointerId === state.pointerId,
+            to('Pressed', state => state),
+          ),
+        ],
+        ReleasedPointer: [
+          when(
+            (state, message) => message.pointerId === state.pointerId,
+            to('Idle', () => Idle()),
+          ),
+        ],
+        CancelledPointer: [
+          when(
+            (state, message) => message.pointerId === state.pointerId,
+            to('Idle', () => Idle()),
+          ),
+        ],
+      },
+    },
+    Dragging: {
+      on: {
+        MovedPointer: [
+          when(
+            (state, message) => message.pointerId === state.pointerId,
+            to('Dragging', (state, message) =>
+              Dragging({
+                pointerId: state.pointerId,
+                startX: state.startX,
+                startY: state.startY,
+                currentX: message.x,
+                currentY: message.y,
+              }),
+            ),
+          ),
+        ],
+        ReleasedPointer: [
+          when(
+            (state, message) => message.pointerId === state.pointerId,
+            to('Settling', state =>
+              Settling({ endX: state.currentX, endY: state.currentY }),
+            ),
+          ),
+        ],
+        CancelledPointer: [
+          when(
+            (state, message) => message.pointerId === state.pointerId,
+            to('Settling', state =>
+              Settling({ endX: state.startX, endY: state.startY }),
+            ),
+          ),
+        ],
+      },
+    },
+    Settling: {
+      on: {
+        CompletedSettle: to('Idle', () => Idle()),
+        PressedPointer: to('Pressed', (_state, message) =>
+          Pressed({
+            pointerId: message.pointerId,
+            startX: message.x,
+            startY: message.y,
+          }),
+        ),
+      },
+    },
+  },
+})
+
+// TESTS
+
+describe('drag gesture machine', () => {
+  it('treats press then release with no movement as a tap', () => {
+    const [pressed] = gestureMachine.transition(
+      Idle(),
+      PressedPointer({ pointerId: 1, x: 10, y: 10 }),
+    )
+    expect(pressed).toStrictEqual(
+      Pressed({ pointerId: 1, startX: 10, startY: 10 }),
+    )
+
+    const [idle] = gestureMachine.transition(
+      pressed,
+      ReleasedPointer({ pointerId: 1 }),
+    )
+    expect(idle).toStrictEqual(Idle())
+  })
+
+  it('stays Pressed below the drag threshold', () => {
+    const pressed = Pressed({ pointerId: 1, startX: 0, startY: 0 })
+    const [stillPressed] = gestureMachine.transition(
+      pressed,
+      MovedPointer({ pointerId: 1, x: 3, y: 4 }),
+    )
+    expect(stillPressed).toBe(pressed)
+  })
+
+  it('starts dragging once the threshold is crossed', () => {
+    const [dragging] = gestureMachine.transition(
+      Pressed({ pointerId: 1, startX: 0, startY: 0 }),
+      MovedPointer({ pointerId: 1, x: 8, y: 0 }),
+    )
+    expect(dragging).toStrictEqual(
+      Dragging({
+        pointerId: 1,
+        startX: 0,
+        startY: 0,
+        currentX: 8,
+        currentY: 0,
+      }),
+    )
+  })
+
+  it('settles at the origin when the drag is cancelled', () => {
+    const [settling] = gestureMachine.transition(
+      Dragging({
+        pointerId: 1,
+        startX: 5,
+        startY: 5,
+        currentX: 50,
+        currentY: 50,
+      }),
+      CancelledPointer({ pointerId: 1 }),
+    )
+    expect(settling).toStrictEqual(Settling({ endX: 5, endY: 5 }))
+  })
+
+  it('lets a new press interrupt the settle animation', () => {
+    const [pressed] = gestureMachine.transition(
+      Settling({ endX: 5, endY: 5 }),
+      PressedPointer({ pointerId: 2, x: 5, y: 5 }),
+    )
+    expect(pressed).toStrictEqual(
+      Pressed({ pointerId: 2, startX: 5, startY: 5 }),
+    )
+  })
+
+  it('ignores events from other pointers in every active state', () => {
+    const otherPointerMessages: ReadonlyArray<GestureMessage> = [
+      MovedPointer({ pointerId: 2, x: 100, y: 100 }),
+      ReleasedPointer({ pointerId: 2 }),
+      CancelledPointer({ pointerId: 2 }),
+    ]
+    const activeStates: ReadonlyArray<GestureState> = [
+      Pressed({ pointerId: 1, startX: 0, startY: 0 }),
+      Dragging({
+        pointerId: 1,
+        startX: 0,
+        startY: 0,
+        currentX: 10,
+        currentY: 10,
+      }),
+    ]
+
+    for (const state of activeStates) {
+      for (const message of otherPointerMessages) {
+        expect(gestureMachine.step(state, message)._tag).toBe('Ignored')
+      }
+    }
+  })
+
+  it('decides every cell of the state and message matrix explicitly', () => {
+    const sampleMessages: ReadonlyArray<GestureMessage> = [
+      PressedPointer({ pointerId: 1, x: 0, y: 0 }),
+      MovedPointer({ pointerId: 1, x: 20, y: 0 }),
+      ReleasedPointer({ pointerId: 1 }),
+      CancelledPointer({ pointerId: 1 }),
+      CompletedSettle(),
+    ]
+
+    const transitionedTags = (state: GestureState): ReadonlyArray<string> =>
+      pipe(
+        sampleMessages,
+        Array.filter(
+          message =>
+            gestureMachine.step(state, message)._tag === 'Transitioned',
+        ),
+        Array.map(message => message._tag),
+      )
+
+    expect(transitionedTags(Idle())).toEqual(['PressedPointer'])
+    expect(
+      transitionedTags(Pressed({ pointerId: 1, startX: 0, startY: 0 })),
+    ).toEqual(['MovedPointer', 'ReleasedPointer', 'CancelledPointer'])
+    expect(
+      transitionedTags(
+        Dragging({
+          pointerId: 1,
+          startX: 0,
+          startY: 0,
+          currentX: 1,
+          currentY: 1,
+        }),
+      ),
+    ).toEqual(['MovedPointer', 'ReleasedPointer', 'CancelledPointer'])
+    expect(transitionedTags(Settling({ endX: 0, endY: 0 }))).toEqual([
+      'PressedPointer',
+      'CompletedSettle',
+    ])
+  })
+
+  it('ignores a release that arrives in Idle', () => {
+    const result = gestureMachine.step(
+      Idle(),
+      ReleasedPointer({ pointerId: 1 }),
+    )
+    expect(result._tag).toBe('Ignored')
+  })
+})

--- a/packages/foldkit/src/statechart/examples/resumableUpload.md
+++ b/packages/foldkit/src/statechart/examples/resumableUpload.md
@@ -1,0 +1,46 @@
+# Resumable Upload Protocol
+
+Code: `resumableUpload.test.ts` (`Idle | Creating | Uploading | Paused |
+Completing | Done | Failed`, a chunked upload with pause and resume).
+
+## The problem this solves
+
+Protocol clients have a precise notion of legality: the server's responses
+are only meaningful relative to where the client believes it is. The bug
+class is "we accepted message X in state Y": a duplicate chunk
+acknowledgement advancing the cursor twice, an acknowledgement for a chunk
+the client never sent, a response racing a pause and mutating state the
+pause was supposed to freeze. Hand-written update code tends to encode the
+happy path and treat the rest as unreachable, which the network disproves.
+
+## What the machine buys
+
+- Legality is the table. `SucceededChunk` only matters in `Uploading`, and
+  only when `message.chunkIndex === state.nextChunkIndex`. Duplicates,
+  out-of-order acks, and acks from the future are all `Ignored`, asserted
+  directly in the tests.
+- The pause race is an explicit absent cell. `Paused` has no entry for
+  `SucceededChunk`, so an acknowledgement that arrives after the user paused
+  does not advance the cursor, and resume re-requests the same chunk. In
+  hand-written code this behavior would be an accident of branch ordering;
+  here it is a visible, reviewable decision (and changing the policy is
+  adding one edge).
+- The Commands attached to edges are the protocol's outbound actions, and
+  because Commands carry their `args` as data, the test asserts the full
+  request sequence (`CreateUpload`, `UploadChunk(0..2)`, `CompleteUpload`)
+  step by step without mocking a transport. The machine plus its commands
+  is effectively an executable sequence diagram.
+- The advance-or-complete decision is an ordered guard pair on one message,
+  mirroring how the spec would phrase it: more chunks means upload the next,
+  last chunk means finalize.
+
+## Honest limits
+
+- Resume re-uploads the chunk that was in flight at pause time, which
+  assumes chunk uploads are idempotent on the server. That assumption lives
+  in the protocol, not the machine; the table just makes it visible.
+- No timeout handling is shown. A real client would run a Subscription gated
+  on the `Uploading` tag that dispatches a timeout Message, exactly like the
+  backoff timer in the main spike's integration sketch.
+- The fake Commands resolve synchronously; real ones need the services
+  channel (`R`) the spike has not added.

--- a/packages/foldkit/src/statechart/examples/resumableUpload.test.ts
+++ b/packages/foldkit/src/statechart/examples/resumableUpload.test.ts
@@ -1,0 +1,328 @@
+import { Effect, Schema as S } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import * as Command from '../../command/public.js'
+import { m, ts } from '../../schema/index.js'
+import { defineMachine, to, when } from '../statechart.js'
+
+// STATE
+
+const Idle = ts('Idle')
+const Creating = ts('Creating', { totalChunks: S.Number })
+const Uploading = ts('Uploading', {
+  uploadId: S.String,
+  nextChunkIndex: S.Number,
+  totalChunks: S.Number,
+})
+const Paused = ts('Paused', {
+  uploadId: S.String,
+  nextChunkIndex: S.Number,
+  totalChunks: S.Number,
+})
+const Completing = ts('Completing', { uploadId: S.String })
+const Done = ts('Done', { uploadId: S.String })
+const Failed = ts('Failed', { reason: S.String })
+
+const UploadState = S.Union([
+  Idle,
+  Creating,
+  Uploading,
+  Paused,
+  Completing,
+  Done,
+  Failed,
+])
+type UploadState = typeof UploadState.Type
+
+// MESSAGE
+
+const ClickedUpload = m('ClickedUpload', { totalChunks: S.Number })
+const SucceededCreate = m('SucceededCreate', { uploadId: S.String })
+const FailedCreate = m('FailedCreate', { reason: S.String })
+const SucceededChunk = m('SucceededChunk', { chunkIndex: S.Number })
+const FailedChunk = m('FailedChunk', { chunkIndex: S.Number, reason: S.String })
+const ClickedPause = m('ClickedPause')
+const ClickedResume = m('ClickedResume')
+const SucceededComplete = m('SucceededComplete')
+const FailedComplete = m('FailedComplete', { reason: S.String })
+
+const UploadMessage = S.Union([
+  ClickedUpload,
+  SucceededCreate,
+  FailedCreate,
+  SucceededChunk,
+  FailedChunk,
+  ClickedPause,
+  ClickedResume,
+  SucceededComplete,
+  FailedComplete,
+])
+type UploadMessage = typeof UploadMessage.Type
+
+// COMMAND
+
+const CreateUpload = Command.define(
+  'CreateUpload',
+  { totalChunks: S.Number },
+  SucceededCreate,
+  FailedCreate,
+)(() => Effect.succeed(SucceededCreate({ uploadId: 'upload-1' })))
+
+const UploadChunk = Command.define(
+  'UploadChunk',
+  { uploadId: S.String, chunkIndex: S.Number },
+  SucceededChunk,
+  FailedChunk,
+)(({ chunkIndex }) => Effect.succeed(SucceededChunk({ chunkIndex })))
+
+const CompleteUpload = Command.define(
+  'CompleteUpload',
+  { uploadId: S.String },
+  SucceededComplete,
+  FailedComplete,
+)(() => Effect.succeed(SucceededComplete()))
+
+// MACHINE
+
+const uploadMachine = defineMachine({
+  state: UploadState,
+  message: UploadMessage,
+})({
+  initial: Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedUpload: to(
+          'Creating',
+          (_state, message) => Creating({ totalChunks: message.totalChunks }),
+          (_state, message) => [
+            CreateUpload({ totalChunks: message.totalChunks }),
+          ],
+        ),
+      },
+    },
+    Creating: {
+      on: {
+        SucceededCreate: to(
+          'Uploading',
+          (state, message) =>
+            Uploading({
+              uploadId: message.uploadId,
+              nextChunkIndex: 0,
+              totalChunks: state.totalChunks,
+            }),
+          (_state, message) => [
+            UploadChunk({ uploadId: message.uploadId, chunkIndex: 0 }),
+          ],
+        ),
+        FailedCreate: to('Failed', (_state, message) =>
+          Failed({ reason: message.reason }),
+        ),
+      },
+    },
+    Uploading: {
+      on: {
+        SucceededChunk: [
+          when(
+            (state, message) =>
+              message.chunkIndex === state.nextChunkIndex &&
+              state.nextChunkIndex + 1 < state.totalChunks,
+            to(
+              'Uploading',
+              state =>
+                Uploading({
+                  uploadId: state.uploadId,
+                  nextChunkIndex: state.nextChunkIndex + 1,
+                  totalChunks: state.totalChunks,
+                }),
+              state => [
+                UploadChunk({
+                  uploadId: state.uploadId,
+                  chunkIndex: state.nextChunkIndex + 1,
+                }),
+              ],
+            ),
+          ),
+          when(
+            (state, message) => message.chunkIndex === state.nextChunkIndex,
+            to(
+              'Completing',
+              state => Completing({ uploadId: state.uploadId }),
+              state => [CompleteUpload({ uploadId: state.uploadId })],
+            ),
+          ),
+        ],
+        FailedChunk: [
+          when(
+            (state, message) => message.chunkIndex === state.nextChunkIndex,
+            to('Failed', (_state, message) =>
+              Failed({ reason: message.reason }),
+            ),
+          ),
+        ],
+        ClickedPause: to('Paused', state =>
+          Paused({
+            uploadId: state.uploadId,
+            nextChunkIndex: state.nextChunkIndex,
+            totalChunks: state.totalChunks,
+          }),
+        ),
+      },
+    },
+    Paused: {
+      on: {
+        ClickedResume: to(
+          'Uploading',
+          state =>
+            Uploading({
+              uploadId: state.uploadId,
+              nextChunkIndex: state.nextChunkIndex,
+              totalChunks: state.totalChunks,
+            }),
+          state => [
+            UploadChunk({
+              uploadId: state.uploadId,
+              chunkIndex: state.nextChunkIndex,
+            }),
+          ],
+        ),
+      },
+    },
+    Completing: {
+      on: {
+        SucceededComplete: to('Done', state =>
+          Done({ uploadId: state.uploadId }),
+        ),
+        FailedComplete: to('Failed', (_state, message) =>
+          Failed({ reason: message.reason }),
+        ),
+      },
+    },
+    Failed: {
+      on: {
+        ClickedUpload: to(
+          'Creating',
+          (_state, message) => Creating({ totalChunks: message.totalChunks }),
+          (_state, message) => [
+            CreateUpload({ totalChunks: message.totalChunks }),
+          ],
+        ),
+      },
+    },
+  },
+})
+
+// TESTS
+
+describe('resumable upload protocol', () => {
+  it('emits the protocol commands step by step for a three chunk upload', () => {
+    const [creating, createCommands] = uploadMachine.transition(
+      Idle(),
+      ClickedUpload({ totalChunks: 3 }),
+    )
+    expect(creating).toStrictEqual(Creating({ totalChunks: 3 }))
+    expect(createCommands.map(command => command.name)).toEqual([
+      'CreateUpload',
+    ])
+
+    const [uploadingFirst, firstChunkCommands] = uploadMachine.transition(
+      creating,
+      SucceededCreate({ uploadId: 'u1' }),
+    )
+    expect(uploadingFirst).toStrictEqual(
+      Uploading({ uploadId: 'u1', nextChunkIndex: 0, totalChunks: 3 }),
+    )
+    expect(firstChunkCommands.map(command => command.args)).toEqual([
+      { uploadId: 'u1', chunkIndex: 0 },
+    ])
+
+    const [uploadingSecond, secondChunkCommands] = uploadMachine.transition(
+      uploadingFirst,
+      SucceededChunk({ chunkIndex: 0 }),
+    )
+    expect(uploadingSecond).toStrictEqual(
+      Uploading({ uploadId: 'u1', nextChunkIndex: 1, totalChunks: 3 }),
+    )
+    expect(secondChunkCommands.map(command => command.args)).toEqual([
+      { uploadId: 'u1', chunkIndex: 1 },
+    ])
+
+    const [uploadingThird] = uploadMachine.transition(
+      uploadingSecond,
+      SucceededChunk({ chunkIndex: 1 }),
+    )
+
+    const [completing, completeCommands] = uploadMachine.transition(
+      uploadingThird,
+      SucceededChunk({ chunkIndex: 2 }),
+    )
+    expect(completing).toStrictEqual(Completing({ uploadId: 'u1' }))
+    expect(completeCommands.map(command => command.name)).toEqual([
+      'CompleteUpload',
+    ])
+
+    const [done] = uploadMachine.transition(completing, SucceededComplete())
+    expect(done).toStrictEqual(Done({ uploadId: 'u1' }))
+  })
+
+  it('ignores duplicate and out of order chunk acknowledgements', () => {
+    const uploading = Uploading({
+      uploadId: 'u1',
+      nextChunkIndex: 2,
+      totalChunks: 5,
+    })
+
+    const duplicate = uploadMachine.step(
+      uploading,
+      SucceededChunk({ chunkIndex: 0 }),
+    )
+    expect(duplicate._tag).toBe('Ignored')
+
+    const fromTheFuture = uploadMachine.step(
+      uploading,
+      SucceededChunk({ chunkIndex: 3 }),
+    )
+    expect(fromTheFuture._tag).toBe('Ignored')
+  })
+
+  it('does not advance the cursor when an acknowledgement races a pause', () => {
+    const paused = Paused({ uploadId: 'u1', nextChunkIndex: 2, totalChunks: 5 })
+
+    const racedAcknowledgement = uploadMachine.step(
+      paused,
+      SucceededChunk({ chunkIndex: 2 }),
+    )
+    expect(racedAcknowledgement._tag).toBe('Ignored')
+
+    const [resumed, resumeCommands] = uploadMachine.transition(
+      paused,
+      ClickedResume(),
+    )
+    expect(resumed).toStrictEqual(
+      Uploading({ uploadId: 'u1', nextChunkIndex: 2, totalChunks: 5 }),
+    )
+    expect(resumeCommands.map(command => command.args)).toEqual([
+      { uploadId: 'u1', chunkIndex: 2 },
+    ])
+  })
+
+  it('fails only on the chunk currently in flight', () => {
+    const uploading = Uploading({
+      uploadId: 'u1',
+      nextChunkIndex: 2,
+      totalChunks: 5,
+    })
+
+    const staleFailure = uploadMachine.step(
+      uploading,
+      FailedChunk({ chunkIndex: 1, reason: 'timeout' }),
+    )
+    expect(staleFailure._tag).toBe('Ignored')
+
+    const [failed] = uploadMachine.transition(
+      uploading,
+      FailedChunk({ chunkIndex: 2, reason: 'timeout' }),
+    )
+    expect(failed).toStrictEqual(Failed({ reason: 'timeout' }))
+  })
+})

--- a/packages/foldkit/src/statechart/examples/rowSync.md
+++ b/packages/foldkit/src/statechart/examples/rowSync.md
@@ -1,0 +1,54 @@
+# Per-Row Sync (One Machine, Many Instances)
+
+Code: `rowSync.test.ts` (`Synced | Editing | Saving | Conflict` per row,
+mapped over a table of rows).
+
+## The problem this solves
+
+Per-entity lifecycle state (save status per row, upload status per file,
+membership status per participant) is the state that most reliably smears
+across a hand-written `update` over time. Each new message handler
+re-implements "find the row, check what state it is in, decide whether this
+applies", and the conflict-handling rules end up duplicated and slightly
+different per branch.
+
+## What the machine buys
+
+This is where the cost argument flips. The fixed costs of the table
+(vocabulary, two-stage define) are paid once, while every instance gets the
+benefits:
+
+- The machine is defined once and applied per row with a plain
+  `Array.map`; `transition` is just a function. The app-side glue is the
+  ~15 line `applyRowMessage` helper: find the row, transition its `sync`
+  field with `evo`, and lift the row's Commands into the table's Message
+  with `Command.mapMessages` so results route back to the same row. That is
+  the standard Submodel wiring, with the machine sitting where the child
+  `update` would.
+- Routing correctness is testable end to end: the test runs the emitted
+  `SaveRow` Command and asserts the result comes back as
+  `GotRowMessage({ rowId: '2', ... })`, already addressed to the row that
+  initiated it.
+- Per-row staleness is pruned the same way as in the autosave example: a
+  `SucceededSave` aimed at a row that is `Synced` is a no-op for that row,
+  with no per-branch guards in the app's `update`.
+- Analysis amortizes. `unreachableStates` and `deadTransitions` run once
+  against the definition and certify the lifecycle for every row that will
+  ever exist, which no amount of per-instance testing of a hand-written
+  `update` gives you.
+- The conflict flow (`Conflict` with keep-mine re-saving against the new
+  baseline versus take-theirs adopting the server value) is four edges, and
+  both resolutions are forced to produce a legal next state.
+
+## Honest limits
+
+- Message routing by row id is app code, not machine code; the machine knows
+  nothing about collections. A real module might ship a `forEntity` helper,
+  but the spike deliberately keeps the machine ignorant of where its state
+  lives.
+- All rows share one Message union, so a row's messages must be wrapped
+  (`GotRowMessage`) to carry the id. That is ordinary Foldkit practice but
+  worth naming as a requirement.
+- There is no cross-row coordination (for example "only one row may be
+  Editing"). That is parent-level state and belongs in the parent's
+  `update`, not in the per-row machine.

--- a/packages/foldkit/src/statechart/examples/rowSync.test.ts
+++ b/packages/foldkit/src/statechart/examples/rowSync.test.ts
@@ -1,0 +1,238 @@
+import { Array, Effect, Match as M, Schema as S } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import * as Command from '../../command/public.js'
+import { m, ts } from '../../schema/index.js'
+import { evo } from '../../struct/index.js'
+import { defineMachine, to } from '../statechart.js'
+
+// STATE
+
+const Synced = ts('Synced', { value: S.String })
+const Editing = ts('Editing', { baseline: S.String, draft: S.String })
+const Saving = ts('Saving', { baseline: S.String, draft: S.String })
+const Conflict = ts('Conflict', { draft: S.String, serverValue: S.String })
+
+const RowSyncState = S.Union([Synced, Editing, Saving, Conflict])
+type RowSyncState = typeof RowSyncState.Type
+
+// MESSAGE
+
+const StartedEditing = m('StartedEditing')
+const ChangedDraft = m('ChangedDraft', { draft: S.String })
+const ClickedSave = m('ClickedSave')
+const SucceededSave = m('SucceededSave')
+const FailedSaveConflict = m('FailedSaveConflict', { serverValue: S.String })
+const ClickedKeepMine = m('ClickedKeepMine')
+const ClickedTakeTheirs = m('ClickedTakeTheirs')
+
+const RowSyncMessage = S.Union([
+  StartedEditing,
+  ChangedDraft,
+  ClickedSave,
+  SucceededSave,
+  FailedSaveConflict,
+  ClickedKeepMine,
+  ClickedTakeTheirs,
+])
+type RowSyncMessage = typeof RowSyncMessage.Type
+
+// COMMAND
+
+const SaveRow = Command.define(
+  'SaveRow',
+  { draft: S.String },
+  SucceededSave,
+  FailedSaveConflict,
+)(() => Effect.succeed(SucceededSave()))
+
+// MACHINE
+
+const rowSyncMachine = defineMachine({
+  state: RowSyncState,
+  message: RowSyncMessage,
+})({
+  initial: Synced({ value: '' }),
+  states: {
+    Synced: {
+      on: {
+        StartedEditing: to('Editing', state =>
+          Editing({ baseline: state.value, draft: state.value }),
+        ),
+      },
+    },
+    Editing: {
+      on: {
+        ChangedDraft: to('Editing', (state, message) =>
+          Editing({ baseline: state.baseline, draft: message.draft }),
+        ),
+        ClickedSave: to(
+          'Saving',
+          state => Saving({ baseline: state.baseline, draft: state.draft }),
+          state => [SaveRow({ draft: state.draft })],
+        ),
+      },
+    },
+    Saving: {
+      on: {
+        SucceededSave: to('Synced', state => Synced({ value: state.draft })),
+        FailedSaveConflict: to('Conflict', (state, message) =>
+          Conflict({ draft: state.draft, serverValue: message.serverValue }),
+        ),
+      },
+    },
+    Conflict: {
+      on: {
+        ClickedKeepMine: to(
+          'Saving',
+          state => Saving({ baseline: state.serverValue, draft: state.draft }),
+          state => [SaveRow({ draft: state.draft })],
+        ),
+        ClickedTakeTheirs: to('Synced', state =>
+          Synced({ value: state.serverValue }),
+        ),
+      },
+    },
+  },
+})
+
+// APP
+
+const Row = S.Struct({ id: S.String, sync: RowSyncState })
+type Row = typeof Row.Type
+
+const TableModel = S.Struct({ rows: S.Array(Row) })
+type TableModel = typeof TableModel.Type
+
+const GotRowMessage = m('GotRowMessage', {
+  rowId: S.String,
+  message: RowSyncMessage,
+})
+
+const TableMessage = S.Union([GotRowMessage])
+type TableMessage = typeof TableMessage.Type
+
+type TableUpdateReturn = [
+  TableModel,
+  ReadonlyArray<Command.Command<TableMessage>>,
+]
+const withTableUpdateReturn = M.withReturnType<TableUpdateReturn>()
+
+const applyRowMessage = (
+  row: Row,
+  rowId: string,
+  rowMessage: RowSyncMessage,
+): [Row, ReadonlyArray<Command.Command<TableMessage>>] => {
+  if (row.id !== rowId) {
+    return [row, []]
+  }
+
+  const [nextSync, commands] = rowSyncMachine.transition(row.sync, rowMessage)
+
+  return [
+    evo(row, { sync: () => nextSync }),
+    Command.mapMessages(commands, message => GotRowMessage({ rowId, message })),
+  ]
+}
+
+const update = (model: TableModel, message: TableMessage): TableUpdateReturn =>
+  M.value(message).pipe(
+    withTableUpdateReturn,
+    M.tagsExhaustive({
+      GotRowMessage: ({ rowId, message: rowMessage }) => {
+        const rowUpdates = Array.map(model.rows, row =>
+          applyRowMessage(row, rowId, rowMessage),
+        )
+
+        return [
+          evo(model, { rows: () => Array.map(rowUpdates, ([row]) => row) }),
+          Array.flatMap(rowUpdates, ([_row, rowCommands]) => rowCommands),
+        ]
+      },
+    }),
+  )
+
+// TESTS
+
+describe('per row sync machine', () => {
+  const model: TableModel = {
+    rows: [
+      { id: '1', sync: Synced({ value: 'alpha' }) },
+      { id: '2', sync: Editing({ baseline: 'beta', draft: 'beta 2' }) },
+      { id: '3', sync: Conflict({ draft: 'mine', serverValue: 'theirs' }) },
+    ],
+  }
+
+  it('transitions only the addressed row and leaves the rest untouched', () => {
+    const [nextModel] = update(
+      model,
+      GotRowMessage({ rowId: '2', message: ClickedSave() }),
+    )
+
+    expect(nextModel.rows.map(row => row.sync._tag)).toEqual([
+      'Synced',
+      'Saving',
+      'Conflict',
+    ])
+    expect(Array.get(nextModel.rows, 0)).toEqual(Array.get(model.rows, 0))
+    expect(Array.get(nextModel.rows, 2)).toEqual(Array.get(model.rows, 2))
+  })
+
+  it('routes row commands back through the row envelope', () => {
+    const [, commands] = update(
+      model,
+      GotRowMessage({ rowId: '2', message: ClickedSave() }),
+    )
+
+    expect(commands.map(command => command.name)).toEqual(['SaveRow'])
+
+    const resultMessages = commands.map(command =>
+      Effect.runSync(command.effect),
+    )
+    expect(resultMessages).toEqual([
+      GotRowMessage({ rowId: '2', message: SucceededSave() }),
+    ])
+  })
+
+  it('ignores a row message that does not apply to that row state', () => {
+    const [nextModel, commands] = update(
+      model,
+      GotRowMessage({ rowId: '1', message: SucceededSave() }),
+    )
+
+    expect(nextModel.rows.map(row => row.sync)).toEqual(
+      model.rows.map(row => row.sync),
+    )
+    expect(commands).toEqual([])
+  })
+
+  it('resolves a conflict either way', () => {
+    const conflict = Conflict({ draft: 'mine', serverValue: 'theirs' })
+
+    const [keptMine, retryCommands] = rowSyncMachine.transition(
+      conflict,
+      ClickedKeepMine(),
+    )
+    expect(keptMine).toStrictEqual(
+      Saving({ baseline: 'theirs', draft: 'mine' }),
+    )
+    expect(retryCommands.map(command => command.name)).toEqual(['SaveRow'])
+
+    const [tookTheirs] = rowSyncMachine.transition(
+      conflict,
+      ClickedTakeTheirs(),
+    )
+    expect(tookTheirs).toStrictEqual(Synced({ value: 'theirs' }))
+  })
+
+  it('amortizes one definition and one analysis across every row', () => {
+    expect(rowSyncMachine.stateTags).toEqual([
+      'Synced',
+      'Editing',
+      'Saving',
+      'Conflict',
+    ])
+    expect(rowSyncMachine.unreachableStates()).toEqual([])
+    expect(rowSyncMachine.deadTransitions()).toEqual([])
+  })
+})

--- a/packages/foldkit/src/statechart/examples/staleAsyncPruning.md
+++ b/packages/foldkit/src/statechart/examples/staleAsyncPruning.md
@@ -1,0 +1,48 @@
+# Stale Async Pruning
+
+Code: `staleAsyncPruning.test.ts` (an autosave editor: `Viewing | Editing |
+Saving | SaveFailed`).
+
+## The problem this solves
+
+The classic Elm-architecture bug is a completion Message arriving for work
+the user already abandoned. A `SucceededSave` lands after the user cancelled,
+navigated away, or kicked off a retry, and a `Match` branch in a hand-written
+`update` happily writes the stale result into the Model. The usual defense is
+a request id check repeated inside every async result branch, and the bug
+returns whenever someone adds a branch and forgets the check.
+
+## What the machine buys
+
+Two distinct layers of pruning, both visible in the table rather than
+scattered through `update`:
+
+1. Cross-state staleness is pruned by topology. `Saving` is the only state
+   with an edge for `SucceededSave`, so a success arriving in `Viewing`
+   (after a cancel) cannot be handled by any code path. There is nothing to
+   forget. The test asserts the `step` result is
+   `Ignored { stateTag: 'Viewing', messageTag: 'SucceededSave' }`, which is
+   exactly the log line you want in development.
+2. Same-state staleness (a success from attempt 1 arriving while attempt 2
+   is in flight) still needs a generation token, but the check lives in one
+   place: a `when` guard comparing `message.attempt` to `state.attempt`. The
+   guard list has no `otherwise`, so a mismatched attempt is `Ignored`,
+   observable, and provably cannot reach the build function.
+
+A third effect falls out for free: `ChangedDraft` has no edge from `Saving`,
+so edits during a save are dropped explicitly rather than silently merged
+into a Model that is about to be overwritten. Whether to drop or buffer them
+is a product decision, but the table forces the decision to be made and makes
+the current answer readable.
+
+## Honest limits
+
+- The machine does not eliminate the generation token; `attempt` still lives
+  in `Saving` and rides along on the result Messages. What it eliminates is
+  the scattering of the comparison.
+- Dropping `ChangedDraft` during `Saving` is the simple policy. Buffering
+  keystrokes during a save would need an extra field on `Saving` and a
+  self-edge, at which point the table grows like any other code.
+- The fake `SaveDraft` Command resolves synchronously for the test. A real
+  one is an RPC, which needs the services channel (`R`) the spike has not
+  added yet.

--- a/packages/foldkit/src/statechart/examples/staleAsyncPruning.test.ts
+++ b/packages/foldkit/src/statechart/examples/staleAsyncPruning.test.ts
@@ -1,0 +1,216 @@
+import { Effect, Schema as S } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import * as Command from '../../command/public.js'
+import { m, ts } from '../../schema/index.js'
+import { defineMachine, to, when } from '../statechart.js'
+
+// STATE
+
+const Viewing = ts('Viewing', { savedText: S.String })
+const Editing = ts('Editing', { savedText: S.String, draft: S.String })
+const Saving = ts('Saving', {
+  savedText: S.String,
+  draft: S.String,
+  attempt: S.Number,
+})
+const SaveFailed = ts('SaveFailed', {
+  savedText: S.String,
+  draft: S.String,
+  attempt: S.Number,
+  reason: S.String,
+})
+
+const EditorState = S.Union([Viewing, Editing, Saving, SaveFailed])
+type EditorState = typeof EditorState.Type
+
+// MESSAGE
+
+const StartedEditing = m('StartedEditing')
+const ChangedDraft = m('ChangedDraft', { draft: S.String })
+const ClickedSave = m('ClickedSave')
+const ClickedCancel = m('ClickedCancel')
+const ClickedRetry = m('ClickedRetry')
+const SucceededSave = m('SucceededSave', { attempt: S.Number })
+const FailedSave = m('FailedSave', { attempt: S.Number, reason: S.String })
+
+const EditorMessage = S.Union([
+  StartedEditing,
+  ChangedDraft,
+  ClickedSave,
+  ClickedCancel,
+  ClickedRetry,
+  SucceededSave,
+  FailedSave,
+])
+type EditorMessage = typeof EditorMessage.Type
+
+// COMMAND
+
+const SaveDraft = Command.define(
+  'SaveDraft',
+  { draft: S.String, attempt: S.Number },
+  SucceededSave,
+  FailedSave,
+)(({ attempt }) => Effect.succeed(SucceededSave({ attempt })))
+
+// MACHINE
+
+const editorMachine = defineMachine({
+  state: EditorState,
+  message: EditorMessage,
+})({
+  initial: Viewing({ savedText: '' }),
+  states: {
+    Viewing: {
+      on: {
+        StartedEditing: to('Editing', state =>
+          Editing({ savedText: state.savedText, draft: state.savedText }),
+        ),
+      },
+    },
+    Editing: {
+      on: {
+        ChangedDraft: to('Editing', (state, message) =>
+          Editing({ savedText: state.savedText, draft: message.draft }),
+        ),
+        ClickedCancel: to('Viewing', state =>
+          Viewing({ savedText: state.savedText }),
+        ),
+        ClickedSave: to(
+          'Saving',
+          state =>
+            Saving({
+              savedText: state.savedText,
+              draft: state.draft,
+              attempt: 1,
+            }),
+          state => [SaveDraft({ draft: state.draft, attempt: 1 })],
+        ),
+      },
+    },
+    Saving: {
+      on: {
+        SucceededSave: [
+          when(
+            (state, message) => message.attempt === state.attempt,
+            to('Viewing', state => Viewing({ savedText: state.draft })),
+          ),
+        ],
+        FailedSave: [
+          when(
+            (state, message) => message.attempt === state.attempt,
+            to('SaveFailed', (state, message) =>
+              SaveFailed({
+                savedText: state.savedText,
+                draft: state.draft,
+                attempt: state.attempt,
+                reason: message.reason,
+              }),
+            ),
+          ),
+        ],
+      },
+    },
+    SaveFailed: {
+      on: {
+        ClickedRetry: to(
+          'Saving',
+          state =>
+            Saving({
+              savedText: state.savedText,
+              draft: state.draft,
+              attempt: state.attempt + 1,
+            }),
+          state => [
+            SaveDraft({ draft: state.draft, attempt: state.attempt + 1 }),
+          ],
+        ),
+        ClickedCancel: to('Viewing', state =>
+          Viewing({ savedText: state.savedText }),
+        ),
+      },
+    },
+  },
+})
+
+// TESTS
+
+describe('stale async pruning', () => {
+  it('saves the draft on the happy path', () => {
+    const [saving, commands] = editorMachine.transition(
+      Editing({ savedText: 'old', draft: 'new' }),
+      ClickedSave(),
+    )
+    expect(saving).toStrictEqual(
+      Saving({ savedText: 'old', draft: 'new', attempt: 1 }),
+    )
+    expect(commands.map(command => command.name)).toEqual(['SaveDraft'])
+
+    const [viewing] = editorMachine.transition(
+      saving,
+      SucceededSave({ attempt: 1 }),
+    )
+    expect(viewing).toStrictEqual(Viewing({ savedText: 'new' }))
+  })
+
+  it('drops a success that arrives after the user cancelled', () => {
+    const viewing = Viewing({ savedText: 'old' })
+    const result = editorMachine.step(viewing, SucceededSave({ attempt: 1 }))
+
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Viewing',
+      messageTag: 'SucceededSave',
+      state: viewing,
+    })
+  })
+
+  it('drops a success from a superseded attempt while a retry is in flight', () => {
+    const saving = Saving({ savedText: 'old', draft: 'new', attempt: 2 })
+
+    const staleResult = editorMachine.step(
+      saving,
+      SucceededSave({ attempt: 1 }),
+    )
+    expect(staleResult._tag).toBe('Ignored')
+
+    const [viewing] = editorMachine.transition(
+      saving,
+      SucceededSave({ attempt: 2 }),
+    )
+    expect(viewing).toStrictEqual(Viewing({ savedText: 'new' }))
+  })
+
+  it('routes a failure into retry with an incremented attempt', () => {
+    const [failed] = editorMachine.transition(
+      Saving({ savedText: 'old', draft: 'new', attempt: 1 }),
+      FailedSave({ attempt: 1, reason: 'offline' }),
+    )
+    expect(failed).toStrictEqual(
+      SaveFailed({
+        savedText: 'old',
+        draft: 'new',
+        attempt: 1,
+        reason: 'offline',
+      }),
+    )
+
+    const [retrying, commands] = editorMachine.transition(
+      failed,
+      ClickedRetry(),
+    )
+    expect(retrying).toStrictEqual(
+      Saving({ savedText: 'old', draft: 'new', attempt: 2 }),
+    )
+    expect(commands.map(command => command.args)).toEqual([
+      { draft: 'new', attempt: 2 },
+    ])
+  })
+
+  it('drops edits that arrive while a save is in flight', () => {
+    const saving = Saving({ savedText: 'old', draft: 'new', attempt: 1 })
+    const result = editorMachine.step(saving, ChangedDraft({ draft: 'newer' }))
+    expect(result._tag).toBe('Ignored')
+  })
+})

--- a/packages/foldkit/src/statechart/index.ts
+++ b/packages/foldkit/src/statechart/index.ts
@@ -1,0 +1,1 @@
+export * from './statechart.js'

--- a/packages/foldkit/src/statechart/statechart.test.ts
+++ b/packages/foldkit/src/statechart/statechart.test.ts
@@ -1,0 +1,715 @@
+import {
+  Duration,
+  Effect,
+  Match as M,
+  Option,
+  Schema as S,
+  Stream,
+} from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import * as Command from '../command/public.js'
+import * as ManagedResource from '../managedResource/public.js'
+import { m, ts } from '../schema/index.js'
+import { evo } from '../struct/index.js'
+import * as Subscription from '../subscription/public.js'
+import { defineMachine, otherwise, to, when } from './statechart.js'
+
+// REMOTE DATA
+
+const Idle = ts('Idle')
+const Loading = ts('Loading')
+const Error = ts('Error', { error: S.String })
+const Ok = ts('Ok', { data: S.String })
+
+const RemoteData = S.Union([Idle, Loading, Error, Ok])
+type RemoteData = typeof RemoteData.Type
+
+const ClickedFetch = m('ClickedFetch')
+const SucceededFetch = m('SucceededFetch', { data: S.String })
+const FailedFetch = m('FailedFetch', { error: S.String })
+const ClickedRetry = m('ClickedRetry')
+
+const RemoteDataMessage = S.Union([
+  ClickedFetch,
+  SucceededFetch,
+  FailedFetch,
+  ClickedRetry,
+])
+type RemoteDataMessage = typeof RemoteDataMessage.Type
+
+const remoteDataMachine = defineMachine({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: to('Loading', () => Loading()),
+      },
+    },
+    Loading: {
+      on: {
+        SucceededFetch: to('Ok', (_state, message) =>
+          Ok({ data: message.data }),
+        ),
+        FailedFetch: to('Error', (_state, message) =>
+          Error({ error: message.error }),
+        ),
+      },
+    },
+    Error: {
+      on: {
+        ClickedRetry: to('Loading', () => Loading()),
+      },
+    },
+    Ok: {
+      on: {
+        ClickedFetch: to('Loading', () => Loading()),
+      },
+    },
+  },
+})
+
+// CONNECTION
+
+const MAX_CONNECT_ATTEMPTS = 5
+const BASE_BACKOFF_DELAY_MILLIS = 250
+
+const backoffDelayMillis = (attemptCount: number): number =>
+  BASE_BACKOFF_DELAY_MILLIS * 2 ** (attemptCount - 1)
+
+const Disconnected = ts('Disconnected')
+const Connecting = ts('Connecting', { attemptCount: S.Number })
+const Connected = ts('Connected', { sessionId: S.String })
+const Reconnecting = ts('Reconnecting', {
+  attemptCount: S.Number,
+  delayMillis: S.Number,
+})
+const Failed = ts('Failed', { attemptCount: S.Number, reason: S.String })
+const Suspended = ts('Suspended')
+
+const ConnectionState = S.Union([
+  Disconnected,
+  Connecting,
+  Connected,
+  Reconnecting,
+  Failed,
+  Suspended,
+])
+type ConnectionState = typeof ConnectionState.Type
+
+const ClickedConnect = m('ClickedConnect')
+const ClickedDisconnect = m('ClickedDisconnect')
+const SocketOpened = m('SocketOpened', { sessionId: S.String })
+const SocketErrored = m('SocketErrored', { reason: S.String })
+const SocketClosed = m('SocketClosed', { reason: S.String })
+const TimedOutBackoff = m('TimedOutBackoff')
+const ReleasedSocket = m('ReleasedSocket')
+const CompletedLogTransition = m('CompletedLogTransition')
+
+const ConnectionMessage = S.Union([
+  ClickedConnect,
+  ClickedDisconnect,
+  SocketOpened,
+  SocketErrored,
+  SocketClosed,
+  TimedOutBackoff,
+  ReleasedSocket,
+  CompletedLogTransition,
+])
+type ConnectionMessage = typeof ConnectionMessage.Type
+
+const LogTransition = Command.define(
+  'LogTransition',
+  { description: S.String },
+  CompletedLogTransition,
+)(() => Effect.succeed(CompletedLogTransition()))
+
+const connectionMachine = defineMachine({
+  state: ConnectionState,
+  message: ConnectionMessage,
+})({
+  initial: Disconnected(),
+  states: {
+    Disconnected: {
+      on: {
+        ClickedConnect: to('Connecting', () => Connecting({ attemptCount: 1 })),
+      },
+    },
+    Connecting: {
+      on: {
+        SocketOpened: to(
+          'Connected',
+          (_state, message) => Connected({ sessionId: message.sessionId }),
+          (_state, message) => [
+            LogTransition({
+              description: `Opened session ${message.sessionId}`,
+            }),
+          ],
+        ),
+        SocketErrored: [
+          when(
+            state => state.attemptCount < MAX_CONNECT_ATTEMPTS,
+            to('Reconnecting', state =>
+              Reconnecting({
+                attemptCount: state.attemptCount,
+                delayMillis: backoffDelayMillis(state.attemptCount),
+              }),
+            ),
+          ),
+          otherwise(
+            to('Failed', (state, message) =>
+              Failed({
+                attemptCount: state.attemptCount,
+                reason: message.reason,
+              }),
+            ),
+          ),
+        ],
+      },
+    },
+    Connected: {
+      on: {
+        SocketClosed: to('Reconnecting', () =>
+          Reconnecting({
+            attemptCount: 1,
+            delayMillis: backoffDelayMillis(1),
+          }),
+        ),
+        ClickedDisconnect: to('Disconnected', () => Disconnected()),
+      },
+    },
+    Reconnecting: {
+      on: {
+        TimedOutBackoff: to('Connecting', state =>
+          Connecting({ attemptCount: state.attemptCount + 1 }),
+        ),
+        ClickedDisconnect: to('Disconnected', () => Disconnected()),
+      },
+    },
+    Failed: {
+      on: {
+        ClickedConnect: to('Connecting', () => Connecting({ attemptCount: 1 })),
+      },
+    },
+    Suspended: {
+      on: {
+        ClickedConnect: to('Connecting', () => Connecting({ attemptCount: 1 })),
+      },
+    },
+  },
+})
+
+// INTEGRATION
+
+const AppModel = S.Struct({
+  connection: ConnectionState,
+  isDebugPanelOpen: S.Boolean,
+})
+type AppModel = typeof AppModel.Type
+
+type AppUpdateReturn = [
+  AppModel,
+  ReadonlyArray<Command.Command<ConnectionMessage>>,
+]
+const withAppUpdateReturn = M.withReturnType<AppUpdateReturn>()
+
+const update = (model: AppModel, message: ConnectionMessage): AppUpdateReturn =>
+  M.value(message).pipe(
+    withAppUpdateReturn,
+    M.tag(
+      'ClickedConnect',
+      'ClickedDisconnect',
+      'SocketOpened',
+      'SocketErrored',
+      'SocketClosed',
+      'TimedOutBackoff',
+      connectionMessage => {
+        const [nextConnection, commands] = connectionMachine.transition(
+          model.connection,
+          connectionMessage,
+        )
+        return [evo(model, { connection: () => nextConnection }), commands]
+      },
+    ),
+    M.tag('ReleasedSocket', 'CompletedLogTransition', () => [model, []]),
+    M.exhaustive,
+  )
+
+// The Machine owns transitions only. Lifecycle effects stay in ordinary
+// primitives gated on the state tag. The socket is a ManagedResource that
+// exists while the Machine is in Connecting or Connected; its lifecycle
+// Messages feed the Machine: a successful open dispatches SocketOpened
+// (Connecting to Connected) and a failed open dispatches SocketErrored,
+// which drives the reconnect-or-fail guard.
+
+const SOCKET_URL = 'wss://example.test/socket'
+
+const Socket = ManagedResource.tag<WebSocket>()('Socket')
+
+const managedResources = ManagedResource.make<AppModel, ConnectionMessage>()(
+  entry => ({
+    socket: entry(S.Option(S.Null), {
+      resource: Socket,
+      modelToMaybeRequirements: model =>
+        M.value(model.connection).pipe(
+          M.tag('Connecting', 'Connected', () => Option.some(null)),
+          M.orElse(() => Option.none()),
+        ),
+      acquire: () =>
+        Effect.callback<WebSocket, string>(resume => {
+          const socket = new WebSocket(SOCKET_URL)
+          socket.addEventListener('open', () => resume(Effect.succeed(socket)))
+          socket.addEventListener('error', () =>
+            resume(Effect.fail('Socket failed to open')),
+          )
+        }),
+      release: socket => Effect.sync(() => socket.close()),
+      onAcquired: socket => SocketOpened({ sessionId: socket.url }),
+      onReleased: () => ReleasedSocket(),
+      onAcquireError: error => SocketErrored({ reason: String(error) }),
+    }),
+  }),
+)
+
+// The backoff timer is a Subscription gated on the Reconnecting tag: the
+// Stream sleeps for the state's delayMillis, emits TimedOutBackoff (driving
+// Reconnecting back to Connecting), and tears down whenever the Machine
+// leaves Reconnecting.
+
+const subscriptions = Subscription.make<AppModel, ConnectionMessage>()(
+  entry => ({
+    backoffTimer: entry(
+      { maybeDelayMillis: S.Option(S.Number) },
+      {
+        modelToDependencies: model => ({
+          maybeDelayMillis: M.value(model.connection).pipe(
+            M.tag('Reconnecting', ({ delayMillis }) =>
+              Option.some(delayMillis),
+            ),
+            M.orElse(() => Option.none()),
+          ),
+        }),
+        dependenciesToStream: ({ maybeDelayMillis }) =>
+          Option.match(maybeDelayMillis, {
+            onNone: () => Stream.empty,
+            onSome: delayMillis =>
+              Stream.fromEffect(
+                Effect.as(
+                  Effect.sleep(Duration.millis(delayMillis)),
+                  TimedOutBackoff(),
+                ),
+              ),
+          }),
+      },
+    ),
+  }),
+)
+
+// TYPE-LEVEL GUARANTEES
+
+const narrowingMachine = defineMachine({
+  state: ConnectionState,
+  message: ConnectionMessage,
+})({
+  initial: Disconnected(),
+  states: {
+    Connecting: {
+      on: {
+        SocketErrored: [
+          when(
+            (state, message) => {
+              const sourceTag: 'Connecting' = state._tag
+              const messageTag: 'SocketErrored' = message._tag
+              return sourceTag.length + messageTag.length > 0
+            },
+            to('Reconnecting', state =>
+              Reconnecting({
+                attemptCount: state.attemptCount,
+                delayMillis: backoffDelayMillis(state.attemptCount),
+              }),
+            ),
+          ),
+          otherwise(
+            to('Failed', (state, message) => {
+              const sourceTag: 'Connecting' = state._tag
+              const messageTag: 'SocketErrored' = message._tag
+              return Failed({
+                attemptCount: state.attemptCount,
+                reason: `${sourceTag} ${messageTag} ${message.reason}`,
+              })
+            }),
+          ),
+        ],
+      },
+    },
+  },
+})
+
+const wrongVariantMachine = defineMachine({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: Idle(),
+  states: {
+    Idle: {
+      on: {
+        // @ts-expect-error the build function must return the Loading variant named by the target tag
+        ClickedFetch: to('Loading', () => Idle()),
+      },
+    },
+  },
+})
+
+const wrongTargetTagMachine = defineMachine({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: Idle(),
+  states: {
+    Idle: {
+      on: {
+        // @ts-expect-error 'Loadingg' is not a state tag
+        ClickedFetch: to('Loadingg', () => Loading()),
+      },
+    },
+  },
+})
+
+const unknownStateTagMachine = defineMachine({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: Idle(),
+  states: {
+    // @ts-expect-error 'Idl' is not a state tag
+    Idl: {
+      on: {},
+    },
+  },
+})
+
+const unknownMessageTagMachine = defineMachine({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: Idle(),
+  states: {
+    Idle: {
+      on: {
+        // @ts-expect-error 'ClickedFetchh' is not a Message tag
+        ClickedFetchh: to('Loading', () => Loading()),
+      },
+    },
+  },
+})
+
+const shadowedGuardMachine = defineMachine({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: [
+          otherwise(to('Loading', () => Loading())),
+          when(
+            () => true,
+            to('Ok', () => Ok({ data: 'unreachable' })),
+          ),
+        ],
+      },
+    },
+  },
+})
+
+// TESTS
+
+describe('remote data machine', () => {
+  it('starts at the initial state with the full tag set from the Schema', () => {
+    expect(remoteDataMachine.initial).toStrictEqual(Idle())
+    expect(remoteDataMachine.stateTags).toEqual([
+      'Idle',
+      'Loading',
+      'Error',
+      'Ok',
+    ])
+  })
+
+  it('transitions along the obvious edges', () => {
+    const [loading] = remoteDataMachine.transition(Idle(), ClickedFetch())
+    expect(loading).toStrictEqual(Loading())
+
+    const [ok] = remoteDataMachine.transition(
+      Loading(),
+      SucceededFetch({ data: 'payload' }),
+    )
+    expect(ok).toStrictEqual(Ok({ data: 'payload' }))
+
+    const [errored] = remoteDataMachine.transition(
+      Loading(),
+      FailedFetch({ error: 'boom' }),
+    )
+    expect(errored).toStrictEqual(Error({ error: 'boom' }))
+
+    const [retrying] = remoteDataMachine.transition(
+      Error({ error: 'boom' }),
+      ClickedRetry(),
+    )
+    expect(retrying).toStrictEqual(Loading())
+  })
+
+  it('reports unmatched messages as Ignored without changing state', () => {
+    const idle = Idle()
+    const result = remoteDataMachine.step(idle, ClickedRetry())
+
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Idle',
+      messageTag: 'ClickedRetry',
+      state: Idle(),
+    })
+
+    const [unchanged, commands] = remoteDataMachine.transition(
+      idle,
+      ClickedRetry(),
+    )
+    expect(unchanged).toBe(idle)
+    expect(commands).toEqual([])
+  })
+
+  it('exposes the edge set as data', () => {
+    expect(remoteDataMachine.edges).toEqual([
+      {
+        from: 'Idle',
+        messageTag: 'ClickedFetch',
+        target: 'Loading',
+        guard: { _tag: 'Unguarded' },
+      },
+      {
+        from: 'Loading',
+        messageTag: 'SucceededFetch',
+        target: 'Ok',
+        guard: { _tag: 'Unguarded' },
+      },
+      {
+        from: 'Loading',
+        messageTag: 'FailedFetch',
+        target: 'Error',
+        guard: { _tag: 'Unguarded' },
+      },
+      {
+        from: 'Error',
+        messageTag: 'ClickedRetry',
+        target: 'Loading',
+        guard: { _tag: 'Unguarded' },
+      },
+      {
+        from: 'Ok',
+        messageTag: 'ClickedFetch',
+        target: 'Loading',
+        guard: { _tag: 'Unguarded' },
+      },
+    ])
+  })
+
+  it('finds every state reachable from Idle', () => {
+    const reachable = remoteDataMachine.reachableFrom('Idle')
+    expect(reachable).toEqual(new Set(['Idle', 'Loading', 'Error', 'Ok']))
+    expect(remoteDataMachine.unreachableStates()).toEqual([])
+    expect(remoteDataMachine.deadTransitions()).toEqual([])
+  })
+
+  it('emits a Mermaid state diagram', () => {
+    expect(remoteDataMachine.toMermaid()).toBe(
+      [
+        'stateDiagram-v2',
+        '  Idle',
+        '  Loading',
+        '  Error',
+        '  Ok',
+        '  [*] --> Idle',
+        '  Idle --> Loading: ClickedFetch',
+        '  Loading --> Ok: SucceededFetch',
+        '  Loading --> Error: FailedFetch',
+        '  Error --> Loading: ClickedRetry',
+        '  Ok --> Loading: ClickedFetch',
+      ].join('\n'),
+    )
+  })
+})
+
+describe('connection machine', () => {
+  it('walks the happy path and emits the edge command', () => {
+    const [connecting] = connectionMachine.transition(
+      Disconnected(),
+      ClickedConnect(),
+    )
+    expect(connecting).toStrictEqual(Connecting({ attemptCount: 1 }))
+
+    const result = connectionMachine.step(
+      Connecting({ attemptCount: 1 }),
+      SocketOpened({ sessionId: 'abc' }),
+    )
+    expect(result._tag).toBe('Transitioned')
+
+    if (result._tag === 'Transitioned') {
+      expect(result.from).toBe('Connecting')
+      expect(result.to).toBe('Connected')
+      expect(result.state).toStrictEqual(Connected({ sessionId: 'abc' }))
+
+      const commandNames = result.commands.map(command => command.name)
+      expect(commandNames).toEqual(['LogTransition'])
+
+      const commandResults = result.commands.map(command =>
+        Effect.runSync(command.effect),
+      )
+      expect(commandResults).toEqual([CompletedLogTransition()])
+    }
+  })
+
+  it('reconnects with exponential backoff below the attempt limit', () => {
+    const [reconnecting] = connectionMachine.transition(
+      Connecting({ attemptCount: 4 }),
+      SocketErrored({ reason: 'boom' }),
+    )
+    expect(reconnecting).toStrictEqual(
+      Reconnecting({ attemptCount: 4, delayMillis: 2000 }),
+    )
+
+    const [connectingAgain] = connectionMachine.transition(
+      Reconnecting({ attemptCount: 4, delayMillis: 2000 }),
+      TimedOutBackoff(),
+    )
+    expect(connectingAgain).toStrictEqual(Connecting({ attemptCount: 5 }))
+  })
+
+  it('fails at the attempt limit via the otherwise guard', () => {
+    const [failed] = connectionMachine.transition(
+      Connecting({ attemptCount: 5 }),
+      SocketErrored({ reason: 'boom' }),
+    )
+    expect(failed).toStrictEqual(Failed({ attemptCount: 5, reason: 'boom' }))
+  })
+
+  it('ignores messages with no edge from the current state', () => {
+    const result = connectionMachine.step(Disconnected(), TimedOutBackoff())
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Disconnected',
+      messageTag: 'TimedOutBackoff',
+      state: Disconnected(),
+    })
+  })
+
+  it('reports Suspended as unreachable and its edge as dead', () => {
+    const reachable = connectionMachine.reachableFrom('Disconnected')
+    expect(reachable).toEqual(
+      new Set([
+        'Disconnected',
+        'Connecting',
+        'Connected',
+        'Reconnecting',
+        'Failed',
+      ]),
+    )
+
+    expect(connectionMachine.unreachableStates()).toEqual(['Suspended'])
+
+    expect(connectionMachine.deadTransitions()).toEqual([
+      {
+        edge: {
+          from: 'Suspended',
+          messageTag: 'ClickedConnect',
+          target: 'Connecting',
+          guard: { _tag: 'Unguarded' },
+        },
+        reason: 'UnreachableSource',
+      },
+    ])
+  })
+
+  it('emits a Mermaid state diagram with guard labels', () => {
+    expect(connectionMachine.toMermaid()).toBe(
+      [
+        'stateDiagram-v2',
+        '  Disconnected',
+        '  Connecting',
+        '  Connected',
+        '  Reconnecting',
+        '  Failed',
+        '  Suspended',
+        '  [*] --> Disconnected',
+        '  Disconnected --> Connecting: ClickedConnect',
+        '  Connecting --> Connected: SocketOpened',
+        '  Connecting --> Reconnecting: SocketErrored [when 1]',
+        '  Connecting --> Failed: SocketErrored [otherwise]',
+        '  Connected --> Reconnecting: SocketClosed',
+        '  Connected --> Disconnected: ClickedDisconnect',
+        '  Reconnecting --> Connecting: TimedOutBackoff',
+        '  Reconnecting --> Disconnected: ClickedDisconnect',
+        '  Failed --> Connecting: ClickedConnect',
+        '  Suspended --> Connecting: ClickedConnect',
+      ].join('\n'),
+    )
+  })
+})
+
+describe('type-level guarantees', () => {
+  it('narrows state and message to the table position without annotations', () => {
+    const [failed] = narrowingMachine.transition(
+      Connecting({ attemptCount: 0 }),
+      SocketErrored({ reason: 'boom' }),
+    )
+    expect(failed).toStrictEqual(
+      Reconnecting({ attemptCount: 0, delayMillis: 125 }),
+    )
+  })
+
+  it('still constructs machines whose tables were rejected at the type level', () => {
+    expect(wrongVariantMachine.initial).toStrictEqual(Idle())
+    expect(wrongTargetTagMachine.initial).toStrictEqual(Idle())
+    expect(unknownStateTagMachine.initial).toStrictEqual(Idle())
+    expect(unknownMessageTagMachine.initial).toStrictEqual(Idle())
+  })
+
+  it('reports guards listed after otherwise as dead', () => {
+    expect(shadowedGuardMachine.deadTransitions()).toEqual([
+      {
+        edge: {
+          from: 'Idle',
+          messageTag: 'ClickedFetch',
+          target: 'Ok',
+          guard: { _tag: 'When', position: 1 },
+        },
+        reason: 'ShadowedByOtherwise',
+      },
+    ])
+  })
+})
+
+describe('integration', () => {
+  it('splices the machine into update via evo', () => {
+    const model: AppModel = {
+      connection: Disconnected(),
+      isDebugPanelOpen: false,
+    }
+
+    const [nextModel, commands] = update(model, ClickedConnect())
+    expect(nextModel.connection).toStrictEqual(Connecting({ attemptCount: 1 }))
+    expect(nextModel.isDebugPanelOpen).toBe(false)
+    expect(commands).toEqual([])
+
+    const [unchangedModel, ignoredCommands] = update(model, ReleasedSocket())
+    expect(unchangedModel).toBe(model)
+    expect(ignoredCommands).toEqual([])
+  })
+
+  it('wires the gating sketch records', () => {
+    expect(Object.keys(managedResources)).toEqual(['socket'])
+    expect(Object.keys(subscriptions)).toEqual(['backoffTimer'])
+  })
+})

--- a/packages/foldkit/src/statechart/statechart.ts
+++ b/packages/foldkit/src/statechart/statechart.ts
@@ -1,0 +1,643 @@
+import {
+  Array,
+  Match as M,
+  Option,
+  Predicate,
+  Record,
+  Schema,
+  pipe,
+} from 'effect'
+
+import type { Command } from '../command/index.js'
+
+// STATE
+
+/** Any value discriminated by a `_tag` field. Both states and Messages satisfy this shape. */
+export type Tagged = Readonly<{ _tag: string }>
+
+/** The union of `_tag` literals in a Tagged union. */
+export type TagOf<Union extends Tagged> = Union['_tag']
+
+/** The single variant of a Tagged union carrying the given tag. */
+export type Variant<Union extends Tagged, Tag extends TagOf<Union>> = Extract<
+  Union,
+  Readonly<{ _tag: Tag }>
+>
+
+// EDGE
+
+/**
+ * A single transition edge. The target state tag is a literal value, so the
+ * edge set of a Machine is enumerable data. `build` constructs the target
+ * variant from the source state and the triggering Message. `maybeCommands`
+ * holds transition-time effects, dispatched as ordinary Commands.
+ *
+ * The correlation between `target` and `build`'s return variant is enforced
+ * by {@link to}'s signature, not by this type. Keeping this type free of the
+ * target tag is what lets TypeScript infer the source state and trigger
+ * Message from the transition table position.
+ *
+ * Construct with {@link to}.
+ */
+export type Edge<
+  State extends Tagged,
+  Message extends Tagged,
+  SourceState extends State,
+  TriggerMessage extends Message,
+> = Readonly<{
+  _tag: 'Edge'
+  target: TagOf<State>
+  build: (state: SourceState, message: TriggerMessage) => State
+  maybeCommands: Option.Option<
+    (
+      state: SourceState,
+      message: TriggerMessage,
+    ) => ReadonlyArray<Command<Message>>
+  >
+}>
+
+/** A guarded Edge that fires only when its predicate holds. Construct with {@link when}. */
+export type When<
+  State extends Tagged,
+  Message extends Tagged,
+  SourceState extends State,
+  TriggerMessage extends Message,
+> = Readonly<{
+  _tag: 'When'
+  predicate: (state: SourceState, message: TriggerMessage) => boolean
+  edge: Edge<State, Message, SourceState, TriggerMessage>
+}>
+
+/** The unconditional fallback Edge at the end of a guard list. Construct with {@link otherwise}. */
+export type Otherwise<
+  State extends Tagged,
+  Message extends Tagged,
+  SourceState extends State,
+  TriggerMessage extends Message,
+> = Readonly<{
+  _tag: 'Otherwise'
+  edge: Edge<State, Message, SourceState, TriggerMessage>
+}>
+
+/** One entry in an ordered guard list: a {@link When} or the {@link Otherwise} fallback. */
+export type GuardedEdge<
+  State extends Tagged,
+  Message extends Tagged,
+  SourceState extends State,
+  TriggerMessage extends Message,
+> =
+  | When<State, Message, SourceState, TriggerMessage>
+  | Otherwise<State, Message, SourceState, TriggerMessage>
+
+/**
+ * The transition table: for each source state tag, the Messages it responds
+ * to and the Edge (or ordered guard list) each Message fires. States absent
+ * from the table, and Messages absent from a state's `on` record, are
+ * ignored: {@link Machine.step} reports them as `Ignored` rather than
+ * transitioning.
+ */
+export type TransitionTable<
+  State extends Tagged,
+  Message extends Tagged,
+> = Readonly<{
+  [SourceTag in TagOf<State>]?: Readonly<{
+    on: Readonly<{
+      [MessageTag in TagOf<Message>]?:
+        | Edge<
+            State,
+            Message,
+            Variant<State, SourceTag>,
+            Variant<Message, MessageTag>
+          >
+        | ReadonlyArray<
+            GuardedEdge<
+              State,
+              Message,
+              Variant<State, SourceTag>,
+              Variant<Message, MessageTag>
+            >
+          >
+    }>
+  }>
+}>
+
+/**
+ * Declares a transition Edge to the state variant named by `target`. The
+ * `build` function receives the source state and triggering Message, both
+ * narrowed to the variants the Edge sits under in the transition table, and
+ * must return the target variant. Optional `commands` attach transition-time
+ * effects.
+ *
+ * Only meaningful inside a {@link TransitionTable}: the source and trigger
+ * types flow in from the table position contextually.
+ */
+export const to = <
+  State extends Tagged,
+  Message extends Tagged,
+  SourceState extends State,
+  TriggerMessage extends Message,
+  const TargetTag extends TagOf<State>,
+>(
+  target: TargetTag,
+  build: (
+    state: NoInfer<SourceState>,
+    message: NoInfer<TriggerMessage>,
+  ) => NoInfer<Variant<State, TargetTag>>,
+  commands?: (
+    state: NoInfer<SourceState>,
+    message: NoInfer<TriggerMessage>,
+  ) => NoInfer<ReadonlyArray<Command<Message>>>,
+): Edge<State, Message, SourceState, TriggerMessage> => ({
+  _tag: 'Edge',
+  target,
+  build,
+  maybeCommands: Option.fromNullishOr(commands),
+})
+
+/**
+ * Guards an Edge with a predicate. Guard lists run in order; the first match
+ * fires.
+ *
+ * The parameters are `NoInfer` so the type arguments resolve from the guard
+ * list's table position alone. Inferring from the nested `to` call instead
+ * would fix the source state to the wrong variant.
+ */
+export const when = <
+  State extends Tagged,
+  Message extends Tagged,
+  SourceState extends State,
+  TriggerMessage extends Message,
+>(
+  predicate: (
+    state: NoInfer<SourceState>,
+    message: NoInfer<TriggerMessage>,
+  ) => boolean,
+  edge: NoInfer<Edge<State, Message, SourceState, TriggerMessage>>,
+): When<State, Message, SourceState, TriggerMessage> => ({
+  _tag: 'When',
+  predicate,
+  edge,
+})
+
+/** The unconditional fallback at the end of a guard list. The parameter is `NoInfer` for the same reason as {@link when}'s. */
+export const otherwise = <
+  State extends Tagged,
+  Message extends Tagged,
+  SourceState extends State,
+  TriggerMessage extends Message,
+>(
+  edge: NoInfer<Edge<State, Message, SourceState, TriggerMessage>>,
+): Otherwise<State, Message, SourceState, TriggerMessage> => ({
+  _tag: 'Otherwise',
+  edge,
+})
+
+// RESULT
+
+/** A step that matched an Edge: the next state plus any transition-time Commands. */
+export type Transitioned<
+  State extends Tagged,
+  Message extends Tagged,
+> = Readonly<{
+  _tag: 'Transitioned'
+  from: TagOf<State>
+  to: TagOf<State>
+  messageTag: TagOf<Message>
+  state: State
+  commands: ReadonlyArray<Command<Message>>
+}>
+
+/** A step that matched no Edge: the state is unchanged and the Message is observable as ignored. */
+export type Ignored<State extends Tagged, Message extends Tagged> = Readonly<{
+  _tag: 'Ignored'
+  stateTag: TagOf<State>
+  messageTag: TagOf<Message>
+  state: State
+}>
+
+/** The observable outcome of one step: `Transitioned` or `Ignored`. */
+export type TransitionResult<State extends Tagged, Message extends Tagged> =
+  | Transitioned<State, Message>
+  | Ignored<State, Message>
+
+// ANALYSIS
+
+/** Which guard construct an Edge sits under, with its position in the guard list. */
+export type EdgeGuard =
+  | Readonly<{ _tag: 'Unguarded' }>
+  | Readonly<{ _tag: 'When'; position: number }>
+  | Readonly<{ _tag: 'Otherwise'; position: number }>
+
+/** One Edge of the table as plain data: source, trigger, target, and guard placement. */
+export type EdgeSummary<
+  State extends Tagged,
+  Message extends Tagged,
+> = Readonly<{
+  from: TagOf<State>
+  messageTag: TagOf<Message>
+  target: TagOf<State>
+  guard: EdgeGuard
+}>
+
+/** Why a transition can never fire. */
+export type DeadTransitionReason = 'UnreachableSource' | 'ShadowedByOtherwise'
+
+/** An Edge that can never fire, with the reason. */
+export type DeadTransition<
+  State extends Tagged,
+  Message extends Tagged,
+> = Readonly<{
+  edge: EdgeSummary<State, Message>
+  reason: DeadTransitionReason
+}>
+
+// MACHINE
+
+/** A compiled state Machine: a pure transition function plus static analysis over the Edge set. */
+export type Machine<State extends Tagged, Message extends Tagged> = Readonly<{
+  initial: State
+  stateTags: ReadonlyArray<TagOf<State>>
+  edges: ReadonlyArray<EdgeSummary<State, Message>>
+  transition: (
+    state: State,
+    message: Message,
+  ) => [State, ReadonlyArray<Command<Message>>]
+  step: (state: State, message: Message) => TransitionResult<State, Message>
+  reachableFrom: (tag: TagOf<State>) => ReadonlySet<TagOf<State>>
+  unreachableStates: () => ReadonlyArray<TagOf<State>>
+  deadTransitions: () => ReadonlyArray<DeadTransition<State, Message>>
+  toMermaid: () => string
+}>
+
+/**
+ * The Schemas a Machine is defined over: the state union and the Message
+ * union. Passed to `defineMachine`'s first stage so the type parameters are
+ * fully resolved before the transition table is checked.
+ */
+export type MachineSchemas<
+  State extends Tagged,
+  Message extends Tagged,
+> = Readonly<{
+  state: Schema.Top &
+    Readonly<{ Type: State; members: ReadonlyArray<Schema.Top> }>
+  message: Schema.Top & Readonly<{ Type: Message }>
+}>
+
+/** The Machine definition: the initial state and the transition table. */
+export type MachineDefinition<
+  State extends Tagged,
+  Message extends Tagged,
+> = Readonly<{
+  initial: State
+  states: TransitionTable<State, Message>
+}>
+
+type LooseEdge<State extends Tagged, Message extends Tagged> = Edge<
+  State,
+  Message,
+  State,
+  Message
+>
+
+type LooseGuardedEdge<
+  State extends Tagged,
+  Message extends Tagged,
+> = GuardedEdge<State, Message, State, Message>
+
+type LooseTable<State extends Tagged, Message extends Tagged> = Readonly<
+  Record<
+    TagOf<State>,
+    Readonly<{
+      on: Readonly<
+        Record<
+          TagOf<Message>,
+          | LooseEdge<State, Message>
+          | ReadonlyArray<LooseGuardedEdge<State, Message>>
+        >
+      >
+    }>
+  >
+>
+
+const isGuardList = <State extends Tagged, Message extends Tagged>(
+  edgeOrGuardedEdges:
+    | LooseEdge<State, Message>
+    | ReadonlyArray<LooseGuardedEdge<State, Message>>,
+): edgeOrGuardedEdges is ReadonlyArray<LooseGuardedEdge<State, Message>> =>
+  globalThis.Array.isArray(edgeOrGuardedEdges)
+
+const extractMemberTag = (member: unknown): Option.Option<string> =>
+  pipe(
+    Option.some(member),
+    Option.filter(Predicate.hasProperty('fields')),
+    Option.map(struct => struct.fields),
+    Option.filter(Predicate.hasProperty('_tag')),
+    Option.map(fields => fields._tag),
+    Option.filter(Predicate.hasProperty('schema')),
+    Option.map(tagField => tagField.schema),
+    Option.filter(Predicate.hasProperty('literal')),
+    Option.map(literalSchema => literalSchema.literal),
+    Option.filter(Predicate.isString),
+  )
+
+/**
+ * Compiles a declarative transition table into a {@link Machine}.
+ *
+ * Two stages: the first takes the state and Message union Schemas and fixes
+ * the type parameters, the second takes the initial state and the transition
+ * table. The split is what lets TypeScript narrow `state` and `message`
+ * inside every Edge from its table position: a single-call form checks the
+ * table while the type parameters are still being inferred, and the
+ * narrowing collapses.
+ *
+ * The Machine is not a runtime: `transition` has the same shape as a Foldkit
+ * `update` branch and returns `[nextState, commands]`, so the machine state
+ * lives in the Model and the Foldkit runtime never learns the Machine
+ * exists. Messages that match no Edge leave the state unchanged; use `step`
+ * when the `Ignored` outcome should be observable.
+ *
+ * Because every Edge names a literal target tag, the Edge set is plain data:
+ * `reachableFrom`, `unreachableStates`, `deadTransitions`, and `toMermaid`
+ * all read it directly.
+ */
+export const defineMachine =
+  <State extends Tagged, Message extends Tagged>(
+    schemas: MachineSchemas<State, Message>,
+  ) =>
+  (definition: MachineDefinition<State, Message>): Machine<State, Message> => {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const looseStates = definition.states as unknown as LooseTable<
+      State,
+      Message
+    >
+
+    const initialTag = definition.initial._tag
+
+    const stateTags = pipe(
+      schemas.state.members,
+      Array.map(member =>
+        Option.getOrThrowWith(
+          extractMemberTag(member),
+          () =>
+            new Error(
+              'defineMachine: every member of the state union Schema must be a TaggedStruct',
+            ),
+        ),
+      ),
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      tags => tags as ReadonlyArray<TagOf<State>>,
+    )
+
+    const makeEdgeSummary = (
+      from: TagOf<State>,
+      messageTag: TagOf<Message>,
+      target: TagOf<State>,
+      guard: EdgeGuard,
+    ): EdgeSummary<State, Message> => ({ from, messageTag, target, guard })
+
+    const summarizeEntry = (
+      from: TagOf<State>,
+      messageTag: TagOf<Message>,
+      edgeOrGuardedEdges:
+        | LooseEdge<State, Message>
+        | ReadonlyArray<LooseGuardedEdge<State, Message>>,
+    ): ReadonlyArray<EdgeSummary<State, Message>> =>
+      isGuardList(edgeOrGuardedEdges)
+        ? Array.map(edgeOrGuardedEdges, (guardedEdge, position) =>
+            guardedEdge._tag === 'When'
+              ? makeEdgeSummary(from, messageTag, guardedEdge.edge.target, {
+                  _tag: 'When',
+                  position,
+                })
+              : makeEdgeSummary(from, messageTag, guardedEdge.edge.target, {
+                  _tag: 'Otherwise',
+                  position,
+                }),
+          )
+        : [
+            makeEdgeSummary(from, messageTag, edgeOrGuardedEdges.target, {
+              _tag: 'Unguarded',
+            }),
+          ]
+
+    const edges: ReadonlyArray<EdgeSummary<State, Message>> = pipe(
+      Record.toEntries(looseStates),
+      Array.flatMap(([sourceTag, stateEntry]) =>
+        pipe(
+          Record.toEntries(stateEntry.on),
+          Array.flatMap(([messageTag, edgeOrGuardedEdges]) =>
+            summarizeEntry(sourceTag, messageTag, edgeOrGuardedEdges),
+          ),
+        ),
+      ),
+    )
+
+    const chooseEdge = (
+      edgeOrGuardedEdges:
+        | LooseEdge<State, Message>
+        | ReadonlyArray<LooseGuardedEdge<State, Message>>,
+      state: State,
+      message: Message,
+    ): Option.Option<LooseEdge<State, Message>> =>
+      isGuardList(edgeOrGuardedEdges)
+        ? pipe(
+            edgeOrGuardedEdges,
+            Array.findFirst(guardedEdge =>
+              guardedEdge._tag === 'When'
+                ? guardedEdge.predicate(state, message)
+                : true,
+            ),
+            Option.map(guardedEdge => guardedEdge.edge),
+          )
+        : Option.some(edgeOrGuardedEdges)
+
+    const makeTransitioned = (
+      state: State,
+      message: Message,
+      edge: LooseEdge<State, Message>,
+    ): Transitioned<State, Message> => ({
+      _tag: 'Transitioned',
+      from: state._tag,
+      to: edge.target,
+      messageTag: message._tag,
+      state: edge.build(state, message),
+      commands: Option.match(edge.maybeCommands, {
+        onNone: () => [],
+        onSome: buildCommands => buildCommands(state, message),
+      }),
+    })
+
+    const makeIgnored = (
+      state: State,
+      message: Message,
+    ): Ignored<State, Message> => ({
+      _tag: 'Ignored',
+      stateTag: state._tag,
+      messageTag: message._tag,
+      state,
+    })
+
+    const step = (
+      state: State,
+      message: Message,
+    ): TransitionResult<State, Message> =>
+      pipe(
+        Record.get(looseStates, state._tag),
+        Option.flatMap(stateEntry => Record.get(stateEntry.on, message._tag)),
+        Option.flatMap(edgeOrGuardedEdges =>
+          chooseEdge(edgeOrGuardedEdges, state, message),
+        ),
+        Option.match({
+          onNone: () => makeIgnored(state, message),
+          onSome: edge => makeTransitioned(state, message, edge),
+        }),
+      )
+
+    const transition = (
+      state: State,
+      message: Message,
+    ): [State, ReadonlyArray<Command<Message>>] => {
+      const result = step(state, message)
+
+      if (result._tag === 'Transitioned') {
+        return [result.state, result.commands]
+      } else {
+        return [result.state, []]
+      }
+    }
+
+    const targetsFrom = (tag: TagOf<State>): ReadonlyArray<TagOf<State>> =>
+      pipe(
+        edges,
+        Array.filter(edgeSummary => edgeSummary.from === tag),
+        Array.map(edgeSummary => edgeSummary.target),
+      )
+
+    const reachableFrom = (tag: TagOf<State>): ReadonlySet<TagOf<State>> => {
+      const visit = (
+        frontier: ReadonlyArray<TagOf<State>>,
+        visited: ReadonlySet<TagOf<State>>,
+      ): ReadonlySet<TagOf<State>> =>
+        Array.matchLeft(frontier, {
+          onEmpty: () => visited,
+          onNonEmpty: (head, tail) =>
+            visited.has(head)
+              ? visit(tail, visited)
+              : visit(
+                  [...tail, ...targetsFrom(head)],
+                  new Set([...visited, head]),
+                ),
+        })
+
+      return visit([tag], new Set())
+    }
+
+    const unreachableStates = (): ReadonlyArray<TagOf<State>> => {
+      const reachable = reachableFrom(initialTag)
+      return Array.filter(stateTags, stateTag => !reachable.has(stateTag))
+    }
+
+    const makeDeadTransition = (
+      edge: EdgeSummary<State, Message>,
+      reason: DeadTransitionReason,
+    ): DeadTransition<State, Message> => ({ edge, reason })
+
+    const guardPosition = (
+      edgeSummary: EdgeSummary<State, Message>,
+    ): Option.Option<number> =>
+      edgeSummary.guard._tag === 'Unguarded'
+        ? Option.none()
+        : Option.some(edgeSummary.guard.position)
+
+    const shadowedEdges = (): ReadonlyArray<DeadTransition<State, Message>> =>
+      pipe(
+        edges,
+        Array.groupBy(
+          edgeSummary => `${edgeSummary.from}|${edgeSummary.messageTag}`,
+        ),
+        Record.values,
+        Array.flatMap(group => {
+          const maybeOtherwisePosition = pipe(
+            group,
+            Array.findFirst(
+              edgeSummary => edgeSummary.guard._tag === 'Otherwise',
+            ),
+            Option.flatMap(guardPosition),
+          )
+
+          return Option.match(maybeOtherwisePosition, {
+            onNone: () => [],
+            onSome: otherwisePosition =>
+              pipe(
+                group,
+                Array.filter(edgeSummary =>
+                  Option.match(guardPosition(edgeSummary), {
+                    onNone: () => false,
+                    onSome: position => position > otherwisePosition,
+                  }),
+                ),
+                Array.map(edgeSummary =>
+                  makeDeadTransition(edgeSummary, 'ShadowedByOtherwise'),
+                ),
+              ),
+          })
+        }),
+      )
+
+    const deadTransitions = (): ReadonlyArray<
+      DeadTransition<State, Message>
+    > => {
+      const reachable = reachableFrom(initialTag)
+
+      const unreachableSourceEdges = pipe(
+        edges,
+        Array.filter(edgeSummary => !reachable.has(edgeSummary.from)),
+        Array.map(edgeSummary =>
+          makeDeadTransition(edgeSummary, 'UnreachableSource'),
+        ),
+      )
+
+      return [...unreachableSourceEdges, ...shadowedEdges()]
+    }
+
+    const toMermaid = (): string => {
+      const guardLabel = (guard: EdgeGuard): string =>
+        M.value(guard).pipe(
+          M.tagsExhaustive({
+            Unguarded: () => '',
+            When: ({ position }) => ` [when ${position + 1}]`,
+            Otherwise: () => ' [otherwise]',
+          }),
+        )
+
+      const stateLines = Array.map(stateTags, stateTag => `  ${stateTag}`)
+
+      const transitionLines = Array.map(
+        edges,
+        edgeSummary =>
+          `  ${edgeSummary.from} --> ${edgeSummary.target}: ${edgeSummary.messageTag}${guardLabel(edgeSummary.guard)}`,
+      )
+
+      return Array.join(
+        [
+          'stateDiagram-v2',
+          ...stateLines,
+          `  [*] --> ${initialTag}`,
+          ...transitionLines,
+        ],
+        '\n',
+      )
+    }
+
+    return {
+      initial: definition.initial,
+      stateTags,
+      edges,
+      transition,
+      step,
+      reachableFrom,
+      unreachableStates,
+      deadTransitions,
+      toMermaid,
+    }
+  }


### PR DESCRIPTION
A declarative transition table that compiles to a plain
transition(state, message) => [nextState, commands] function, spliced
into update with evo. Includes defineMachine, to, when, otherwise,
step with observable Ignored results, reachability analysis, dead
transition detection, and Mermaid output. Not exported from the
package surface; findings in src/statechart/SPIKE_NOTES.md.

https://claude.ai/code/session_011AcEBUCtitgDqtXTvSdxCC