### PR TITLE
refactor: adopt Foldkit UI view-only components across examples

### DIFF
--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "clsx": "^2.1.1",
     "effect": "4.0.0-beta.83",

--- a/examples/auth/src/page/loggedIn/page/settings.ts
+++ b/examples/auth/src/page/loggedIn/page/settings.ts
@@ -1,5 +1,7 @@
 import { Html, html } from 'foldkit/html'
 
+import { Button } from '@foldkit/ui'
+
 import { Session } from '../../../domain/session'
 import { ClickedLogout, type Message } from '../message'
 
@@ -52,15 +54,19 @@ export const view = (session: Session): Html => {
             [h.Class('text-xl font-semibold text-gray-800 mb-4')],
             ['Actions'],
           ),
-          h.button(
-            [
-              h.OnClick(ClickedLogout()),
-              h.Class(
-                'px-6 py-3 bg-red-500 text-white font-medium rounded-lg hover:bg-red-600 transition cursor-pointer',
+          Button.view<Message>({
+            onClick: ClickedLogout(),
+            toView: attributes =>
+              h.button(
+                [
+                  ...attributes.button,
+                  h.Class(
+                    'px-6 py-3 bg-red-500 text-white font-medium rounded-lg hover:bg-red-600 transition cursor-pointer',
+                  ),
+                ],
+                ['Sign Out'],
               ),
-            ],
-            ['Sign Out'],
-          ),
+          }),
         ],
       ),
     ],

--- a/examples/auth/src/page/loggedOut/page/login.ts
+++ b/examples/auth/src/page/loggedOut/page/login.ts
@@ -23,6 +23,8 @@ import { Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
+import { Button, Input } from '@foldkit/ui'
+
 import { Session } from '../../../domain/session'
 import { homeRouter } from '../../../route'
 
@@ -141,6 +143,10 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       ],
 
       SubmittedForm: () => {
+        if (model.isSubmitting) {
+          return [model, [], Option.none()]
+        }
+
         if (!isFormValid(model)) {
           return [model, [], Option.none()]
         }
@@ -205,49 +211,58 @@ const fieldView = (
     fieldToBorderClass(field),
   )
 
-  return h.div(
-    [],
-    [
+  return Input.view<Message>({
+    id,
+    type,
+    value: field.value,
+    placeholder,
+    onInput: onUpdate,
+    isInvalid: field._tag === 'Invalid',
+    toView: attributes =>
       h.div(
-        [h.Class('flex items-center gap-2 mb-1')],
+        [],
         [
-          h.label(
-            [h.For(id), h.Class('block text-sm font-medium text-gray-700')],
-            [labelText],
+          h.div(
+            [h.Class('flex items-center gap-2 mb-1')],
+            [
+              h.label(
+                [
+                  ...attributes.label,
+                  h.Class('block text-sm font-medium text-gray-700'),
+                ],
+                [labelText],
+              ),
+              M.value(field).pipe(
+                M.tagsExhaustive({
+                  NotValidated: () => h.empty,
+                  Validating: () =>
+                    h.span([h.Class('text-blue-600 text-sm')], ['...']),
+                  Valid: () =>
+                    h.span([h.Class('text-green-600 text-sm')], ['✓']),
+                  Invalid: () => h.empty,
+                }),
+              ),
+            ],
           ),
+          h.input([...attributes.input, h.Class(inputClass)]),
           M.value(field).pipe(
             M.tagsExhaustive({
               NotValidated: () => h.empty,
-              Validating: () =>
-                h.span([h.Class('text-blue-600 text-sm')], ['...']),
-              Valid: () => h.span([h.Class('text-green-600 text-sm')], ['✓']),
-              Invalid: () => h.empty,
+              Validating: () => h.empty,
+              Valid: () => h.empty,
+              Invalid: ({ errors }) =>
+                h.div(
+                  [
+                    ...attributes.description,
+                    h.Class('text-red-600 text-sm mt-1'),
+                  ],
+                  [Array.headNonEmpty(errors)],
+                ),
             }),
           ),
         ],
       ),
-      h.input([
-        h.Id(id),
-        h.Type(type),
-        h.Value(field.value),
-        h.Placeholder(placeholder),
-        h.Class(inputClass),
-        h.OnInput(onUpdate),
-      ]),
-      M.value(field).pipe(
-        M.tagsExhaustive({
-          NotValidated: () => h.empty,
-          Validating: () => h.empty,
-          Valid: () => h.empty,
-          Invalid: ({ errors }) =>
-            h.div(
-              [h.Class('text-red-600 text-sm mt-1')],
-              [Array.headNonEmpty(errors)],
-            ),
-        }),
-      ),
-    ],
-  )
+  })
 }
 
 export const view = Submodel.defineView<Model, Message>((model): Html => {
@@ -293,21 +308,25 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
                 'password',
                 'Enter your password',
               ),
-              h.button(
-                [
-                  h.Type('submit'),
-                  h.Disabled(!canSubmit),
-                  h.Class(
-                    clsx(
-                      'w-full py-3 font-medium rounded-lg transition',
-                      canSubmit
-                        ? 'bg-blue-500 text-white hover:bg-blue-600 cursor-pointer'
-                        : 'bg-gray-300 text-gray-500 cursor-not-allowed',
-                    ),
+              Button.view<Message>({
+                type: 'submit',
+                isDisabled: !canSubmit,
+                toView: attributes =>
+                  h.button(
+                    [
+                      ...attributes.button,
+                      h.Class(
+                        clsx(
+                          'w-full py-3 font-medium rounded-lg transition',
+                          canSubmit
+                            ? 'bg-blue-500 text-white hover:bg-blue-600 cursor-pointer'
+                            : 'bg-gray-300 text-gray-500 cursor-not-allowed',
+                        ),
+                      ),
+                    ],
+                    [model.isSubmitting ? 'Signing in...' : 'Sign In'],
                   ),
-                ],
-                [model.isSubmitting ? 'Signing in...' : 'Sign In'],
-              ),
+              }),
             ],
           ),
           h.div(

--- a/examples/canvas-art/package.json
+++ b/examples/canvas-art/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/canvas-art/src/main.ts
+++ b/examples/canvas-art/src/main.ts
@@ -13,6 +13,8 @@ import { Document, Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
+import { Button } from '@foldkit/ui'
+
 // MODEL
 
 const CANVAS_WIDTH = 600
@@ -211,24 +213,32 @@ const controlsView = (model: Model): Html => {
   return h.div(
     [h.Class('flex gap-3 mt-4')],
     [
-      h.button(
-        [
-          h.Class(
-            'min-w-20 px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-500',
+      Button.view<Message>({
+        onClick: ClickedTogglePlay(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'min-w-20 px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-500',
+              ),
+            ],
+            [model.isRunning ? 'Pause' : 'Play'],
           ),
-          h.OnClick(ClickedTogglePlay()),
-        ],
-        [model.isRunning ? 'Pause' : 'Play'],
-      ),
-      h.button(
-        [
-          h.Class(
-            'min-w-20 px-4 py-2 bg-zinc-700 text-white rounded hover:bg-zinc-600',
+      }),
+      Button.view<Message>({
+        onClick: ClickedClear(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'min-w-20 px-4 py-2 bg-zinc-700 text-white rounded hover:bg-zinc-600',
+              ),
+            ],
+            ['Clear'],
           ),
-          h.OnClick(ClickedClear()),
-        ],
-        ['Clear'],
-      ),
+      }),
       h.p(
         [h.Class('px-4 py-2 text-zinc-400 text-sm self-center')],
         [

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/counter/src/main.ts
+++ b/examples/counter/src/main.ts
@@ -3,6 +3,8 @@ import { Command, Runtime } from 'foldkit'
 import { Document, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 
+import { Button } from '@foldkit/ui'
+
 // MODEL
 
 export const Model = S.Struct({ count: S.Number })
@@ -66,18 +68,24 @@ export const view = (model: Model): Document => {
         h.div(
           [h.Class('flex flex-wrap justify-center gap-4')],
           [
-            h.button(
-              [h.OnClick(ClickedDecrement()), h.Class(buttonStyle)],
-              ['-'],
-            ),
-            h.button(
-              [h.OnClick(ClickedReset()), h.Class(buttonStyle)],
-              ['Reset'],
-            ),
-            h.button(
-              [h.OnClick(ClickedIncrement()), h.Class(buttonStyle)],
-              ['+'],
-            ),
+            Button.view<Message>({
+              onClick: ClickedDecrement(),
+              toView: attributes =>
+                h.button([...attributes.button, h.Class(buttonStyle)], ['-']),
+            }),
+            Button.view<Message>({
+              onClick: ClickedReset(),
+              toView: attributes =>
+                h.button(
+                  [...attributes.button, h.Class(buttonStyle)],
+                  ['Reset'],
+                ),
+            }),
+            Button.view<Message>({
+              onClick: ClickedIncrement(),
+              toView: attributes =>
+                h.button([...attributes.button, h.Class(buttonStyle)], ['+']),
+            }),
           ],
         ),
       ],

--- a/examples/counters/package.json
+++ b/examples/counters/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/counters/src/counter.ts
+++ b/examples/counters/src/counter.ts
@@ -3,6 +3,8 @@ import { Command, Submodel } from 'foldkit'
 import { Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 
+import { Button } from '@foldkit/ui'
+
 // MODEL
 
 export const Model = S.Struct({ count: S.Number })
@@ -46,12 +48,20 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
       ),
     ],
     [
-      h.button([h.OnClick(ClickedDecrement()), h.Class(buttonStyle)], ['-']),
+      Button.view<Message>({
+        onClick: ClickedDecrement(),
+        toView: attributes =>
+          h.button([...attributes.button, h.Class(buttonStyle)], ['-']),
+      }),
       h.span(
         [h.Class('w-12 text-center text-2xl font-mono tabular-nums')],
         [model.count.toString()],
       ),
-      h.button([h.OnClick(ClickedIncrement()), h.Class(buttonStyle)], ['+']),
+      Button.view<Message>({
+        onClick: ClickedIncrement(),
+        toView: attributes =>
+          h.button([...attributes.button, h.Class(buttonStyle)], ['+']),
+      }),
     ],
   )
 })

--- a/examples/counters/src/main.ts
+++ b/examples/counters/src/main.ts
@@ -4,6 +4,8 @@ import { Document, Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
+import { Button } from '@foldkit/ui'
+
 import * as Counter from './counter'
 
 // MODEL
@@ -127,15 +129,19 @@ const rowView = (row: Row): Html => {
           }),
         ],
       ),
-      h.button(
-        [
-          h.OnClick(ClickedRemoveRow({ id: row.id })),
-          h.Class(
-            'rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:border-red-300 hover:text-red-600 transition cursor-pointer',
+      Button.view<Message>({
+        onClick: ClickedRemoveRow({ id: row.id }),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:border-red-300 hover:text-red-600 transition cursor-pointer',
+              ),
+            ],
+            ['Remove'],
           ),
-        ],
-        ['Remove'],
-      ),
+      }),
     ],
   )
 }
