### PR TITLE
docs(ui): clarify how the Dialog opens the native dialog element

### DIFF
--- a/.changeset/dialog-show-dialog-docstrings.md
+++ b/.changeset/dialog-show-dialog-docstrings.md
@@ -1,0 +1,10 @@
+---
+'@foldkit/ui': patch
+---
+
+Clarify the Dialog docstrings about how the native `<dialog>` is opened. The
+`ShowDialog` command and the component view go through `Dom.showDialog`, which
+calls `show()` rather than native `showModal()` so other high-z-index overlays
+stay interactive. The docs now describe the high z-index, focus trap,
+component-supplied backdrop, and `cancel` event on Esc instead of implying
+native modal semantics.

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -155,7 +155,11 @@ type UpdateReturn = readonly [
 ]
 const withUpdateReturn = M.withReturnType<UpdateReturn>()
 
-/** Locks page scroll and opens the native dialog element with `show()`. */
+/** Locks page scroll and opens the native dialog element through
+ *  `Dom.showDialog`, which calls `show()` (not native `showModal()`) so other
+ *  high-z-index overlays stay interactive. It layers the dialog with a high
+ *  z-index, traps focus, and dispatches a `cancel` event on Esc. The Dialog
+ *  component supplies its own backdrop. */
 export const ShowDialog = Command.define(
   'ShowDialog',
   { id: S.String, maybeFocusSelector: S.Option(S.String) },
@@ -397,7 +401,9 @@ export type ViewInputs = Readonly<{
 }>
 
 /** Renders a headless dialog component backed by the native `<dialog>`
- *  element opened with `show()`. */
+ *  element. `ShowDialog` opens it through `Dom.showDialog`, which uses `show()`
+ *  (not native `showModal()`) with a high z-index, a focus trap, a
+ *  component-supplied backdrop, and a `cancel` event dispatched on Esc. */
 export const view = defineView<Model, Message, ViewInputs>(
   (model, viewInputs): Html => {
     const h = html<Message>()


### PR DESCRIPTION
## Summary

Issue #533 reported that the Dialog docstrings say the native `<dialog>` is opened with `show()` while the `ShowDialog` command calls `Dom.showModal()`, and asked to change the docstrings to say `showModal()`.

While fixing this I checked the actual code path. The premise turned out to be inverted: `Dom.showModal` deliberately calls the native `element.show()`, not native `showModal()`. The helper is named `showModal` but uses `show()` on purpose so that DevTools and any other high-z-index overlay stay interactive. See `packages/foldkit/src/dom/dom.ts` (the `showModal` docstring and the `element.show()` call). The original docstrings saying `show()` were accurate about the underlying DOM call.

So rather than "correct" accurate docstrings into inaccurate ones (which would have wrongly asserted native top layer and `::backdrop` semantics that `show()` does not provide), this PR clarifies them. Both the `ShowDialog` doc and the component `view` doc now explain that opening goes through `Dom.showModal`, which uses `show()` (not native `showModal()`) with a high z-index, a manual focus trap, a component-supplied backdrop, and a `cancel` event dispatched on Esc.

## Changes

- `packages/ui/src/dialog/index.ts`: rewrite the two docstrings (the `ShowDialog` command and the `view` export) to describe the real open path accurately.
- `.changeset/dialog-showmodal-docstrings.md`: patch changeset for `@foldkit/ui`.

Docstring-only change, no behavior change. `@foldkit/ui` typecheck and `oxlint` pass; `changeset status` reports the expected `@foldkit/ui` patch (with the fixed-group siblings).

Closes #533

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_