### PR TITLE
fix(foldkit): make shared const VNode views safe to reuse anywhere

### DIFF
--- a/.changeset/dedupe-cross-render-vnode-reuse.md
+++ b/.changeset/dedupe-cross-render-vnode-reuse.md
@@ -1,0 +1,20 @@
+---
+'foldkit': patch
+---
+
+Clone any reused `VNode` object the runtime encounters before patching, so a
+view fragment held as a shared `const` no longer corrupts diffing. Snabbdom
+records each element's live DOM node by mutating `vnode.elm` in place and
+assumes one `VNode` object per tree position. A module- or closure-level
+constant (`const icon = h.span(...)`) re-enters the next render still carrying
+the `.elm` snabbdom set last time; when its position shifts toward an earlier
+sibling, the new slot is patched before the old one is removed, so the removal
+deletes the freshly placed node and the element appears stuck on its previous
+row. `dedupeSharedVNodes` now freshens any `VNode` arriving with an `.elm`
+already set, in addition to the within-render duplicates it already handled.
+`createLazy` and `createKeyedLazy` results are exempt, since they return the
+same object by reference on purpose and rely on snabbdom's same-vnode
+short-circuit, as do `createLazy`/`createKeyedLazy` views embedded through
+`h.submodel`, so memoization still composes across a Submodel boundary. Reusing
+a plain `VNode` value across positions is now safe; factories are no longer
+required to avoid this.

--- a/.changeset/devtools-restore-const-icon-vnodes.md
+++ b/.changeset/devtools-restore-const-icon-vnodes.md
@@ -1,0 +1,9 @@
+---
+'@foldkit/devtools': patch
+---
+
+Render the overlay's shared icons (pause, diff dots, filter check, scroll-to-top
+arrow) and the empty-inspector placeholder from plain `VNode` constants again.
+The per-call factory workaround these used is no longer needed now that the
+runtime clones a reused `VNode` before patching, so a shared constant can sit at
+more than one position safely. No visible behavior change.

