### PR TITLE
feat(ui): add animatePanel helper to Disclosure for animated open/close

### DIFF
--- a/.changeset/disclosure-animate-panel.md
+++ b/.changeset/disclosure-animate-panel.md
@@ -1,0 +1,12 @@
+---
+'@foldkit/ui': minor
+---
+
+Add `animatePanel` to the `Ui.Disclosure` attribute bundle, so disclosures can
+animate their expand and collapse. It wraps panel content in a CSS-grid
+container that transitions height (`grid-template-rows: 0fr → 1fr` with
+`overflow: hidden`), keeping the panel mounted while collapsed so the transition
+has something to animate from and to. Render the panel unconditionally and pass
+it through `attributes.animatePanel` instead of gating it on `isOpen`. The
+collapsed content is marked `aria-hidden`. Mirrors the `Ui.Animation`
+`animateSize` flag.

--- a/examples/ui-showcase/src/scene.test.ts
+++ b/examples/ui-showcase/src/scene.test.ts
@@ -81,6 +81,16 @@ describe('view', () => {
     })
   })
 
+  test('the Disclosure panel stays mounted while collapsed so it can animate', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(modelForRoute(DisclosureRoute())),
+      Scene.expect(
+        Scene.text('Foldkit is an Elm-inspired UI framework', { exact: false }),
+      ).toExist(),
+    )
+  })
+
   test('the NotFound route renders the 404 panel and a Go Home link', () => {
     Scene.scene(
       { update, view },

--- a/examples/ui-showcase/src/ui/view/disclosure.ts
+++ b/examples/ui-showcase/src/ui/view/disclosure.ts
@@ -51,19 +51,19 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
                     ),
                   ],
                 ),
