### PR TITLE
feat(foldkit): provide resource-lifetime scope to ManagedResource acquire

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -38,6 +38,7 @@
     "generative-art-example",
     "web-components-example",
     "embedding-example",
+    "managed-resource-layer-example",
     "pixel-art-react-comparison",
     "@foldkit/performance-harness",
     "@foldkit/examples-e2e",

--- a/.changeset/scope-aware-managed-resource-acquire.md
+++ b/.changeset/scope-aware-managed-resource-acquire.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Provide the resource-lifetime `Scope` to a Managed Resource's `acquire`. The `acquire` callback now runs with `Scope.Scope` in its context, the same scope the runtime closes on release or re-acquire. This lets `acquire` build an Effect `Layer` with `Layer.build` or register finalizers with `Effect.addFinalizer` whose teardown is tied to the resource lifecycle, so the tag can hold the bare service value with no wrapper and `release` can be `() => Effect.void`. The explicit `release` callback still runs before the scope finalizers, matching the last-in-first-out order Effect uses for any scope. Existing resources that do not use the scope are unaffected.

--- a/examples/managed-resource-layer/index.html
+++ b/examples/managed-resource-layer/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/src/styles.css" rel="stylesheet" />
+    <title>Managed Resource Layer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/entry.ts"></script>
+  </body>
+</html>

--- a/examples/managed-resource-layer/package.json
+++ b/examples/managed-resource-layer/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "managed-resource-layer-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@effect/platform-browser": "4.0.0-beta.83",
+    "@foldkit/devtools": "workspace:*",
+    "@foldkit/ui": "workspace:*",
+    "@tailwindcss/vite": "^4.3.1",
+    "effect": "4.0.0-beta.83",
+    "foldkit": "workspace:*",
+    "tailwindcss": "^4.3.1"
+  },
+  "devDependencies": {
+    "@foldkit/vite-plugin": "workspace:*",
+    "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "happy-dom": "^20.10.4",
+    "prettier": "^3.8.4",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
+  }
+}

--- a/examples/managed-resource-layer/src/entry.ts
+++ b/examples/managed-resource-layer/src/entry.ts
@@ -1,0 +1,20 @@
+import { Runtime } from 'foldkit'
+
+import { overlay } from '@foldkit/devtools'
+
+import { Message, Model, init, managedResources, update, view } from './main'
+
+const application = Runtime.makeApplication({
+  Model,
+  init,
+  update,
+  view,
+  managedResources,
+  container: document.getElementById('root'),
+  devTools: {
+    overlay,
+    Message,
+  },
+})
+
+Runtime.run(application)

