### PR TITLE
Fix page-owning app coming back blank from back/forward cache

### DIFF
--- a/.changeset/bfcache-restore-blank-page.md
+++ b/.changeset/bfcache-restore-blank-page.md
@@ -1,0 +1,11 @@
+---
+'foldkit': patch
+---
+
+Fix a page-owning app coming back blank from the browser's back/forward cache.
+`BrowserRuntime.runMain` interrupts the runtime on `beforeunload`, which is also
+when the page is frozen into the cache, and that interrupt used to remove the
+bfcache-restore listener along with the rest of the runtime. On restore there
+was nothing left to reload the page, so it came back blank. The listener now
+lives for the page's lifetime, so leaving a page with a full document
+navigation and returning to it reloads cleanly instead of showing a blank page.

--- a/packages/foldkit/src/runtime/bfcacheReload.test.ts
+++ b/packages/foldkit/src/runtime/bfcacheReload.test.ts
@@ -1,0 +1,93 @@
+import { Match as M, Schema as S } from 'effect'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type Document, html } from '../html/index.js'
+import { m } from '../message/index.js'
+import { evo } from '../struct/index.js'
+import { makeApplication, run } from './runtime.js'
+
+const Incremented = m('Incremented')
+const Message = S.Union([Incremented])
+type Message = typeof Message.Type
+
+const Model = S.Struct({ count: S.Number })
+type Model = typeof Model.Type
+
+const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<never>] =>
+  M.value(message).pipe(
+    M.withReturnType<readonly [Model, ReadonlyArray<never>]>(),
+    M.tag('Incremented', () => [evo(model, { count: count => count + 1 }), []]),
+    M.exhaustive,
+  )
+
+const APP_TEXT = 'bfcache-app-content'
+
+const h = html<Message>()
+
+const view = (model: Model): Document => ({
+  title: 'Bfcache test app',
+  body: h.div([h.Id('bfcache-app')], [`${APP_TEXT}:${model.count}`]),
+})
+
+const dispatchPageShow = (isRestoredFromBfcache: boolean): void => {
+  const event = new Event('pageshow')
+  Object.defineProperty(event, 'persisted', {
+    value: isRestoredFromBfcache,
+    configurable: true,
+  })
+  window.dispatchEvent(event)
+}
+
+describe('run + back/forward cache restore', () => {
+  let container: HTMLElement
+  let reloadSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    container.id = 'bfcache-root'
+    document.body.appendChild(container)
+    reloadSpy = vi
+      .spyOn(window.location, 'reload')
+      .mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    reloadSpy.mockRestore()
+    document.body.innerHTML = ''
+  })
+
+  // NOTE: `BrowserRuntime.runMain` interrupts the runtime on `beforeunload`,
+  // which is when the browser freezes the page into the back/forward cache.
+  // The interrupt empties the container, so the restore listener must outlive
+  // the runtime scope for the `pageshow` restore to reload the page. Waiting
+  // for the container to blank confirms the interrupt finalizers have run
+  // before the restore is dispatched.
+  it('reloads when restored after the beforeunload interrupt blanks the page', async () => {
+    run(
+      makeApplication({
+        Model,
+        init: () => [{ count: 0 }, []],
+        update,
+        view,
+        container,
+      }),
+    )
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain(`${APP_TEXT}:0`)
+    })
+
+    window.dispatchEvent(new Event('beforeunload'))
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).not.toContain(`${APP_TEXT}:0`)
+    })
+
+    dispatchPageShow(true)
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/foldkit/src/runtime/browserListeners.test.ts
+++ b/packages/foldkit/src/runtime/browserListeners.test.ts
@@ -1,10 +1,13 @@
-import { afterEach, beforeAll, beforeEach, expect } from 'vitest'
+import { afterEach, beforeAll, beforeEach, expect, vi } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
 import { type UrlRequest } from '../navigation/urlRequest.js'
 import { type Url } from '../url/index.js'