@@ -163,15 +169,19 @@ export const view = (model: Model): Document => {
           [h.Class('flex flex-col gap-3 w-full max-w-md')],
           model.rows.map(rowView),
         ),
-        h.button(
-          [
-            h.OnClick(ClickedAddRow()),
-            h.Class(
-              'rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 transition cursor-pointer',
+        Button.view<Message>({
+          onClick: ClickedAddRow(),
+          toView: attributes =>
+            h.button(
+              [
+                ...attributes.button,
+                h.Class(
+                  'rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 transition cursor-pointer',
+                ),
+              ],
+              ['+ Add Counter'],
             ),
-          ],
-          ['+ Add Counter'],
-        ),
+        }),
       ],
     ),
   }

--- a/examples/crash-view/package.json
+++ b/examples/crash-view/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/crash-view/src/main.ts
+++ b/examples/crash-view/src/main.ts
@@ -3,6 +3,8 @@ import { Command, Runtime } from 'foldkit'
 import { Document, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 
+import { Button } from '@foldkit/ui'
+
 // MODEL
 
 export const Model = Schema.Null
@@ -38,15 +40,19 @@ export const view = (_model: Model): Document => {
     body: h.div(
       [h.Class('min-h-screen bg-white flex items-center justify-center')],
       [
-        h.button(
-          [
-            h.OnClick(ClickedCrash()),
-            h.Class(
-              'bg-red-600 text-white text-lg font-semibold hover:bg-red-700 px-6 py-3 rounded transition cursor-pointer',
+        Button.view<Message>({
+          onClick: ClickedCrash(),
+          toView: attributes =>
+            h.button(
+              [
+                ...attributes.button,
+                h.Class(
+                  'bg-red-600 text-white text-lg font-semibold hover:bg-red-700 px-6 py-3 rounded transition cursor-pointer',
+                ),
+              ],
+              ['Crash'],
             ),
-          ],
-          ['Crash'],
-        ),
+        }),
       ],
     ),
   }
@@ -79,15 +85,19 @@ export const crashView = ({
               [h.Class('text-gray-700 mb-6 leading-relaxed')],
               [error.message],
             ),
-            h.button(
-              [
-                h.Class(
-                  'bg-red-600 text-white border-none px-6 py-2.5 rounded-md text-sm font-medium cursor-pointer hover:bg-red-700 transition',
+            Button.view<never>({
+              toView: attributes =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      'bg-red-600 text-white border-none px-6 py-2.5 rounded-md text-sm font-medium cursor-pointer hover:bg-red-700 transition',
+                    ),
+                    h.Attribute('onclick', 'location.reload()'),
+                  ],
+                  ['Reload'],
                 ),
-                h.Attribute('onclick', 'location.reload()'),
-              ],
-              ['Reload'],
-            ),
+            }),
           ],
         ),
       ],

--- a/examples/embedding/package.json
+++ b/examples/embedding/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/embedding/src/main.ts
+++ b/examples/embedding/src/main.ts
@@ -5,6 +5,7 @@ import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
 import { overlay } from '@foldkit/devtools'
+import { Button } from '@foldkit/ui'
 
 // MODEL
 
@@ -116,15 +117,19 @@ export const view = (model: Model): Html => {
         [h.Class('text-sm text-gray-600')],
         [`Ticking up by ${model.step} every second`],
       ),
-      h.button(
-        [
-          h.Class(
-            'cursor-pointer rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-500',
+      Button.view<Message>({
+        onClick: ClickedAdvance(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'cursor-pointer rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-500',
+              ),
+            ],
+            [`Advance by ${model.step}`],
           ),
-          h.OnClick(ClickedAdvance()),
-        ],
-        [`Advance by ${model.step}`],
-      ),
+      }),
     ],
   )
 }

--- a/examples/form/src/main.ts
+++ b/examples/form/src/main.ts
@@ -25,7 +25,7 @@ import { m } from 'foldkit/message'
 import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
 
-import { Input, Textarea } from '@foldkit/ui'
+import { Button, Input, Textarea } from '@foldkit/ui'
 
 const nameRules = makeRules({
   rules: [Rule.minLength(2, 'Name must be at least 2 characters')],
@@ -215,6 +215,10 @@ export const update = (
       ],
 
       ClickedFormSubmit: () => {
+        if (model.submission._tag === 'Submitting') {
+          return [model, []]
+        }
+
         if (!isFormValid(model)) {
           return [model, []]
         }
@@ -451,25 +455,29 @@ export const view = (model: Model): Document => {
                 value => UpdatedMessage({ value }),
               ),
 
-              h.button(
-                [
-                  h.Type('submit'),
-                  h.Disabled(!canSubmit),
-                  h.Class(
-                    clsx(
-                      'w-full py-2 px-4 rounded-md transition',
-                      canSubmit
-                        ? 'bg-blue-500 text-white hover:bg-blue-600'
-                        : 'bg-gray-300 text-gray-500 cursor-not-allowed',
-                    ),
+              Button.view<Message>({
+                type: 'submit',
+                isDisabled: !canSubmit,
+                toView: attributes =>
+                  h.button(
+                    [
+                      ...attributes.button,
+                      h.Class(
+                        clsx(
+                          'w-full py-2 px-4 rounded-md transition',
+                          canSubmit
+                            ? 'bg-blue-500 text-white hover:bg-blue-600'
+                            : 'bg-gray-300 text-gray-500 cursor-not-allowed',
+                        ),
+                      ),
+                    ],
+                    [
+                      model.submission._tag === 'Submitting'
+                        ? 'Joining...'
+                        : 'Join Waitlist',
+                    ],
                   ),
-                ],
-                [
-                  model.submission._tag === 'Submitting'
-                    ? 'Joining...'
-                    : 'Join Waitlist',
-                ],
-              ),
+              }),
             ],
           ),
 

--- a/examples/job-application/src/view/attachments.ts
+++ b/examples/job-application/src/view/attachments.ts
@@ -3,7 +3,7 @@ import { Array, Match as M, Number, Option } from 'effect'
 import { File, Submodel } from 'foldkit'
 import { type Html, html } from 'foldkit/html'
 
-import { FileDrop } from '@foldkit/ui'
+import { Button, FileDrop } from '@foldkit/ui'
 
 import { Attachments } from '../step'
 
@@ -56,16 +56,19 @@ const resumeView = (resume: File.File): Html => {
           ),
         ],
       ),
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(Attachments.RemovedResume()),
-          h.Class(
-            'text-sm text-gray-400 hover:text-red-500 transition cursor-pointer',
+      Button.view<Attachments.Message>({
+        onClick: Attachments.RemovedResume(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'text-sm text-gray-400 hover:text-red-500 transition cursor-pointer',
+              ),
+            ],
+            ['Remove'],
           ),
-        ],
-        ['Remove'],
-      ),
+      }),
     ],
   )
 }
@@ -92,16 +95,19 @@ const additionalFileView = (file: File.File, fileIndex: number): Html => {
           ),
         ],
       ),
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(Attachments.RemovedAdditionalFile({ fileIndex })),
-          h.Class(
-            'text-xs text-gray-400 hover:text-red-500 transition cursor-pointer',
+      Button.view<Attachments.Message>({
+        onClick: Attachments.RemovedAdditionalFile({ fileIndex }),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'text-xs text-gray-400 hover:text-red-500 transition cursor-pointer',
+              ),
+            ],
+            ['Remove'],
           ),
-        ],
-        ['Remove'],
-      ),
+      }),
     ],
   )
 }

--- a/examples/job-application/src/view/education.ts
+++ b/examples/job-application/src/view/education.ts
@@ -2,6 +2,8 @@ import { Submodel } from 'foldkit'
 import type { CalendarDate } from 'foldkit/calendar'
 import { type Html, createKeyedLazy, html } from 'foldkit/html'
 
+import { Button } from '@foldkit/ui'
+
 import { Education } from '../step'
 import { educationEntryView } from './educationEntry'
 
@@ -38,16 +40,19 @@ export const educationView = Submodel.defineView<
           lazyEntry(entry.id, entryView, [entry, model.today]),
         ),
       ),
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(Education.ClickedAddEntry()),
-          h.Class(
-            'w-full rounded-lg border-2 border-dashed border-gray-300 px-4 py-3 text-sm font-medium text-gray-600 hover:border-indigo-400 hover:text-indigo-600 transition cursor-pointer',
+      Button.view<Education.Message>({
+        onClick: Education.ClickedAddEntry(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'w-full rounded-lg border-2 border-dashed border-gray-300 px-4 py-3 text-sm font-medium text-gray-600 hover:border-indigo-400 hover:text-indigo-600 transition cursor-pointer',
+              ),
+            ],
+            ['+ Add Education'],
           ),
-        ],
-        ['+ Add Education'],
-      ),
+      }),
     ],
   )
 })

--- a/examples/job-application/src/view/educationEntry.ts
+++ b/examples/job-application/src/view/educationEntry.ts
@@ -4,7 +4,7 @@ import { Submodel } from 'foldkit'
 import { type CalendarDate } from 'foldkit/calendar'
 import { type Html, html } from 'foldkit/html'
 
-import { Checkbox, Listbox } from '@foldkit/ui'
+import { Button, Checkbox, Listbox } from '@foldkit/ui'
 
 import { Education } from '../step'
 import { inputField } from './field'
@@ -157,16 +157,19 @@ export const educationEntryView = Submodel.defineView<
       h.div(
         [h.Class('flex justify-end')],
         [
-          h.button(
-            [
-              h.Type('button'),
-              h.OnClick(Education.Entry.ClickedRemoveSelf()),
-              h.Class(
-                'text-sm text-gray-400 hover:text-red-500 transition cursor-pointer',
+          Button.view<Education.Entry.Message>({
+            onClick: Education.Entry.ClickedRemoveSelf(),
+            toView: attributes =>
+              h.button(
+                [
+                  ...attributes.button,
+                  h.Class(
+                    'text-sm text-gray-400 hover:text-red-500 transition cursor-pointer',
+                  ),
+                ],
+                ['Remove education'],
               ),
-            ],
-            ['Remove education'],
-          ),
+          }),
         ],
       ),
     ],