--- a/examples/managed-resource-layer/src/main.ts
+++ b/examples/managed-resource-layer/src/main.ts
@@ -1,0 +1,296 @@
+import { Context, Effect, Layer, Match as M, Option, Schema as S } from 'effect'
+import { Command, ManagedResource, Runtime } from 'foldkit'
+import { Document, Html, html } from 'foldkit/html'
+import { m } from 'foldkit/message'
+import { ts } from 'foldkit/schema'
+import { evo } from 'foldkit/struct'
+
+import { Button } from '@foldkit/ui'
+
+// ENGINE
+
+interface ComputeEngine {
+  readonly engineId: string
+  readonly square: (value: number) => number
+}
+
+class ComputeEngineService extends Context.Service<
+  ComputeEngineService,
+  ComputeEngine
+>()('ComputeEngineService') {}
+
+const engineLayer: Layer.Layer<ComputeEngineService> = Layer.effect(
+  ComputeEngineService,
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      const engineId = `engine-${crypto.randomUUID().slice(0, 8)}`
+      return { engineId, square: value => value * value }
+    }),
+    ({ engineId }) => Effect.log(`Tore down ${engineId}`),
+  ),
+)
+
+// MANAGED RESOURCE
+
+const Engine = ManagedResource.tag<ComputeEngine>()('ComputeEngine')
+type EngineService = ManagedResource.ServiceOf<typeof Engine>
+
+// MODEL
+
+export const EngineOff = ts('EngineOff')
+export const EngineBooting = ts('EngineBooting')
+export const EngineReady = ts('EngineReady', { engineId: S.String })
+export const EngineFailed = ts('EngineFailed', { reason: S.String })
+
+const EngineState = S.Union([
+  EngineOff,
+  EngineBooting,
+  EngineReady,
+  EngineFailed,
+])
+type EngineState = typeof EngineState.Type
+
+export const Model = S.Struct({
+  engine: EngineState,
+  computeCount: S.Number,
+  lastResult: S.Option(S.Number),
+})
+export type Model = typeof Model.Type
+
+// MESSAGE
+
+export const ClickedStartEngine = m('ClickedStartEngine')
+export const ClickedStopEngine = m('ClickedStopEngine')
+export const StartedEngine = m('StartedEngine', { engineId: S.String })
+export const StoppedEngine = m('StoppedEngine')
+export const FailedStartEngine = m('FailedStartEngine', { reason: S.String })
+export const ClickedCompute = m('ClickedCompute')
+export const ComputedSquare = m('ComputedSquare', { result: S.Number })
+export const SkippedCompute = m('SkippedCompute')
+
+export const Message = S.Union([
+  ClickedStartEngine,
+  ClickedStopEngine,
+  StartedEngine,
+  StoppedEngine,
+  FailedStartEngine,
+  ClickedCompute,
+  ComputedSquare,
+  SkippedCompute,
+])
+export type Message = typeof Message.Type
+
+// COMMAND
+
+export const Compute = Command.define(
+  'Compute',
+  { value: S.Number },
+  ComputedSquare,
+  SkippedCompute,
+)(({ value }) =>
+  Effect.gen(function* () {
+    const engine = yield* Engine.get
+    return ComputedSquare({ result: engine.square(value) })
+  }).pipe(
+    Effect.catchTag('ResourceNotAvailable', () =>
+      Effect.succeed(SkippedCompute()),
+    ),
+  ),
+)
+
+// UPDATE
+
+type UpdateReturn = readonly [
+  Model,
+  ReadonlyArray<Command.Command<Message, never, EngineService>>,
+]
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    M.withReturnType<UpdateReturn>(),
+    M.tagsExhaustive({
+      ClickedStartEngine: () => [
+        evo(model, { engine: () => EngineBooting() }),
+        [],
+      ],
+
+      ClickedStopEngine: () => [evo(model, { engine: () => EngineOff() }), []],
+
+      StartedEngine: ({ engineId }) => [
+        evo(model, { engine: () => EngineReady({ engineId }) }),
+        [],
+      ],
+
+      StoppedEngine: () => [model, []],
+
+      FailedStartEngine: ({ reason }) => [
+        evo(model, { engine: () => EngineFailed({ reason }) }),
+        [],
+      ],
+
+      ClickedCompute: () => {
+        const nextValue = model.computeCount + 1
+        return [
+          evo(model, { computeCount: () => nextValue }),
+          [Compute({ value: nextValue })],
+        ]
+      },
+
+      ComputedSquare: ({ result }) => [
+        evo(model, { lastResult: () => Option.some(result) }),
+        [],
+      ],
+
+      SkippedCompute: () => [model, []],
+    }),
+  )
+
+// INIT
+
+export const init: Runtime.ApplicationInit<Model, Message> = () => [
+  { engine: EngineOff(), computeCount: 0, lastResult: Option.none() },
+  [],
+]
+
+// MANAGED RESOURCE
+
+export const managedResources = ManagedResource.make<Model, Message>()(
+  entry => ({
+    engine: entry(S.Option(S.Null), {
+      resource: Engine,
+      modelToMaybeRequirements: model =>
+        M.value(model.engine).pipe(
+          M.tag('EngineBooting', 'EngineReady', () => Option.some(null)),
+          M.tag('EngineOff', 'EngineFailed', () => Option.none()),
+          M.exhaustive,
+        ),
+      acquire: () =>
+        Layer.build(engineLayer).pipe(
+          Effect.map(context => Context.get(context, ComputeEngineService)),
+        ),
+      release: () => Effect.void,
+      onAcquired: ({ engineId }) => StartedEngine({ engineId }),
+      onReleased: () => StoppedEngine(),
+      onAcquireError: error => FailedStartEngine({ reason: String(error) }),
+    }),
+  }),
+)
+
+// VIEW
+
+const buttonClassName =
+  'px-6 py-3 font-semibold text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed'
+
+const primaryButton = (
+  label: string,
+  message: Message,
+  colorClassName: string,
+): Html => {
+  const h = html<Message>()
+
+  return Button.view<Message>({
+    onClick: message,
+    toView: attributes =>
+      h.button(
+        [...attributes.button, h.Class(`${buttonClassName} ${colorClassName}`)],
+        [label],
+      ),
+  })
+}
+
+const engineStatusView = (engine: EngineState): Html => {
+  const h = html<Message>()
+
+  const status = M.value(engine).pipe(
+    M.tag('EngineOff', () => ({
+      colorClassName: 'text-gray-500',
+      text: 'Engine is off.',
+    })),
+    M.tag('EngineBooting', () => ({
+      colorClassName: 'text-amber-600',
+      text: 'Booting engine...',
+    })),
+    M.tag('EngineReady', ({ engineId }) => ({
+      colorClassName: 'text-green-600',
+      text: `Engine ready: ${engineId}`,
+    })),
+    M.tag('EngineFailed', ({ reason }) => ({
+      colorClassName: 'text-red-600',
+      text: `Engine failed: ${reason}`,
+    })),
+    M.exhaustive,
+  )
+
+  return h.keyed('p')(
+    engine._tag,
+    [h.Class(status.colorClassName)],
+    [status.text],
+  )
+}
+
+const engineControlsView = (engine: EngineState): Html => {
+  const h = html<Message>()
+
+  const controls = M.value(engine).pipe(
+    M.tag('EngineBooting', 'EngineReady', () => ({
+      key: 'Running',
+      label: 'Stop engine',
+      message: ClickedStopEngine(),
+      colorClassName: 'bg-red-500 hover:bg-red-600',
+    })),
+    M.tag('EngineOff', 'EngineFailed', () => ({
+      key: 'Stopped',
+      label: 'Start engine',
+      message: ClickedStartEngine(),
+      colorClassName: 'bg-green-500 hover:bg-green-600',
+    })),
+    M.exhaustive,
+  )
+
+  return h.keyed('div')(
+    controls.key,
+    [h.Class('flex gap-3')],
+    [primaryButton(controls.label, controls.message, controls.colorClassName)],
+  )
+}
+
+const resultView = (maybeResult: Option.Option<number>): Html => {
+  const h = html<Message>()
+
+  const text = Option.match(maybeResult, {
+    onNone: () => 'No result yet.',
+    onSome: value => `Last result: ${value}`,
+  })
+
+  return h.div([h.Class('text-gray-800')], [text])
+}
+
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: 'Managed Resource Layer',
+    body: h.div(
+      [h.Class('min-h-screen bg-gray-100 flex items-center justify-center')],
+      [
+        h.div(
+          [h.Class('bg-white p-8 rounded-lg shadow flex flex-col gap-5 w-96')],
+          [
+            h.h1(
+              [h.Class('text-xl font-bold text-gray-900')],
+              ['Layer-backed Managed Resource'],
+            ),
+            engineStatusView(model.engine),
+            engineControlsView(model.engine),
+            primaryButton(
+              'Compute next square',
+              ClickedCompute(),
+              'bg-blue-500 hover:bg-blue-600',
+            ),
+            resultView(model.lastResult),
+          ],
+        ),
+      ],
+    ),
+  }
+}

