### PR TITLE
Add clipboard event attributes with synchronous clipboardData access

### DIFF
--- a/.changeset/clipboard-event-attributes.md
+++ b/.changeset/clipboard-event-attributes.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add clipboard event attributes with synchronous clipboardData access. `OnPastePreventDefault` hands the handler the clipboard's text/plain payload; returning `Some` suppresses the browser's default insertion and dispatches the Message, returning `None` lets the browser paste normally. `OnCopyText` and `OnCutText` write Model-derived text to the clipboard inside the gesture and suppress the default payload; the cut variant also dispatches a Message so update can remove the cut content from the Model.

--- a/packages/foldkit/src/html/clipboard.test.ts
+++ b/packages/foldkit/src/html/clipboard.test.ts
@@ -1,0 +1,198 @@
+import { describe, it } from '@effect/vitest'
+import { Context, Option } from 'effect'
+import { afterEach, beforeEach, expect } from 'vitest'
+
+import { MountTracker } from '../mount/index.js'
+import { Dispatch } from '../runtime/index.js'
+import { html } from './index.js'
+import {
+  type DispatchSync,
+  clearRuntime,
+  setRuntime,
+} from './runtimeSingleton.js'
+
+const setUpRuntime = (dispatched: Array<unknown>): void => {
+  const dispatchSync: DispatchSync = message => {
+    dispatched.push(message)
+  }
+  const dispatchService = Dispatch.of({
+    dispatchAsync: () =>
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      Promise.resolve() as unknown as ReturnType<
+        typeof Dispatch.Service.dispatchAsync
+      >,
+    dispatchSync,
+  })
+  const context = Context.make(Dispatch, dispatchService).pipe(
+    Context.add(MountTracker, {
+      started: () => {},
+      ended: () => {},
+    }),
+  )
+  setRuntime(dispatchSync, context)
+}
+
+type PastedText = Readonly<{ _tag: 'PastedText'; text: string }>
+
+const PastedText = (args: { text: string }): PastedText => ({
+  _tag: 'PastedText',
+  ...args,
+})
+
+type CutSelection = Readonly<{ _tag: 'CutSelection' }>
+
+const CutSelection = (): CutSelection => ({ _tag: 'CutSelection' })
+
+type Message = PastedText | CutSelection
+
+const fakeClipboardEvent = (initialData: Record<string, string> = {}) => {
+  const data: Record<string, string> = { ...initialData }
+  let isDefaultPrevented = false
+  return {
+    event: {
+      clipboardData: {
+        getData: (format: string) => data[format] ?? '',
+        setData: (format: string, value: string) => {
+          data[format] = value
+        },
+      },
+      preventDefault: () => {
+        isDefaultPrevented = true
+      },
+    },
+    readData: (format: string) => data[format],
+    isDefaultPrevented: () => isDefaultPrevented,
+  }
+}
+
+const fakeClipboardEventWithoutData = () => {
+  let isDefaultPrevented = false
+  return {
+    event: {
+      clipboardData: null,
+      preventDefault: () => {
+        isDefaultPrevented = true
+      },
+    },
+    isDefaultPrevented: () => isDefaultPrevented,
+  }
+}
+
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+const handlerOf = (
+  vnode: ReturnType<ReturnType<typeof html<Message>>['div']>,
+  eventName: string,
+): ((event: unknown) => void) =>
+  vnode?.data?.on?.[eventName] as unknown as (event: unknown) => void
+/* eslint-enable @typescript-eslint/consistent-type-assertions */
+
+describe('clipboard attributes', () => {
+  let dispatched: Array<unknown>
+
+  beforeEach(() => {
+    dispatched = []
+    setUpRuntime(dispatched)
+  })
+
+  afterEach(() => {
+    clearRuntime()
+  })
+
+  describe('OnPastePreventDefault', () => {
+    it('prevents default and dispatches when the handler returns Some', () => {
+      const h = html<Message>()
+      const vnode = h.div(
+        [h.OnPastePreventDefault(text => Option.some(PastedText({ text })))],
+        [],
+      )
+
+      const fake = fakeClipboardEvent({ 'text/plain': 'pasted content' })
+      handlerOf(vnode, 'paste')(fake.event)
+
+      expect(fake.isDefaultPrevented()).toBe(true)
+      expect(dispatched).toEqual([
+        { _tag: 'PastedText', text: 'pasted content' },
+      ])
+    })
+
+    it('leaves the paste to the browser when the handler returns None', () => {
+      const h = html<Message>()
+      const vnode = h.div([h.OnPastePreventDefault(() => Option.none())], [])
+
+      const fake = fakeClipboardEvent({ 'text/plain': 'pasted content' })
+      handlerOf(vnode, 'paste')(fake.event)
+
+      expect(fake.isDefaultPrevented()).toBe(false)
+      expect(dispatched).toEqual([])
+    })
+
+    it('passes an empty string when the event carries no clipboardData', () => {
+      const h = html<Message>()
+      const vnode = h.div(
+        [h.OnPastePreventDefault(text => Option.some(PastedText({ text })))],
+        [],
+      )
+
+      const fake = fakeClipboardEventWithoutData()
+      handlerOf(vnode, 'paste')(fake.event)
+
+      expect(fake.isDefaultPrevented()).toBe(true)
+      expect(dispatched).toEqual([{ _tag: 'PastedText', text: '' }])
+    })
+  })
+
+  describe('OnCopyText', () => {
+    it('writes the text to the clipboard and prevents default', () => {
+      const h = html<Message>()
+      const vnode = h.div([h.OnCopyText('serialized selection')], [])
+
+      const fake = fakeClipboardEvent()
+      handlerOf(vnode, 'copy')(fake.event)
+
+      expect(fake.readData('text/plain')).toBe('serialized selection')
+      expect(fake.isDefaultPrevented()).toBe(true)
+      expect(dispatched).toEqual([])
+    })
+
+    it('leaves the copy to the browser when the event carries no clipboardData', () => {
+      const h = html<Message>()
+      const vnode = h.div([h.OnCopyText('serialized selection')], [])
+
+      const fake = fakeClipboardEventWithoutData()
+      handlerOf(vnode, 'copy')(fake.event)
+
+      expect(fake.isDefaultPrevented()).toBe(false)
+    })
+  })
+
+  describe('OnCutText', () => {
+    it('writes the text to the clipboard, prevents default, and dispatches', () => {
+      const h = html<Message>()
+      const vnode = h.div(
+        [h.OnCutText('serialized selection', CutSelection())],
+        [],
+      )
+
+      const fake = fakeClipboardEvent()
+      handlerOf(vnode, 'cut')(fake.event)
+
+      expect(fake.readData('text/plain')).toBe('serialized selection')
+      expect(fake.isDefaultPrevented()).toBe(true)
+      expect(dispatched).toEqual([{ _tag: 'CutSelection' }])
+    })
+
+    it('leaves the cut to the browser when the event carries no clipboardData', () => {
+      const h = html<Message>()
+      const vnode = h.div(
+        [h.OnCutText('serialized selection', CutSelection())],
+        [],
+      )
+
+      const fake = fakeClipboardEventWithoutData()
+      handlerOf(vnode, 'cut')(fake.event)
+
+      expect(fake.isDefaultPrevented()).toBe(false)
+      expect(dispatched).toEqual([])
+    })
+  })
+})

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -473,6 +473,11 @@ export type Attribute<Message> = Data.TaggedEnum<{
   OnCopy: { readonly message: Message }
   OnCut: { readonly message: Message }
   OnPaste: { readonly message: Message }
+  OnPastePreventDefault: {
+    readonly f: (text: string) => Option.Option<Message>
+  }
+  OnCopyText: { readonly text: string }
+  OnCutText: { readonly text: string; readonly message: Message }
   OnCancel: { readonly message: Message }
   OnToggle: { readonly f: (isOpen: boolean) => Message }
   OnContextMenu: { readonly message: Message }
@@ -725,6 +730,9 @@ const {
   OnCopy,
   OnCut,
   OnPaste,
+  OnPastePreventDefault,
+  OnCopyText,
+  OnCutText,
   OnCancel,
   OnToggle,
   OnContextMenu,
@@ -1330,6 +1338,42 @@ const attributeMatcher: (
       ({ message }) =>
       (ctx: BuildContext) =>
         updateDataOn(ctx, { paste: () => ctx.dispatch(message) }),
+    OnPastePreventDefault:
+      ({ f }) =>
+      (ctx: BuildContext) =>
+        updateDataOn(ctx, {
+          paste: (event: ClipboardEvent) => {
+            const text = event.clipboardData?.getData('text/plain') ?? ''
+            const maybeMessage = f(text)
+            if (Option.isSome(maybeMessage)) {
+              event.preventDefault()
+              ctx.dispatch(maybeMessage.value)
+            }
+          },
+        }),
+    OnCopyText:
+      ({ text }) =>
+      (ctx: BuildContext) =>
+        updateDataOn(ctx, {
+          copy: (event: ClipboardEvent) => {
+            if (event.clipboardData) {
+              event.clipboardData.setData('text/plain', text)
+              event.preventDefault()
+            }
+          },
+        }),
+    OnCutText:
+      ({ text, message }) =>
+      (ctx: BuildContext) =>
+        updateDataOn(ctx, {
+          cut: (event: ClipboardEvent) => {
+            if (event.clipboardData) {
+              event.clipboardData.setData('text/plain', text)
+              event.preventDefault()
+              ctx.dispatch(message)
+            }
+          },
+        }),
     OnCancel:
       ({ message }) =>
       (ctx: BuildContext) =>
@@ -3060,6 +3104,22 @@ type HtmlAttributes<Message> = {
     readonly _tag: 'OnPaste'
     readonly message: Message
   }
+  OnPastePreventDefault: (f: (text: string) => Option.Option<Message>) => {
+    readonly _tag: 'OnPastePreventDefault'
+    readonly f: (text: string) => Option.Option<Message>
+  }
+  OnCopyText: (text: string) => {
+    readonly _tag: 'OnCopyText'
+    readonly text: string
+  }
+  OnCutText: (
+    text: string,
+    message: Message,
+  ) => {
+    readonly _tag: 'OnCutText'
+    readonly text: string
+    readonly message: Message
+  }
   OnCancel: (message: Message) => {
     readonly _tag: 'OnCancel'
     readonly message: Message
@@ -3804,6 +3864,52 @@ const htmlAttributes = <Message>(): HtmlAttributes<Message> => ({
   OnCopy: (message: Message) => OnCopy({ message }),
   OnCut: (message: Message) => OnCut({ message }),
   OnPaste: (message: Message) => OnPaste({ message }),
+  /**
+   * Paste handler with synchronous clipboard access. The function receives
+   * the clipboard's `text/plain` payload. Returning `Some` calls
+   * `preventDefault`, suppressing the browser's default insertion, and
+   * dispatches the Message. Returning `None` leaves the paste to the
+   * browser.
+   *
+   * Like `OnKeyDownPreventDefault`, the side effect lives inside the
+   * framework's event handler. The clipboard is only readable and
+   * `preventDefault` only works synchronously inside the originating paste
+   * event; a Command resolves a frame too late.
+   *
+   * @example
+   * ```typescript
+   * h.OnPastePreventDefault(text => Option.some(PastedText({ text })))
+   * ```
+   */
+  OnPastePreventDefault: (f: (text: string) => Option.Option<Message>) =>
+    OnPastePreventDefault({ f }),
+  /**
+   * Copy handler that synchronously writes `text` to the clipboard as
+   * `text/plain` and calls `preventDefault`, replacing the browser's default
+   * copy payload. Derive `text` from the Model at view time, for example a
+   * markdown serialization of the current selection. The clipboard is only
+   * writable synchronously inside the originating copy event, so the write
+   * runs in the framework's event handler rather than a Command.
+   *
+   * @example
+   * ```typescript
+   * h.OnCopyText(serializeSelectionToMarkdown(model))
+   * ```
+   */
+  OnCopyText: (text: string) => OnCopyText({ text }),
+  /**
+   * Cut handler that synchronously writes `text` to the clipboard as
+   * `text/plain`, calls `preventDefault`, and dispatches `message` so update
+   * can remove the cut content from the Model. The clipboard is only
+   * writable synchronously inside the originating cut event, so the write
+   * runs in the framework's event handler rather than a Command.
+   *
+   * @example
+   * ```typescript
+   * h.OnCutText(serializeSelectionToMarkdown(model), CutSelection())
+   * ```
+   */
+  OnCutText: (text: string, message: Message) => OnCutText({ text, message }),
   OnCancel: (message: Message) => OnCancel({ message }),
   OnToggle: (f: (isOpen: boolean) => Message) => OnToggle({ f }),
   OnContextMenu: (message: Message) => OnContextMenu({ message }),

--- a/packages/website/src/page/core/view.ts
+++ b/packages/website/src/page/core/view.ts
@@ -204,6 +204,21 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('OnClickFocus'),
         ' takes a selector and a Message; it synchronously focuses the element matching the selector and then dispatches.',
       ),
+      para(
+        'The clipboard family follows the same rule. ',
+        inlineCode('OnPastePreventDefault'),
+        ' hands your function the clipboard’s text/plain payload. Returning ',
+        inlineCode('Some'),
+        ' suppresses the browser’s default insertion and dispatches the Message carrying the pasted content; ',
+        inlineCode('None'),
+        ' lets the browser paste normally. ',
+        inlineCode('OnCopyText'),
+        ' and ',
+        inlineCode('OnCutText'),
+        ' go the other way: they write Model-derived text to the clipboard and call ',
+        inlineCode('preventDefault'),
+        ' inside the gesture, since the clipboard is only writable there. The cut variant also dispatches a Message so update can remove the cut content from the Model.',
+      ),
       highlightedCodeBlock(
         h.div(
           [

--- a/packages/website/src/snippet/eventHandlerSideEffects.ts
+++ b/packages/website/src/snippet/eventHandlerSideEffects.ts
@@ -12,6 +12,22 @@ h.input([
   ),
 ])
 
+// OnPastePreventDefault: reads the clipboard's text/plain
+// payload synchronously inside the paste event. Some
+// suppresses the browser's default insertion and dispatches
+// the Message; None lets the browser paste normally.
+//
+// OnCopyText and OnCutText write Model-derived text to the
+// clipboard inside the gesture and suppress the default
+// payload. The cut variant also dispatches a Message so
+// update can delete the selection.
+h.div([
+  h.Contenteditable('true'),
+  h.OnPastePreventDefault(text => Option.some(PastedText({ text }))),
+  h.OnCopyText(serializeSelectionToMarkdown(model)),
+  h.OnCutText(serializeSelectionToMarkdown(model), CutSelection()),
+])
+
 // OnClickFocus: synchronously focuses the element matching
 // the selector, then dispatches the Message. The focus runs
 // inside the click event, so iOS Safari opens the on-screen


### PR DESCRIPTION
## Summary

Adds three new clipboard event attributes to the HTML builder that provide synchronous access to clipboard data during paste, copy, and cut gestures. These attributes follow Foldkit's principle of confining side effects to event handlers when the browser API requires synchronous access.

## Changes

- **`OnPastePreventDefault`**: A paste handler that receives the clipboard's `text/plain` payload. Returning `Some` with a Message suppresses the browser's default insertion and dispatches the Message; returning `None` lets the browser paste normally.

- **`OnCopyText`**: A copy handler that synchronously writes Model-derived text to the clipboard as `text/plain` and calls `preventDefault`, replacing the browser's default copy payload.

- **`OnCutText`**: A cut handler that writes text to the clipboard, calls `preventDefault`, and dispatches a Message so update can remove the cut content from the Model.

## Implementation Details

- All three attributes handle the case where `clipboardData` is `null` by either passing an empty string (paste) or leaving the gesture to the browser (copy/cut).
- The handlers live in the framework's event listener rather than Commands, since the clipboard is only readable/writable synchronously within the originating gesture.
- `OnPastePreventDefault` uses `Option` to allow handlers to conditionally suppress the default behavior, following the same pattern as `OnKeyDownPreventDefault`.
- Comprehensive test coverage validates all three attributes, including edge cases like missing `clipboardData`.
- Documentation added to the website explaining the synchronous nature of these handlers and their use cases.

https://claude.ai/code/session_01CdgJwSaCbQeL6zwgwCUZWt