--- a/examples/job-application/src/view/index.ts
+++ b/examples/job-application/src/view/index.ts
@@ -2,6 +2,8 @@ import clsx from 'clsx'
 import { Array, Equal, HashSet, Match as M, Option, pipe } from 'effect'
 import { type Document, type Html, html } from 'foldkit/html'
 
+import { Button } from '@foldkit/ui'
+
 import { Step } from '../domain'
 import {
   ClickedNext,
@@ -120,32 +122,38 @@ const navigationButtons = (model: Model): Html => {
       ...(isFirstStep(model)
         ? [h.empty]
         : [
-            h.keyed('button')(
-              'previous',
-              [
-                h.Type('button'),
-                h.OnClick(ClickedPrevious()),
-                h.Class(
-                  'rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition cursor-pointer',
+            Button.view<Message>({
+              onClick: ClickedPrevious(),
+              toView: attributes =>
+                h.keyed('button')(
+                  'previous',
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      'rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition cursor-pointer',
+                    ),
+                  ],
+                  ['← Previous'],
                 ),
-              ],
-              ['← Previous'],
-            ),
+            }),
           ]),
       ...(isLastStep(model)
         ? []
         : [
-            h.keyed('button')(
-              'next',
-              [
-                h.Type('button'),
-                h.OnClick(ClickedNext()),
-                h.Class(
-                  'rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition cursor-pointer',
+            Button.view<Message>({
+              onClick: ClickedNext(),
+              toView: attributes =>
+                h.keyed('button')(
+                  'next',
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      'rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition cursor-pointer',
+                    ),
+                  ],
+                  ['Next →'],
                 ),
-              ],
-              ['Next →'],
-            ),
+            }),
           ]),
     ],
   )
@@ -253,21 +261,24 @@ const mobilePreviewToggle = (model: Model): Html => {
     'mobile-toggle',
     [h.Class('fixed bottom-4 right-4 xl:hidden')],
     [
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(ToggledPreview()),
-          h.Class(
-            clsx(
-              'rounded-full px-4 py-2 text-sm font-medium shadow-lg transition cursor-pointer',
-              model.isPreviewVisible
-                ? 'bg-gray-800 text-white'
-                : 'bg-indigo-600 text-white',
-            ),
+      Button.view<Message>({
+        onClick: ToggledPreview(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                clsx(
+                  'rounded-full px-4 py-2 text-sm font-medium shadow-lg transition cursor-pointer',
+                  model.isPreviewVisible
+                    ? 'bg-gray-800 text-white'
+                    : 'bg-indigo-600 text-white',
+                ),
+              ),
+            ],
+            [model.isPreviewVisible ? 'Hide Preview' : 'Preview'],
           ),
-        ],
-        [model.isPreviewVisible ? 'Hide Preview' : 'Preview'],
-      ),
+      }),
     ],
   )
 }

--- a/examples/job-application/src/view/review.ts
+++ b/examples/job-application/src/view/review.ts
@@ -2,6 +2,8 @@ import { Match as M, Option } from 'effect'
 import { File } from 'foldkit'
 import { type Html, html } from 'foldkit/html'
 
+import { Button } from '@foldkit/ui'
+
 import type { Message } from '../message'
 import type { Model } from '../model'
 import * as Education from '../step/education'
@@ -253,15 +255,19 @@ const submissionSection = (
           [h.Class('pt-4 space-y-2')],
           [
             ...(isSubmittable ? [] : [blockedNotice()]),
-            h.keyed('button')(
-              'submit',
-              [
-                h.Type('button'),
-                ...(isSubmittable ? [h.OnClick(onSubmit)] : [h.Disabled(true)]),
-                h.Class(submitButtonClass(isSubmittable)),
-              ],
-              ['Submit Application'],
-            ),
+            Button.view<Message>({
+              onClick: onSubmit,
+              isDisabled: !isSubmittable,
+              toView: attributes =>
+                h.keyed('button')(
+                  'submit',
+                  [
+                    ...attributes.button,
+                    h.Class(submitButtonClass(isSubmittable)),
+                  ],
+                  ['Submit Application'],
+                ),
+            }),
           ],
         ),
       Submitting: () =>
@@ -269,15 +275,18 @@ const submissionSection = (
           'submit-pending',
           [h.Class('pt-4')],
           [
-            h.button(
-              [
-                h.Type('button'),
-                h.Class(
-                  'w-full rounded-lg bg-indigo-400 px-4 py-3 text-sm font-semibold text-white cursor-wait',
+            Button.view<Message>({
+              toView: attributes =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      'w-full rounded-lg bg-indigo-400 px-4 py-3 text-sm font-semibold text-white cursor-wait',
+                    ),
+                  ],
+                  ['Submitting...'],
                 ),
-              ],
-              ['Submitting...'],
-            ),
+            }),
           ],
         ),
       SubmitSuccess: () =>
@@ -316,15 +325,19 @@ const submissionSection = (
               [error],
             ),
             ...(isSubmittable ? [] : [blockedNotice()]),
-            h.keyed('button')(
-              'submit',
-              [
-                h.Type('button'),
-                ...(isSubmittable ? [h.OnClick(onSubmit)] : [h.Disabled(true)]),
-                h.Class(submitButtonClass(isSubmittable)),
-              ],
-              ['Try Again'],
-            ),
+            Button.view<Message>({
+              onClick: onSubmit,
+              isDisabled: !isSubmittable,
+              toView: attributes =>
+                h.keyed('button')(
+                  'submit',
+                  [
+                    ...attributes.button,
+                    h.Class(submitButtonClass(isSubmittable)),
+                  ],
+                  ['Try Again'],
+                ),
+            }),
           ],
         ),
     }),

--- a/examples/job-application/src/view/skillEntry.ts
+++ b/examples/job-application/src/view/skillEntry.ts
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { Submodel } from 'foldkit'
 import { type Html, html } from 'foldkit/html'
 
-import { RadioGroup } from '@foldkit/ui'
+import { Button, RadioGroup } from '@foldkit/ui'
 
 import { ProficiencyLevel } from '../domain'
 import { Skills } from '../step'
@@ -77,16 +77,19 @@ export const skillEntryView = Submodel.defineView<
       h.div(
         [h.Class('flex justify-end')],
         [
-          h.button(
-            [
-              h.Type('button'),
-              h.OnClick(Skills.Entry.ClickedRemoveSelf()),
-              h.Class(
-                'text-sm text-gray-400 hover:text-red-500 transition cursor-pointer',
+          Button.view<Skills.Entry.Message>({
+            onClick: Skills.Entry.ClickedRemoveSelf(),
+            toView: attributes =>
+              h.button(
+                [
+                  ...attributes.button,
+                  h.Class(
+                    'text-sm text-gray-400 hover:text-red-500 transition cursor-pointer',
+                  ),
+                ],
+                ['Remove skill'],
               ),
-            ],
-            ['Remove skill'],
-          ),
+          }),
         ],
       ),
     ],

--- a/examples/job-application/src/view/skills.ts
+++ b/examples/job-application/src/view/skills.ts
@@ -1,6 +1,8 @@
 import { Submodel } from 'foldkit'
 import { type Html, html } from 'foldkit/html'
 
+import { Button } from '@foldkit/ui'
+
 import { Skills } from '../step'
 import { skillEntryView } from './skillEntry'
 
@@ -27,16 +29,19 @@ export const skillsView = Submodel.defineView<Skills.Model, Skills.Message>(
             }),
           ),
         ),
-        h.button(
-          [
-            h.Type('button'),
-            h.OnClick(Skills.ClickedAddEntry()),
-            h.Class(
-              'w-full rounded-lg border-2 border-dashed border-gray-300 px-4 py-3 text-sm font-medium text-gray-600 hover:border-indigo-400 hover:text-indigo-600 transition cursor-pointer',
+        Button.view<Skills.Message>({
+          onClick: Skills.ClickedAddEntry(),
+          toView: attributes =>
+            h.button(
+              [
+                ...attributes.button,
+                h.Class(
+                  'w-full rounded-lg border-2 border-dashed border-gray-300 px-4 py-3 text-sm font-medium text-gray-600 hover:border-indigo-400 hover:text-indigo-600 transition cursor-pointer',
+                ),
+              ],
+              ['+ Add Skill'],
             ),
-          ],
-          ['+ Add Skill'],
-        ),
+        }),
       ],
     )
   },

--- a/examples/job-application/src/view/stepNav.ts
+++ b/examples/job-application/src/view/stepNav.ts
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { Equal, HashSet, Match, Number, flow } from 'effect'
 import { type Html, html } from 'foldkit/html'
 
-import { Menu } from '@foldkit/ui'
+import { Button, Menu } from '@foldkit/ui'
 
 import { Step } from '../domain'
 import type { Message } from '../message'
@@ -107,20 +107,22 @@ export const stepList = (
             step,
             [],
             [
-              h.button(
-                [
-                  h.Type('button'),
-                  ...(status === 'Current' ? [h.AriaCurrent('step')] : []),
-                  ...(clickable
-                    ? [h.OnClick(onSelectedStep(step))]
-                    : [h.AriaDisabled(true)]),
-                  h.Class(stepButtonClass(status, hasErrors)),
-                ],
-                [
-                  stepMarker(status, index, hasErrors),
-                  h.span([], [Step.show(step)]),
-                ],
-              ),
+              Button.view<Message>({
+                onClick: onSelectedStep(step),
+                isDisabled: !clickable,
+                toView: attributes =>
+                  h.button(
+                    [
+                      ...attributes.button,
+                      ...(status === 'Current' ? [h.AriaCurrent('step')] : []),
+                      h.Class(stepButtonClass(status, hasErrors)),
+                    ],
+                    [
+                      stepMarker(status, index, hasErrors),
+                      h.span([], [Step.show(step)]),
+                    ],
+                  ),
+              }),
             ],
           )
         }),

--- a/examples/job-application/src/view/workEntry.ts
+++ b/examples/job-application/src/view/workEntry.ts
@@ -1,7 +1,7 @@
 import { Submodel } from 'foldkit'
 import { type Html, html } from 'foldkit/html'
 