--- a/examples/managed-resource-layer/src/scene.test.ts
+++ b/examples/managed-resource-layer/src/scene.test.ts
@@ -1,0 +1,69 @@
+import { Option } from 'effect'
+import { Scene } from 'foldkit'
+import { describe, test } from 'vitest'
+
+import {
+  Compute,
+  ComputedSquare,
+  EngineOff,
+  EngineReady,
+  type Model,
+  update,
+  view,
+} from './main'
+
+const offModel: Model = {
+  engine: EngineOff(),
+  computeCount: 0,
+  lastResult: Option.none(),
+}
+
+const readyModel: Model = {
+  engine: EngineReady({ engineId: 'engine-1' }),
+  computeCount: 2,
+  lastResult: Option.none(),
+}
+
+describe('view', () => {
+  test('initial view shows the engine off with a Start button', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(offModel),
+      Scene.expect(Scene.text('Engine is off.')).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Start engine' })).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Stop engine' })).toBeAbsent(),
+      Scene.expect(Scene.text('No result yet.')).toExist(),
+    )
+  })
+
+  test('clicking Start engine enters the booting state and shows Stop', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(offModel),
+      Scene.click(Scene.role('button', { name: 'Start engine' })),
+      Scene.expect(Scene.text('Booting engine...')).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Stop engine' })).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Start engine' })).toBeAbsent(),
+    )
+  })
+
+  test('a ready engine shows its id and the Stop button', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(readyModel),
+      Scene.expect(Scene.text('Engine ready: engine-1')).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Stop engine' })).toExist(),
+    )
+  })
+
+  test('clicking Compute fires the Compute command and renders the result', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(readyModel),
+      Scene.click(Scene.role('button', { name: 'Compute next square' })),
+      Scene.Command.expectExact(Compute({ value: 3 })),
+      Scene.Command.resolve(Compute, ComputedSquare({ result: 9 })),
+      Scene.expect(Scene.text('Last result: 9')).toExist(),
+    )
+  })
+})

