### PR TITLE
feat(foldkit): add Subscription.fromEvent for DOM-event subscriptions

### DIFF
--- a/.changeset/subscription-from-event.md
+++ b/.changeset/subscription-from-event.md
@@ -1,0 +1,16 @@
+---
+'foldkit': minor
+---
+
+Add `Subscription.fromEvent` to `foldkit`. It builds a Stream around a DOM
+event source, registering the listener with `addEventListener` when the
+Stream's scope opens and removing it when the scope closes. The
+`addEventListener` call happens inside the acquire Effect and the matching
+`removeEventListener` is registered only after acquire completes, so the
+listener never leaks on interruption. Pass the `target` directly for
+always-present globals like `window` or `document`, or as a thunk when it may
+not exist until the scope opens. The `toMessage` mapper runs synchronously in
+the browser's event dispatch, so `event.preventDefault()` works. Wrap the
+result in `Stream.when` inside a `Subscription.make` entry to gate it on a
+Model condition, or pass it to `Subscription.persistent` for a record-lifetime
+listener.

--- a/packages/foldkit/src/subscription/fromEvent.test.ts
+++ b/packages/foldkit/src/subscription/fromEvent.test.ts
@@ -1,0 +1,121 @@
+import { Effect, Fiber, Stream } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { fromEvent } from './fromEvent.js'
+
+const tick = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0))
+
+const drain = <Message>(
+  stream: Stream.Stream<Message>,
+  sink: Array<Message>,
+): Effect.Effect<void> =>
+  Stream.runForEach(stream, message =>
+    Effect.sync(() => {
+      sink.push(message)
+    }),
+  )
+
+describe('fromEvent', () => {
+  it('emits a Message for every dispatched event', async () => {
+    const target = new EventTarget()
+    const received: Array<string> = []
+
+    const fiber = Effect.runFork(
+      drain(
+        fromEvent<CustomEvent<string>, string>({
+          target,
+          type: 'ping',
+          toMessage: event => event.detail,
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'a' }))
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'b' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual(['a', 'b'])
+  })
+
+  it('removes the listener when the scope closes', async () => {
+    const target = new EventTarget()
+    const received: Array<string> = []
+
+    const fiber = Effect.runFork(
+      drain(
+        fromEvent<CustomEvent<string>, string>({
+          target,
+          type: 'ping',
+          toMessage: event => event.detail,
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'a' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'b' }))
+    await tick()
+
+    expect(received).toEqual(['a'])
+  })
+
+  it('resolves a thunk target inside the acquire Effect', async () => {
+    const target = new EventTarget()
+    let isResolved = false
+    const received: Array<string> = []
+
+    const fiber = Effect.runFork(
+      drain(
+        fromEvent<CustomEvent<string>, string>({
+          target: () => {
+            isResolved = true
+            return target
+          },
+          type: 'ping',
+          toMessage: event => event.detail,
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    expect(isResolved).toBe(true)
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'a' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual(['a'])
+  })
+
+  it('forwards listener options', async () => {
+    const target = new EventTarget()
+    const received: Array<string> = []
+
+    const fiber = Effect.runFork(
+      drain(
+        fromEvent<CustomEvent<string>, string>({
+          target,
+          type: 'ping',
+          toMessage: event => event.detail,
+          options: { once: true },
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'a' }))
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'b' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual(['a'])
+  })
+})

--- a/packages/foldkit/src/subscription/fromEvent.ts
+++ b/packages/foldkit/src/subscription/fromEvent.ts
@@ -1,0 +1,85 @@
+import { Effect, Queue, Stream } from 'effect'
+
+/**
+ * Configuration for the `fromEvent` Stream helper.
+ *
+ * `target` is read inside the acquire Effect, never before it, so the
+ * resolved `EventTarget` is captured at the moment the Subscription's scope
+ * opens. Pass a thunk when the target may not exist until the scope opens, or
+ * pass the `EventTarget` directly for always-present globals like `window` or
+ * `document`.
+ *
+ * `toMessage(event)` transforms each dispatched event into a Message. The
+ * mapper runs synchronously in the same call stack as the browser's event
+ * dispatch, so calling `event.preventDefault()` inside it works as expected.
+ */
+export type FromEventConfig<EventType extends Event, Message> = Readonly<{
+  target: EventTarget | (() => EventTarget)
+  type: string
+  toMessage: (event: EventType) => Message
+  options?: AddEventListenerOptions
+}>
+
+const resolveTarget = (
+  target: EventTarget | (() => EventTarget),
+): EventTarget => (typeof target === 'function' ? target() : target)
+
+/**
+ * Build a Stream that emits a Message for every dispatch of a DOM event,
+ * registering the listener when the Stream's scope opens and removing it when
+ * the scope closes.
+ *
+ * The listener lifecycle uses `Effect.acquireRelease`. The `addEventListener`
+ * call happens inside the acquire Effect, and the matching
+ * `removeEventListener` is registered only after acquire completes, so the
+ * listener never leaks on interruption.
+ *
+ * This is a Stream, not a Subscription entry. Wrap it with
+ * `Subscription.persistent` for a listener whose lifetime spans the whole
+ * Subscriptions record, or plug it into a `Subscription.make` entry's
+ * `dependenciesToStream` (typically behind `Stream.when`) to gate it on a
+ * Model condition.
+ *
+ * @example
+ * ```typescript
+ * const subscriptions = Subscription.make<Model, Message>()(entry => ({
+ *   shortcut: entry(
+ *     { isListening: S.Boolean },
+ *     {
+ *       modelToDependencies: model => ({ isListening: model.isListening }),
+ *       dependenciesToStream: ({ isListening }) =>
+ *         Stream.when(
+ *           Subscription.fromEvent<KeyboardEvent, Message>({
+ *             target: window,
+ *             type: 'keydown',
+ *             toMessage: event => PressedKey({ key: event.key }),
+ *           }),
+ *           Effect.sync(() => isListening),
+ *         ),
+ *     },
+ *   ),
+ * }))
+ * ```
+ */
+export const fromEvent = <EventType extends Event, Message>(
+  config: FromEventConfig<EventType, Message>,
+): Stream.Stream<Message> =>
+  Stream.callback<Message>(queue =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        const target = resolveTarget(config.target)
+
+        const handleEvent = (event: Event): void => {
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+          Queue.offerUnsafe(queue, config.toMessage(event as EventType))
+        }
+
+        target.addEventListener(config.type, handleEvent, config.options)
+        return { target, handleEvent }
+      }),
+      ({ target, handleEvent }) =>
+        Effect.sync(() => {
+          target.removeEventListener(config.type, handleEvent, config.options)
+        }),
+    ).pipe(Effect.flatMap(() => Effect.never)),
+  )

--- a/packages/foldkit/src/subscription/public.ts
+++ b/packages/foldkit/src/subscription/public.ts
@@ -9,3 +9,7 @@ export type {
 export { animationFrame } from './animationFrame.js'
 
 export type { AnimationFrameConfig } from './animationFrame.js'
+
+export { fromEvent } from './fromEvent.js'
+
+export type { FromEventConfig } from './fromEvent.js'

--- a/packages/website/src/page/core/subscriptions.ts
+++ b/packages/website/src/page/core/subscriptions.ts
@@ -38,6 +38,12 @@ const animationFramesHeader: TableOfContentsEntry = {
   text: 'Animation Frames',
 }
 
+const domEventsHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'dom-events',
+  text: 'DOM Events',
+}
+
 const advancedHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'advanced',
@@ -60,6 +66,7 @@ export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
   autoCounterHeader,
   animationFramesHeader,
+  domEventsHeader,
   advancedHeader,
   equivalenceHeader,
   readDependenciesHeader,
@@ -313,6 +320,66 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ' uses ',
         inlineCode('Subscription.animationFrame'),
         ' for per-frame physics.',
+      ),
+
+      // DOM EVENTS
+
+      tableOfContentsEntryToHeader(domEventsHeader),
+      para(
+        'For DOM events that are not tied to a specific element in your rendered tree (global keyboard shortcuts on ',
+        inlineCode('window'),
+        ', media-query changes, ',
+        inlineCode('document'),
+        ' visibility), ',
+        inlineCode('Subscription.fromEvent'),
+        ' builds the ',
+        inlineCode('addEventListener'),
+        ' and ',
+        inlineCode('removeEventListener'),
+        ' lifecycle for you. It returns a Stream that registers the listener when the scope opens and removes it when the scope closes, so you never hand-roll the ',
+        inlineCode('Effect.acquireRelease'),
+        ' yourself.',
+      ),
+      para(
+        'Because ',
+        inlineCode('fromEvent'),
+        ' is a Stream rather than a complete entry, you gate it the same way as any other Stream. Wrap it in ',
+        inlineCode('Stream.when'),
+        ' inside an ',
+        inlineCode('entry'),
+        ' to bind it to a Model condition, or pass it to ',
+        inlineCode('Subscription.persistent'),
+        ' for a listener that runs for the whole Subscriptions record. Here is a global keyboard shortcut gated on ',
+        inlineCode('isListening'),
+        ':',
+      ),
+      highlightedCodeBlock(
+        h.div(
+          [
+            h.Class('text-sm'),
+            h.InnerHTML(Snippet.subscriptionFromEventHighlighted),
+          ],
+          [],
+        ),
+        Snippet.subscriptionFromEventRaw,
+        'Copy DOM event subscription example to clipboard',
+        copiedSnippets,
+        'mb-8',
+      ),
+      para(
+        'The ',
+        inlineCode('toMessage'),
+        ' mapper runs synchronously in the same call stack as the browser’s event dispatch, so calling ',
+        inlineCode('event.preventDefault()'),
+        ' inside it works. Pass the ',
+        inlineCode('target'),
+        ' as a thunk when it may not exist until the scope opens, or directly for always-present globals like ',
+        inlineCode('window'),
+        ' and ',
+        inlineCode('document'),
+        '. For events tied to a specific rendered element, reach for ',
+        link(coreMountRouter(), 'Mount'),
+        ' instead, which hands you the element directly.',
       ),
 
       // ADVANCED

--- a/packages/website/src/snippet/index.ts
+++ b/packages/website/src/snippet/index.ts
@@ -286,6 +286,8 @@ export { default as subscriptionAnimationFrameRaw } from './subscriptionAnimatio
 export { default as subscriptionAnimationFrameHighlighted } from './subscriptionAnimationFrame.ts?highlighted'
 export { default as subscriptionEquivalenceRaw } from './subscriptionEquivalence.ts?raw'
 export { default as subscriptionEquivalenceHighlighted } from './subscriptionEquivalence.ts?highlighted'
+export { default as subscriptionFromEventRaw } from './subscriptionFromEvent.ts?raw'
+export { default as subscriptionFromEventHighlighted } from './subscriptionFromEvent.ts?highlighted'
 export { default as comparisonFoldkitModelRaw } from './comparisonFoldkitModel.ts?raw'
 export { default as comparisonFoldkitModelHighlighted } from './comparisonFoldkitModel.ts?highlighted'
 export { default as comparisonReactStateRaw } from './comparisonReactState.tsx?raw'

--- a/packages/website/src/snippet/subscriptionFromEvent.ts
+++ b/packages/website/src/snippet/subscriptionFromEvent.ts
@@ -1,0 +1,38 @@
+import { Effect, Schema as S, Stream } from 'effect'
+import { Subscription } from 'foldkit'
+import { m } from 'foldkit/message'
+
+// MESSAGE
+
+const PressedKey = m('PressedKey', { key: S.String })
+
+const Message = S.Union([PressedKey])
+type Message = typeof Message.Type
+
+// MODEL
+
+const Model = S.Struct({
+  isListening: S.Boolean,
+})
+
+type Model = typeof Model.Type
+
+// SUBSCRIPTION
+
+const subscriptions = Subscription.make<Model, Message>()(entry => ({
+  shortcut: entry(
+    { isListening: S.Boolean },
+    {
+      modelToDependencies: model => ({ isListening: model.isListening }),
+      dependenciesToStream: ({ isListening }) =>
+        Stream.when(
+          Subscription.fromEvent<KeyboardEvent, Message>({
+            target: window,
+            type: 'keydown',
+            toMessage: event => PressedKey({ key: event.key }),
+          }),
+          Effect.sync(() => isListening),
+        ),
+    },
+  ),
+}))


### PR DESCRIPTION
## What

Adds `Subscription.fromEvent`, a helper that turns a DOM event source (keydown, resize, media-query change) into a Stream without hand-rolling the `addEventListener` / `removeEventListener` lifecycle. Previously the only path was reverse-engineering the internal `animationFrame` subscription and writing the `Effect.acquireRelease` plumbing by hand.

## How it works

`fromEvent` builds the listener inside a `Stream.callback` via `Effect.acquireRelease`, matching the `animationFrame` exemplar:

- The `addEventListener` call happens inside the acquire Effect, so the resource is constructed inside acquire, never before it.
- The matching `removeEventListener` is registered only after acquire completes, using the same handler reference and the same options, so the listener never leaks on interruption.
- The `target` is resolved inside acquire. Pass it directly for always-present globals like `window` or `document`, or as a thunk when it may not exist until the scope opens.
- The `toMessage` mapper runs synchronously in the browser's event dispatch, so `event.preventDefault()` works.

It returns a raw `Stream`, not an entry shape, so it composes with `Stream.when` inside a `Subscription.make` entry (to gate on a Model condition) or with `Subscription.persistent` (for a record-lifetime listener). This mirrors the Stream-level `fromEventListener` option from the issue.

### Signature

```typescript
export const fromEvent: <EventType extends Event, Message>(
  config: Readonly<{
    target: EventTarget | (() => EventTarget)
    type: string
    toMessage: (event: EventType) => Message
    options?: AddEventListenerOptions
  }>,
) => Stream.Stream<Message>
```

## Changes

- `packages/foldkit/src/subscription/fromEvent.ts`: the helper, with TSDoc on both public exports.
- `packages/foldkit/src/subscription/public.ts`: barrel re-export of `fromEvent` and `FromEventConfig`.
- `packages/foldkit/src/subscription/fromEvent.test.ts`: tests for emission, listener removal on scope close (the no-leak case), thunk-target resolution inside acquire, and options forwarding.
- `packages/website/src/page/core/subscriptions.ts` and a new snippet: a DOM Events section documenting the pattern with a global keyboard shortcut wired into `Subscription.make`.
- `.changeset/subscription-from-event.md`: minor bump for `foldkit`.

Closes #534

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_