### PR TITLE
perf(devtools): cut per-jump overhead in time-travel navigation

### DIFF
--- a/.changeset/devtools-time-travel-overhead.md
+++ b/.changeset/devtools-time-travel-overhead.md
@@ -1,0 +1,29 @@
+---
+'@foldkit/devtools': patch
+'foldkit': minor
+---
+
+Cut avoidable per-jump overhead in DevTools time-travel navigation.
+
+Each navigation used to resolve the model for the target index twice: once in
+`JumpTo` to render the host app, and again in `InspectState` to feed the
+inspector panel. For a mid-segment jump that replayed the segment from the
+nearest keyframe twice. `store.jumpTo` now returns the model it resolved, and a
+single `JumpToAndInspect` command renders the host and builds the inspection
+from that one resolution. Inspect-only navigation (no host pause) still resolves
+once on its own.
+
+Scrubbing the timeline no longer enqueues a full jump-plus-inspect for every
+`pointermove`. The slider thumb still tracks every move (cheap, model-only), but
+the heavy navigation is coalesced to one per animation frame via a pending-index
+field and an `animationFrame` subscription, so a fast drag can't fall behind the
+cursor.
+
+DevTools config gains a `keyframeInterval` option (alongside `maxEntries`) to
+trade memory for faster jumps. Smaller intervals store more model snapshots and
+shorten the replay each jump walks, down to `1` where every jump is a
+constant-time snapshot lookup. It is still forced to `1` automatically when
+`excludeFromHistory` is active.
+
+Also fix the overlay's "Clear history" and "Jump to top" buttons, which
+silently did nothing when clicked.