--- a/examples/managed-resource-layer/src/story.test.ts
+++ b/examples/managed-resource-layer/src/story.test.ts
@@ -1,0 +1,113 @@
+import { Option } from 'effect'
+import { Story } from 'foldkit'
+import { describe, expect, test } from 'vitest'
+
+import {
+  ClickedCompute,
+  ClickedStartEngine,
+  ClickedStopEngine,
+  Compute,
+  ComputedSquare,
+  EngineBooting,
+  EngineFailed,
+  EngineOff,
+  EngineReady,
+  FailedStartEngine,
+  type Model,
+  SkippedCompute,
+  StartedEngine,
+  update,
+} from './main'
+
+const offModel: Model = {
+  engine: EngineOff(),
+  computeCount: 0,
+  lastResult: Option.none(),
+}
+
+const readyModel: Model = {
+  engine: EngineReady({ engineId: 'engine-1' }),
+  computeCount: 2,
+  lastResult: Option.none(),
+}
+
+describe('update', () => {
+  describe('engine lifecycle', () => {
+    test('ClickedStartEngine requests the engine by entering EngineBooting', () => {
+      Story.story(
+        update,
+        Story.with(offModel),
+        Story.message(ClickedStartEngine()),
+        Story.model(model => {
+          expect(model.engine._tag).toBe('EngineBooting')
+        }),
+      )
+    })
+
+    test('StartedEngine marks the engine ready with its id', () => {
+      Story.story(
+        update,
+        Story.with({ ...offModel, engine: EngineBooting() }),
+        Story.message(StartedEngine({ engineId: 'engine-7' })),
+        Story.model(model => {
+          expect(model.engine).toStrictEqual(
+            EngineReady({ engineId: 'engine-7' }),
+          )
+        }),
+      )
+    })
+
+    test('ClickedStopEngine releases the engine by entering EngineOff', () => {
+      Story.story(
+        update,
+        Story.with(readyModel),
+        Story.message(ClickedStopEngine()),
+        Story.model(model => {
+          expect(model.engine._tag).toBe('EngineOff')
+        }),
+      )
+    })
+
+    test('FailedStartEngine records the failure reason', () => {
+      Story.story(
+        update,
+        Story.with({ ...offModel, engine: EngineBooting() }),
+        Story.message(FailedStartEngine({ reason: 'boot timeout' })),
+        Story.model(model => {
+          expect(model.engine).toStrictEqual(
+            EngineFailed({ reason: 'boot timeout' }),
+          )
+        }),
+      )
+    })
+  })
+
+  describe('compute', () => {
+    test('ClickedCompute increments the counter and fires Compute with the next value', () => {
+      Story.story(
+        update,
+        Story.with(readyModel),
+        Story.message(ClickedCompute()),
+        Story.model(model => {
+          expect(model.computeCount).toBe(3)
+        }),
+        Story.Command.expectExact(Compute({ value: 3 })),
+        Story.Command.resolve(Compute, ComputedSquare({ result: 9 })),
+        Story.model(model => {
+          expect(model.lastResult).toStrictEqual(Option.some(9))
+        }),
+      )
+    })
+
+    test('SkippedCompute leaves the model unchanged', () => {
+      Story.story(
+        update,
+        Story.with(readyModel),
+        Story.message(SkippedCompute()),
+        Story.model(model => {
+          expect(model).toStrictEqual(readyModel)
+        }),
+      )
+    })
+  })
+})

--- a/examples/managed-resource-layer/src/styles.css
+++ b/examples/managed-resource-layer/src/styles.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/examples/managed-resource-layer/src/vitest-setup.ts
+++ b/examples/managed-resource-layer/src/vitest-setup.ts
@@ -1,0 +1,3 @@
+import { setup } from 'foldkit/test/vitest'
+
+setup()

--- a/examples/managed-resource-layer/tsconfig.json
+++ b/examples/managed-resource-layer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"],
+  "exclude": ["node_modules", "dist", "../../packages/foldkit/src"]
+}

--- a/examples/managed-resource-layer/vite.config.ts
+++ b/examples/managed-resource-layer/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+
+import { foldkit } from '@foldkit/vite-plugin'
+import tailwindcss from '@tailwindcss/vite'
+
+import { foldkitAliases } from '../vite.aliases'
+
+export default defineConfig({
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9991 })],
+  resolve: {
+    alias: foldkitAliases(__dirname),
+  },
+  server: {
+    fs: {
+      allow: ['../../'],
+    },
+  },
+})

--- a/examples/managed-resource-layer/vitest.config.ts
+++ b/examples/managed-resource-layer/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['./src/vitest-setup.ts'],
+    server: {
+      deps: {
+        inline: ['foldkit', '@foldkit/ui', '@foldkit/devtools'],
+      },
+    },
+  },
+})

--- a/packages/foldkit/src/runtime/managedResource.ts
+++ b/packages/foldkit/src/runtime/managedResource.ts
@@ -1,4 +1,4 @@
-import { type Effect, Option, Record, type Schema } from 'effect'
+import { type Effect, Option, Record, type Schema, type Scope } from 'effect'
 
 import type { ManagedResource } from '../managedResource/index.js'
 