-                model.disclosureDemo.isOpen
-                  ? h.div(
-                      [...attributes.panel, h.Class(panelClassName)],
-                      [
-                        h.p(
-                          [h.Class('text-gray-800')],
-                          [
-                            'Foldkit is an Elm-inspired UI framework powered by Effect. It brings the Model-View-Update architecture to TypeScript with Schema-typed state, explicit side effects via commands, and composable headless UI components.',
-                          ],
-                        ),
-                      ],
-                    )
-                  : h.empty,
+                attributes.animatePanel(
+                  h.div(
+                    [...attributes.panel, h.Class(panelClassName)],
+                    [
+                      h.p(
+                        [h.Class('text-gray-800')],
+                        [
+                          'Foldkit is an Elm-inspired UI framework powered by Effect. It brings the Model-View-Update architecture to TypeScript with Schema-typed state, explicit side effects via commands, and composable headless UI components.',
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
               ],
             ),
         },

--- a/packages/ui/src/disclosure/index.ts
+++ b/packages/ui/src/disclosure/index.ts
@@ -153,12 +153,23 @@ export const reflectOpenState: Reflect<Model, boolean> = Function.dual(
 
 // VIEW
 
+const panelSizeTransition = 'grid-template-rows 200ms ease-out'
+
 /** Attribute groups the disclosure component provides to the consumer's
  *  `toView` callback. The consumer composes the button + panel layout
  *  themselves using these bundles. */
 export type DisclosureAttributes = Readonly<{
   button: ReadonlyArray<ChildAttribute>
   panel: ReadonlyArray<ChildAttribute>
+  /** Wraps panel content in a CSS-grid container that smoothly animates
+   *  height (`grid-template-rows: 0fr → 1fr` with `overflow: hidden`) as
+   *  the disclosure opens and closes. Unlike the bare conditional render,
+   *  the panel stays mounted while collapsed, so the transition has
+   *  something to animate from and to. Spread the `panel` bundle onto the
+   *  element you pass in, and render it unconditionally rather than gating
+   *  on `isOpen`. The collapsed content is marked `aria-hidden`. Mirrors the
+   *  `Ui.Animation` `animateSize` flag. */
+  animatePanel: (content: Html) => Html
 }>
 
 /** Per-render view inputs passed to `view` via `h.submodel`'s `viewInputs` field.
@@ -216,9 +227,31 @@ export const view = defineView<Model, Message, ViewInputs>(
       ...(isOpen ? [h.DataAttribute('open', '')] : []),
     ]
 
+    const animatePanel = (content: Html): Html =>
+      h.div(
+        [
+          h.Style({
+            display: 'grid',
+            gridTemplateRows: isOpen ? '1fr' : '0fr',
+            transition: panelSizeTransition,
+            overflow: 'hidden',
+          }),
+        ],
+        [
+          h.div(
+            [
+              h.Style({ minHeight: '0px', overflow: 'hidden' }),
+              ...(isOpen ? [] : [h.AriaHidden(true)]),
+            ],
+            [content],
+          ),
+        ],
+      )
+
     return toView({
       button: childAttributes(buttonAttributes),
       panel: childAttributes(panelAttributes),
+      animatePanel,
     })
   },
 )

--- a/packages/website/src/page/ui/disclosure.ts
+++ b/packages/website/src/page/ui/disclosure.ts
@@ -53,19 +53,19 @@ export const disclosureDemo = (disclosureModel: Disclosure.Model) => {
                       ),
                     ],
                   ),
-                  disclosureModel.isOpen
-                    ? h.div(
-                        [...attributes.panel, h.Class(panelClassName)],
-                        [
-                          h.p(
-                            [h.Class('text-gray-800 dark:text-gray-200')],
-                            [
-                              'Foldkit is an Elm-inspired UI framework powered by Effect. It brings the Model-View-Update architecture to TypeScript with Schema-typed state, explicit side effects via commands, and composable headless UI components.',
-                            ],
-                          ),
-                        ],
-                      )
-                    : h.empty,
+                  attributes.animatePanel(
+                    h.div(
+                      [...attributes.panel, h.Class(panelClassName)],
+                      [
+                        h.p(
+                          [h.Class('text-gray-800 dark:text-gray-200')],
+                          [
+                            'Foldkit is an Elm-inspired UI framework powered by Effect. It brings the Model-View-Update architecture to TypeScript with Schema-typed state, explicit side effects via commands, and composable headless UI components.',
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
                 ],
               ),
           },

--- a/packages/website/src/page/ui/disclosurePage.ts
+++ b/packages/website/src/page/ui/disclosurePage.ts
@@ -165,6 +165,12 @@ const disclosureAttributesProps: ReadonlyArray<PropEntry> = [
     description:
       'Spread onto the panel element. Includes the panel id (`${id}-panel`) and a `data-open` attribute when open.',
   },
+  {
+    name: 'animatePanel',
+    type: '(content: Html) => Html',
+    description:
+      'Wraps panel content in a CSS-grid container that animates height as the disclosure opens and closes. Render the panel unconditionally (rather than gating on isOpen) and pass it here; the panel stays mounted while collapsed so the height transition has something to animate. The collapsed content is marked aria-hidden.',
+  },
 ]
 
 const outMessageProps: ReadonlyArray<PropEntry> = [
@@ -267,6 +273,13 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           'Copy disclosure example to clipboard',
           copiedSnippets,
           'mb-8',
+        ),
+        para(
+          'To animate the expand and collapse, render the panel unconditionally and pass it through ',
+          inlineCode('attributes.animatePanel'),
+          ' instead of gating it on ',
+          inlineCode('isOpen'),
+          '. It wraps the content in a CSS-grid container that transitions its height, keeping the panel mounted while collapsed so there is something to animate.',
         ),
         heading(stylingHeader.level, stylingHeader.id, stylingHeader.text),
         para(


### PR DESCRIPTION
Disclosure is headless, so consumers compose the panel themselves and
previously had to gate it on `isOpen`, which removes it from the DOM and
leaves a CSS height transition nothing to animate. Add an opt-in
`animatePanel` render helper to the published `DisclosureAttributes`
bundle. It wraps panel content in a CSS-grid container
(`grid-template-rows: 0fr/1fr` with `overflow: hidden`), keeping the
panel mounted while collapsed so its height animates smoothly. Collapsed
content is marked `aria-hidden`. Mirrors the `Ui.Animation` `animateSize`
flag.

Render the panel unconditionally and pass it through
`attributes.animatePanel` rather than gating on `isOpen`. Update the
website docs and demo plus the ui-showcase demo to use it, and add a
scene test asserting the panel stays mounted while collapsed.

Closes #349