-import { Checkbox, DatePicker } from '@foldkit/ui'
+import { Button, Checkbox, DatePicker } from '@foldkit/ui'
 
 import { WorkHistory } from '../step'
 import {
@@ -154,16 +154,19 @@ export const workEntryView = Submodel.defineView<
       h.div(
         [h.Class('flex justify-end')],
         [
-          h.button(
-            [
-              h.Type('button'),
-              h.OnClick(WorkHistory.Entry.ClickedRemoveSelf()),
-              h.Class(
-                'text-sm text-gray-400 hover:text-red-500 transition cursor-pointer',
+          Button.view<WorkHistory.Entry.Message>({
+            onClick: WorkHistory.Entry.ClickedRemoveSelf(),
+            toView: attributes =>
+              h.button(
+                [
+                  ...attributes.button,
+                  h.Class(
+                    'text-sm text-gray-400 hover:text-red-500 transition cursor-pointer',
+                  ),
+                ],
+                ['Remove position'],
               ),
-            ],
-            ['Remove position'],
-          ),
+          }),
         ],
       ),
     ],

--- a/examples/job-application/src/view/workHistory.ts
+++ b/examples/job-application/src/view/workHistory.ts
@@ -1,6 +1,8 @@
 import { Submodel } from 'foldkit'
 import { type Html, html } from 'foldkit/html'
 
+import { Button } from '@foldkit/ui'
+
 import { WorkHistory } from '../step'
 import { workEntryView } from './workEntry'
 
@@ -29,16 +31,19 @@ export const workHistoryView = Submodel.defineView<
           }),
         ),
       ),
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(WorkHistory.ClickedAddEntry()),
-          h.Class(
-            'w-full rounded-lg border-2 border-dashed border-gray-300 px-4 py-3 text-sm font-medium text-gray-600 hover:border-indigo-400 hover:text-indigo-600 transition cursor-pointer',
+      Button.view<WorkHistory.Message>({
+        onClick: WorkHistory.ClickedAddEntry(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'w-full rounded-lg border-2 border-dashed border-gray-300 px-4 py-3 text-sm font-medium text-gray-600 hover:border-indigo-400 hover:text-indigo-600 transition cursor-pointer',
+              ),
+            ],
+            ['+ Add Position'],
           ),
-        ],
-        ['+ Add Position'],
-      ),
+      }),
     ],
   )
 })

--- a/examples/map/package.json
+++ b/examples/map/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
+    "clsx": "^2.1.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",
     "maplibre-gl": "^5.24.0",

--- a/examples/map/src/main.ts
+++ b/examples/map/src/main.ts
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import {
   Array,
   Effect,
@@ -18,6 +19,8 @@ import { m } from 'foldkit/message'
 import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
 import type { Map as MapInstance } from 'maplibre-gl'
+
+import { Button, Input } from '@foldkit/ui'
 
 import { Location, featuredLocations } from './locations'
 import { getMap, removeMap, setMap } from './mapHost'
@@ -539,17 +542,21 @@ const sidebarView = (model: Model): Html => {
       h.div(
         [h.Class('px-5 py-3 border-b border-slate-200')],
         [
-          h.input([
-            h.Id(SEARCH_INPUT_ID),
-            h.Type('search'),
-            h.Placeholder('Filter locations'),
-            h.AriaLabel('Filter locations'),
-            h.Class(
-              'w-full px-3 py-2 text-sm rounded-md border border-slate-300 outline-none focus:border-slate-500 focus:ring-2 focus:ring-slate-200',
-            ),
-            h.Value(model.searchQuery),
-            h.OnInput(value => UpdatedSearchQuery({ value })),
-          ]),
+          Input.view<Message>({
+            id: SEARCH_INPUT_ID,
+            type: 'search',
+            value: model.searchQuery,
+            placeholder: 'Filter locations',
+            onInput: value => UpdatedSearchQuery({ value }),
+            toView: attributes =>
+              h.input([
+                ...attributes.input,
+                h.AriaLabel('Filter locations'),
+                h.Class(
+                  'w-full px-3 py-2 text-sm rounded-md border border-slate-300 outline-none focus:border-slate-500 focus:ring-2 focus:ring-slate-200',
+                ),
+              ]),
+          }),
         ],
       ),
       h.ul(
@@ -588,25 +595,31 @@ const locationListItemView =
     return h.li(
       [],
       [
-        h.button(
-          [
-            h.Type('button'),
-            h.AriaPressed(isSelected ? 'true' : 'false'),
-            h.OnClick(ClickedLocation({ locationId: location.id })),
-            h.Class(
-              isSelected
-                ? 'w-full text-left px-5 py-3 cursor-pointer bg-slate-100 border-l-2 border-slate-900'
-                : 'w-full text-left px-5 py-3 cursor-pointer hover:bg-slate-100 border-l-2 border-transparent',
+        Button.view<Message>({
+          onClick: ClickedLocation({ locationId: location.id }),
+          toView: attributes =>
+            h.button(
+              [
+                ...attributes.button,
+                h.AriaPressed(isSelected ? 'true' : 'false'),
+                h.Class(
+                  clsx(
+                    'w-full text-left px-5 py-3 cursor-pointer border-l-2',
+                    isSelected
+                      ? 'bg-slate-100 border-slate-900'
+                      : 'hover:bg-slate-100 border-transparent',
+                  ),
+                ),
+              ],
+              [
+                h.div([h.Class('text-sm font-medium')], [location.name]),
+                h.div(
+                  [h.Class('text-xs text-slate-500 mt-0.5')],
+                  [location.region],
+                ),
+              ],
             ),
-          ],
-          [
-            h.div([h.Class('text-sm font-medium')], [location.name]),
-            h.div(
-              [h.Class('text-xs text-slate-500 mt-0.5')],
-              [location.region],
-            ),
-          ],
-        ),
+        }),
       ],
     )
   }
@@ -618,17 +631,20 @@ const footerView = (model: Model): Html => {
   return h.div(
     [h.Class('border-t border-slate-200 px-5 py-3 space-y-2')],
     [
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(ClickedFindMe()),
-          h.Disabled(isLocating),
-          h.Class(
-            'w-full px-3 py-2 text-sm font-medium rounded-md bg-slate-900 text-white hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed',
+      Button.view<Message>({
+        onClick: ClickedFindMe(),
+        isDisabled: isLocating,
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'w-full px-3 py-2 text-sm font-medium rounded-md bg-slate-900 text-white hover:bg-slate-800 data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed',
+              ),
+            ],
+            [isLocating ? 'Locating…' : 'Find my location'],
           ),
-        ],
-        [isLocating ? 'Locating…' : 'Find my location'],
-      ),
+      }),
       Option.match(model.maybeUserLocation, {
         onNone: () => h.empty,
         onSome: ({ lng, lat }) =>
@@ -770,16 +786,19 @@ const geolocateFailedContentView = (reason: string): Html => {
         ['Could not locate you'],
       ),
       h.p([h.Class('text-sm text-slate-600')], [reason]),
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(DismissedGeolocate()),
-          h.Class(
-            'mt-4 px-4 py-2 text-sm font-medium rounded-md bg-slate-900 text-white hover:bg-slate-800',
+      Button.view<Message>({
+        onClick: DismissedGeolocate(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'mt-4 px-4 py-2 text-sm font-medium rounded-md bg-slate-900 text-white hover:bg-slate-800',
+              ),
+            ],
+            ['Dismiss'],
           ),
-        ],
-        ['Dismiss'],
-      ),
+      }),
     ],
   )
 }

--- a/examples/query-sync/src/main.ts
+++ b/examples/query-sync/src/main.ts
@@ -20,7 +20,7 @@ import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
 import { Url, toString as urlToString } from 'foldkit/url'
 
-import { Listbox } from '@foldkit/ui'
+import { Button, Input, Listbox } from '@foldkit/ui'
 import { AnchorConfig } from '@foldkit/ui/listbox'
 
 import { type Dinosaur, dinosaurs } from './data'
@@ -582,15 +582,18 @@ const sortableColumnHeader = (
   return h.th(
     [h.AriaSort(ariaSortValue(column, fields.sorting))],
     [
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(ClickedColumnHeader({ column })),
-          h.AriaLabel(sortAriaLabel(column, fields.sorting)),
-          h.Class(clsx(headerButtonClass, alignment)),
-        ],
-        isRightAligned ? [indicator, label] : [label, indicator],
-      ),
+      Button.view<Message>({
+        onClick: ClickedColumnHeader({ column }),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.AriaLabel(sortAriaLabel(column, fields.sorting)),
+              h.Class(clsx(headerButtonClass, alignment)),
+            ],
+            isRightAligned ? [indicator, label] : [label, indicator],
+          ),
+      }),
     ],
   )
 }
