### PR TITLE
Key dispatch stack on globalThis to survive multiple bundler instances

### DIFF
--- a/.changeset/strong-otters-tap.md
+++ b/.changeset/strong-otters-tap.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Key the render dispatch stack on a `globalThis` symbol so foldkit survives being instantiated more than once in a page. When a bundler split `foldkit` and `@foldkit/ui` into separate instances (Vite dev optimizing them in separate passes, or `@foldkit/ui` externalized while `foldkit` is inlined under Vitest), each copy got its own empty dispatch stack. The runtime pushed a render frame onto one instance's stack while a `@foldkit/ui` component's element constructors read another instance's empty stack, crashing with "must be called inside a runtime-driven render" or "dispatchAcrossBoundary missing wrap for ancestor". The stack now resolves to a single shared array regardless of how a bundler splits the module graph.

--- a/packages/foldkit/src/html/runtimeSingleton.test.ts
+++ b/packages/foldkit/src/html/runtimeSingleton.test.ts
@@ -80,4 +80,17 @@ describe('runtimeSingleton', () => {
     }).toThrow('view exploded')
     expect(() => requireDispatch()).toThrow(/runtime-driven render/)
   })
+
+  it('shares the dispatch stack across module instances via globalThis', () => {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const globalRecord = globalThis as Record<symbol, Array<unknown>>
+    const stack = globalRecord[Symbol.for('foldkit/html/runtimeStack')]
+    expect(Array.isArray(stack)).toBe(true)
+
+    const dispatch: DispatchSync = () => {}
+    setRuntime(dispatch, makeContext(dispatch))
+    expect(stack.length).toBe(1)
+    clearRuntime()
+    expect(stack.length).toBe(0)
+  })
 })

--- a/packages/foldkit/src/html/runtimeSingleton.ts
+++ b/packages/foldkit/src/html/runtimeSingleton.ts
@@ -18,7 +18,31 @@ export type Frame = Readonly<{
   boundaryId: BoundaryId
 }>
 
-const stack: Array<Frame> = []
+// NOTE: the dispatch stack is keyed on a `Symbol.for` global rather than a
+// plain module-level array. A bundler can instantiate foldkit's internal
+// modules more than once in a single page (e.g. `foldkit` and `@foldkit/ui`
+// optimized in separate Vite passes, or `@foldkit/ui` externalized while
+// `foldkit` is inlined under Vitest). Each copy would otherwise get its own
+// empty stack, so the runtime pushes a render frame onto one instance's stack
+// while a UI component's element constructors read another instance's empty
+// stack and throw. Resolving the array from `globalThis` once at load time
+// collapses every duplicate onto a single shared stack, which also carries the
+// boundary registry across instances via the frame it holds.
+const RUNTIME_STACK_KEY = Symbol.for('foldkit/html/runtimeStack')
+
+const getOrCreateGlobalStack = (): Array<Frame> => {
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  const globalRecord = globalThis as Record<symbol, Array<Frame> | undefined>
+  const existing = globalRecord[RUNTIME_STACK_KEY]
+  if (existing !== undefined) {
+    return existing
+  }
+  const created: Array<Frame> = []
+  globalRecord[RUNTIME_STACK_KEY] = created
+  return created
+}
+
+const stack: Array<Frame> = getOrCreateGlobalStack()
 
 /** Pushes a new dispatch and runtime context onto the singleton stack. The
  *  runtime calls this before invoking a user `view`, and any test or


### PR DESCRIPTION
## Summary

Foldkit's render dispatch stack is now keyed on a `globalThis` symbol instead of a module-level array. This ensures a single shared stack across all instances of foldkit's internal modules, even when a bundler instantiates them separately.

## Problem

When a bundler splits foldkit into multiple instances (e.g., Vite optimizing `foldkit` and `@foldkit/ui` in separate passes, or `@foldkit/ui` externalized while `foldkit` is inlined under Vitest), each copy gets its own empty dispatch stack. The runtime pushes a render frame onto one instance's stack while a UI component's element constructors read another instance's empty stack, causing crashes with "must be called inside a runtime-driven render" or "dispatchAcrossBoundary missing wrap for ancestor".

## Changes

- Replaced the module-level `stack` array with `getOrCreateGlobalStack()`, which resolves the stack from `globalThis[Symbol.for('foldkit/html/runtimeStack')]` at load time
- The shared stack also carries the boundary registry across instances via the frame it holds
- Added test coverage verifying the stack is shared across module instances and responds correctly to `setRuntime` and `clearRuntime`
- Added changeset documenting the fix as a patch release

## Implementation Details

The `Symbol.for()` global ensures every module instance resolves to the same symbol key. The getter lazily creates the array on first access and caches it in `globalThis`, collapsing all duplicates onto a single shared stack regardless of how the bundler splits the module graph.

https://claude.ai/code/session_01QzEHDcPCQ9VqNPCvXaj4tn