### PR TITLE
feat(website): scroll mobile menu to active page on open

### DIFF
--- a/packages/website/src/docsNav.ts
+++ b/packages/website/src/docsNav.ts
@@ -87,6 +87,8 @@ import { type GroupKey } from './sidebarStorage'
 
 export const DOCS_SIDEBAR_NAV_ID = 'docs-sidebar-nav'
 
+export const MOBILE_MENU_NAV_ID = 'mobile-menu-nav'
+
 // NAV PAGE
 
 export type NavPage = Readonly<{

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -36,7 +36,12 @@ import { Dialog, Disclosure, Menu, Tabs } from '@foldkit/ui'
 import { inject } from '@vercel/analytics'
 import * as SpeedInsights from '@vercel/speed-insights'
 
-import { DOCS_SIDEBAR_NAV_ID, allPages, findActiveSectionKey } from './docsNav'
+import {
+  DOCS_SIDEBAR_NAV_ID,
+  MOBILE_MENU_NAV_ID,
+  allPages,
+  findActiveSectionKey,
+} from './docsNav'
 import { GitHubStarsRemoteData } from './githubStars'
 import {
   CompletedApplyTheme,
@@ -46,6 +51,7 @@ import {
   CompletedNavigateInternal,
   CompletedSaveSidebarState,
   CompletedSaveThemePreference,
+  CompletedScrollMobileMenuActiveLinkIntoView,
   CompletedScrollSidebarActiveLinkIntoView,
   CompletedScrollToAnchor,
   CompletedScrollToTop,
@@ -807,9 +813,12 @@ export const update = (
           evo(model, {
             mobileMenuDialog: () => nextMobileMenuDialog,
           }),
-          Command.mapMessages(mobileMenuDialogCommands, message =>
-            GotMobileMenuDialogMessage({ message }),
-          ),
+          [
+            ...Command.mapMessages(mobileMenuDialogCommands, message =>
+              GotMobileMenuDialogMessage({ message }),
+            ),
+            ScrollMobileMenuActiveLinkIntoView(),
+          ],
         ]
       },
 
@@ -1178,6 +1187,7 @@ export const update = (
       'CompletedScrollToTop',
       'CompletedScrollToAnchor',
       'CompletedScrollSidebarActiveLinkIntoView',
+      'CompletedScrollMobileMenuActiveLinkIntoView',
       'CompletedApplyTheme',
       'CompletedSaveThemePreference',
       'CompletedSaveSidebarState',
@@ -1276,6 +1286,18 @@ const ScrollSidebarActiveLinkIntoView = Command.define(
   Dom.scrollIntoViewIfNotVisible(
     `#${DOCS_SIDEBAR_NAV_ID} [aria-current="page"]`,
   ).pipe(Effect.ignore, Effect.as(CompletedScrollSidebarActiveLinkIntoView())),
+)
+
+const ScrollMobileMenuActiveLinkIntoView = Command.define(
+  'ScrollMobileMenuActiveLinkIntoView',
+  CompletedScrollMobileMenuActiveLinkIntoView,
+)(
+  Dom.scrollIntoViewIfNotVisible(
+    `#${MOBILE_MENU_NAV_ID} [aria-current="page"]`,
+  ).pipe(
+    Effect.ignore,
+    Effect.as(CompletedScrollMobileMenuActiveLinkIntoView()),
+  ),
 )
 
 const ApplyTheme = Command.define(

--- a/packages/website/src/message.ts
+++ b/packages/website/src/message.ts
@@ -30,6 +30,9 @@ export const CompletedSaveSidebarState = m('CompletedSaveSidebarState')
 export const CompletedScrollSidebarActiveLinkIntoView = m(
   'CompletedScrollSidebarActiveLinkIntoView',
 )
+export const CompletedScrollMobileMenuActiveLinkIntoView = m(
+  'CompletedScrollMobileMenuActiveLinkIntoView',
+)
 export const SucceededCopyLink = m('SucceededCopyLink')
 export const FailedCopyLink = m('FailedCopyLink')
 export const ClickedLink = m('ClickedLink', {
@@ -172,6 +175,7 @@ export const Message = S.Union([
   CompletedSaveThemePreference,
   CompletedSaveSidebarState,
   CompletedScrollSidebarActiveLinkIntoView,
+  CompletedScrollMobileMenuActiveLinkIntoView,
   SucceededCopyLink,
   FailedCopyLink,
   ClickedLink,

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -7,6 +7,7 @@ import { Dialog, Disclosure } from '@foldkit/ui'
 
 import {
   DOCS_SIDEBAR_NAV_ID,
+  MOBILE_MENU_NAV_ID,
   type NavPage,
   docsSections,
   findActiveSectionKey,
@@ -381,6 +382,7 @@ export const sidebarView = (model: Model): Html => {
         h.nav(
           [
             h.AriaLabel('Documentation'),
+            h.Id(MOBILE_MENU_NAV_ID),
             h.Class('flex-1 overflow-y-auto'),
             h.Tabindex(-1),
             h.Autofocus(true),


### PR DESCRIPTION
When the mobile menu opens, scroll the active nav link into view and
center it within the menu's scroll container, mirroring the sidebar's
ScrollSidebarActiveLinkIntoView behavior on navigation.