@@ -7,7 +7,7 @@ export type ManagedResourceConfig<Model, Message> = {
   readonly schema: Schema.Schema<any>
   readonly resource: ManagedResource<any>
   readonly modelToMaybeRequirements: (model: Model) => any
-  readonly acquire: (params: any) => Effect.Effect<any, unknown>
+  readonly acquire: (params: any) => Effect.Effect<any, unknown, Scope.Scope>
   readonly release: (value: any) => Effect.Effect<void>
   readonly onAcquired: (value: any) => Message
   readonly onReleased: () => Message
@@ -54,7 +54,7 @@ export type Entry<Model, Message, Requirements, Value, Service = unknown> = {
   readonly modelToMaybeRequirements: (model: Model) => Requirements
   readonly acquire: (
     params: AcquireParams<Requirements>,
-  ) => Effect.Effect<Value, unknown>
+  ) => Effect.Effect<Value, unknown, Scope.Scope>
   readonly release: (value: Value) => Effect.Effect<void>
   readonly onAcquired: (value: Value) => Message
   readonly onReleased: () => Message
@@ -91,7 +91,7 @@ export type EntryBuilder<Model, Message> = <
     ) => Schema.Schema.Type<RequirementsSchema>
     readonly acquire: (
       params: AcquireParams<Schema.Schema.Type<RequirementsSchema>>,
-    ) => Effect.Effect<Value, unknown>
+    ) => Effect.Effect<Value, unknown, Scope.Scope>
     readonly release: (value: Value) => Effect.Effect<void>
     readonly onAcquired: (value: Value) => Message
     readonly onReleased: () => Message
@@ -146,8 +146,17 @@ export type EntryBuilder<Model, Message> = <
  * - `acquire` — Creates the resource from the unwrapped params. The returned
  *   Effect should fail when acquisition fails: errors in the error channel
  *   flow to `onAcquireError` as a message instead of crashing the runtime.
+ *   `acquire` runs with the resource-lifetime `Scope.Scope` in its context, so
+ *   it can build an Effect `Layer` with `Layer.build` or register finalizers
+ *   with `Effect.addFinalizer` whose teardown is tied to the resource. Those
+ *   finalizers run when the resource is released or re-acquired, after the
+ *   explicit `release` callback (scope finalizers run in last-in-first-out
+ *   order, and the runtime registers `release` after `acquire` completes). A
+ *   `Layer`-built resource therefore needs only `release: () => Effect.void`:
+ *   the `Layer` finalizers run automatically when the scope closes.
  * - `release` — Tears down the resource. Errors thrown here are silently
- *   swallowed: release must not block cleanup.
+ *   swallowed: release must not block cleanup. Resources that register their
+ *   teardown as scope finalizers in `acquire` leave this as `() => Effect.void`.
  * - `onAcquired` — Message dispatched when `acquire` succeeds.
  * - `onAcquireError` — Message dispatched when `acquire` fails.
  * - `onReleased` — Message dispatched after `release` completes.

