### PR TITLE
fix(create-foldkit-app): require Node >=22.22.2

### DIFF
--- a/.changeset/create-foldkit-app-node-engine.md
+++ b/.changeset/create-foldkit-app-node-engine.md
@@ -1,0 +1,8 @@
+---
+'create-foldkit-app': patch
+---
+
+Raise the declared minimum Node version to 22.22.2. The bundled effect
+dependency pulls in ini, which requires Node ^22.22.2, ^24.15.0, or >=26.0.0,
+so the previous >=22.19.0 declaration understated the real requirement and
+surfaced an EBADENGINE warning when installing on Node 22.19.0.

--- a/packages/create-foldkit-app/package.json
+++ b/packages/create-foldkit-app/package.json
@@ -44,6 +44,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.19.0"
+    "node": ">=22.22.2"
   }
 }


### PR DESCRIPTION
The bundled effect dependency pulls in ini, which requires Node ^22.22.2, ^24.15.0, or >=26.0.0. The previous >=22.19.0 engines declaration understated the real requirement and triggered an EBADENGINE warning when installing on Node 22.19.0.