### PR TITLE
fix(website): correct ui-showcase view source links

### DIFF
--- a/packages/website/src/link.ts
+++ b/packages/website/src/link.ts
@@ -4,7 +4,7 @@ export const exampleSourceHref = (slug: string): string =>
   `${exampleBase}/${slug}/src/main.ts`
 
 export const uiShowcaseViewSourceHref = (slug: string): string =>
-  `https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/view/${slug}.ts`
+  `https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/ui/view/${slug}.ts`
 
 export const Link = {
   elm: 'https://elm-lang.org',


### PR DESCRIPTION
The 'real Foldkit app' links on the UI docs pages pointed to
examples/ui-showcase/src/view/{slug}.ts, but the view files live at
examples/ui-showcase/src/ui/view/{slug}.ts. Add the missing ui/ segment.