@@ -713,14 +716,19 @@ const browseView = (model: Model, route: typeof BrowseRoute.Type): Html => {
       h.div(
         [h.Class('flex flex-wrap items-start gap-3 mb-6')],
         [
-          h.input([
-            h.Value(Option.getOrElse(fields.search, () => '')),
-            h.Placeholder('Search by name…'),
-            h.OnInput(value => ChangedSearchInput({ value })),
-            h.Class(
-              'flex-1 min-w-48 px-4 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500',
-            ),
-          ]),
+          Input.view<Message>({
+            id: 'dinosaur-search',
+            value: Option.getOrElse(fields.search, () => ''),
+            placeholder: 'Search by name…',
+            onInput: value => ChangedSearchInput({ value }),
+            toView: attributes =>
+              h.input([
+                ...attributes.input,
+                h.Class(
+                  'flex-1 min-w-48 px-4 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500',
+                ),
+              ]),
+          }),
           h.submodel({
             slotId: model.dietListbox.id,
             model: model.dietListbox,

--- a/examples/shopping-cart/package.json
+++ b/examples/shopping-cart/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/shopping-cart/src/domain/cart.ts
+++ b/examples/shopping-cart/src/domain/cart.ts
@@ -48,6 +48,19 @@ export const changeQuantity = (itemId: string, quantity: number) =>
         }),
       )
 
+export const incrementQuantity = (itemId: string) =>
+  mapCartItem(
+    itemId,
+    evo({
+      quantity: Number.increment,
+    }),
+  )
+
+export const decrementQuantity =
+  (itemId: string) =>
+  (cart: Cart): Cart =>
+    changeQuantity(itemId, itemQuantity(itemId)(cart) - 1)(cart)
+
 export const itemQuantity =
   (itemId: string) =>
   (cart: Cart): number =>

--- a/examples/shopping-cart/src/main.ts
+++ b/examples/shopping-cart/src/main.ts
@@ -39,9 +39,11 @@ export const ChangedUrl = m('ChangedUrl', { url: Url })
 export const GotProductsMessage = m('GotProductsMessage', {
   message: Products.Message,
 })
-export const ClickedQuantityChange = m('ClickedQuantityChange', {
+export const ClickedIncrementQuantity = m('ClickedIncrementQuantity', {
   itemId: S.String,
-  quantity: S.Number,
+})
+export const ClickedDecrementQuantity = m('ClickedDecrementQuantity', {
+  itemId: S.String,
 })
 export const ClickedRemoveCartItem = m('ClickedRemoveCartItem', {
   itemId: S.String,
@@ -58,7 +60,8 @@ export const Message = S.Union([
   ClickedLink,
   ChangedUrl,
   GotProductsMessage,
-  ClickedQuantityChange,
+  ClickedIncrementQuantity,
+  ClickedDecrementQuantity,
   ClickedRemoveCartItem,
   ClickedClearCart,
   UpdatedDeliveryInstructions,
@@ -152,10 +155,17 @@ export const update = (model: Model, message: Message): UpdateReturn =>
                 }),
                 mappedCommands,
               ],
-              ChangedQuantity: ({ itemId, quantity }) => [
+              IncrementedQuantity: ({ itemId }) => [
                 evo(model, {
                   productsPage: () => nextProductsModel,
-                  cart: Cart.changeQuantity(itemId, quantity),
+                  cart: Cart.incrementQuantity(itemId),
+                }),
+                mappedCommands,
+              ],
+              DecrementedQuantity: ({ itemId }) => [
+                evo(model, {
+                  productsPage: () => nextProductsModel,
+                  cart: Cart.decrementQuantity(itemId),
                 }),
                 mappedCommands,
               ],
@@ -164,9 +174,16 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         })
       },
 
-      ClickedQuantityChange: ({ itemId, quantity }) => [
+      ClickedIncrementQuantity: ({ itemId }) => [
         evo(model, {
-          cart: Cart.changeQuantity(itemId, quantity),
+          cart: Cart.incrementQuantity(itemId),
+        }),
+        [],
+      ],
+
+      ClickedDecrementQuantity: ({ itemId }) => [
+        evo(model, {
+          cart: Cart.decrementQuantity(itemId),
         }),
         [],
       ],

--- a/examples/shopping-cart/src/page/cart.ts
+++ b/examples/shopping-cart/src/page/cart.ts
@@ -1,10 +1,13 @@
-import { Array, Number, Option } from 'effect'
+import { Array, Option } from 'effect'
 import { Html, html } from 'foldkit/html'
+
+import { Button } from '@foldkit/ui'
 
 import { Cart } from '../domain'
 import {
   ClickedClearCart,
-  ClickedQuantityChange,
+  ClickedDecrementQuantity,
+  ClickedIncrementQuantity,
   ClickedRemoveCartItem,
   Message,
 } from '../main'
@@ -76,53 +79,55 @@ export const view = (cart: Cart.Cart): Html => {
                         h.div(
                           [h.Class('flex items-center gap-2')],
                           [
-                            h.button(
-                              [
-                                h.Class(
-                                  'bg-gray-200 hover:bg-gray-300 text-gray-800 w-8 h-8 rounded flex items-center justify-center',
-                                ),
-                                h.OnClick(
-                                  ClickedQuantityChange({
-                                    itemId: cartItem.item.id,
-                                    quantity: Number.decrement(
-                                      cartItem.quantity,
+                            Button.view<Message>({
+                              onClick: ClickedDecrementQuantity({
+                                itemId: cartItem.item.id,
+                              }),
+                              toView: attributes =>
+                                h.button(
+                                  [
+                                    ...attributes.button,
+                                    h.Class(
+                                      'bg-gray-200 hover:bg-gray-300 text-gray-800 w-8 h-8 rounded flex items-center justify-center',
                                     ),
-                                  }),
+                                  ],
+                                  ['-'],
                                 ),
-                              ],
-                              ['-'],
-                            ),
+                            }),
                             h.span(
                               [h.Class('px-3 py-1 font-medium')],
                               [String(cartItem.quantity)],
                             ),
-                            h.button(
-                              [
-                                h.Class(
-                                  'bg-gray-200 hover:bg-gray-300 text-gray-800 w-8 h-8 rounded flex items-center justify-center',
+                            Button.view<Message>({
+                              onClick: ClickedIncrementQuantity({
+                                itemId: cartItem.item.id,
+                              }),
+                              toView: attributes =>
+                                h.button(
+                                  [
+                                    ...attributes.button,
+                                    h.Class(
+                                      'bg-gray-200 hover:bg-gray-300 text-gray-800 w-8 h-8 rounded flex items-center justify-center',
+                                    ),
+                                  ],
+                                  ['+'],
                                 ),
-                                h.OnClick(
-                                  ClickedQuantityChange({
-                                    itemId: cartItem.item.id,
-                                    quantity: cartItem.quantity + 1,
-                                  }),
+                            }),
+                            Button.view<Message>({
+                              onClick: ClickedRemoveCartItem({
+                                itemId: cartItem.item.id,
+                              }),
+                              toView: attributes =>
+                                h.button(
+                                  [
+                                    ...attributes.button,
+                                    h.Class(
+                                      'bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded ml-2',
+                                    ),
+                                  ],
+                                  ['Remove'],
                                 ),
-                              ],
-                              ['+'],
-                            ),
-                            h.button(
-                              [
-                                h.Class(
-                                  'bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded ml-2',
-                                ),
-                                h.OnClick(
-                                  ClickedRemoveCartItem({
-                                    itemId: cartItem.item.id,
-                                  }),
-                                ),
-                              ],
-                              ['Remove'],
-                            ),
+                            }),
                           ],
                         ),
                       ],
@@ -161,15 +166,19 @@ export const view = (cart: Cart.Cart): Html => {
                       ],
                       ['Continue Shopping'],
                     ),
-                    h.button(
-                      [
-                        h.Class(
-                          'bg-red-500 hover:bg-red-600 text-white px-6 py-2 rounded-lg font-medium',
+                    Button.view<Message>({
+                      onClick: ClickedClearCart(),
+                      toView: attributes =>
+                        h.button(
+                          [
+                            ...attributes.button,
+                            h.Class(
+                              'bg-red-500 hover:bg-red-600 text-white px-6 py-2 rounded-lg font-medium',
+                            ),
+                          ],
+                          ['Clear Cart'],
                         ),
-                        h.OnClick(ClickedClearCart()),
-                      ],
-                      ['Clear Cart'],
-                    ),
+                    }),
                     h.a(
                       [
                         h.Href(checkoutRouter()),

--- a/examples/shopping-cart/src/page/checkout.ts
+++ b/examples/shopping-cart/src/page/checkout.ts
@@ -1,6 +1,8 @@
 import { Array, Option } from 'effect'
 import { Html, html } from 'foldkit/html'
 
+import { Button, Textarea } from '@foldkit/ui'
+
 import { Cart } from '../domain'
 import {
   ClickedPlaceOrder,
@@ -139,30 +141,36 @@ export const view = (
                 ),
               ],
             ),
-            h.div(
-              [h.Class('mb-6')],
-              [
-                h.h3(
-                  [h.Class('text-lg font-semibold text-gray-800 mb-2')],
-                  ['Delivery Instructions'],
-                ),
-                h.textarea(
+            Textarea.view<Message>({
+              id: 'delivery-instructions',
+              value: deliveryInstructions,
+              placeholder: 'Special delivery instructions (optional)...',
+              onInput: value => UpdatedDeliveryInstructions({ value }),
+              toView: attributes =>
+                h.div(
+                  [h.Class('mb-6')],
                   [
-                    h.Value(deliveryInstructions),
-                    h.Placeholder(
-                      'Special delivery instructions (optional)...',
+                    h.label(
+                      [
+                        ...attributes.label,
+                        h.Class(
+                          'block text-lg font-semibold text-gray-800 mb-2',
+                        ),
+                      ],
+                      ['Delivery Instructions'],
                     ),
-                    h.Class(
-                      'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 h-24 resize-none',
-                    ),
-                    h.OnInput((value: string) =>
-                      UpdatedDeliveryInstructions({ value }),
+                    h.textarea(
+                      [
+                        ...attributes.textarea,
+                        h.Class(
+                          'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 h-24 resize-none',
+                        ),
+                      ],
+                      [],
                     ),
                   ],
-                  [],
                 ),
-              ],
-            ),
+            }),
             h.div(
               [h.Class('flex gap-4 justify-center')],
               [
@@ -175,15 +183,19 @@ export const view = (
                   ],
                   ['Back to Cart'],
                 ),
-                h.button(
-                  [
-                    h.Class(
-                      'bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg font-medium',
+                Button.view<Message>({
+                  onClick: ClickedPlaceOrder(),
+                  toView: attributes =>
+                    h.button(
+                      [
+                        ...attributes.button,
+                        h.Class(
+                          'bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg font-medium',
+                        ),
+                      ],
+                      ['Place Order'],
                     ),
-                    h.OnClick(ClickedPlaceOrder()),
-                  ],
-                  ['Place Order'],
-                ),
+                }),
               ],
             ),
           ],

--- a/examples/shopping-cart/src/page/products.ts
+++ b/examples/shopping-cart/src/page/products.ts
@@ -5,6 +5,8 @@ import { m } from 'foldkit/message'
 import { replaceUrl } from 'foldkit/navigation'
 import { evo } from 'foldkit/struct'
 
+import { Button, Input } from '@foldkit/ui'
+
 import { Cart, Item } from '../domain'
 import { cartRouter, productsRouter } from '../route'
 
@@ -21,32 +23,42 @@ export type Model = typeof Model.Type
 const CompletedReplaceUrl = m('CompletedReplaceUrl')
 const ChangedSearchInput = m('ChangedSearchInput', { value: S.String })
 export const ClickedAddToCart = m('ClickedAddToCart', { item: Item.Item })
-export const ClickedChangeQuantity = m('ClickedChangeQuantity', {
+export const ClickedIncrementQuantity = m('ClickedIncrementQuantity', {
   itemId: S.String,
-  quantity: S.Number,
+})
+export const ClickedDecrementQuantity = m('ClickedDecrementQuantity', {
+  itemId: S.String,
 })
 
 export const Message = S.Union([
   CompletedReplaceUrl,
   ChangedSearchInput,
   ClickedAddToCart,
-  ClickedChangeQuantity,
+  ClickedIncrementQuantity,
+  ClickedDecrementQuantity,
 ])
 export type Message = typeof Message.Type
 
 // OUT MESSAGE
 
 export const AddedToCart = m('AddedToCart', { item: Item.Item })
-export const ChangedQuantity = m('ChangedQuantity', {
+export const IncrementedQuantity = m('IncrementedQuantity', {
   itemId: S.String,
-  quantity: S.Number,
+})
+export const DecrementedQuantity = m('DecrementedQuantity', {
+  itemId: S.String,
 })
 
-export const OutMessage = S.Union([AddedToCart, ChangedQuantity])
+export const OutMessage = S.Union([
+  AddedToCart,
+  IncrementedQuantity,
+  DecrementedQuantity,
+])
 export type OutMessage = typeof OutMessage.Type
 
 export type AddedToCart = typeof AddedToCart.Type
-export type ChangedQuantity = typeof ChangedQuantity.Type
+export type IncrementedQuantity = typeof IncrementedQuantity.Type
+export type DecrementedQuantity = typeof DecrementedQuantity.Type
 
 // INIT
 
@@ -96,10 +108,16 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         Option.some(AddedToCart({ item })),
       ],
 
-      ClickedChangeQuantity: ({ itemId, quantity }) => [
+      ClickedIncrementQuantity: ({ itemId }) => [
         model,
         [],
-        Option.some(ChangedQuantity({ itemId, quantity })),
+        Option.some(IncrementedQuantity({ itemId })),
+      ],
+
+      ClickedDecrementQuantity: ({ itemId }) => [
+        model,
+        [],
+        Option.some(DecrementedQuantity({ itemId })),
       ],
     }),
   )
@@ -130,14 +148,20 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
             h.search(
               [h.Class('mb-6')],
               [
-                h.input([
-                  h.Value(model.searchText),
-                  h.Placeholder('Search products...'),
-                  h.Class(
-                    'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
-                  ),
-                  h.OnInput((value: string) => ChangedSearchInput({ value })),
-                ]),
+                Input.view<Message>({
+                  id: 'product-search',
+                  value: model.searchText,
+                  placeholder: 'Search products...',
+                  onInput: value => ChangedSearchInput({ value }),
+                  toView: attributes =>
+                    h.input([
+                      ...attributes.input,
+                      h.AriaLabel('Search products'),
+                      h.Class(
+                        'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                      ),
+                    ]),
+                }),
               ],
             ),
             h.section(
@@ -165,33 +189,37 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                       ],
                     ),
                     Cart.itemQuantity(product.id)(cart) === 0
-                      ? h.button(
-                          [
-                            h.Class(
-                              'bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg font-medium',
+                      ? Button.view<Message>({
+                          onClick: ClickedAddToCart({ item: product }),
+                          toView: attributes =>
+                            h.button(
+                              [
+                                ...attributes.button,
+                                h.Class(
+                                  'bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg font-medium',
+                                ),
+                              ],
+                              ['Add to Cart'],
                             ),
-                            h.OnClick(ClickedAddToCart({ item: product })),
-                          ],
-                          ['Add to Cart'],
-                        )
+                        })
                       : h.div(
                           [h.Class('flex items-center gap-2')],
                           [
-                            h.button(
-                              [
-                                h.Class(
-                                  'bg-gray-200 hover:bg-gray-300 text-gray-800 w-8 h-8 rounded flex items-center justify-center',
+                            Button.view<Message>({
+                              onClick: ClickedDecrementQuantity({
+                                itemId: product.id,
+                              }),
+                              toView: attributes =>
+                                h.button(
+                                  [
+                                    ...attributes.button,
+                                    h.Class(
+                                      'bg-gray-200 hover:bg-gray-300 text-gray-800 w-8 h-8 rounded flex items-center justify-center',
+                                    ),
+                                  ],
+                                  ['-'],
                                 ),
-                                h.OnClick(
-                                  ClickedChangeQuantity({
-                                    itemId: product.id,
-                                    quantity:
-                                      Cart.itemQuantity(product.id)(cart) - 1,
-                                  }),
-                                ),
-                              ],
-                              ['-'],
-                            ),
+                            }),
                             h.span(
                               [
                                 h.Class(
@@ -200,21 +228,21 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                               ],
                               [String(Cart.itemQuantity(product.id)(cart))],
                             ),
-                            h.button(
-                              [
-                                h.Class(
-                                  'bg-gray-200 hover:bg-gray-300 text-gray-800 w-8 h-8 rounded flex items-center justify-center',
+                            Button.view<Message>({
+                              onClick: ClickedIncrementQuantity({
+                                itemId: product.id,
+                              }),
+                              toView: attributes =>
+                                h.button(
+                                  [
+                                    ...attributes.button,
+                                    h.Class(
+                                      'bg-gray-200 hover:bg-gray-300 text-gray-800 w-8 h-8 rounded flex items-center justify-center',
+                                    ),
+                                  ],
+                                  ['+'],
                                 ),
-                                h.OnClick(
-                                  ClickedChangeQuantity({
-                                    itemId: product.id,
-                                    quantity:
-                                      Cart.itemQuantity(product.id)(cart) + 1,
-                                  }),
-                                ),
-                              ],
-                              ['+'],
-                            ),
+                            }),
                           ],
                         ),
                   ],

--- a/examples/shopping-cart/src/story.test.ts
+++ b/examples/shopping-cart/src/story.test.ts
@@ -7,8 +7,9 @@ import { products } from './data/products'
 import {
   ChangedUrl,
   ClickedClearCart,
+  ClickedDecrementQuantity,
+  ClickedIncrementQuantity,
   ClickedPlaceOrder,
-  ClickedQuantityChange,
   ClickedRemoveCartItem,
   GotProductsMessage,
   type Model,
@@ -127,16 +128,44 @@ describe('update', () => {
       )
     })
 
-    test('ClickedQuantityChange replaces the quantity for an item', () => {
+    test('ClickedIncrementQuantity raises the quantity for an item', () => {
       Story.story(
         update,
         Story.with({
           ...baseModel,
           cart: [{ item: apple, quantity: 1 }],
         }),
-        Story.message(ClickedQuantityChange({ itemId: '1', quantity: 5 })),
+        Story.message(ClickedIncrementQuantity({ itemId: '1' })),
         Story.model(model => {
-          expect(model.cart[0]?.quantity).toBe(5)
+          expect(model.cart[0]?.quantity).toBe(2)
+        }),
+      )
+    })
+
+    test('ClickedDecrementQuantity lowers the quantity for an item', () => {
+      Story.story(
+        update,
+        Story.with({
+          ...baseModel,
+          cart: [{ item: apple, quantity: 2 }],
+        }),
+        Story.message(ClickedDecrementQuantity({ itemId: '1' })),
+        Story.model(model => {
+          expect(model.cart[0]?.quantity).toBe(1)
+        }),
+      )
+    })
+
+    test('ClickedDecrementQuantity removes the item when it reaches zero', () => {
+      Story.story(
+        update,
+        Story.with({
+          ...baseModel,
+          cart: [{ item: apple, quantity: 1 }],
+        }),
+        Story.message(ClickedDecrementQuantity({ itemId: '1' })),
+        Story.model(model => {
+          expect(model.cart).toHaveLength(0)
         }),
       )
     })

--- a/examples/stopwatch/package.json
+++ b/examples/stopwatch/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/stopwatch/src/main.ts
+++ b/examples/stopwatch/src/main.ts
@@ -14,6 +14,8 @@ import { Document, Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
+import { Button } from '@foldkit/ui'
+
 const TICK_INTERVAL_MS = 10
 
 // MODEL
@@ -196,13 +198,17 @@ export const view = (model: Model): Document => {
             h.div(
               [h.Class('flex')],
               [
-                h.button(
-                  [
-                    h.OnClick(ClickedReset()),
-                    h.Class(buttonStyle + ' bg-gray-500 hover:bg-gray-600'),
-                  ],
-                  ['Reset'],
-                ),
+                Button.view<Message>({
+                  onClick: ClickedReset(),
+                  toView: attributes =>
+                    h.button(
+                      [
+                        ...attributes.button,
+                        h.Class(buttonStyle + ' bg-gray-500 hover:bg-gray-600'),
+                      ],
+                      ['Reset'],
+                    ),
+                }),
                 startStopButton(model.isRunning),
               ],
             ),
@@ -217,20 +223,28 @@ const startStopButton = (isRunning: boolean): Html => {
   const h = html<Message>()
 
   return isRunning
-    ? h.button(
-        [
-          h.OnClick(ClickedStop()),
-          h.Class(buttonStyle + ' bg-red-500 hover:bg-red-600'),
-        ],
-        ['Stop'],
-      )
-    : h.button(
-        [
-          h.OnClick(ClickedStart()),
-          h.Class(buttonStyle + ' bg-green-500 hover:bg-green-600'),
-        ],
-        ['Start'],
-      )
+    ? Button.view<Message>({
+        onClick: ClickedStop(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(buttonStyle + ' bg-red-500 hover:bg-red-600'),
+            ],
+            ['Stop'],
+          ),
+      })
+    : Button.view<Message>({
+        onClick: ClickedStart(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(buttonStyle + ' bg-green-500 hover:bg-green-600'),
+            ],
+            ['Start'],
+          ),
+      })
 }
 
 // STYLE

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
+    "clsx": "^2.1.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.3.1"

--- a/examples/todo/src/main.ts
+++ b/examples/todo/src/main.ts
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import {
   Array,
   Clock,
@@ -16,6 +17,7 @@ import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
 
 import { BrowserKeyValueStore } from '@effect/platform-browser'
+import { Button, Checkbox, Input } from '@foldkit/ui'
 
 // CONSTANT
 
@@ -198,15 +200,15 @@ export const update = (
       },
 
       StartedEditing: ({ id }) => {
-        const todo = Array.findFirst(model.todos, t => t.id === id)
+        const maybeTodo = Array.findFirst(model.todos, todo => todo.id === id)
         return [
           evo(model, {
             editing: () =>
               Editing({
                 id,
-                text: Option.match(todo, {
+                text: Option.match(maybeTodo, {
                   onNone: () => '',
-                  onSome: t => t.text,
+                  onSome: todo => todo.text,
                 }),
               }),
           }),
@@ -363,35 +365,54 @@ const editingTodoView = (todo: Todo, text: string): Html => {
     `${todo.id}:editing`,
     [h.Class('flex items-center gap-3 p-3 bg-gray-50 rounded-lg')],
     [
-      h.input([
-        h.Type('text'),
-        h.Id(`edit-${todo.id}`),
-        h.AriaLabel('Edit todo'),
-        h.Value(text),
-        h.Class(
-          'flex-1 px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500',
-        ),
-        h.OnInput(text => UpdatedEditingTodo({ text })),
-      ]),
-      h.button(
-        [
-          h.OnClick(SavedEdit()),
-          h.Class(
-            'px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600',
+      Input.view<Message>({
+        id: `edit-${todo.id}`,
+        value: text,
+        onInput: text => UpdatedEditingTodo({ text }),
+        toView: attributes =>
+          h.input([
+            ...attributes.input,
+            h.AriaLabel('Edit todo'),
+            h.Class(
+              'flex-1 px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500',
+            ),
+          ]),
+      }),
+      Button.view<Message>({
+        onClick: SavedEdit(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600',
+              ),
+            ],
+            ['Save'],
           ),
-        ],
-        ['Save'],
-      ),
-      h.button(
-        [
-          h.OnClick(CancelledEdit()),
-          h.Class('px-3 py-1 bg-gray-500 text-white rounded hover:bg-gray-600'),
-        ],
-        ['Cancel'],
-      ),
+      }),
+      Button.view<Message>({
+        onClick: CancelledEdit(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'px-3 py-1 bg-gray-500 text-white rounded hover:bg-gray-600',
+              ),
+            ],
+            ['Cancel'],
+          ),
+      }),
     ],
   )
 }
+
+const checkboxBoxClassName = (isChecked: boolean): string =>
+  clsx(
+    'flex h-4 w-4 items-center justify-center rounded border transition cursor-pointer',
+    isChecked ? 'border-blue-600 bg-blue-600' : 'border-gray-300',
+  )
 
 const nonEditingTodoView = (todo: Todo): Html => {
   const h = html<Message>()
@@ -400,14 +421,33 @@ const nonEditingTodoView = (todo: Todo): Html => {
     `${todo.id}:viewing`,
     [h.Class('flex items-center gap-3 p-3 hover:bg-gray-50 rounded-lg group')],
     [
-      h.input([
-        h.Type('checkbox'),
-        h.Id(`todo-${todo.id}`),
-        h.AriaLabel(todo.text),
-        h.Value(todo.completed ? 'on' : ''),
-        h.Class('w-4 h-4 text-blue-600 rounded focus:ring-blue-500'),
-        h.OnClick(ToggledTodo({ id: todo.id })),
-      ]),
+      h.submodel({
+        slotId: `${todo.id}-checkbox`,
+        model: Checkbox.init({
+          id: `todo-${todo.id}`,
+          isChecked: todo.completed,
+        }),
+        view: Checkbox.view,
+        viewInputs: {
+          toView: attributes =>
+            h.div(
+              [h.Class('flex items-center')],
+              [
+                h.div(
+                  [
+                    ...attributes.checkbox,
+                    h.Class(checkboxBoxClassName(todo.completed)),
+                  ],
+                  todo.completed
+                    ? [h.span([h.Class('text-white text-xs')], ['✓'])]
+                    : [],
+                ),
+                h.span([...attributes.label, h.AriaLabel(todo.text)], []),
+              ],
+            ),
+        },
+        toParentMessage: () => ToggledTodo({ id: todo.id }),
+      }),
       h.span(
         [
           h.Class(
@@ -417,16 +457,20 @@ const nonEditingTodoView = (todo: Todo): Html => {
         ],
         [todo.text],
       ),
-      h.button(
-        [
-          h.OnClick(DeletedTodo({ id: todo.id })),
-          h.AriaLabel(`Delete ${todo.text}`),
-          h.Class(
-            'px-2 py-1 text-red-600 opacity-0 group-hover:opacity-100 hover:bg-red-100 rounded transition-opacity',
+      Button.view<Message>({
+        onClick: DeletedTodo({ id: todo.id }),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.AriaLabel(`Delete ${todo.text}`),
+              h.Class(
+                'px-2 py-1 text-red-600 opacity-0 group-hover:opacity-100 hover:bg-red-100 rounded transition-opacity',
+              ),
+            ],
+            ['×'],
           ),
-        ],
-        ['×'],
-      ),
+      }),
     ],
   )
 }
@@ -436,19 +480,23 @@ const filterButtonView =
   (filter: Filter, label: string): Html => {
     const h = html<Message>()
 
-    return h.button(
-      [
-        h.OnClick(SelectedFilter({ filter })),
-        h.Class(
-          `px-3 py-1 rounded ${
-            model.filter === filter
-              ? 'bg-blue-500 text-white'
-              : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-          }`,
+    return Button.view<Message>({
+      onClick: SelectedFilter({ filter }),
+      toView: attributes =>
+        h.button(
+          [
+            ...attributes.button,
+            h.Class(
+              `px-3 py-1 rounded ${
+                model.filter === filter
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`,
+            ),
+          ],
+          [label],
         ),
-      ],
-      [label],
-    )
+    })
   }
 
 const footerView = (
@@ -484,31 +532,39 @@ const footerView = (
               Array.match(model.todos, {
                 onEmpty: () => h.empty,
                 onNonEmpty: todos =>
-                  h.button(
-                    [
-                      h.OnClick(ToggledAll()),
-                      h.Class(
-                        'px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded hover:bg-gray-300',
+                  Button.view<Message>({
+                    onClick: ToggledAll(),
+                    toView: attributes =>
+                      h.button(
+                        [
+                          ...attributes.button,
+                          h.Class(
+                            'px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded hover:bg-gray-300',
+                          ),
+                        ],
+                        [
+                          Array.every(todos, todo => todo.completed)
+                            ? 'Mark all active'
+                            : 'Mark all complete',
+                        ],
                       ),
-                    ],
-                    [
-                      Array.every(todos, t => t.completed)
-                        ? 'Mark all active'
-                        : 'Mark all complete',
-                    ],
-                  ),
+                  }),
               }),
 
               completedCount > 0
-                ? h.button(
-                    [
-                      h.OnClick(ClearedCompleted()),
-                      h.Class(
-                        'px-3 py-1 text-sm bg-red-100 text-red-700 rounded hover:bg-red-200',
+                ? Button.view<Message>({
+                    onClick: ClearedCompleted(),
+                    toView: attributes =>
+                      h.button(
+                        [
+                          ...attributes.button,
+                          h.Class(
+                            'px-3 py-1 text-sm bg-red-100 text-red-700 rounded hover:bg-red-200',
+                          ),
+                        ],
+                        [`Clear ${completedCount} completed`],
                       ),
-                    ],
-                    [`Clear ${completedCount} completed`],
-                  )
+                  })
                 : h.empty,
             ],
           ),
@@ -548,28 +604,36 @@ export const view = (model: Model): Document => {
           h.form(
             [h.Class('mb-6'), h.OnSubmit(AddedTodo())],
             [
-              h.label([h.For('new-todo'), h.Class('sr-only')], ['New todo']),
               h.div(
                 [h.Class('flex gap-3')],
                 [
-                  h.input([
-                    h.Id('new-todo'),
-                    h.Value(model.newTodoText),
-                    h.Placeholder('What needs to be done?'),
-                    h.Class(
-                      'flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
-                    ),
-                    h.OnInput(text => UpdatedNewTodo({ text })),
-                  ]),
-                  h.button(
-                    [
-                      h.Type('submit'),
-                      h.Class(
-                        'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500',
+                  Input.view<Message>({
+                    id: 'new-todo',
+                    value: model.newTodoText,
+                    placeholder: 'What needs to be done?',
+                    onInput: text => UpdatedNewTodo({ text }),
+                    toView: attributes =>
+                      h.input([
+                        ...attributes.input,
+                        h.AriaLabel('New todo'),
+                        h.Class(
+                          'flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                        ),
+                      ]),
+                  }),
+                  Button.view<Message>({
+                    type: 'submit',
+                    toView: attributes =>
+                      h.button(
+                        [
+                          ...attributes.button,
+                          h.Class(
+                            'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500',
+                          ),
+                        ],
+                        ['Add'],
                       ),
-                    ],
-                    ['Add'],
-                  ),
+                  }),
                 ],
               ),
             ],

--- a/examples/weather/package.json
+++ b/examples/weather/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/weather/src/main.ts
+++ b/examples/weather/src/main.ts
@@ -10,6 +10,8 @@ import { m } from 'foldkit/message'
 import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
 
+import { Button, Input } from '@foldkit/ui'
+
 // MODEL
 
 export const WeatherData = S.Struct({
@@ -77,12 +79,17 @@ export const update = (
         [],
       ],
 
-      SubmittedWeatherForm: () => [
-        evo(model, {
-          weather: () => WeatherLoading(),
-        }),
-        [FetchWeather({ zipCode: model.zipCodeInput })],
-      ],
+      SubmittedWeatherForm: () => {
+        if (model.weather._tag === 'WeatherLoading') {
+          return [model, []]
+        }
+        return [
+          evo(model, {
+            weather: () => WeatherLoading(),
+          }),
+          [FetchWeather({ zipCode: model.zipCodeInput })],
+        ]
+      },
 
       SucceededFetchWeather: ({ weather }) => [
         evo(model, {
@@ -265,32 +272,40 @@ export const view = (model: Model): Document => {
             h.OnSubmit(SubmittedWeatherForm()),
           ],
           [
-            h.label([h.For('location'), h.Class('sr-only')], ['Zip code']),
-            h.input([
-              h.Id('location'),
-              h.Class(
-                'w-full px-4 py-2 rounded-lg border-2 border-blue-300 focus:border-blue-500 outline-none',
-              ),
-              h.Autocomplete('off'),
-              h.DataAttribute('1p-ignore', ''),
-              h.Placeholder('Enter a zip code'),
-              h.Value(model.zipCodeInput),
-              h.OnInput(value => UpdatedZipCodeInput({ value })),
-            ]),
-            h.button(
-              [
-                h.Type('submit'),
-                h.Disabled(model.weather._tag === 'WeatherLoading'),
-                h.Class(
-                  'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition disabled:opacity-50',
+            Input.view<Message>({
+              id: 'location',
+              value: model.zipCodeInput,
+              placeholder: 'Enter a zip code',
+              onInput: value => UpdatedZipCodeInput({ value }),
+              toView: attributes =>
+                h.input([
+                  ...attributes.input,
+                  h.Autocomplete('off'),
+                  h.DataAttribute('1p-ignore', ''),
+                  h.AriaLabel('Zip code'),
+                  h.Class(
+                    'w-full px-4 py-2 rounded-lg border-2 border-blue-300 focus:border-blue-500 outline-none',
+                  ),
+                ]),
+            }),
+            Button.view<Message>({
+              type: 'submit',
+              isDisabled: model.weather._tag === 'WeatherLoading',
+              toView: attributes =>
+                h.button(
+                  [
+                    ...attributes.button,
+                    h.Class(
+                      'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition data-[disabled]:opacity-50',
+                    ),
+                  ],
+                  [
+                    model.weather._tag === 'WeatherLoading'
+                      ? 'Loading...'
+                      : 'Get Weather',
+                  ],
                 ),
-              ],
-              [
-                model.weather._tag === 'WeatherLoading'
-                  ? 'Loading...'
-                  : 'Get Weather',
-              ],
-            ),
+            }),
           ],
         ),
 

--- a/examples/web-components/src/main.ts
+++ b/examples/web-components/src/main.ts
@@ -6,7 +6,7 @@ import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 import 'vanilla-colorful/hex-color-picker.js'
 
-import { Input } from '@foldkit/ui'
+import { Button, Input } from '@foldkit/ui'
 import '@shoelace-style/shoelace/dist/components/qr-code/qr-code.js'
 
 // MODEL
@@ -300,17 +300,22 @@ const swatchRow = (
   return h.div(
     [h.Class('flex flex-wrap gap-1.5 max-w-[10rem]')],
     PRESET_COLORS.map(color =>
-      h.button(
-        [
-          h.Type('button'),
-          h.OnClick(onChange(color)),
-          h.Title(color),
-          h.AriaLabel(`Use ${color}`),
-          h.Class(swatchClass(color.toLowerCase() === active.toLowerCase())),
-          h.Style({ backgroundColor: color }),
-        ],
-        [],
-      ),
+      Button.view<Message>({
+        onClick: onChange(color),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Title(color),
+              h.AriaLabel(`Use ${color}`),
+              h.Class(
+                swatchClass(color.toLowerCase() === active.toLowerCase()),
+              ),
+              h.Style({ backgroundColor: color }),
+            ],
+            [],
+          ),
+      }),
     ),
   )
 }

--- a/examples/websocket-chat/package.json
+++ b/examples/websocket-chat/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@effect/platform-browser": "4.0.0-beta.83",
     "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
     "effect": "4.0.0-beta.83",
     "foldkit": "workspace:*",

--- a/examples/websocket-chat/src/main.ts
+++ b/examples/websocket-chat/src/main.ts
@@ -16,6 +16,8 @@ import { m } from 'foldkit/message'
 import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
 
+import { Button, Input } from '@foldkit/ui'
+
 const WS_URL = 'wss://ws.postman-echo.com/raw'
 const CONNECTION_TIMEOUT_MS = 5000
 
@@ -538,15 +540,19 @@ const connectButtonView = (): Html => {
   return h.div(
     [h.Class('p-6 border-t border-gray-200 flex items-center justify-center')],
     [
-      h.button(
-        [
-          h.OnClick(ClickedConnect()),
-          h.Class(
-            'bg-blue-500 hover:bg-blue-600 text-white font-semibold px-8 py-3 rounded-lg transition',
+      Button.view<Message>({
+        onClick: ClickedConnect(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'bg-blue-500 hover:bg-blue-600 text-white font-semibold px-8 py-3 rounded-lg transition',
+              ),
+            ],
+            ['Connect to Chat'],
           ),
-        ],
-        ['Connect to Chat'],
-      ),
+      }),
     ],
   )
 }
@@ -569,25 +575,33 @@ const messageInputView = (messageInput: string): Html => {
       h.div(
         [h.Class('flex gap-3')],
         [
-          h.input([
-            h.Type('text'),
-            h.Value(messageInput),
-            h.Placeholder('Type a message...'),
-            h.OnInput(value => UpdatedMessageInput({ value })),
-            h.Class(
-              'flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
-            ),
-          ]),
-          h.button(
-            [
-              h.Type('submit'),
-              h.Disabled(String.isEmpty(messageInput.trim())),
-              h.Class(
-                'bg-blue-500 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold px-6 py-3 rounded-lg transition',
+          Input.view<Message>({
+            id: 'message',
+            value: messageInput,
+            placeholder: 'Type a message...',
+            onInput: value => UpdatedMessageInput({ value }),
+            toView: attributes =>
+              h.input([
+                ...attributes.input,
+                h.Class(
+                  'flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                ),
+              ]),
+          }),
+          Button.view<Message>({
+            type: 'submit',
+            isDisabled: String.isEmpty(messageInput.trim()),
+            toView: attributes =>
+              h.button(
+                [
+                  ...attributes.button,
+                  h.Class(
+                    'bg-blue-500 hover:bg-blue-600 data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed text-white font-semibold px-6 py-3 rounded-lg transition',
+                  ),
+                ],
+                ['Send'],
               ),
-            ],
-            ['Send'],
-          ),
+          }),
         ],
       ),
     ],
@@ -610,15 +624,19 @@ const errorView = (error: string): Html => {
           h.p([h.Class('text-red-600 text-sm')], [error]),
         ],
       ),
-      h.button(
-        [
-          h.OnClick(ClickedConnect()),
-          h.Class(
-            'w-full bg-blue-500 hover:bg-blue-600 text-white font-semibold px-6 py-3 rounded-lg transition',
+      Button.view<Message>({
+        onClick: ClickedConnect(),
+        toView: attributes =>
+          h.button(
+            [
+              ...attributes.button,
+              h.Class(
+                'w-full bg-blue-500 hover:bg-blue-600 text-white font-semibold px-6 py-3 rounded-lg transition',
+              ),
+            ],
+            ['Try Again'],
           ),
-        ],
-        ['Try Again'],
-      ),
+      }),
     ],
   )
 }

--- a/packages/examples-e2e/e2e/shopping-cart.spec.ts
+++ b/packages/examples-e2e/e2e/shopping-cart.spec.ts
@@ -12,4 +12,22 @@ test.describe('shopping-cart example', () => {
     await page.getByRole('link', { name: 'Cart', exact: true }).click()
     await expect(page).toHaveURL(/\/cart/)
   })
+
+  test('adjusts cart quantity with the steppers', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Add to Cart' }).first().click()
+    await expect(
+      page.getByRole('link', { name: 'Cart (1)', exact: true }),
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: '+', exact: true }).click()
+    await expect(
+      page.getByRole('link', { name: 'Cart (2)', exact: true }),
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: '-', exact: true }).click()
+    await expect(
+      page.getByRole('link', { name: 'Cart (1)', exact: true }),
+    ).toBeVisible()
+  })
 })

--- a/packages/examples-e2e/e2e/todo.spec.ts
+++ b/packages/examples-e2e/e2e/todo.spec.ts
@@ -15,4 +15,17 @@ test.describe('todo example', () => {
     await page.getByRole('button', { name: 'Add' }).click()
     await expect(page.getByText('Write Playwright tests')).toBeVisible()
   })
+
+  test('toggles a todo complete', async ({ page }) => {
+    await page.goto('/')
+    await page
+      .getByPlaceholder('What needs to be done?')
+      .fill('Write Playwright tests')
+    await page.getByRole('button', { name: 'Add' }).click()
+
+    const checkbox = page.getByRole('checkbox')
+    await expect(checkbox).not.toBeChecked()
+    await checkbox.click()
+    await expect(checkbox).toBeChecked()
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -225,6 +228,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -280,6 +286,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -335,6 +344,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -390,6 +402,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -445,6 +460,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -744,9 +762,15 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       effect:
         specifier: 4.0.0-beta.83
         version: 4.0.0-beta.83
@@ -982,6 +1006,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1092,6 +1119,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1147,9 +1177,15 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       effect:
         specifier: 4.0.0-beta.83
         version: 4.0.0-beta.83
@@ -1263,6 +1299,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1385,6 +1424,9 @@ importers:
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -2595,24 +2637,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -2671,36 +2717,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -2830,24 +2882,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -4153,24 +4209,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## Summary

Adopt the Foldkit UI components across the example apps, replacing hand-rolled DOM with `Button`, `Input`, `Textarea`, `Select`, and `Checkbox`. `@foldkit/ui` is wired into the examples that lacked it.

## Details

- **View-only components** (`Button`, `Input`, `Textarea`, `Select`) replace hand-rolled buttons, text inputs, textareas, and selects across 16 examples (weather, counter, counters, canvas-art, crash-view, stopwatch, todo, map, web-components, query-sync, shopping-cart, embedding, websocket-chat, auth, form, job-application).
- **Submit buttons** (weather, form, auth) use `Button.view` with `isDisabled` plus a guard in `update`, because `Button` exposes disabled state via `aria-disabled` / `data-disabled` rather than the native `disabled` attribute, so it doesn't block native form submission on its own. Disabled-state Tailwind variants move from `disabled:` to `data-[disabled]:`.
- **todo's completion checkbox** adopts `Checkbox`. A submodel's model is threaded by the parent every render and never persisted by the runtime, so the `Checkbox` model is derived as a pure projection of `todo.completed` rather than stored. `todo` stays the single source of truth, and bulk actions (mark all, clear completed) stay in sync with no extra wiring.

## Left unchanged (intentional)

- Buttons/inputs that are the interactive surface of another component (Calendar/DatePicker day cells, Tabs triggers, RadioGroup/Listbox options, Tooltip triggers). They already carry that component's attribute group; wrapping them in `Button` would double-wrap the boundary and break the parent's keyboard/selection wiring.
- Stateful widgets already using Foldkit UI: pixel-art `Dialog`, api-cache `Tabs`, job-application `Checkbox`.
- map's geolocate overlay: visibility is derived from the geolocation state machine and the `Locating…` phase is non-dismissable, so `Dialog`'s escape/backdrop dismissal and open/close animation would fight the state machine rather than help.

## Testing

`pnpm pre-push` (build, lint, typecheck, unit tests) passes. Website e2e runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYjwC5G5c3apyUEqVScD4e)_