--- a/packages/devtools/src/overlay.ts
+++ b/packages/devtools/src/overlay.ts
@@ -134,6 +134,7 @@ const Model = S.Struct({
   expandedPaths: S.HashSet(S.String),
   changedPaths: S.HashSet(S.String),
   affectedPaths: S.HashSet(S.String),
+  maybePendingScrubIndex: S.Option(S.Number),
   inspectorTabs: InspectorTabsModel,
   // NOTE: empirically, inlining `Slider.Model` here throws
   // "Cannot read properties of undefined (reading 'ast')" when running slider
@@ -163,7 +164,6 @@ const ClickedToggle = m('ClickedToggle')
 const ClickedRow = m('ClickedRow', { index: S.Number })
 const ClickedResume = m('ClickedResume')
 const ClickedClear = m('ClickedClear')
-const CompletedJump = m('CompletedJump')
 const CompletedResume = m('CompletedResume')
 const ClickedFollowLatest = m('ClickedFollowLatest')
 const ClickedScrollToTopPill = m('ClickedScrollToTopPill')
@@ -182,6 +182,7 @@ const ReceivedInspectedState = m('ReceivedInspectedState', {
   affectedPaths: S.HashSet(S.String),
 })
 const ToggledTreeNode = m('ToggledTreeNode', { path: S.String })
+const TickedScrubFrame = m('TickedScrubFrame')
 const GotInspectorTabsMessage = m('GotInspectorTabsMessage', {
   message: S.Unknown,
 })
@@ -209,7 +210,6 @@ const Message = S.Union([
   ClickedFollowLatest,
   ClickedScrollToTopPill,
   ScrolledMessageList,
-  CompletedJump,
   CompletedResume,
   CompletedClear,
   LockedScroll,
@@ -218,6 +218,7 @@ const Message = S.Union([
   CrossedMobileBreakpoint,
   ReceivedInspectedState,
   ToggledTreeNode,
+  TickedScrubFrame,
   GotInspectorTabsMessage,
   ReceivedStoreUpdate,
   GotSubmodelFilterMessage,
@@ -364,24 +365,36 @@ export const UnlockScroll = Command.define(
   UnlockedScroll,
 )(unlockScroll.pipe(Effect.as(UnlockedScroll())))
 
-const buildInspectionEffect = (index: number) =>
+const buildInspectionFromModel = (index: number, model: unknown) =>
   Effect.gen(function* () {
     const store = yield* StoreService
-    const model = yield* store.getModelAtIndex(index)
     const maybeMessage = yield* store.getMessageAtIndex(index)
     const diff = yield* store.getDiffAtIndex(index)
     return ReceivedInspectedState({ model, maybeMessage, ...diff })
   })
 
-export const JumpTo = Command.define(
-  'JumpTo',
+const buildInspectionEffect = (index: number) =>
+  Effect.gen(function* () {
+    const store = yield* StoreService
+    const model = yield* store.getModelAtIndex(index)
+    return yield* buildInspectionFromModel(index, model)
+  })
+
+// NOTE: jump and inspect both need the model at `index`. Resolving it twice
+// (once to render the host, once to feed the inspector) replays the segment
+// from the nearest keyframe twice for a mid-segment jump. `store.jumpTo`
+// returns the model it resolved so the inspector reuses that single
+// resolution. Inspect-only navigation (no host pause) still uses
+// `InspectState`, which resolves once on its own.
+export const JumpToAndInspect = Command.define(
+  'JumpToAndInspect',
   { index: S.Number },
-  CompletedJump,
+  ReceivedInspectedState,
 )(({ index }) =>
   Effect.gen(function* () {
     const store = yield* StoreService
-    yield* store.jumpTo(index)
-    return CompletedJump()
+    const model = yield* store.jumpTo(index)
+    return yield* buildInspectionFromModel(index, model)
   }),
 )
 
@@ -456,8 +469,8 @@ const makeUpdate = (
   const clear = Command.mapEffect(Clear(), provideContext)
   const scrollToTop = Command.mapEffect(ScrollToTop(), provideContext)
 
-  const jumpTo = (index: number) =>
-    Command.mapEffect(JumpTo({ index }), provideContext)
+  const jumpToAndInspect = (index: number) =>
+    Command.mapEffect(JumpToAndInspect({ index }), provideContext)
   const inspectState = (index: number) =>
     Command.mapEffect(InspectState({ index }), provideContext)
 
@@ -488,10 +501,7 @@ const makeUpdate = (
             M.withReturnType<
               [Model, ReadonlyArray<Command.Command<Message>>]
             >(),
-            M.when('TimeTravel', () => [
-              model,
-              [jumpTo(index), inspectState(index)],
-            ]),
+            M.when('TimeTravel', () => [model, [jumpToAndInspect(index)]]),
             M.when('Inspect', () => [
               evo(model, {
                 selectedIndex: () => index,
@@ -700,30 +710,43 @@ const makeUpdate = (
             innerMessage => GotScrubberSliderMessage({ message: innerMessage }),
           )
 
-          const additionalCommands = Option.match(maybeOutMessage, {
-            onNone: () => [],
+          // NOTE: the thumb tracks every pointermove (cheap, model-only via
+          // `nextSlider`), but the heavy jump-plus-inspect is coalesced to one
+          // navigation per animation frame. Each `ChangedValue` overwrites the
+          // pending host index; the `TickedScrubFrame` subscription flushes the
+          // latest on the next frame, so a fast drag can't enqueue jumps faster
+          // than they complete.
+          const nextMaybePendingScrubIndex = Option.match(maybeOutMessage, {
+            onNone: () => model.maybePendingScrubIndex,
             onSome: outMessage =>
               M.value(outMessage).pipe(
                 M.tagsExhaustive({
-                  ChangedValue: ({ value }) => {
-                    const hostIndex = sliderValueToHostIndex(
-                      value,
-                      model.startIndex,
-                    )
-                    return [jumpTo(hostIndex), inspectState(hostIndex)]
-                  },
+                  ChangedValue: ({ value }) =>
+                    Option.some(
+                      sliderValueToHostIndex(value, model.startIndex),
+                    ),
                 }),
               ),
           })
 
           return [
-            evo(model, { scrubberSlider: () => nextSlider }),
-            [...mappedSliderCommands, ...additionalCommands],
+            evo(model, {
+              scrubberSlider: () => nextSlider,
+              maybePendingScrubIndex: () => nextMaybePendingScrubIndex,
+            }),
+            mappedSliderCommands,
           ]
         },
+        TickedScrubFrame: () =>
+          Option.match(model.maybePendingScrubIndex, {
+            onNone: (): UpdateReturn => [model, []],
+            onSome: (hostIndex): UpdateReturn => [
+              evo(model, { maybePendingScrubIndex: () => Option.none() }),
+              [jumpToAndInspect(hostIndex)],
+            ],
+          }),
       }),
       M.tag(
-        'CompletedJump',
         'CompletedResume',
         'CompletedClear',
         'LockedScroll',
@@ -749,6 +772,10 @@ const makeOverlaySubscriptions = (store: DevToolsStore, shadow: ShadowRoot) => {
   })
 
   const ownSubscriptions = Subscription.make<Model, Message>()(_entry => ({
+    scrubFrame: Subscription.animationFrame<Model, Message>({
+      isActive: model => Option.isSome(model.maybePendingScrubIndex),
+      toMessage: () => TickedScrubFrame(),
+    }),
     storeUpdates: Subscription.persistent(
       Stream.concat(
         Stream.fromEffect(
@@ -1143,14 +1170,15 @@ const makeView = (
       ['Click a message to inspect'],
     )
 
-  const noMessageView: Html = h.div(
-    [
-      h.Class(
-        'flex-1 flex items-center justify-center text-dt-muted text-2xs font-mono min-w-0',
-      ),
-    ],
-    ['init: no Message'],
-  )
+  const noMessageView = (): Html =>
+    h.div(
+      [
+        h.Class(
+          'flex-1 flex items-center justify-center text-dt-muted text-2xs font-mono min-w-0',
+        ),
+      ],
+      ['init: no Message'],
+    )
 
   const modelTabContent = (
     inspectedModel: unknown,
@@ -1204,7 +1232,7 @@ const makeView = (
     timestamp: string,
   ): Html =>
     Option.match(maybeInspectedMessage, {
-      onNone: () => noMessageView,
+      onNone: noMessageView,
       onSome: rawMessage => {
         const message = unwrapIfFiltered(rawMessage, maybeSubmodelFilter)
 
@@ -1626,10 +1654,11 @@ const makeView = (
 
   const statusClass = 'text-base font-mono'
 
-  const clearHistoryButton: Html = h.button(
-    [h.Class(headerButtonClass), h.OnClick(ClickedClear())],
-    ['Clear history'],
-  )
+  const clearHistoryButton = (): Html =>
+    h.button(
+      [h.Class(headerButtonClass), h.OnClick(ClickedClear())],
+      ['Clear history'],
+    )
 
   const submodelLabel = (tag: string): string =>
     pipe(tag, String_.replace(/^Got/, ''), String_.replace(/Message$/, ''))
@@ -1683,17 +1712,18 @@ const makeView = (
       ],
     )
 
-  const scrollToTopPillView: Html = h.button(
-    [
-      h.Key('scroll-pill'),
-      h.Class('dt-scroll-pill'),
-      h.OnClick(ClickedScrollToTopPill()),
-    ],
-    [
-      arrowUpIconView(),
-      h.span([h.Class('dt-scroll-pill-text')], ['Jump to top']),
-    ],
-  )
+  const scrollToTopPillView = (): Html =>
+    h.button(
+      [
+        h.Key('scroll-pill'),
+        h.Class('dt-scroll-pill'),
+        h.OnClick(ClickedScrollToTopPill()),
+      ],
+      [
+        arrowUpIconView(),
+        h.span([h.Class('dt-scroll-pill-text')], ['Jump to top']),
+      ],
+    )
 
   const submodelFilterView = (model: Model): Html => {
     const buttonLabel = Option.match(model.maybeSubmodelFilter, {
@@ -1804,7 +1834,7 @@ const makeView = (
 
     const maybeClearHistoryButton = OptionExt.when(
       !model.isPaused,
-      clearHistoryButton,
+      clearHistoryButton(),
     )
 
     return h.header(
@@ -2101,7 +2131,7 @@ const makeView = (
                 }),
                 ...OptionExt.when(
                   !model.isFollowingTop,
-                  scrollToTopPillView,
+                  scrollToTopPillView(),
                 ).pipe(Option.toArray),
                 messageListView(model),
               ],
@@ -2115,7 +2145,8 @@ const makeView = (
       ],
     )
 
-  const interactionBlocker = h.div([h.Class('dt-interaction-blocker')], [])
+  const interactionBlocker = (): Html =>
+    h.div([h.Class('dt-interaction-blocker')], [])
 
   return (model: Model): Html =>
     h.div(
@@ -2123,7 +2154,7 @@ const makeView = (
       [
         ...OptionExt.when(
           model.isPaused && mode === 'TimeTravel',
-          interactionBlocker,
+          interactionBlocker(),
         ).pipe(Option.toArray),
         ...OptionExt.when(model.isOpen, panelView(model)).pipe(Option.toArray),
         badgeView(model),
@@ -2220,6 +2251,7 @@ export const createOverlay = (
           expandedPaths: HashSet.empty(),
           changedPaths: HashSet.empty(),
           affectedPaths: HashSet.empty(),
+          maybePendingScrubIndex: Option.none(),
           inspectorTabs: Tabs.init({ id: INSPECTOR_TABS_ID }),
           scrubberSlider: Slider.init({
             id: SCRUBBER_SLIDER_ID,

--- a/packages/foldkit/src/devTools/store.test.ts
+++ b/packages/foldkit/src/devTools/store.test.ts
@@ -516,6 +516,27 @@ describe('DevToolsStore', () => {
       expect(rendered[rendered.length - 1]).toEqual({ count: 2 })
     })
 
+    it('returns the resolved model so callers skip a second resolution', () => {
+      const { bridge, store, rendered } = makeStore()
+      const replaySpy = vi.spyOn(bridge, 'replay')
+
+      recordIncrements(store, 35)
+      replaySpy.mockClear()
+
+      const midSegmentIndex = 5
+      const returnedModel = run(store.jumpTo(midSegmentIndex))
+
+      expect(returnedModel).toEqual({ count: 6 })
+      expect(returnedModel).toEqual(rendered[rendered.length - 1])
+
+      const replaysForOneResolution = replaySpy.mock.calls.length
+      expect(replaysForOneResolution).toBeGreaterThan(0)
+
+      replaySpy.mockClear()
+      expect(run(store.getModelAtIndex(midSegmentIndex))).toEqual(returnedModel)
+      expect(replaySpy).toHaveBeenCalledTimes(replaysForOneResolution)
+    })
+
     it('exits paused state on resume and marks the render pending', () => {
       let markedPendingCount = 0
       const { store } = makeStore({

--- a/packages/foldkit/src/devTools/store.ts
+++ b/packages/foldkit/src/devTools/store.ts
@@ -401,7 +401,8 @@ export const createDevToolsStore = (
     const jumpTo = (index: number) =>
       Effect.gen(function* () {
         const state = yield* SubscriptionRef.get(stateRef)
-        yield* bridge.render(resolveModel(state, index))
+        const model = resolveModel(state, index)
+        yield* bridge.render(model)
         yield* SubscriptionRef.set(
           stateRef,
           evo(state, {
@@ -409,6 +410,7 @@ export const createDevToolsStore = (
             pausedAtIndex: () => index,
           }),
         )
+        return model
       })
 
     const resume = Effect.gen(function* () {
@@ -501,7 +503,7 @@ export type DevToolsStore = Readonly<{
   getModelAtIndex: (index: number) => Effect.Effect<unknown>
   getMessageAtIndex: (index: number) => Effect.Effect<Option.Option<unknown>>
   getDiffAtIndex: (index: number) => Effect.Effect<DiffResult>
-  jumpTo: (index: number) => Effect.Effect<void>
+  jumpTo: (index: number) => Effect.Effect<unknown>
   resume: Effect.Effect<void>
   clear: Effect.Effect<void>
   stateRef: SubscriptionRef.SubscriptionRef<StoreState>

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -143,6 +143,7 @@ export type DevToolsOverlay = (
  * - `overlay`: The in-browser overlay factory from `@foldkit/devtools`. Without it, DevTools still records history and serves the WebSocket bridge (so the DevTools MCP server works), but no visual overlay is mounted. Pass `DevTools.overlay` to show the panel.
  * - `excludeFromHistory`: Message `_tag` values whose dispatches should not be recorded in DevTools history. The Messages still drive `update` and the runtime as usual; they just don't appear in the history panel and don't pay the per-Message diff cost. Use for high-frequency Messages (animation frames, pointer moves, scroll events) that would flood history without adding insight.
  * - `maxEntries`: Maximum number of recorded Messages retained in history before the oldest is evicted. Defaults to 100. Clamped to the range 20-500: smaller values keep the panel snappy under high message rates, larger values give you more scroll-back. Each retained entry stores a full Model snapshot, so memory cost scales linearly with both `maxEntries` and your Model size.
+ * - `keyframeInterval`: Number of recorded Messages between full Model snapshots. Defaults to 31. Time-travel to an index replays `update` forward from the nearest earlier keyframe, so this is a memory/time tradeoff: smaller values store more snapshots (more memory) but make each jump cheaper, down to `1` where every jump is a constant-time snapshot lookup with no replay. Reach for a denser interval when the app has a heavy `update` and time-travel jumps feel sluggish. Clamped to a minimum of 1. Forced to 1 automatically when `excludeFromHistory` is active, since excluded Messages are never replayed.
  */
 export type DevToolsConfig =
   | false
@@ -154,6 +155,7 @@ export type DevToolsConfig =
       overlay?: DevToolsOverlay
       excludeFromHistory?: ReadonlyArray<string>
       maxEntries?: number
+      keyframeInterval?: number
       /**
        * The application's `Message` Schema. When provided and the running app
        * is connected to the Foldkit DevTools MCP server, AI agents can dispatch
@@ -179,6 +181,7 @@ const resolveDevToolsMode = (config: DevToolsModeConfig): DevToolsMode => {
 }
 const DEV_TOOLS_MAX_ENTRIES_MIN = 20
 const DEV_TOOLS_MAX_ENTRIES_MAX = 500
+const DEV_TOOLS_KEYFRAME_INTERVAL_MIN = 1
 
 /** Context provided to the slow view callback when a view exceeds the time budget. */
 export type SlowViewContext<Model, Message> = Readonly<{
@@ -982,13 +985,25 @@ const makeRuntime = <
     devTools ?? {},
     Option.liftPredicate(config => config !== false),
     Option.flatMapNullishOr(config => config.maxEntries),
-    Option.map(value =>
-      Math.max(
-        DEV_TOOLS_MAX_ENTRIES_MIN,
-        Math.min(DEV_TOOLS_MAX_ENTRIES_MAX, value),
-      ),
-    ),
-    Option.getOrUndefined,
+    Option.match({
+      onNone: () => undefined,
+      onSome: value =>
+        Math.max(
+          DEV_TOOLS_MAX_ENTRIES_MIN,
+          Math.min(DEV_TOOLS_MAX_ENTRIES_MAX, value),
+        ),
+    }),
+  )
+
+  const devToolsKeyframeInterval: number | undefined = pipe(
+    devTools ?? {},
+    Option.liftPredicate(config => config !== false),
+    Option.flatMapNullishOr(config => config.keyframeInterval),
+    Option.match({
+      onNone: () => undefined,
+      onSome: value =>
+        Math.max(DEV_TOOLS_KEYFRAME_INTERVAL_MIN, Math.floor(value)),
+    }),
   )
 
   const maybeFreezeModel = (model: Model): Model =>
@@ -1665,10 +1680,17 @@ const makeRuntime = <
               markRenderPending: SubscriptionRef.set(isRenderPendingRef, true),
             },
             {
-              ...(isExcludingMessages && { keyframeInterval: 1 }),
+              ...(devToolsKeyframeInterval !== undefined && {
+                keyframeInterval: devToolsKeyframeInterval,
+              }),
               ...(devToolsMaxEntries !== undefined && {
                 maxEntries: devToolsMaxEntries,
               }),
+              // NOTE: exclusion forces keyframeInterval to 1 regardless of any
+              // configured value, since excluded Messages are never replayed
+              // and a denser interval would leave gaps in the replayed model.
+              // Spread last so it wins over `keyframeInterval` above.
+              ...(isExcludingMessages && { keyframeInterval: 1 }),
             },
           )
           maybeDevToolsStore = Option.some(devToolsStore)

--- a/packages/website/src/page/core/devtools.ts
+++ b/packages/website/src/page/core/devtools.ts
@@ -67,6 +67,12 @@ const maxEntriesHeader: TableOfContentsEntry = {
   text: 'maxEntries',
 }
 
+const keyframeIntervalHeader: TableOfContentsEntry = {
+  level: 'h3',
+  id: 'keyframe-interval',
+  text: 'keyframeInterval',
+}
+
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
   configurationHeader,
@@ -77,6 +83,7 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   messageHeader,
   excludeFromHistoryHeader,
   maxEntriesHeader,
+  keyframeIntervalHeader,
 ]
 
 export const view = (copiedSnippets: CopiedSnippets): Html => {
@@ -256,6 +263,37 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ),
         Snippet.devtoolsMaxEntriesRaw,
         'Raising the DevTools history cap',
+        copiedSnippets,
+        'mb-8',
+      ),
+      tableOfContentsEntryToHeader(keyframeIntervalHeader),
+      para(
+        'Number of recorded Messages between full Model snapshots. Defaults to ',
+        inlineCode('31'),
+        '. Time-travel to an index replays ',
+        inlineCode('update'),
+        ' forward from the nearest earlier keyframe, so this is a memory and time tradeoff: smaller values store more snapshots and shorten the replay each jump walks, down to ',
+        inlineCode('1'),
+        ' where every jump is a constant-time snapshot lookup with no replay. Reach for a denser interval when your app has a heavy ',
+        inlineCode('update'),
+        ' and time-travel jumps feel sluggish. Clamped to a minimum of ',
+        inlineCode('1'),
+        ', and forced to ',
+        inlineCode('1'),
+        ' automatically when ',
+        inlineCode('excludeFromHistory'),
+        ' is active, since excluded Messages are never replayed.',
+      ),
+      highlightedCodeBlock(
+        h.div(
+          [
+            h.Class('text-sm'),
+            h.InnerHTML(Snippet.devtoolsKeyframeIntervalHighlighted),
+          ],
+          [],
+        ),
+        Snippet.devtoolsKeyframeIntervalRaw,
+        'Snapshotting every entry for constant-time jumps',
         copiedSnippets,
         'mb-8',
       ),

--- a/packages/website/src/snippet/devtoolsKeyframeInterval.ts
+++ b/packages/website/src/snippet/devtoolsKeyframeInterval.ts
@@ -1,0 +1,17 @@
+import { Runtime } from 'foldkit'
+
+import { overlay } from '@foldkit/devtools'
+
+const application = Runtime.makeApplication({
+  Model,
+  init,
+  update,
+  view,
+  container: document.getElementById('root'),
+  devTools: {
+    overlay,
+    keyframeInterval: 1,
+  },
+})
+
+Runtime.run(application)

--- a/packages/website/src/snippet/index.ts
+++ b/packages/website/src/snippet/index.ts
@@ -254,6 +254,8 @@ export { default as devtoolsExcludeFromHistoryRaw } from './devtoolsExcludeFromH
 export { default as devtoolsExcludeFromHistoryHighlighted } from './devtoolsExcludeFromHistory.ts?highlighted'
 export { default as devtoolsMaxEntriesRaw } from './devtoolsMaxEntries.ts?raw'
 export { default as devtoolsMaxEntriesHighlighted } from './devtoolsMaxEntries.ts?highlighted'
+export { default as devtoolsKeyframeIntervalRaw } from './devtoolsKeyframeInterval.ts?raw'
+export { default as devtoolsKeyframeIntervalHighlighted } from './devtoolsKeyframeInterval.ts?highlighted'
 export { default as aiMcpViteConfigRaw } from './aiMcpViteConfig.ts?raw'
 export { default as aiMcpViteConfigHighlighted } from './aiMcpViteConfig.ts?highlighted'
 export { default as aiMcpApplicationConfigRaw } from './aiMcpApplicationConfig.ts?raw'


### PR DESCRIPTION
Time-travel navigation resolved the model for the target index twice per
jump: once in JumpTo to render the host app, once in InspectState to feed
the inspector. For a mid-segment jump that replayed the segment from the
nearest keyframe twice. store.jumpTo now returns the model it resolved, and
a single JumpToAndInspect command renders the host and builds the inspection
from that one resolution. Inspect-only navigation still resolves once on its
own.

Scrubbing no longer enqueues a full jump-plus-inspect for every pointermove.
The slider thumb still tracks every move (model-only), but the heavy
navigation is coalesced to one per animation frame via a pending-index field
and an animationFrame subscription, so a fast drag can't fall behind the
cursor.

Expose keyframeInterval in DevToolsConfig (alongside maxEntries) to trade
memory for faster jumps, down to 1 where every jump is a constant-time
snapshot lookup. Still forced to 1 when excludeFromHistory is active.

Closes #500