--- a/packages/foldkit/src/runtime/managedResourceLifecycle.test.ts
+++ b/packages/foldkit/src/runtime/managedResourceLifecycle.test.ts
@@ -1,0 +1,296 @@
+import {
+  Context,
+  Effect,
+  Fiber,
+  Layer,
+  Match as M,
+  Option,
+  Schema as S,
+} from 'effect'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as Command from '../command/index.js'
+import { html } from '../html/index.js'
+import * as ManagedResource from '../managedResource/index.js'
+import { m } from '../message/index.js'
+import { make } from './managedResource.js'
+import { makeElement } from './runtime.js'
+
+// A model-gated engine whose lifecycle is packaged as an Effect Layer. The
+// Layer registers a finalizer on the resource-lifetime scope provided to
+// `acquire`, so teardown rides on the resource lifecycle without a wrapper.
+
+type EngineShape = Readonly<{ id: string }>
+
+class EngineService extends Context.Service<EngineService, EngineShape>()(
+  'EngineService',
+) {}
+
+const FAIL_ID = 'fail'
+const LAYER_BUILD_ERROR = 'engine layer failed to build'
+
+let log: Array<string> = []
+
+const acquireEngine = (id: string): Effect.Effect<EngineShape, Error> => {
+  if (id === FAIL_ID) {
+    return Effect.fail(new Error(LAYER_BUILD_ERROR))
+  } else {
+    return Effect.sync(() => {
+      log.push(`build:${id}`)
+      return { id }
+    })
+  }
+}
+
+const makeEngineLayer = (id: string): Layer.Layer<EngineService, Error> =>
+  Layer.effect(
+    EngineService,
+    Effect.acquireRelease(acquireEngine(id), () =>
+      Effect.sync(() => {
+        log.push(`finalize:${id}`)
+      }),
+    ),
+  )
+
+const Engine = ManagedResource.tag<EngineShape>()('Engine')
+type EngineServiceId = ManagedResource.ServiceOf<typeof Engine>
+
+const RequestedEngine = m('RequestedEngine', { id: S.String })
+const StoppedEngine = m('StoppedEngine')
+const AcquiredEngine = m('AcquiredEngine')
+const ReleasedEngine = m('ReleasedEngine')
+const FailedEngine = m('FailedEngine', { error: S.String })
+const ClickedRead = m('ClickedRead')
+const SucceededRead = m('SucceededRead', { value: S.String })
+const FailedRead = m('FailedRead')
+
+const Message = S.Union([
+  RequestedEngine,
+  StoppedEngine,
+  AcquiredEngine,
+  ReleasedEngine,
+  FailedEngine,
+  ClickedRead,
+  SucceededRead,
+  FailedRead,
+])
+type Message = typeof Message.Type
+
+const Model = S.Struct({
+  requested: S.Option(S.String),
+  status: S.String,
+  readValue: S.String,
+})
+type Model = typeof Model.Type
+
+const ReadEngine = Command.define(
+  'ReadEngine',
+  SucceededRead,
+  FailedRead,
+)(
+  Engine.get.pipe(
+    Effect.map(({ id }) => SucceededRead({ value: id })),
+    Effect.catchTag('ResourceNotAvailable', () => Effect.succeed(FailedRead())),
+  ),
+)
+
+type UpdateReturn = readonly [
+  Model,
+  ReadonlyArray<Command.Command<Message, never, EngineServiceId>>,
+]
+
+const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    M.withReturnType<UpdateReturn>(),
+    M.tagsExhaustive({
+      RequestedEngine: ({ id }) => [
+        { ...model, requested: Option.some(id) },
+        [],
+      ],
+      StoppedEngine: () => [{ ...model, requested: Option.none() }, []],
+      AcquiredEngine: () => [{ ...model, status: 'acquired' }, []],
+      ReleasedEngine: () => [{ ...model, status: 'released' }, []],
+      FailedEngine: ({ error }) => [
+        { ...model, status: `failed:${error}` },
+        [],
+      ],
+      ClickedRead: () => [model, [ReadEngine()]],
+      SucceededRead: ({ value }) => [{ ...model, readValue: value }, []],
+      FailedRead: () => [{ ...model, readValue: 'unavailable' }, []],
+    }),
+  )
+
+const managedResources = make<Model, Message>()(entry => ({
+  engine: entry(S.Option(S.Struct({ id: S.String })), {
+    resource: Engine,
+    modelToMaybeRequirements: model =>
+      Option.map(model.requested, id => ({ id })),
+    acquire: ({ id }) =>
+      Layer.build(makeEngineLayer(id)).pipe(
+        Effect.map(context => Context.get(context, EngineService)),
+      ),
+    release: () =>
+      Effect.sync(() => {
+        log.push('release')
+      }),
+    onAcquired: () => AcquiredEngine(),
+    onReleased: () => ReleasedEngine(),
+    onAcquireError: error => FailedEngine({ error: String(error) }),
+  }),
+}))
+
+const h = html<Message>()
+
+const view = (model: Model) =>
+  h.div(
+    [],
+    [
+      h.button([h.OnClick(RequestedEngine({ id: 'b' }))], ['request-b']),
+      h.button([h.OnClick(StoppedEngine())], ['stop']),
+      h.button([h.OnClick(ClickedRead())], ['read']),
+      h.div([], [`status:${model.status}`]),
+      h.div([], [`value:${model.readValue}`]),
+    ],
+  )
+
+const crash = {
+  view: (context: Readonly<{ error: Error }>) =>
+    h.div([], [`Crash view: ${context.error.message}`]),
+}
+
+let container: HTMLElement
+
+beforeEach(() => {
+  log = []
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  container = document.createElement('div')
+  container.id = 'app'
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+// The first acquire is driven by `init` so it rides the guaranteed initial
+// model emission. That also establishes the model subscription, so later
+// button-driven requirement changes are observed.
+const startEngineApp = (initialId: string) =>
+  makeElement({
+    Model,
+    init: () => [
+      { requested: Option.some(initialId), status: 'idle', readValue: 'none' },
+      [],
+    ],
+    update,
+    view,
+    crash,
+    container,
+    managedResources,
+  })
+
+const awaitBodyText = (text: string): Promise<void> =>
+  vi.waitFor(() => {
+    expect(document.body.textContent).toContain(text)
+  })
+
+const awaitLogEntry = (entry: string): Promise<void> =>
+  vi.waitFor(() => {
+    expect(log).toContain(entry)
+  })
+
+const clickButton = (label: string): void => {
+  const button = Array.from(document.body.querySelectorAll('button')).find(
+    candidate => candidate.textContent === label,
+  )
+  expect(button, `button "${label}"`).toBeTruthy()
+  button?.click()
+}
+
+describe('managed resource lifecycle with a Layer-built resource', () => {
+  it('acquires and exposes the bare service value via the resource ref', async () => {
+    const element = startEngineApp('a')
+    const fiber = Effect.runFork(element.start())
+
+    try {
+      await awaitBodyText('status:acquired')
+      expect(log).toStrictEqual(['build:a'])
+
+      clickButton('read')
+      await awaitBodyText('value:a')
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('runs the Layer finalizer when the resource is released', async () => {
+    const element = startEngineApp('a')
+    const fiber = Effect.runFork(element.start())
+
+    try {
+      await awaitBodyText('status:acquired')
+
+      clickButton('stop')
+      await awaitLogEntry('finalize:a')
+      await awaitBodyText('status:released')
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('closes the old scope before building the new one on a param change', async () => {
+    const element = startEngineApp('a')
+    const fiber = Effect.runFork(element.start())
+
+    try {
+      await awaitBodyText('status:acquired')
+
+      clickButton('request-b')
+      await awaitLogEntry('build:b')
+
+      const finalizeAIndex = log.indexOf('finalize:a')
+      const buildBIndex = log.indexOf('build:b')
+      expect(finalizeAIndex).toBeGreaterThanOrEqual(0)
+      expect(finalizeAIndex).toBeLessThan(buildBIndex)
+
+      clickButton('read')
+      await awaitBodyText('value:b')
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('dispatches onAcquireError and leaves the ref empty when acquire fails', async () => {
+    const element = startEngineApp(FAIL_ID)
+    const fiber = Effect.runFork(element.start())
+
+    try {
+      await awaitBodyText(`failed:Error: ${LAYER_BUILD_ERROR}`)
+
+      expect(log.some(entry => entry.startsWith('build:'))).toBe(false)
+      expect(log.some(entry => entry.startsWith('finalize:'))).toBe(false)
+
+      clickButton('read')
+      await awaitBodyText('value:unavailable')
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('runs the explicit release before the Layer finalizer on teardown', async () => {
+    const element = startEngineApp('a')
+    const fiber = Effect.runFork(element.start())
+
+    try {
+      await awaitBodyText('status:acquired')
+
+      clickButton('stop')
+      await awaitLogEntry('finalize:a')
+
+      expect(log).toStrictEqual(['build:a', 'release', 'finalize:a'])
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+})

--- a/packages/website/src/page/core/managedResources.ts
+++ b/packages/website/src/page/core/managedResources.ts
@@ -25,6 +25,12 @@ const accessingManagedResourcesHeader: TableOfContentsEntry = {
   text: 'Accessing Managed Resources in Commands',
 }
 
+const buildingLayerHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'building-a-layer-in-acquire',
+  text: 'Building a Layer in acquire',
+}
+
 const composingSubmodelsHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'composing-child-submodels',
@@ -34,6 +40,7 @@ const composingSubmodelsHeader: TableOfContentsEntry = {
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
   accessingManagedResourcesHeader,
+  buildingLayerHeader,
   composingSubmodelsHeader,
 ]
 
@@ -136,6 +143,48 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ' has been received), the ',
         inlineCode('catchTag'),
         ' is a safety net that never fires. But if your model logic has a bug, you get a graceful error message instead of a crash.',
+      ),
+      tableOfContentsEntryToHeader(buildingLayerHeader),
+      para(
+        'When a resource’s setup and teardown are already packaged as an Effect ',
+        inlineCode('Layer'),
+        ', you do not have to unpack it by hand. ',
+        inlineCode('acquire'),
+        ' runs with the resource-lifetime ',
+        inlineCode('Scope'),
+        ' in its context, the same scope the runtime closes on release or re-acquire. So ',
+        inlineCode('Layer.build'),
+        ' registers the Layer’s finalizers on it, and you map the built context down to the bare service value.',
+      ),
+      highlightedCodeBlock(
+        h.div(
+          [
+            h.Class('text-sm'),
+            h.InnerHTML(Snippet.managedResourcesLayerHighlighted),
+          ],
+          [],
+        ),
+        Snippet.managedResourcesLayerRaw,
+        'Copy Layer-backed Managed Resource example to clipboard',
+        copiedSnippets,
+        'mb-8',
+      ),
+      para(
+        'The resource tag holds the bare service value, so Commands read it through ',
+        inlineCode('.get'),
+        ' with no wrapper to destructure. Any finalizer registered during ',
+        inlineCode('acquire'),
+        ', whether through ',
+        inlineCode('Layer.build'),
+        ' or ',
+        inlineCode('Effect.addFinalizer'),
+        ', tears down with the resource, so ',
+        inlineCode('release'),
+        ' is simply ',
+        inlineCode('() => Effect.void'),
+        '. The explicit ',
+        inlineCode('release'),
+        ' callback still runs first, then the scope finalizers, matching the last-in-first-out order Effect uses for any scope.',
       ),
       tableOfContentsEntryToHeader(composingSubmodelsHeader),
       para(

--- a/packages/website/src/snippet/index.ts
+++ b/packages/website/src/snippet/index.ts
@@ -36,6 +36,8 @@ export { default as managedResourcesCommandRaw } from './managedResourcesCommand
 export { default as managedResourcesCommandHighlighted } from './managedResourcesCommand.ts?highlighted'
 export { default as managedResourcesLiftRaw } from './managedResourcesLift.ts?raw'
 export { default as managedResourcesLiftHighlighted } from './managedResourcesLift.ts?highlighted'
+export { default as managedResourcesLayerRaw } from './managedResourcesLayer.ts?raw'
+export { default as managedResourcesLayerHighlighted } from './managedResourcesLayer.ts?highlighted'
 export { default as routingDefineRoutesRaw } from './routingDefineRoutes.ts?raw'
 export { default as routingDefineRoutesHighlighted } from './routingDefineRoutes.ts?highlighted'
 export { default as routingBuildRoutersRaw } from './routingBuildRouters.ts?raw'

--- a/packages/website/src/snippet/managedResourcesLayer.ts
+++ b/packages/website/src/snippet/managedResourcesLayer.ts
@@ -1,0 +1,37 @@
+import { Context, Effect, Layer, Option, Schema as S } from 'effect'
+import { ManagedResource } from 'foldkit'
+
+// A heavy engine whose init and teardown are packaged as an Effect Layer.
+interface ChessEngine {
+  readonly bestMove: (fen: string) => Effect.Effect<string>
+}
+
+class ChessEngineService extends Context.Service<
+  ChessEngineService,
+  ChessEngine
+>()('ChessEngineService') {}
+
+declare const engineLayer: Layer.Layer<ChessEngineService>
+
+// 1. The Managed Resource holds the bare service value, with no wrapper.
+const Engine = ManagedResource.tag<ChessEngine>()('ChessEngine')
+
+// 2. acquire runs with the resource-lifetime Scope in its context, so
+//    Layer.build registers the Layer's finalizers on it. They tear down when
+//    the resource is released or re-acquired.
+const managedResources = ManagedResource.make<Model, Message>()(entry => ({
+  engine: entry(S.Option(S.Struct({ slug: S.String })), {
+    resource: Engine,
+    modelToMaybeRequirements: model =>
+      Option.map(model.maybeAnalysisSlug, slug => ({ slug })),
+    acquire: () =>
+      Layer.build(engineLayer).pipe(
+        Effect.map(context => Context.get(context, ChessEngineService)),
+      ),
+    // The scope closes on release, so the Layer finalizers run automatically.
+    release: () => Effect.void,
+    onAcquired: () => StartedEngine(),
+    onReleased: () => StoppedEngine(),
+    onAcquireError: error => FailedStartEngine({ error: String(error) }),
+  }),
+}))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,6 +619,52 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  examples/managed-resource-layer:
+    dependencies:
+      '@effect/platform-browser':
+        specifier: 4.0.0-beta.83
+        version: 4.0.0-beta.83(effect@4.0.0-beta.83)
+      '@foldkit/devtools':
+        specifier: workspace:*
+        version: link:../../packages/devtools
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@tailwindcss/vite':
+        specifier: ^4.3.1
+        version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      effect:
+        specifier: 4.0.0-beta.83
+        version: 4.0.0-beta.83
+      foldkit:
+        specifier: workspace:*
+        version: link:../../packages/foldkit
+      tailwindcss:
+        specifier: ^4.3.1
+        version: 4.3.1
+    devDependencies:
+      '@foldkit/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-foldkit
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^6.0.2
+        version: 6.0.2(@vue/compiler-sfc@3.5.38)(prettier@3.8.4)
+      happy-dom:
+        specifier: ^20.10.4
+        version: 20.10.4
+      prettier:
+        specifier: ^3.8.4
+        version: 3.8.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.3)(happy-dom@20.10.4)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   examples/map:
     dependencies:
       '@effect/platform-browser':


### PR DESCRIPTION
A Managed Resource's `acquire` callback now runs with the resource-lifetime
`Scope.Scope` in its context, the same scope the runtime closes on release or
re-acquire. This lets `acquire` build an Effect `Layer` with `Layer.build` or
register finalizers with `Effect.addFinalizer` whose teardown is tied to the
resource lifecycle, instead of manually creating a Scope and hoisting it through
the stored value.

The runtime already ran `acquire` under the `Stream.scoped` scope via
`Effect.acquireRelease`; widening `acquire`'s requirements channel to
`Scope.Scope` is enough to thread that scope into `Layer.build`. Existing
resources that do not use the scope are unaffected, since an Effect requiring
nothing satisfies the wider type.

Teardown is last-in-first-out: the explicit `release` callback runs before the
scope finalizers registered during `acquire`, because the runtime registers
`release` only after `acquire` completes. So a Layer-built resource holds the
bare service value with no wrapper and needs only `release: () => Effect.void`.

Adds runtime lifecycle tests that drive a Layer-built resource end to end
(acquire, finalizer-on-release, re-acquire ordering, acquire-failure routing,
and the release-vs-finalizer order), a `core/managed-resources` docs section
with a snippet, and a runnable `managed-resource-layer` example.