### PR TITLE
fix(ci): clean stale untracked overlay-styles leftover on session start

### DIFF
--- a/scripts/cloud-session-setup.sh
+++ b/scripts/cloud-session-setup.sh
@@ -2,22 +2,41 @@
 #
 # Prepare the workspace for a Claude Code cloud session.
 #
-# Cloud sandboxes are provisioned with a node_modules that may be stale (wrong
-# package versions) and never has packages built. Both states produce errors
-# that look like pre-existing branch problems but are not:
+# Cloud sandboxes are provisioned from a cached working-directory snapshot. That
+# snapshot can carry three kinds of state that look like pre-existing branch
+# problems but are not:
 #
-#   * Stale node_modules -> downstream typecheck/build hits "Property X does not
-#     exist on type Y" because the wrong dependency version resolved.
-#   * Missing dist/      -> downstream typecheck fails with "Cannot find module
-#     'foldkit'" because foldkit's package.json `exports` map points at dist/.
+#   * Stale node_modules    -> downstream typecheck/build hits "Property X does
+#     not exist on type Y" because the wrong dependency version resolved.
+#   * Missing dist/         -> downstream typecheck fails with "Cannot find
+#     module 'foldkit'" because foldkit's package.json `exports` map points at
+#     dist/.
+#   * Stale untracked files -> a never-committed leftover baked into the
+#     snapshot reappears as an untracked file every session, tripping the
+#     "commit and push" Stop hook into nagging about work nobody did.
 #
-# Reconciling node_modules to the lockfile and building the three prerequisite
-# packages eliminates both classes of phantom error before the agent runs any
-# checks.
+# Reconciling node_modules to the lockfile, building the prerequisite packages,
+# and removing known stale leftovers eliminates all three classes of phantom
+# problem before the agent runs any checks.
 
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
+
+# The @foldkit/devtools extraction moved overlay-styles.ts out of the foldkit
+# core package, but a never-tracked copy lingers in cloud snapshots at the old
+# path and reappears as an untracked file every session. The canonical file now
+# lives at packages/devtools/src/overlay-styles.ts. Remove the leftover, guarded
+# on "still untracked" so a file legitimately committed here later is untouched.
+stale_leftovers=(
+  'packages/foldkit/src/devTools/overlay-styles.ts'
+)
+for path in "${stale_leftovers[@]}"; do
+  if [[ -f "$path" ]] && ! git ls-files --error-unmatch "$path" >/dev/null 2>&1; then
+    echo "[setup] removing stale untracked leftover: $path"
+    rm -f "$path"
+  fi
+done
 
 echo "[setup] reconciling node_modules with pnpm-lock.yaml"
 pnpm install --frozen-lockfile


### PR DESCRIPTION
The @foldkit/devtools extraction left a never-tracked copy of
overlay-styles.ts at packages/foldkit/src/devTools/overlay-styles.ts. Cloud
sandboxes provision from a cached working-directory snapshot that has this
file baked in, so it reappears as an untracked file in every session and
trips the "commit and push" Stop hook into nagging about work nobody did.

The canonical file now lives at packages/devtools/src/overlay-styles.ts. The
SessionStart setup script removes the leftover at the start of each session,
guarded on the path still being untracked so a file legitimately committed
there later is never deleted.