### PR TITLE
docs(website): caution against withConstructorDefault on route fields

### DIFF
--- a/packages/website/src/page/routing.ts
+++ b/packages/website/src/page/routing.ts
@@ -336,6 +336,20 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('S.FiniteFromString'),
         ' automatically parses string query values into numbers.',
       ),
+      warningCallout(
+        'Don’t put Schema.withConstructorDefault on route fields.',
+        'A field that carries ',
+        inlineCode('Schema.withConstructorDefault'),
+        ' becomes optional in the tagged struct’s constructor-input type, and ',
+        inlineCode('Route.mapTo'),
+        ' consumes that constructor-input type on its encode side. It no longer matches the required field that ',
+        inlineCode('Route.query'),
+        ' parses, so the ',
+        inlineCode('Route.query'),
+        ' plus ',
+        inlineCode('Route.mapTo'),
+        ' pipe stops typechecking. Drop the default and the router composes again.',
+      ),
       para(
         'For a complete routing example, see the ',
         link(


### PR DESCRIPTION
## Summary

Adds a caution to the Query Parameters section of the routing docs about putting `Schema.withConstructorDefault` on route fields.

A field that carries `Schema.withConstructorDefault` becomes optional in the tagged struct's constructor-input type. `Route.mapTo` consumes that constructor-input type on its encode side, so it no longer matches the required field that `Route.query` parses. The `Route.query` plus `Route.mapTo` pipe then stops typechecking. Dropping the default lets the router compose again.

This is the resolution the issue accepts: a short docs note rather than a library change. The note lives next to where `Route.query` and `Route.mapTo` are documented, uses the page's existing `warningCallout` helper, and matches its voice.

## Changes

- `packages/website/src/page/routing.ts`: one `warningCallout` in the Query Parameters section.

No changeset is included. The `website` package is private and unpublished, matching how other website-only docs changes in this repo are handled.

## Verification

- `pnpm --filter website typecheck` passes.
- `pnpm lint` (oxlint) and `prettier --check` pass.

Closes #529

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_