### PR TITLE
fix(website): preserve slashes in API module OG image titles

### DIFF
--- a/packages/website/scripts/metadata.ts
+++ b/packages/website/scripts/metadata.ts
@@ -1,6 +1,5 @@
 import { Match as M, Option } from 'effect'
 
-import { slugToModuleName } from '../src/page/apiReference/domain'
 import { findBySlug } from '../src/page/example/meta'
 import { type AppRoute } from '../src/route'
 
@@ -11,6 +10,8 @@ export type PageMetadata = Readonly<{
   description: string
   section: string
 }>
+
+export type ApiModuleNameResolver = (slug: string) => string
 
 const SITE_DESCRIPTION =
   'A TypeScript frontend framework built on Effect-TS, using The Elm Architecture (TEA). Single state tree, pure update functions, explicit side effects, and type-safe routing. An alternative to React for teams that value correctness.'
@@ -393,11 +394,14 @@ const METADATA_BY_TAG: Record<StaticRouteTag, PageMetadata> = {
   },
 }
 
-export const routeToMetadata = (route: AppRoute): PageMetadata =>
+export const routeToMetadata = (
+  route: AppRoute,
+  resolveApiModuleName: ApiModuleNameResolver,
+): PageMetadata =>
   M.value(route).pipe(
     M.withReturnType<PageMetadata>(),
     M.tag('ApiModule', ({ moduleSlug }) => {
-      const moduleName = slugToModuleName(moduleSlug)
+      const moduleName = resolveApiModuleName(moduleSlug)
       return docs(
         moduleName,
         `API documentation for the ${moduleName} module.`,

--- a/packages/website/scripts/og-image.ts
+++ b/packages/website/scripts/og-image.ts
@@ -7,7 +7,11 @@ import satori, { type Font } from 'satori'
 import { Resvg } from '@resvg/resvg-js'
 
 import { type AppRoute } from '../src/route'
-import { type PageMetadata, routeToMetadata } from './metadata'
+import {
+  type ApiModuleNameResolver,
+  type PageMetadata,
+  routeToMetadata,
+} from './metadata'
 
 // LOGO
 
@@ -189,11 +193,12 @@ const renderOgImage =
     fonts: Array<Font>,
     ogDir: string,
     routeToUrlPath: (route: AppRoute) => string,
+    resolveApiModuleName: ApiModuleNameResolver,
   ) =>
   (route: AppRoute) =>
     pipe(
       Effect.gen(function* () {
-        const metadata = routeToMetadata(route)
+        const metadata = routeToMetadata(route, resolveApiModuleName)
         const template = ogTemplate(metadata)
         const slug = urlPathToSlug(routeToUrlPath(route))
 
@@ -226,6 +231,7 @@ export const generateOgImages = (
   routes: ReadonlyArray<AppRoute>,
   routeToUrlPath: (route: AppRoute) => string,
   distDir: string,
+  resolveApiModuleName: ApiModuleNameResolver,
 ) =>
   Effect.gen(function* () {
     yield* Console.log('Generating OG images...')
@@ -235,9 +241,11 @@ export const generateOgImages = (
     const ogDir = resolve(distDir, 'og')
     yield* fs.makeDirectory(ogDir, { recursive: true })
 
-    yield* Effect.forEach(routes, renderOgImage(fonts, ogDir, routeToUrlPath), {
-      concurrency: 8,
-    })
+    yield* Effect.forEach(
+      routes,
+      renderOgImage(fonts, ogDir, routeToUrlPath, resolveApiModuleName),
+      { concurrency: 8 },
+    )
 
     yield* Console.log(`Generated ${Array.length(routes)} OG images.`)
   })
@@ -284,8 +292,9 @@ export const injectMetaTags = (
   html: string,
   route: AppRoute,
   urlPath: string,
+  resolveApiModuleName: ApiModuleNameResolver,
 ): string => {
-  const metadata = routeToMetadata(route)
+  const metadata = routeToMetadata(route, resolveApiModuleName)
   const slug = urlPathToSlug(urlPath)
   const ogImageUrl = `${SITE_URL}/og/${slug}.png`
   const pageUrl = `${SITE_URL}${urlPath}`

--- a/packages/website/scripts/prerender.ts
+++ b/packages/website/scripts/prerender.ts
@@ -6,6 +6,7 @@ import {
   Effect,
   Match as M,
   Option,
+  Record,
   Schema as S,
   String as Str,
   Stream,
@@ -20,8 +21,10 @@ import { type Browser, chromium } from 'playwright'
 import { NodeRuntime, NodeServices } from '@effect/platform-node'
 
 import {
+  type ApiModule,
   moduleNameToSlug,
   parseTypedocJson,
+  slugToModuleName,
 } from '../src/page/apiReference/domain'
 import { TypeDocJson } from '../src/page/apiReference/typedoc'
 import { exampleSlugs } from '../src/page/example/meta'
@@ -204,7 +207,7 @@ import {
   shouldExportMarkdown,
   urlPathToMarkdownPath,
 } from './markdown'
-import { routeToMetadata } from './metadata'
+import { type ApiModuleNameResolver, routeToMetadata } from './metadata'
 import { generateOgImages, injectMetaTags } from './og-image'
 
 // ROUTES
@@ -534,13 +537,11 @@ const captureRoutePage = (browser: Browser, url: string, route: AppRoute) =>
 
 const ApiDocJson = S.fromJsonString(TypeDocJson)
 
-const readApiModuleSlugs = Effect.gen(function* () {
+const readApiModules = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem
   const raw = yield* fs.readFileString(API_JSON_PATH)
   const apiDoc = yield* S.decodeUnknownEffect(ApiDocJson)(raw)
-  return Array.map(parseTypedocJson(apiDoc).modules, ({ name }) =>
-    moduleNameToSlug(name),
-  )
+  return parseTypedocJson(apiDoc).modules
 })
 
 type PrerenderResult = Readonly<{
@@ -549,8 +550,28 @@ type PrerenderResult = Readonly<{
   markdown: string
 }>
 
+const buildApiModuleNameResolver = (
+  modules: ReadonlyArray<ApiModule>,
+): ApiModuleNameResolver => {
+  const nameBySlug = Record.fromIterableWith(modules, ({ name }) => [
+    moduleNameToSlug(name),
+    name,
+  ])
+  return slug =>
+    pipe(
+      nameBySlug,
+      Record.get(slug),
+      Option.getOrElse(() => slugToModuleName(slug)),
+    )
+}
+
 const prerenderRoute =
-  (browser: Browser, baseHtml: string) => (route: AppRoute) =>
+  (
+    browser: Browser,
+    baseHtml: string,
+    resolveApiModuleName: ApiModuleNameResolver,
+  ) =>
+  (route: AppRoute) =>
     Effect.gen(function* () {
       const urlPath = routeToUrlPath(route)
       const outputPath = routeToOutputPath(route)
@@ -559,7 +580,12 @@ const prerenderRoute =
 
       const captured = yield* captureRoutePage(browser, url, route)
       const injectedHtml = injectHtml(baseHtml, captured.html)
-      const outputHtml = injectMetaTags(injectedHtml, route, urlPath)
+      const outputHtml = injectMetaTags(
+        injectedHtml,
+        route,
+        urlPath,
+        resolveApiModuleName,
+      )
 
       const fs = yield* FileSystem.FileSystem
       yield* fs.makeDirectory(dirname(outputFilePath), {
@@ -632,20 +658,21 @@ ${entries}
 
 // PROGRAM
 
-const resultToIndexEntry = (result: PrerenderResult): LlmsIndexEntry => ({
-  urlPath: result.urlPath,
-  metadata: routeToMetadata(result.route),
-})
+const resultToIndexEntry =
+  (resolveApiModuleName: ApiModuleNameResolver) =>
+  (result: PrerenderResult): LlmsIndexEntry => ({
+    urlPath: result.urlPath,
+    metadata: routeToMetadata(result.route, resolveApiModuleName),
+  })
 
-const resultToFullEntry = (
-  result: PrerenderResult,
-  orderIndex: number,
-): LlmsFullEntry => ({
-  urlPath: result.urlPath,
-  metadata: routeToMetadata(result.route),
-  markdown: result.markdown,
-  orderIndex,
-})
+const resultToFullEntry =
+  (resolveApiModuleName: ApiModuleNameResolver) =>
+  (result: PrerenderResult, orderIndex: number): LlmsFullEntry => ({
+    urlPath: result.urlPath,
+    metadata: routeToMetadata(result.route, resolveApiModuleName),
+    markdown: result.markdown,
+    orderIndex,
+  })
 
 const program = Effect.scoped(
   Effect.gen(function* () {
@@ -654,10 +681,19 @@ const program = Effect.scoped(
     yield* previewServerResource
     const browser = yield* playwrightBrowserResource
 
-    const apiModuleSlugs = yield* readApiModuleSlugs
+    const apiModules = yield* readApiModules
+    const apiModuleSlugs = Array.map(apiModules, ({ name }) =>
+      moduleNameToSlug(name),
+    )
+    const resolveApiModuleName = buildApiModuleNameResolver(apiModules)
     const routes = enumerateRoutes(apiModuleSlugs)
 
-    yield* generateOgImages(routes, routeToUrlPath, DIST_DIR)
+    yield* generateOgImages(
+      routes,
+      routeToUrlPath,
+      DIST_DIR,
+      resolveApiModuleName,
+    )
 
     const fs = yield* FileSystem.FileSystem
     const baseHtml = yield* fs.readFileString(resolve(DIST_DIR, 'index.html'))
@@ -672,7 +708,7 @@ const program = Effect.scoped(
 
     const results = yield* Effect.forEach(
       routes,
-      prerenderRoute(browser, baseHtml),
+      prerenderRoute(browser, baseHtml, resolveApiModuleName),
       { concurrency: 4 },
     )
 
@@ -688,8 +724,14 @@ const program = Effect.scoped(
       buildSitemap(routes, lastModification),
     )
 
-    const indexEntries = Array.map(markdownResults, resultToIndexEntry)
-    const fullEntries = Array.map(markdownResults, resultToFullEntry)
+    const indexEntries = Array.map(
+      markdownResults,
+      resultToIndexEntry(resolveApiModuleName),
+    )
+    const fullEntries = Array.map(
+      markdownResults,
+      resultToFullEntry(resolveApiModuleName),
+    )
 
     yield* fs.writeFileString(
       resolve(DIST_DIR, 'llms.txt'),


### PR DESCRIPTION
`moduleNameToSlug` collapses slashes into hyphens, so for nested API
modules the slug is ambiguous: `Ui/Listbox/Multi` and `UiListboxMulti`
both encode to `ui-listbox-multi`. `slugToModuleName` recovers the
PascalCase form but has no way to know which hyphens were originally
slashes, so OG image and meta tag titles for nested modules rendered as
`UiListboxMulti` instead of `Ui/Listbox/Multi`.

The runtime title already resolves the slug against the loaded API data
so the live document title displays the real namespaced name. Mirror
that approach for the prerender path: thread an `ApiModuleNameResolver`
from `prerender` through `og-image` and `metadata`, built from the
parsed typedoc modules so the real names with slashes are used.