### PR TITLE
Add Elm comparison guide link to Getting Started

### DIFF
--- a/packages/website/src/page/gettingStarted.ts
+++ b/packages/website/src/page/gettingStarted.ts
@@ -15,6 +15,7 @@ import {
   aiOverviewRouter,
   comingFromReactRouter,
   coreArchitectureRouter,
+  elmComparisonRouter,
   examplesRouter,
 } from '../route'
 import { type CopiedSnippets, codeBlock } from '../view/codeBlock'
@@ -85,10 +86,12 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ],
       ),
       infoCallout(
-        'Coming from React?',
-        'If you’re familiar with React, check out the ',
+        'Coming from React or Elm?',
+        'If you know React, the ',
         link(comingFromReactRouter(), 'Coming from React'),
-        ' guide to understand how your existing knowledge applies.',
+        ' guide maps your existing knowledge onto Foldkit. If you know Elm, see ',
+        link(elmComparisonRouter(), 'Foldkit vs Elm: Side by Side'),
+        '.',
       ),
       tableOfContentsEntryToHeader(projectStructureHeader),
       para('A new Foldkit project has the following structure:'),


### PR DESCRIPTION
## Summary
Updated the Getting Started page to include a link to the Elm comparison guide alongside the existing React guide, helping developers familiar with Elm understand how Foldkit relates to their existing knowledge.

## Changes
- Imported `elmComparisonRouter` from the route module
- Updated the info callout to reference both React and Elm developers
- Added a link to the "Foldkit vs Elm: Side by Side" guide
- Refined the callout text to be more concise while maintaining clarity

## Details
The callout now serves both React and Elm developers by providing dedicated guides for each. The text was streamlined to flow naturally between the two links, making it clear that developers from either background can find relevant comparison material.

https://claude.ai/code/session_01URYscgiP4A5VpQ9CxjhXsK