### PR TITLE
fix(foldkit): keep a keyed Submodel root from deregistering its own wrap

### DIFF
--- a/.changeset/submodel-keyed-root-wrap.md
+++ b/.changeset/submodel-keyed-root-wrap.md
@@ -1,0 +1,13 @@
+---
+'foldkit': patch
+---
+
+Fix a Submodel whose root vnode changes identity across renders (most
+commonly a keyed element used as the Submodel's root, whose key changes)
+crashing on a later interaction with `dispatchAcrossBoundary missing wrap
+for ancestor`. The root's destroy hook ran after the next render had
+already re-registered the boundary, evicting the live wrap. The destroy
+hook now skips deregistration when the boundary was re-registered in the
+same render cycle, so a keyed Submodel root works without wrapping it in a
+stable element. The `missing wrap` error no longer asserts a single
+most-likely cause.

--- a/packages/foldkit/src/html/boundary.ts
+++ b/packages/foldkit/src/html/boundary.ts
@@ -239,13 +239,13 @@ const dispatchAcrossBoundary = (
     if (descriptor === undefined) {
       throw new Error(
         `Foldkit: dispatchAcrossBoundary missing wrap for ancestor ` +
-          `"${ancestorBoundary}" of boundary "${boundaryId}". This means a ` +
-          `Submodel's wrap was deregistered between event scheduling and ` +
-          `dispatch. Most likely cause: a slot callback (h.submodel ` +
-          `\`viewInputs\` function value) was invoked from a deferred context ` +
-          `(setTimeout, Promise.then, stored callback) after the parent ` +
-          `Submodel unmounted. Slot callbacks must be invoked synchronously ` +
-          `inside the render in which they were created.`,
+          `"${ancestorBoundary}" of boundary "${boundaryId}". The Submodel's ` +
+          `wrap was absent from the registry at dispatch time. A known cause: ` +
+          `a slot callback (an h.submodel \`viewInputs\` function value) was ` +
+          `invoked from a deferred context (setTimeout, Promise.then, a ` +
+          `stored callback) after the parent Submodel unmounted. Slot ` +
+          `callbacks must be invoked synchronously inside the render that ` +
+          `created them.`,
       )
     }
     wrapped = descriptor.toParentMessage(wrapped)
@@ -281,7 +281,13 @@ export const getOrCreateBoundaryDispatch = (
  *  per-render duplicate-slotId tracking map so siblings inside the
  *  same parent boundary can be re-validated. Does NOT touch `wraps`
  *  or `boundaryDispatches`. Those persist across renders and are
- *  evicted by vnode destroy hooks instead. */
+ *  evicted by vnode destroy hooks instead.
+ *
+ *  Clear `seenThisRender` only here, at the start of a cycle, never
+ *  between the view and patch phases. The Submodel destroy hook reads
+ *  it during patch to tell a same-cycle remount (a keyed root whose
+ *  key changed) from a true unmount; clearing it mid-cycle would
+ *  resurrect the `dispatchAcrossBoundary missing wrap` crash. */
 export const beginRender = (registry: BoundaryRegistry): void => {
   registry.seenThisRender.clear()
 }

--- a/packages/foldkit/src/html/submodel.test.ts
+++ b/packages/foldkit/src/html/submodel.test.ts
@@ -248,12 +248,42 @@ describe('h.submodel', () => {
 
     expect(registry.wraps.has('destroyable')).toBe(true)
 
-    // Simulate snabbdom removing this vnode from the DOM tree.
+    // A genuine unmount: a later render does not re-register the boundary,
+    // so `beginRender` clears it from `seenThisRender` before snabbdom
+    // removes the vnode and fires destroy.
+    beginRender(registry)
     const destroyHook = result?.data?.hook?.destroy
     expect(destroyHook).toBeDefined()
     destroyHook!(result!)
 
     expect(registry.wraps.has('destroyable')).toBe(false)
+  })
+
+  it('preserves the wrap when the old root vnode is destroyed after the boundary was re-registered the same cycle', () => {
+    const render = () =>
+      submodel({
+        slotId: 'remounted',
+        model: { value: 1 },
+        view: childView,
+        toParentMessage: message => GotChild({ entryId: 'remounted', message }),
+      })
+
+    // Render N: the keyed root is registered and produces a vnode whose
+    // destroy hook fires when snabbdom swaps the root on the next render.
+    const first = render()
+    const firstDestroy = first?.data?.hook?.destroy
+    expect(firstDestroy).toBeDefined()
+
+    // Render N+1: the keyed root's key changed, so the parent re-renders the
+    // same boundary, re-registering it before snabbdom patches.
+    beginRender(registry)
+    render()
+    expect(registry.wraps.has('remounted')).toBe(true)
+
+    // Patch N+1: snabbdom removes the OLD root vnode and fires its destroy
+    // hook. The wrap from the re-render must survive.
+    firstDestroy!(first!)
+    expect(registry.wraps.has('remounted')).toBe(true)
   })
 
   it('composes the user-supplied destroy hook with the boundary cleanup hook', () => {
@@ -284,6 +314,8 @@ describe('h.submodel', () => {
         GotChild({ entryId: 'with-user-destroy', message }),
     })
 
+    // Genuine unmount: the boundary is not re-registered this render.
+    beginRender(registry)
     const destroyHook = result?.data?.hook?.destroy
     destroyHook!(result!)
 

--- a/packages/foldkit/src/html/submodel.ts
+++ b/packages/foldkit/src/html/submodel.ts
@@ -269,7 +269,18 @@ const withBoundaryCleanup = (
   const hook = data.hook ?? {}
   const previousDestroy = hook.destroy
   const compositeDestroy = (removed: VNode): void => {
-    deregisterBoundaryWrap(registry, boundaryId)
+    // NOTE: a Submodel whose root vnode changes snabbdom identity across
+    // renders (e.g. a keyed root whose key changed) re-registers its
+    // boundary in the new view phase, then snabbdom destroys the OLD root
+    // vnode in the following patch phase. That destroy must not evict the
+    // freshly re-registered wrap. `seenThisRender` is cleared in
+    // `beginRender`, so during patch it still reflects the just-completed
+    // view phase: the boundary's presence there means it is live this cycle
+    // (a remount), not a true unmount. Deleting it here would surface later
+    // as `dispatchAcrossBoundary missing wrap`.
+    if (!registry.seenThisRender.has(boundaryId)) {
+      deregisterBoundaryWrap(registry, boundaryId)
+    }
     if (previousDestroy !== undefined) {
       previousDestroy(removed)
     }


### PR DESCRIPTION
A Submodel whose root vnode changes snabbdom identity across renders (a
keyed element used as the root, whose key changes) deregistered its own
boundary wrap. registerBoundaryWrap runs in the view phase; the wrap's
destroy hook runs in the following patch phase. When the root key
changed, snabbdom destroyed the old root and fired destroy after the new
render had already re-registered the boundary, so the live wrap was
evicted. A later dispatch from inside the boundary then threw
dispatchAcrossBoundary missing wrap for ancestor.

The destroy hook now skips deregistration when the boundary is still in
seenThisRender, which marks a same-cycle remount rather than a true
unmount. A keyed Submodel root no longer needs a stable wrapper element.
The missing-wrap error no longer asserts a single most-likely cause.