--- a/packages/devtools/src/overlay.ts
+++ b/packages/devtools/src/overlay.ts
@@ -922,9 +922,8 @@ const makeView = (
   const tagLabelView = (tag: string): Html =>
     h.span([h.Key('tag'), h.Class('json-tag')], [tag])
 
-  const diffDotView = (): Html =>
-    h.span([h.Key('diffdot'), h.Class('diff-dot')], [])
-  const inlineDiffDotView = (): Html => h.span([h.Class('diff-dot-inline')], [])
+  const diffDotView: Html = h.span([h.Key('diffdot'), h.Class('diff-dot')], [])
+  const inlineDiffDotView: Html = h.span([h.Class('diff-dot-inline')], [])
 
   type FlatNode = Readonly<{
     value: unknown
@@ -1047,7 +1046,7 @@ const makeView = (
           indent,
         ],
         [
-          ...(hasDiffDot ? [diffDotView()] : []),
+          ...(hasDiffDot ? [diffDotView] : []),
           ...(String_.isNonEmpty(key) ? [keyView(key)] : []),
           leafValueView(value),
         ],
@@ -1074,7 +1073,7 @@ const makeView = (
       ],
       [
         ...(isRoot ? [] : [arrowView(isExpanded)]),
-        ...(!isRoot && hasDiffDot ? [diffDotView()] : []),
+        ...(!isRoot && hasDiffDot ? [diffDotView] : []),
         ...(String_.isNonEmpty(key) ? [keyView(key)] : []),
         ...(String_.isNonEmpty(tag) ? [tagLabelView(tag)] : []),
         h.span([h.Key('value'), h.Class('json-preview')], [preview]),
@@ -1160,15 +1159,14 @@ const makeView = (
     )
   }
 
-  const emptyInspectorView = (): Html =>
-    h.div(
-      [
-        h.Class(
-          'flex-1 flex items-center justify-center text-dt-muted text-2xs font-mono min-w-0',
-        ),
-      ],
-      ['Click a message to inspect'],
-    )
+  const emptyInspectorView: Html = h.div(
+    [
+      h.Class(
+        'flex-1 flex items-center justify-center text-dt-muted text-2xs font-mono min-w-0',
+      ),
+    ],
+    ['Click a message to inspect'],
+  )
 
   const noMessageView = (): Html =>
     h.div(
@@ -1575,7 +1573,7 @@ const makeView = (
                       ],
                       [
                         Option.match(model.maybeInspectedModel, {
-                          onNone: () => emptyInspectorView(),
+                          onNone: () => emptyInspectorView,
                           onSome: inspectedModel =>
                             inspectorTabContent(
                               model,
@@ -1665,52 +1663,46 @@ const makeView = (
 
   const CHECK_ICON = 'M4.5 12.75l6 6 9-13.5'
 
-  const checkIconView = (): Html =>
-    h.svg(
-      [
-        h.AriaHidden(true),
-        h.Class('dt-filter-check shrink-0'),
-        h.Xmlns('http://www.w3.org/2000/svg'),
-        h.Fill('none'),
-        h.ViewBox('0 0 24 24'),
-        h.StrokeWidth('2'),
-        h.Stroke('currentColor'),
-      ],
-      [
-        h.path(
-          [
-            h.D(CHECK_ICON),
-            h.StrokeLinecap('round'),
-            h.StrokeLinejoin('round'),
-          ],
-          [],
-        ),
-      ],
-    )
+  const checkIconView: Html = h.svg(
+    [
+      h.AriaHidden(true),
+      h.Class('dt-filter-check shrink-0'),
+      h.Xmlns('http://www.w3.org/2000/svg'),
+      h.Fill('none'),
+      h.ViewBox('0 0 24 24'),
+      h.StrokeWidth('2'),
+      h.Stroke('currentColor'),
+    ],
+    [
+      h.path(
+        [h.D(CHECK_ICON), h.StrokeLinecap('round'), h.StrokeLinejoin('round')],
+        [],
+      ),
+    ],
+  )
 
   const filterItemLabel = (item: string): string =>
     String_.isNonEmpty(item) ? submodelLabel(item) : 'All Messages'
 
   const ARROW_UP = 'M4.5 10.5L12 3m0 0l7.5 7.5M12 3v18'
 
-  const arrowUpIconView = (): Html =>
-    h.svg(
-      [
-        h.AriaHidden(true),
-        h.Class('dt-scroll-pill-icon shrink-0'),
-        h.Xmlns('http://www.w3.org/2000/svg'),
-        h.Fill('none'),
-        h.ViewBox('0 0 24 24'),
-        h.StrokeWidth('2'),
-        h.Stroke('currentColor'),
-      ],
-      [
-        h.path(
-          [h.D(ARROW_UP), h.StrokeLinecap('round'), h.StrokeLinejoin('round')],
-          [],
-        ),
-      ],
-    )
+  const arrowUpIconView: Html = h.svg(
+    [
+      h.AriaHidden(true),
+      h.Class('dt-scroll-pill-icon shrink-0'),
+      h.Xmlns('http://www.w3.org/2000/svg'),
+      h.Fill('none'),
+      h.ViewBox('0 0 24 24'),
+      h.StrokeWidth('2'),
+      h.Stroke('currentColor'),
+    ],
+    [
+      h.path(
+        [h.D(ARROW_UP), h.StrokeLinecap('round'), h.StrokeLinejoin('round')],
+        [],
+      ),
+    ],
+  )
 
   const scrollToTopPillView = (): Html =>
     h.button(
@@ -1720,7 +1712,7 @@ const makeView = (
         h.OnClick(ClickedScrollToTopPill()),
       ],
       [
-        arrowUpIconView(),
+        arrowUpIconView,
         h.span([h.Class('dt-scroll-pill-text')], ['Jump to top']),
       ],
     )
@@ -1741,7 +1733,7 @@ const makeView = (
           className: 'dt-filter-item',
           content: h.div(
             [h.Class('flex items-center gap-2')],
-            [checkIconView(), h.span([], [filterItemLabel(item)])],
+            [checkIconView, h.span([], [filterItemLabel(item)])],
           ),
         }),
         buttonContent: h.span(
@@ -1859,7 +1851,7 @@ const makeView = (
           mode === 'TimeTravel',
           h.span(
             [h.Class('pause-column')],
-            isPausedHere ? [pauseIconView()] : [],
+            isPausedHere ? [pauseIconView] : [],
           ),
         ).pipe(Option.toArray),
         h.span([h.Class('dot-column')], []),
@@ -1868,28 +1860,27 @@ const makeView = (
       ],
     )
 
-  const pauseIconView = (): Html =>
-    h.svg(
-      [
-        h.AriaHidden(true),
-        h.Class('dt-pause-icon'),
-        h.Xmlns('http://www.w3.org/2000/svg'),
-        h.Fill('none'),
-        h.ViewBox('0 0 24 24'),
-        h.StrokeWidth('2.5'),
-        h.Stroke('currentColor'),
-      ],
-      [
-        h.path(
-          [
-            h.StrokeLinecap('round'),
-            h.StrokeLinejoin('round'),
-            h.D('M5.75 3v18M18.25 3v18'),
-          ],
-          [],
-        ),
-      ],
-    )
+  const pauseIconView: Html = h.svg(
+    [
+      h.AriaHidden(true),
+      h.Class('dt-pause-icon'),
+      h.Xmlns('http://www.w3.org/2000/svg'),
+      h.Fill('none'),
+      h.ViewBox('0 0 24 24'),
+      h.StrokeWidth('2.5'),
+      h.Stroke('currentColor'),
+    ],
+    [
+      h.path(
+        [
+          h.StrokeLinecap('round'),
+          h.StrokeLinejoin('round'),
+          h.D('M5.75 3v18M18.25 3v18'),
+        ],
+        [],
+      ),
+    ],
+  )
 
   const messageRowView = (
     tag: string,
@@ -1910,12 +1901,12 @@ const makeView = (
           mode === 'TimeTravel',
           h.span(
             [h.Class('pause-column')],
-            isPausedHere ? [pauseIconView()] : [],
+            isPausedHere ? [pauseIconView] : [],
           ),
         ).pipe(Option.toArray),
         h.span(
           [h.Class('dot-column')],
-          isModelChanged ? [inlineDiffDotView()] : [],
+          isModelChanged ? [inlineDiffDotView] : [],
         ),
         h.span([h.Class(indexClass)], [String(absoluteIndex + 1)]),
         h.span([h.Class('text-base text-dt font-mono flex-1 truncate')], [tag]),

--- a/packages/foldkit/src/html/lazy.test.ts
+++ b/packages/foldkit/src/html/lazy.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from '@effect/vitest'
 
 import { MountTracker } from '../mount/index.js'
 import { Dispatch } from '../runtime/index.js'
+import { dedupeSharedVNodes, memoizedVNodes } from '../vdom.js'
 import { createKeyedLazy, createLazy } from './lazy.js'
 import {
   type DispatchSync,
@@ -69,6 +70,22 @@ describe('createLazy', () => {
 
     expect(callCount).toBe(1)
     expect(secondVNode).toBe(firstVNode)
+  })
+
+  it('records its result so dedupeSharedVNodes preserves the cached identity', () => {
+    const viewFn = (label: string) => h('div', {}, [label])
+
+    const lazy = createLazy()
+    const vnode = lazy(viewFn, ['hello'])
+
+    expect(vnode).not.toBeNull()
+    expect(memoizedVNodes.has(vnode!)).toBe(true)
+
+    vnode!.elm = document.createElement('div')
+    const tree = h('section', {}, [vnode!])
+    const result = dedupeSharedVNodes(tree)
+
+    expect(result.children?.[0]).toBe(vnode)
   })
 
   it('recomputes when args change by reference', () => {

--- a/packages/foldkit/src/html/lazy.ts
+++ b/packages/foldkit/src/html/lazy.ts
@@ -1,6 +1,6 @@
 import { Predicate } from 'effect'
 
-import type { VNode } from '../vdom.js'
+import { type VNode, memoizedVNodes } from '../vdom.js'
 import {
   type BoundaryId,
   beginLazyTracking,
@@ -60,6 +60,11 @@ const resolveOrCache = <Args extends ReadonlyArray<unknown>>(
     vnode = fn(...args)
   } finally {
     endLazyTracking(registry)
+  }
+  // NOTE: record the cached vnode so dedupeSharedVNodes keeps it opaque rather
+  // than cloning it as cross-render reuse. See the membership exemption there.
+  if (Predicate.isNotNull(vnode)) {
+    memoizedVNodes.add(vnode)
   }
   onCache({ fn, args, dispatch, vnode, trackedBoundaries })
   return vnode

--- a/packages/foldkit/src/html/submodel.test.ts
+++ b/packages/foldkit/src/html/submodel.test.ts
@@ -6,14 +6,14 @@ import { describe, it } from '@effect/vitest'
 
 import { MountTracker } from '../mount/index.js'
 import { Dispatch } from '../runtime/index.js'
-import type { VNode } from '../vdom.js'
+import { type VNode, dedupeSharedVNodes, memoizedVNodes } from '../vdom.js'
 import {
   type BoundaryRegistry,
   beginRender,
   createBoundaryRegistry,
   registerBoundaryWrap,
 } from './boundary.js'
-import { createKeyedLazy } from './lazy.js'
+import { createKeyedLazy, createLazy } from './lazy.js'
 import {
   type DispatchSync,
   clearRuntime,
@@ -25,6 +25,13 @@ import {
   type SubmodelView as SubmodelViewBranded,
   submodel,
 } from './submodel.js'
+
+const asVNode = (child: VNode | string | undefined): VNode => {
+  if (child === undefined || typeof child === 'string') {
+    throw new Error('expected a VNode')
+  }
+  return child
+}
 
 const setUpRuntime = (
   registry: BoundaryRegistry,
@@ -623,6 +630,43 @@ describe('h.submodel', () => {
         message: { _tag: 'ChildClicked', value: 10 },
       },
     ])
+  })
+
+  it('keeps a memoized child view opaque through the boundary wrapper so dedupe preserves its cached subtree', () => {
+    // A child view memoized by createLazy returns the same VNode object each
+    // render. h.submodel re-wraps it in a fresh boundary vnode every render;
+    // withBoundaryCleanup propagates memoizedVNodes membership onto that
+    // wrapper so dedupeSharedVNodes keeps it opaque and never walks into the
+    // cached subtree, which carries the .elm snabbdom recorded on a prior
+    // patch. Without that propagation the wrapper looks like ordinary view
+    // output and dedupe clones the cached child, defeating memoization.
+    const lazy = createLazy()
+    const buildChild = (value: number) =>
+      h('div', {}, [h('span', {}, [`value: ${value}`])])
+    const memoizedChildView = (model: { value: number }) =>
+      lazy(buildChild, [model.value])
+
+    const wrapper = submodel({
+      slotId: 'memoized-child',
+      model: { value: 1 },
+      view: memoizedChildView,
+      toParentMessage: message =>
+        GotChild({ entryId: 'memoized-child', message }),
+    })
+
+    expect(wrapper).not.toBeNull()
+    expect(memoizedVNodes.has(wrapper!)).toBe(true)
+
+    // Simulate a prior patch recording a live DOM node on the cached subtree.
+    const cachedSpan = asVNode(wrapper!.children?.[0])
+    cachedSpan.elm = document.createElement('span')
+
+    const result = dedupeSharedVNodes(h('section', {}, [wrapper!]))
+
+    expect(asVNode(result.children?.[0])).toBe(wrapper)
+    expect(asVNode(asVNode(result.children?.[0]).children?.[0])).toBe(
+      cachedSpan,
+    )
   })
 
   it('nests h.submodel calls made inside a slot callback under the parent boundary', () => {

--- a/packages/foldkit/src/html/submodel.ts
+++ b/packages/foldkit/src/html/submodel.ts
@@ -1,6 +1,6 @@
 import { Predicate } from 'effect'
 
-import type { VNode } from '../vdom.js'
+import { type VNode, memoizedVNodes } from '../vdom.js'
 import {
   type BoundaryRegistry,
   type WrapDescriptor,
@@ -285,10 +285,18 @@ const withBoundaryCleanup = (
       previousDestroy(removed)
     }
   }
-  return {
+  const wrapped: VNode = {
     ...vnode,
     data: { ...data, hook: { ...hook, destroy: compositeDestroy } },
   }
+  // NOTE: a memoized child view returns the same vnode by reference each render;
+  // this wrapper is fresh but shares its cached children. Propagate membership
+  // so dedupeSharedVNodes keeps the wrapper opaque instead of cloning that
+  // cached subtree every render.
+  if (memoizedVNodes.has(vnode)) {
+    memoizedVNodes.add(wrapped)
+  }
+  return wrapped
 }
 
 export const submodel = <View extends AnySubmodelView>(

--- a/packages/foldkit/src/vdom.test.ts
+++ b/packages/foldkit/src/vdom.test.ts
@@ -1,7 +1,13 @@
 import { h } from 'snabbdom'
 import { describe, expect, it } from 'vitest'
 
-import { type VNode, dedupeSharedVNodes, patch, toVNode } from './vdom.js'
+import {
+  type VNode,
+  dedupeSharedVNodes,
+  memoizedVNodes,
+  patch,
+  toVNode,
+} from './vdom.js'
 
 const asVNode = (child: VNode | string | undefined): VNode => {
   if (child === undefined || typeof child === 'string') {
@@ -32,15 +38,93 @@ describe('dedupeSharedVNodes', () => {
     expect(asVNode(result.children?.[1]).sel).toBe(shared.sel)
   })
 
-  it('resets elm on the cloned occurrence so it gets its own DOM node', () => {
+  it('clears elm on every occurrence of a vnode reused across renders', () => {
     const shared = h('span', {}, ['✓'])
     shared.elm = document.createElement('span')
     const tree = h('div', {}, [shared, shared])
 
     const result = dedupeSharedVNodes(tree)
 
-    expect(asVNode(result.children?.[0]).elm).toBe(shared.elm)
+    expect(asVNode(result.children?.[0])).not.toBe(shared)
+    expect(asVNode(result.children?.[0]).elm).toBeUndefined()
     expect(asVNode(result.children?.[1]).elm).toBeUndefined()
+  })
+
+  it('clones a single-occurrence vnode that carries a stale elm', () => {
+    const reused = h('span', {}, ['✓'])
+    reused.elm = document.createElement('span')
+    const tree = h('div', {}, [reused])
+
+    const result = dedupeSharedVNodes(tree)
+
+    expect(asVNode(result.children?.[0])).not.toBe(reused)
+    expect(asVNode(result.children?.[0]).elm).toBeUndefined()
+  })
+
+  it('preserves the identity of a memoized vnode that carries an elm', () => {
+    const memoized = h('div', {}, [h('span', {}, ['cached'])])
+    memoized.elm = document.createElement('div')
+    memoizedVNodes.add(memoized)
+    const tree = h('section', {}, [memoized])
+
+    const result = dedupeSharedVNodes(tree)
+
+    expect(asVNode(result.children?.[0])).toBe(memoized)
+    expect(asVNode(result.children?.[0]).elm).toBe(memoized.elm)
+  })
+
+  it('keeps a re-wrapped memoized subtree opaque so its cached children survive', () => {
+    const cachedChild = h('span', {}, ['heavy'])
+    cachedChild.elm = document.createElement('span')
+    const memoized = h('div', {}, [cachedChild])
+    memoizedVNodes.add(memoized)
+
+    // Simulate withBoundaryCleanup: a fresh wrapper sharing the cached children,
+    // propagating membership so the cached subtree is not cloned.
+    const wrapper: VNode = {
+      ...memoized,
+      data: { hook: { destroy: () => {} } },
+    }
+    memoizedVNodes.add(wrapper)
+    const tree = h('section', {}, [wrapper])
+
+    const result = dedupeSharedVNodes(tree)
+
+    expect(asVNode(result.children?.[0]).children?.[0]).toBe(cachedChild)
+  })
+
+  it('keeps a memoized vnode opaque even when it carries no elm yet', () => {
+    const memoized = h('div', {}, [h('span', {}, ['cached'])])
+    memoizedVNodes.add(memoized)
+    const tree = h('section', {}, [memoized])
+
+    const result = dedupeSharedVNodes(tree)
+
+    expect(asVNode(result.children?.[0])).toBe(memoized)
+  })
+
+  it('keeps an element on its row when a shared const moves to an earlier sibling', () => {
+    const shared = h('span', { class: { dot: true } }, ['●'])
+    const tree = (selectedRow: number): VNode =>
+      h('ul', {}, [
+        h('li', {}, selectedRow === 0 ? [shared, 'r0'] : ['r0']),
+        h('li', {}, selectedRow === 1 ? [shared, 'r1'] : ['r1']),
+        h('li', {}, selectedRow === 2 ? [shared, 'r2'] : ['r2']),
+      ])
+
+    const rowWithDot = (root: Node | undefined): number =>
+      root instanceof Element
+        ? Array.from(root.querySelectorAll('li')).findIndex(li =>
+            li.querySelector('span'),
+          )
+        : -1
+
+    const container = document.createElement('div')
+    let mounted = patch(toVNode(container), dedupeSharedVNodes(tree(2)))
+    expect(rowWithDot(mounted.elm)).toBe(2)
+
+    mounted = patch(mounted, dedupeSharedVNodes(tree(0)))
+    expect(rowWithDot(mounted.elm)).toBe(0)
   })
 
   it('clones the entire shared subtree, not just its root', () => {

--- a/packages/foldkit/src/vdom.ts
+++ b/packages/foldkit/src/vdom.ts
@@ -24,23 +24,49 @@ export const patch = init([
 ])
 
 // NOTE: snabbdom records each element's live DOM node on `vnode.elm` by
-// mutating the vnode object during patch. A vnode object placed in more than
-// one tree position would share a single `.elm`, so removals and text updates
-// land on the wrong DOM node. View code legitimately reuses vnode values, e.g.
-// `const checkmark = h.span(...)` dropped into several slots, so before each
-// patch we clone any vnode object reached a second time, giving every position
-// its own object.
-// Detection is keyed off a per-patch Set, so a vnode reused across renders (a
-// memoized `createLazy` subtree, the identical object each render) is reached
-// only once per patch and passes through untouched, leaving snabbdom's
-// same-object subtree short-circuit intact. Allocation happens only along
-// paths where a duplicate is actually found; a tree with no reuse returns
-// unchanged.
+// mutating the vnode object during patch, and assumes one vnode object per
+// tree position. A vnode object placed in more than one position would share a
+// single `.elm`, so removals and text updates land on the wrong DOM node.
+//
+// Two ways a view reuses one object, both handled here so the reuse never
+// reaches snabbdom:
+//   1. The same object at two positions within a single render, e.g. a
+//      `const checkmark = h.span(...)` dropped into several slots. Detected via
+//      a per-patch Set: the second time an object is reached it is cloned.
+//   2. The same object across renders, e.g. a module- or closure-level
+//      `const icon = h.span(...)`. Such an object enters the next render still
+//      carrying the `.elm` snabbdom set last time. While it stays at one
+//      position this is harmless (snabbdom short-circuits on `oldVnode ===
+//      newVnode`), but when its position shifts the stale `.elm` misdirects
+//      snabbdom: moving toward an earlier sibling, the new slot is patched
+//      before the old slot is removed, so the removal deletes the freshly
+//      placed node and the element appears stuck on its previous row. Any
+//      vnode arriving with `.elm` already set is therefore cloned with a
+//      cleared `.elm`.
+//
+// `createLazy`/`createKeyedLazy` deliberately return the identical object each
+// render and rely on snabbdom's same-vnode short-circuit, so their results are
+// recorded in `memoizedVNodes` and pass through with identity intact, their
+// subtree left unwalked. The exemption is keyed off membership alone, not off
+// `.elm`: `h.submodel` re-wraps a memoized child view in a fresh boundary vnode
+// each render (sharing the cached children array), and that wrapper carries no
+// `.elm` of its own yet must stay opaque so its cached children are not cloned.
+// `withBoundaryCleanup` propagates membership onto the wrapper for this reason.
+// Allocation happens only along paths where reuse is actually found; a tree of
+// freshly constructed vnodes returns unchanged.
+export const memoizedVNodes = new WeakSet<VNode>()
+
 export const dedupeSharedVNodes = (root: VNode): VNode => {
   const seen = new Set<object>()
   const visit = (node: VNode): VNode => {
-    const base: VNode = seen.has(node) ? { ...node, elm: undefined } : node
-    seen.add(base)
+    const isDuplicate = seen.has(node)
+    if (!isDuplicate && memoizedVNodes.has(node)) {
+      seen.add(node)
+      return node
+    }
+    const base: VNode =
+      isDuplicate || node.elm != null ? { ...node, elm: undefined } : node
+    seen.add(node)
     const children = base.children
     if (children === undefined) {
       return base

--- a/packages/website/src/page/comingFromReact/view.ts
+++ b/packages/website/src/page/comingFromReact/view.ts
@@ -82,49 +82,48 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   faqHeader,
 ]
 
-const patternMappingTable = (): Html =>
-  comparisonTable(
-    ['React Ecosystem', 'Foldkit'],
+const patternMappingTable: Html = comparisonTable(
+  ['React Ecosystem', 'Foldkit'],
+  [
+    [[inlineCode('useState')], ['Model (single state tree)']],
+    [[inlineCode('useReducer')], [inlineCode('update'), ' function']],
     [
-      [[inlineCode('useState')], ['Model (single state tree)']],
-      [[inlineCode('useReducer')], [inlineCode('update'), ' function']],
-      [
-        [inlineCode('useEffect'), ' (one-off)'],
-        ['Commands (returned from ', inlineCode('update'), ')'],
-      ],
-      [
-        [inlineCode('useRef'), ' + ', inlineCode('useEffect'), ' (DOM access)'],
-        ['Mount (', inlineCode('OnMount'), ' with paired cleanup)'],
-      ],
-      [
-        [inlineCode('useContext'), ' / Redux / Zustand'],
-        ['Single Model (no prop drilling)'],
-      ],
-      [
-        [inlineCode('useMemo'), ' / ', inlineCode('useCallback')],
-        ['Not needed (no stale closures)'],
-      ],
-      [['Custom hooks'], ['Domain modules with pure functions']],
-      [['JSX'], ['Plain functions from Model to HTML']],
-      [['Component props'], ['Function parameters']],
-      [['Component state'], ['Part of the single Model']],
-      [['Event handlers'], ['Messages dispatched to ', inlineCode('update')]],
-      [['React Router / TanStack Router'], ['Built-in typed routing']],
-      [
-        ['React Hook Form / Formik'],
-        ['Model + Messages + ', inlineCode('foldkit/fieldValidation')],
-      ],
-      [
-        ['Event streams (useEffect / RxJS)'],
-        ['Subscriptions (automatic lifecycle)'],
-      ],
-      [['Headless UI / Radix UI'], ['Foldkit UI (headless, typed components)']],
-      [
-        ['Error boundaries'],
-        ['Typed errors in Effects + ', inlineCode('crash.view')],
-      ],
+      [inlineCode('useEffect'), ' (one-off)'],
+      ['Commands (returned from ', inlineCode('update'), ')'],
     ],
-  )
+    [
+      [inlineCode('useRef'), ' + ', inlineCode('useEffect'), ' (DOM access)'],
+      ['Mount (', inlineCode('OnMount'), ' with paired cleanup)'],
+    ],
+    [
+      [inlineCode('useContext'), ' / Redux / Zustand'],
+      ['Single Model (no prop drilling)'],
+    ],
+    [
+      [inlineCode('useMemo'), ' / ', inlineCode('useCallback')],
+      ['Not needed (no stale closures)'],
+    ],
+    [['Custom hooks'], ['Domain modules with pure functions']],
+    [['JSX'], ['Plain functions from Model to HTML']],
+    [['Component props'], ['Function parameters']],
+    [['Component state'], ['Part of the single Model']],
+    [['Event handlers'], ['Messages dispatched to ', inlineCode('update')]],
+    [['React Router / TanStack Router'], ['Built-in typed routing']],
+    [
+      ['React Hook Form / Formik'],
+      ['Model + Messages + ', inlineCode('foldkit/fieldValidation')],
+    ],
+    [
+      ['Event streams (useEffect / RxJS)'],
+      ['Subscriptions (automatic lifecycle)'],
+    ],
+    [['Headless UI / Radix UI'], ['Foldkit UI (headless, typed components)']],
+    [
+      ['Error boundaries'],
+      ['Typed errors in Effects + ', inlineCode('crash.view')],
+    ],
+  ],
+)
 
 const chevron = (isOpen: boolean): Html => {
   const h = html<Message>()
@@ -351,7 +350,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
         ),
         tableOfContentsEntryToHeader(translatingConceptsHeader),
         para('Here’s how React patterns map to Foldkit:'),
-        patternMappingTable(),
+        patternMappingTable,
         infoCallout(
           'If you know Redux...',
           'The Model-View-Update pattern will feel familiar. Think of the Model as your Redux store, Messages as actions, and update as your reducer, but without action creators, selectors, or middleware.',

--- a/packages/website/src/page/comingFromTanStackQuery.ts
+++ b/packages/website/src/page/comingFromTanStackQuery.ts
@@ -59,55 +59,50 @@ const faqQuestion = (id: string, text: string): Html => {
   return h.h3([h.Id(id), h.Class('text-lg font-bold mt-8 mb-3')], [text])
 }
 
-const conceptTable = (): Html =>
-  comparisonTable(
-    ['TanStack Query', 'Foldkit'],
+const conceptTable: Html = comparisonTable(
+  ['TanStack Query', 'Foldkit'],
+  [
     [
+      [inlineCode('useQuery')],
+      ['A Command plus an async-state field in the Model'],
+    ],
+    [
+      ['Query cache (keyed by query key)'],
+      ['Model state: one field, or a ', inlineCode('HashMap'), ' keyed by id'],
+    ],
+    [
+      [inlineCode('staleTime'), ' / background refetch'],
+      ['A Subscription gated on a Model condition'],
+    ],
+    [
+      ['Request deduplication'],
+      ['Collapse it in ', inlineCode('update'), ' (it is just state)'],
+    ],
+    [
+      ['Out-of-order response handling'],
+      ['A request id in the Model, checked in ', inlineCode('update')],
+    ],
+    [
+      [inlineCode('invalidateQueries')],
+      ['Mark the field stale and return a refetch Command'],
+    ],
+    [
+      [inlineCode('useMutation')],
+      ['A Message and a Command, the same as any other effect'],
+    ],
+    [
+      ['Retries'],
+      ['Effect’s ', inlineCode('retry'), ' / ', inlineCode('Schedule')],
+    ],
+    [
+      ['TanStack Query Devtools'],
       [
-        [inlineCode('useQuery')],
-        ['A Command plus an async-state field in the Model'],
-      ],
-      [
-        ['Query cache (keyed by query key)'],
-        [
-          'Model state: one field, or a ',
-          inlineCode('HashMap'),
-          ' keyed by id',
-        ],
-      ],
-      [
-        [inlineCode('staleTime'), ' / background refetch'],
-        ['A Subscription gated on a Model condition'],
-      ],
-      [
-        ['Request deduplication'],
-        ['Collapse it in ', inlineCode('update'), ' (it is just state)'],
-      ],
-      [
-        ['Out-of-order response handling'],
-        ['A request id in the Model, checked in ', inlineCode('update')],
-      ],
-      [
-        [inlineCode('invalidateQueries')],
-        ['Mark the field stale and return a refetch Command'],
-      ],
-      [
-        [inlineCode('useMutation')],
-        ['A Message and a Command, the same as any other effect'],
-      ],
-      [
-        ['Retries'],
-        ['Effect’s ', inlineCode('retry'), ' / ', inlineCode('Schedule')],
-      ],
-      [
-        ['TanStack Query Devtools'],
-        [
-          link(coreDevToolsRouter(), 'Foldkit DevTools'),
-          ': inspect the Model and step through every Message',
-        ],
+        link(coreDevToolsRouter(), 'Foldkit DevTools'),
+        ': inspect the Model and step through every Message',
       ],
     ],
-  )
+  ],
+)
 
 export const view = (copiedSnippets: CopiedSnippets): Html => {
   const h = html<Message>()
@@ -135,7 +130,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       ),
       tableOfContentsEntryToHeader(translatingConceptsHeader),
       para('Here is how the TanStack Query model maps onto Foldkit:'),
-      conceptTable(),
+      conceptTable,
       tableOfContentsEntryToHeader(asyncStateHeader),
       para(
         'A query has states: loading, success, error, and often a “refreshing with stale data on screen” state. In Foldkit you model those explicitly as a tagged union and store it in the Model. There is no separate cache. The Model is the cache. A single resource lives in one field; a collection of resources keyed by id lives in a ',


### PR DESCRIPTION
Snabbdom records each element's live DOM node by mutating vnode.elm in place and assumes one VNode object per tree position. A view fragment held as a module- or closure-level const (`const icon = h.span(...)`) re-enters the next render still carrying the elm snabbdom set last time. While it stays at one position this is harmless, but when its position shifts toward an earlier sibling, snabbdom patches the new slot before removing the old one, so the removal deletes the freshly placed node and the element appears stuck on its previous row. This is what left the DevTools time-travel pause icon on the previously selected row.

`dedupeSharedVNodes` already cloned within-render duplicates. Extend it to clone any VNode arriving with elm already set, the signal that an object was reused across renders. `createLazy`/`createKeyedLazy` results are recorded in a `memoizedVNodes` WeakSet and kept opaque, since they return the same object by reference on purpose and rely on snabbdom's same-vnode short-circuit. `h.submodel` re-wraps a memoized child view in a fresh boundary vnode each render, so `withBoundaryCleanup` propagates that membership onto the wrapper, keeping memoization intact across a Submodel boundary.

Reusing a plain VNode value across positions is now safe, so factories are no longer required to avoid this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)