-import { addLinkClickListener } from './browserListeners.js'
+import {
+  addBfcacheRestoreListener,
+  addLinkClickListener,
+} from './browserListeners.js'
 import { type RoutingConfig } from './runtime.js'
 
 declare global {
@@ -208,5 +211,69 @@ describe('addLinkClickListener', () => {
 
     expect(dispatched).toHaveLength(0)
     expect(event.defaultPrevented).toBe(true)
+  })
+})
+
+describe('addBfcacheRestoreListener', () => {
+  const dispatchPageShow = (isRestoredFromBfcache: boolean): void => {
+    const event = new Event('pageshow')
+    Object.defineProperty(event, 'persisted', {
+      value: isRestoredFromBfcache,
+      configurable: true,
+    })
+    window.dispatchEvent(event)
+  }
+
+  let reloadSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    reloadSpy = vi
+      .spyOn(window.location, 'reload')
+      .mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    reloadSpy.mockRestore()
+  })
+
+  it('reloads when the page is restored from the back/forward cache', () => {
+    const removeListener = addBfcacheRestoreListener()
+
+    dispatchPageShow(true)
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    removeListener()
+  })
+
+  it('does not reload on an ordinary (non-bfcache) pageshow', () => {
+    const removeListener = addBfcacheRestoreListener()
+
+    dispatchPageShow(false)
+
+    expect(reloadSpy).not.toHaveBeenCalled()
+    removeListener()
+  })
+
+  // NOTE: A page-owning runtime installs this once and never removes it, so a
+  // second install (HMR re-run) must not stack a second reload onto one
+  // restore.
+  it('registers idempotently across repeated installs', () => {
+    const removeFirst = addBfcacheRestoreListener()
+    const removeSecond = addBfcacheRestoreListener()
+
+    dispatchPageShow(true)
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    removeFirst()
+    removeSecond()
+  })
+
+  it('stops reloading once the listener is removed', () => {
+    const removeListener = addBfcacheRestoreListener()
+    removeListener()
+
+    dispatchPageShow(true)
+
+    expect(reloadSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/foldkit/src/runtime/browserListeners.ts
+++ b/packages/foldkit/src/runtime/browserListeners.ts
@@ -123,17 +123,22 @@ const urlToFoldkitUrl = (url: URL): Url => {
 
 const locationToUrl = (): Url => urlToFoldkitUrl(new URL(window.location.href))
 
-export const addBfcacheRestoreListener = (): (() => void) => {
-  const onPageShow = ({
-    persisted: isRestoredFromBfcache,
-  }: PageTransitionEvent): void => {
-    if (isRestoredFromBfcache) {
-      location.reload()
-    }
+// NOTE: a stable module-level handler keeps registration idempotent.
+// `addEventListener` discards a duplicate registration (same type, same
+// callback reference, same capture), so a page-owning runtime that
+// re-runs under HMR reuses the single listener instead of stacking
+// reloads.
+const reloadOnBfcacheRestore = ({
+  persisted: isRestoredFromBfcache,
+}: PageTransitionEvent): void => {
+  if (isRestoredFromBfcache) {
+    location.reload()
   }
+}
 
-  window.addEventListener('pageshow', onPageShow)
+export const addBfcacheRestoreListener = (): (() => void) => {
+  window.addEventListener('pageshow', reloadOnBfcacheRestore)
   return () => {
-    window.removeEventListener('pageshow', onPageShow)
+    window.removeEventListener('pageshow', reloadOnBfcacheRestore)
   }
 }

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -1777,14 +1777,24 @@ const makeRuntime = <
         )
 
         // NOTE: reloading on bfcache restore is a page-level decision, so
-        // only a page-owning runtime installs the listener. An embedded app
-        // must never force the host page to reload.
-        if (manageDocument) {
-          yield* Effect.acquireRelease(
-            Effect.sync(() => addBfcacheRestoreListener()),
-            removeBfcacheRestoreListener =>
-              Effect.sync(() => removeBfcacheRestoreListener()),
-          )
+        // only a page-owning runtime that manages the document installs the
+        // listener. An app started through `embed` carries a host connector
+        // and must never force the host page to reload, so it is excluded
+        // even when it manages the document.
+        //
+        // The listener is installed for the page's whole lifetime and is
+        // deliberately not torn down with the runtime scope.
+        // `BrowserRuntime.runMain` interrupts the runtime on `beforeunload`,
+        // which is exactly when the browser freezes the page into the
+        // back/forward cache. A scope-bound listener would be removed by that
+        // interrupt before the freeze, so the `pageshow` restore would have
+        // nothing left to reload and the page would come back blank: the
+        // interrupt finalizer empties the container. A full document
+        // navigation (the only way into and out of a cross-origin-isolated
+        // page) is what exercises this path. Registration is idempotent, so an
+        // HMR re-run does not stack listeners.
+        if (manageDocument && Option.isNone(maybeConnector)) {
+          yield* Effect.sync(() => addBfcacheRestoreListener())
         }
 
         if (subscriptions) {


### PR DESCRIPTION
## Summary

Fixed a bug where a page-owning Foldkit app would display a blank page when restored from the browser's back/forward cache. The issue occurred because the bfcache-restore listener was being removed during the runtime interrupt on `beforeunload`, which happens exactly when the page is frozen into the cache.

## Changes

- **browserListeners.ts**: Refactored `addBfcacheRestoreListener` to use a stable module-level handler (`reloadOnBfcacheRestore`) instead of creating a new closure on each call. This makes listener registration idempotent—repeated installs (e.g., during HMR) reuse the same callback reference instead of stacking multiple listeners.

- **runtime.ts**: Updated the bfcache listener installation logic to:
  - Only install for page-owning runtimes that manage the document AND are not embedded (no host connector)
  - Changed from `Effect.acquireRelease` to a simple `Effect.sync` call, so the listener lives for the page's entire lifetime and is not torn down when the runtime scope is interrupted on `beforeunload`
  - Added detailed comments explaining why the listener must survive the runtime interrupt

- **browserListeners.test.ts**: Added comprehensive test suite for `addBfcacheRestoreListener` covering:
  - Reloading on bfcache restore
  - Not reloading on ordinary pageshow events
  - Idempotent registration across repeated installs
  - Listener removal

## Implementation Details

The root cause was that `BrowserRuntime.runMain` interrupts the runtime on `beforeunload`, which is the exact moment the browser freezes the page into the back/forward cache. A scope-bound listener (via `acquireRelease`) would be removed by that interrupt before the freeze, leaving nothing to reload the page on restore.

The fix keeps the listener registered for the page's full lifetime. Since registration is now idempotent (stable callback reference), HMR re-runs don't stack multiple listeners. The listener only applies to page-owning runtimes that manage the document and aren't embedded, ensuring embedded apps never force their host page to reload.

https://claude.ai/code/session_01ED3Q5HpZoaHnL21UbfYcd4