### PR TITLE
feat(foldkit): add commit timing gate to scrollIntoViewIfNotVisible

### DIFF
--- a/.changeset/scroll-into-view-if-not-visible-commit-gate.md
+++ b/.changeset/scroll-into-view-if-not-visible-commit-gate.md
@@ -1,0 +1,11 @@
+---
+'foldkit': minor
+---
+
+Add a `when` option to `Dom.scrollIntoViewIfNotVisible`. It selects the timing
+gate: `'Paint'` (the default) waits for `Render.afterPaint` and keeps the
+existing behavior, while `'Commit'` waits for `Render.afterCommit` so the
+scroll lands in the same frame the DOM patch applies, before the browser
+paints. Use `'Commit'` when the target is brought into view and scrolled by
+the same Message, such as a menu opening, so it appears already scrolled
+rather than visibly jumping.

--- a/packages/foldkit/src/dom/dom.ts
+++ b/packages/foldkit/src/dom/dom.ts
@@ -338,20 +338,37 @@ const findScrollParent = (element: HTMLElement): Option.Option<HTMLElement> => {
  * Defaults to `{ block: 'center' }`; pass a different `block` when the
  * target should land at a specific position when it does need to scroll.
  *
+ * `when` selects the timing gate. `'Paint'` (the default) waits for
+ * `Render.afterPaint`, so the scroll lands after the target is on screen.
+ * `'Commit'` waits for `Render.afterCommit` instead, so the scroll lands in
+ * the same frame the DOM patch applies, before the browser paints. Use
+ * `'Commit'` when the target is brought into view and scrolled by the same
+ * Message (such as a menu opening), so it appears already scrolled rather
+ * than visibly jumping.
+ *
  * Fails with `ElementNotFound` if the selector does not match an `HTMLElement`.
  *
  * @example
  * ```typescript
  * Dom.scrollIntoViewIfNotVisible('#active-nav-link')
  * Dom.scrollIntoViewIfNotVisible('#active-nav-link', { block: 'nearest' })
+ * Dom.scrollIntoViewIfNotVisible('#active-nav-link', { when: 'Commit' })
  * ```
  */
 export const scrollIntoViewIfNotVisible = (
   selector: string,
-  options?: Readonly<{ block?: ScrollLogicalPosition }>,
+  options?: Readonly<{
+    block?: ScrollLogicalPosition
+    when?: 'Paint' | 'Commit'
+  }>,
 ): Effect.Effect<void, ElementNotFound> =>
   Effect.gen(function* () {
-    yield* afterPaint
+    const when = options?.when ?? 'Paint'
+    yield* M.value(when).pipe(
+      M.when('Paint', () => afterPaint),
+      M.when('Commit', () => afterCommit),
+      M.exhaustive,
+    )
     const element = yield* queryHTMLElement(selector)
     Option.match(findScrollParent(element), {
       onNone: () =>

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -1288,13 +1288,15 @@ const ScrollSidebarActiveLinkIntoView = Command.define(
   ).pipe(Effect.ignore, Effect.as(CompletedScrollSidebarActiveLinkIntoView())),
 )
 
+const MOBILE_MENU_ACTIVE_LINK = `#${MOBILE_MENU_NAV_ID} [aria-current="page"]`
+
 const ScrollMobileMenuActiveLinkIntoView = Command.define(
   'ScrollMobileMenuActiveLinkIntoView',
   CompletedScrollMobileMenuActiveLinkIntoView,
 )(
-  Dom.scrollIntoViewIfNotVisible(
-    `#${MOBILE_MENU_NAV_ID} [aria-current="page"]`,
-  ).pipe(
+  Dom.scrollIntoViewIfNotVisible(MOBILE_MENU_ACTIVE_LINK, {
+    when: 'Commit',
+  }).pipe(
     Effect.ignore,
     Effect.as(CompletedScrollMobileMenuActiveLinkIntoView()),
   ),


### PR DESCRIPTION
Add a `when` option that selects the timing gate. `'Paint'` (the default) keeps the existing `Render.afterPaint` behavior. `'Commit'` waits for `Render.afterCommit` instead, so the scroll lands in the same frame the DOM patch applies, before the browser paints.

Use it to fix the website mobile menu. The menu dialog is not animated, so the active-link scroll ran on afterPaint: the open menu painted at the top, then jumped to the active link a frame later. With `when: 'Commit'` the menu now appears already scrolled to the active page.