### PR TITLE
fix(website): decode mobile menu logo synchronously to stop blink

### DIFF
--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -362,6 +362,7 @@ export const sidebarView = (model: Model): Html => {
                   h.Alt('Foldkit'),
                   h.Width('801'),
                   h.Height('200'),
+                  h.Decoding('sync'),
                   h.Class('h-6 w-auto dark:invert'),
                 ]),
                 betaTag,


### PR DESCRIPTION
The mobile menu logo lives inside the Dialog panel, which only renders
when the dialog becomes visible. Each open inserts a fresh img element,
and the browser's default async decode paints it blank for one frame
before swapping in the cached SVG, reading as a blink against the panel
fade-in. Decoding synchronously paints the logo in the same frame.