### PR TITLE
feat(devtools): copy Model, Message, and Command payloads to clipboard

### DIFF
--- a/.changeset/devtools-copy-payload.md
+++ b/.changeset/devtools-copy-payload.md
@@ -1,0 +1,11 @@
+---
+'@foldkit/devtools': minor
+---
+
+Add a copy-to-clipboard control to each inspectable payload in the DevTools
+overlay. The Model snapshot, the inspected Message, and each displayed Command
+now show a small icon button in their header that copies the payload as
+fully-expanded, formatted JSON. The copied text is serialized from the
+underlying data, so it includes every field regardless of which tree nodes are
+collapsed in the inspector. The clipboard write runs in a `CopyPayloadToClipboard`
+Command, dispatched from a `ClickedCopyPayload` Message.

--- a/.changeset/devtools-copy-payload.md
+++ b/.changeset/devtools-copy-payload.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/devtools': minor
+---
+
+Add copy-to-clipboard buttons for Model, Message, and Command payloads in the DevTools overlay. Each button copies fully expanded, formatted JSON regardless of the inspector tree's expanded state.

--- a/packages/devtools/src/overlay-styles.ts
+++ b/packages/devtools/src/overlay-styles.ts
@@ -231,6 +231,29 @@ ul {
 .dt-header-button:hover {
   color: var(--dt-text);
 }
+.dt-copy-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  background: transparent;
+  border: none;
+  color: var(--dt-text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 100ms ease;
+}
+.dt-copy-button:hover {
+  color: var(--dt-text);
+}
+.dt-copy-button:focus-visible {
+  outline: 1px solid var(--dt-accent);
+  outline-offset: -1px;
+}
+.dt-copy-icon {
+  width: 12px;
+  height: 12px;
+}
 .dt-resume-button:hover {
   opacity: 0.7;
 }

--- a/packages/devtools/src/overlay-styles.ts
+++ b/packages/devtools/src/overlay-styles.ts
@@ -254,6 +254,29 @@ ul {
 .dt-header-button:hover {
   color: var(--dt-text);
 }
+.dt-copy-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  background: transparent;
+  border: none;
+  color: var(--dt-text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 100ms ease;
+}
+.dt-copy-button:hover {
+  color: var(--dt-text);
+}
+.dt-copy-button:focus-visible {
+  outline: 1px solid var(--dt-accent);
+  outline-offset: -1px;
+}
+.dt-copy-icon {
+  width: 12px;
+  height: 12px;
+}
 .dt-resume-button:hover {
   opacity: 0.7;
 }

--- a/packages/devtools/src/overlay.test.ts
+++ b/packages/devtools/src/overlay.test.ts
@@ -27,13 +27,20 @@ const initialStoreState: StoreState = {
 
 const makeStore = (
   stateRef: SubscriptionRef.SubscriptionRef<StoreState>,
+  {
+    inspectedModel = {},
+    maybeInspectedMessage = Option.none(),
+  }: Readonly<{
+    inspectedModel?: unknown
+    maybeInspectedMessage?: Option.Option<unknown>
+  }> = {},
 ): DevToolsStore => ({
   recordInit: () => Effect.void,
   recordMessage: () => Effect.void,
   updateLatestModel: () => Effect.void,
   attachRenderedMounts: () => Effect.void,
-  getModelAtIndex: () => Effect.succeed({}),
-  getMessageAtIndex: () => Effect.succeed(Option.none()),
+  getModelAtIndex: () => Effect.succeed(inspectedModel),
+  getMessageAtIndex: () => Effect.succeed(maybeInspectedMessage),
   getDiffAtIndex: () =>
     Effect.succeed({
       changedPaths: HashSet.empty(),
@@ -119,6 +126,223 @@ describe('DevTools interaction blocker', () => {
           overlayShadow().querySelector('.dt-interaction-blocker'),
         ).not.toBeNull()
       })
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(overlayFiber))
+    }
+  })
+})
+
+describe('DevTools payload copy', () => {
+  it('copies the displayed Model, Message, and Command payloads', async () => {
+    const inspectedModel = {
+      profile: {
+        name: 'Ada',
+        preferences: { theme: 'Dark' },
+      },
+    }
+    const inspectedMessage = {
+      _tag: 'GotProfileMessage',
+      message: {
+        _tag: 'UpdatedTheme',
+        theme: 'Light',
+      },
+    }
+    const storeState: StoreState = {
+      ...initialStoreState,
+      entries: [
+        {
+          tag: 'GotProfileMessage',
+          message: inspectedMessage,
+          commands: [
+            { name: 'SaveProfile', args: { userId: 42 } },
+            { name: 'RefreshProfile' },
+          ],
+          mountStarts: [{ name: 'FocusProfile', args: { field: 'name' } }],
+          mountEnds: [],
+          timestamp: 100,
+          isModelChanged: true,
+          diff: {
+            changedPaths: HashSet.empty(),
+            affectedPaths: HashSet.empty(),
+          },
+        },
+      ],
+      maybeLatestModel: Option.some(inspectedModel),
+    }
+    const stateRef = await Effect.runPromise(SubscriptionRef.make(storeState))
+    const store = makeStore(stateRef, {
+      inspectedModel,
+      maybeInspectedMessage: Option.some(inspectedMessage),
+    })
+    const writeText = vi.fn(() => Promise.resolve())
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    localStorage.setItem(
+      'foldkit-devtools',
+      JSON.stringify({ isOpen: true, isFlattened: true }),
+    )
+
+    const overlayFiber = Effect.runFork(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* createOverlay(
+            store,
+            'BottomRight',
+            'TimeTravel',
+            Option.none(),
+          )
+          return yield* Effect.never
+        }),
+      ),
+    )
+
+    try {
+      const modelCopyButton = await vi.waitFor(() => {
+        const button = overlayShadow().querySelector<HTMLButtonElement>(
+          '#dt-inspector-panel-0 button[aria-label="Copy payload as JSON"]',
+        )
+        expect(button).not.toBeNull()
+        return button
+      })
+
+      modelCopyButton?.click()
+
+      await vi.waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(
+          JSON.stringify(inspectedModel, null, 2),
+        )
+      })
+
+      writeText.mockClear()
+      overlayShadow()
+        .querySelector<HTMLButtonElement>('#dt-inspector-tab-1')
+        ?.click()
+
+      const messageCopyButton = await vi.waitFor(() => {
+        expect(
+          overlayShadow()
+            .querySelector('#dt-inspector-tab-1')
+            ?.getAttribute('aria-selected'),
+        ).toBe('true')
+        const button = overlayShadow().querySelector<HTMLButtonElement>(
+          '#dt-inspector-panel-1 button[aria-label="Copy payload as JSON"]',
+        )
+        expect(button).not.toBeNull()
+        return button
+      })
+
+      messageCopyButton?.click()
+
+      await vi.waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(
+          JSON.stringify(inspectedMessage.message, null, 2),
+        )
+      })
+
+      writeText.mockClear()
+      overlayShadow()
+        .querySelector<HTMLButtonElement>('#dt-inspector-tab-2')
+        ?.click()
+
+      const commandCopyButtons = await vi.waitFor(() => {
+        expect(
+          overlayShadow()
+            .querySelector('#dt-inspector-tab-2')
+            ?.getAttribute('aria-selected'),
+        ).toBe('true')
+        const buttons = overlayShadow().querySelectorAll<HTMLButtonElement>(
+          '#dt-inspector-panel-2 button[aria-label="Copy payload as JSON"]',
+        )
+        expect(buttons).toHaveLength(2)
+        return buttons
+      })
+
+      commandCopyButtons.item(0).click()
+
+      await vi.waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(
+          JSON.stringify({ userId: 42, _tag: 'SaveProfile' }, null, 2),
+        )
+      })
+
+      writeText.mockClear()
+      commandCopyButtons.item(1).click()
+
+      await vi.waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(
+          JSON.stringify({ _tag: 'RefreshProfile' }, null, 2),
+        )
+      })
+
+      overlayShadow()
+        .querySelector<HTMLButtonElement>('#dt-inspector-tab-3')
+        ?.click()
+
+      await vi.waitFor(() => {
+        expect(
+          overlayShadow()
+            .querySelector('#dt-inspector-tab-3')
+            ?.getAttribute('aria-selected'),
+        ).toBe('true')
+        expect(
+          overlayShadow().querySelectorAll(
+            '#dt-inspector-panel-3 button[aria-label="Copy payload as JSON"]',
+          ),
+        ).toHaveLength(0)
+      })
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(overlayFiber))
+    }
+  })
+
+  it('keeps rendering when a payload cannot be represented as JSON', async () => {
+    const stateRef = await Effect.runPromise(
+      SubscriptionRef.make(initialStoreState),
+    )
+    const store = makeStore(stateRef, {
+      inspectedModel: { count: 1n },
+    })
+    const writeText = vi.fn(() => Promise.resolve())
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    localStorage.setItem(
+      'foldkit-devtools',
+      JSON.stringify({ isOpen: true, isFlattened: false }),
+    )
+
+    const overlayFiber = Effect.runFork(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* createOverlay(
+            store,
+            'BottomRight',
+            'TimeTravel',
+            Option.none(),
+          )
+          return yield* Effect.never
+        }),
+      ),
+    )
+
+    try {
+      const copyButton = await vi.waitFor(() => {
+        const button = overlayShadow().querySelector<HTMLButtonElement>(
+          '#dt-inspector-panel-0 button[aria-label="Copy payload as JSON"]',
+        )
+        expect(button).not.toBeNull()
+        return button
+      })
+
+      copyButton?.click()
+
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(writeText).not.toHaveBeenCalled()
+      expect(copyButton?.isConnected).toBe(true)
     } finally {
       await Effect.runPromise(Fiber.interrupt(overlayFiber))
     }

--- a/packages/devtools/src/overlay.ts
+++ b/packages/devtools/src/overlay.ts
@@ -182,6 +182,9 @@ const ReceivedInspectedState = m('ReceivedInspectedState', {
   affectedPaths: S.HashSet(S.String),
 })
 const ToggledTreeNode = m('ToggledTreeNode', { path: S.String })
+const ClickedCopyPayload = m('ClickedCopyPayload', { text: S.String })
+const CompletedCopyPayload = m('CompletedCopyPayload')
+const FailedCopyPayload = m('FailedCopyPayload')
 const TickedScrubFrame = m('TickedScrubFrame')
 const GotInspectorTabsMessage = m('GotInspectorTabsMessage', {
   message: S.Unknown,
@@ -218,6 +221,9 @@ const Message = S.Union([
   CrossedMobileBreakpoint,
   ReceivedInspectedState,
   ToggledTreeNode,
+  ClickedCopyPayload,
+  CompletedCopyPayload,
+  FailedCopyPayload,
   TickedScrubFrame,
   GotInspectorTabsMessage,
   ReceivedStoreUpdate,
@@ -342,6 +348,20 @@ const collapsedPreview = (value: unknown): string =>
     M.orElse(() => ''),
   )
 
+const JSON_INDENT = 2
+
+const serializePayload = (value: unknown): string =>
+  JSON.stringify(toInspectableValue(value), null, JSON_INDENT)
+
+const taggedPayload = (
+  name: string,
+  args: Option.Option<Record<string, unknown>>,
+): Record<string, unknown> =>
+  Option.match(args, {
+    onNone: () => ({ _tag: name }),
+    onSome: argsValue => ({ ...argsValue, _tag: name }),
+  })
+
 // UPDATE
 
 type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>]
@@ -435,6 +455,18 @@ export const Clear = Command.define(
     yield* store.clear
     return CompletedClear()
   }),
+)
+
+export const CopyPayloadToClipboard = Command.define(
+  'CopyPayloadToClipboard',
+  { text: S.String },
+  CompletedCopyPayload,
+  FailedCopyPayload,
+)(({ text }) =>
+  Effect.tryPromise(() => navigator.clipboard.writeText(text)).pipe(
+    Effect.as(CompletedCopyPayload()),
+    Effect.catch(() => Effect.succeed(FailedCopyPayload())),
+  ),
 )
 
 export const ScrollToTop = Command.define(
@@ -601,6 +633,10 @@ const makeUpdate = (
           }),
           [],
         ],
+        ClickedCopyPayload: ({ text }) => [
+          model,
+          [CopyPayloadToClipboard({ text })],
+        ],
         ReceivedStoreUpdate: ({
           entries,
           initCommands,
@@ -749,6 +785,8 @@ const makeUpdate = (
       M.tag(
         'CompletedResume',
         'CompletedClear',
+        'CompletedCopyPayload',
+        'FailedCopyPayload',
         'LockedScroll',
         'UnlockedScroll',
         'ScrolledToTop',
@@ -921,6 +959,43 @@ const makeView = (
 
   const tagLabelView = (tag: string): Html =>
     h.span([h.Key('tag'), h.Class('json-tag')], [tag])
+
+  const COPY_ICON =
+    'M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184'
+
+  const copyPayloadButtonView = (payload: unknown): Html =>
+    h.button(
+      [
+        h.Key('copy'),
+        h.Class('dt-copy-button shrink-0'),
+        h.AriaLabel('Copy payload as JSON'),
+        h.Title('Copy as JSON'),
+        h.OnClick(ClickedCopyPayload({ text: serializePayload(payload) })),
+      ],
+      [
+        h.svg(
+          [
+            h.AriaHidden(true),
+            h.Class('dt-copy-icon'),
+            h.Xmlns('http://www.w3.org/2000/svg'),
+            h.Fill('none'),
+            h.ViewBox('0 0 24 24'),
+            h.StrokeWidth('1.5'),
+            h.Stroke('currentColor'),
+          ],
+          [
+            h.path(
+              [
+                h.StrokeLinecap('round'),
+                h.StrokeLinejoin('round'),
+                h.D(COPY_ICON),
+              ],
+              [],
+            ),
+          ],
+        ),
+      ],
+    )
 
   const diffDotView: Html = h.span([h.Key('diffdot'), h.Class('diff-dot')], [])
   const inlineDiffDotView: Html = h.span([h.Class('diff-dot-inline')], [])
@@ -1178,20 +1253,36 @@ const makeView = (
       ['init: no Message'],
     )
 
+  const payloadHeaderView = (label: string, payload: unknown): Html =>
+    h.div(
+      [
+        h.Class(
+          'flex items-center justify-between px-2 py-1 border-b text-2xs text-dt-muted font-mono shrink-0',
+        ),
+      ],
+      [h.span([], [label]), copyPayloadButtonView(payload)],
+    )
+
   const modelTabContent = (
     inspectedModel: unknown,
     expandedPaths: HashSet.HashSet<string>,
     changedPaths: HashSet.HashSet<string>,
     affectedPaths: HashSet.HashSet<string>,
   ): Html =>
-    treeView(
-      inspectedModel,
-      'root',
-      expandedPaths,
-      changedPaths,
-      affectedPaths,
-      Option.none(),
-      true,
+    h.div(
+      [h.Class('flex flex-col flex-1 min-h-0 min-w-0')],
+      [
+        payloadHeaderView('Model', inspectedModel),
+        treeView(
+          inspectedModel,
+          'root',
+          expandedPaths,
+          changedPaths,
+          affectedPaths,
+          Option.none(),
+          true,
+        ),
+      ],
     )
 
   const unwrapIfFiltered = (
@@ -1240,10 +1331,10 @@ const makeView = (
             h.div(
               [
                 h.Class(
-                  'px-2 py-1 border-b text-2xs text-dt-muted font-mono shrink-0',
+                  'flex items-center justify-between px-2 py-1 border-b text-2xs text-dt-muted font-mono shrink-0',
                 ),
               ],
-              [timestamp],
+              [h.span([], [timestamp]), copyPayloadButtonView(message)],
             ),
             h.div(
               [h.Class('flex flex-col flex-1 min-h-0 min-w-0 pt-1 pl-1')],
@@ -1301,10 +1392,7 @@ const makeView = (
     index: number,
     expandedPaths: HashSet.HashSet<string>,
   ): ReadonlyArray<FlatNode> => {
-    const taggedValue = Option.match(command.args, {
-      onNone: () => ({ _tag: command.name }),
-      onSome: argsValue => ({ ...argsValue, _tag: command.name }),
-    })
+    const taggedValue = taggedPayload(command.name, command.args)
     const rootPath = `command-${index}`
     const nodes: Array<FlatNode> = []
     flattenTree({
@@ -1355,6 +1443,9 @@ const makeView = (
                     renderFlatNode,
                   ),
                 ),
+                copyPayloadButtonView(
+                  taggedPayload(command.name, command.args),
+                ),
               ],
             ),
           ),
@@ -1392,10 +1483,7 @@ const makeView = (
     index: number,
     expandedPaths: HashSet.HashSet<string>,
   ): ReadonlyArray<FlatNode> => {
-    const taggedValue = Option.match(mount.args, {
-      onNone: () => ({ _tag: mount.name }),
-      onSome: argsValue => ({ ...argsValue, _tag: mount.name }),
-    })
+    const taggedValue = taggedPayload(mount.name, mount.args)
     const rootPath = `mount-${sectionLabel}-${index}`
     const nodes: Array<FlatNode> = []
     flattenTree({

--- a/packages/devtools/src/overlay.ts
+++ b/packages/devtools/src/overlay.ts
@@ -188,6 +188,9 @@ const Message = defineMessageUnion({
     affectedPaths: Schema.HashSet(Schema.String),
   },
   ToggledTreeNode: { path: Schema.String },
+  ClickedCopyPayload: { payload: Schema.Unknown },
+  SucceededCopyPayloadToClipboard: {},
+  FailedCopyPayloadToClipboard: {},
   TickedScrubFrame: {},
   GotInspectorTabsMessage: { message: Tabs.Message },
   ReceivedStoreUpdate: {
@@ -212,6 +215,7 @@ const MOBILE_BREAKPOINT = 767
 const MOBILE_BREAKPOINT_QUERY = `(max-width: ${MOBILE_BREAKPOINT}px)`
 const TREE_INDENT_PX = 12
 const MAX_PREVIEW_KEYS = 3
+const JSON_INDENT = 2
 const ALL_MESSAGES_VALUE = ''
 const DEVTOOLS_STORAGE_KEY = 'foldkit-devtools'
 const NO_COMMANDS: ReadonlyArray<typeof DisplayCommand.Type> = []
@@ -324,6 +328,33 @@ const collapsedPreview = (value: unknown): string =>
     Match.when(Predicate.isObject, objectPreview),
     Match.orElse(() => ''),
   )
+
+const serializePayload = (value: unknown): Effect.Effect<string, Error> =>
+  Effect.try({
+    try: () => {
+      const serialized = JSON.stringify(
+        toInspectableValue(value),
+        null,
+        JSON_INDENT,
+      )
+
+      if (Predicate.isUndefined(serialized)) {
+        throw new Error('Payload cannot be represented as JSON')
+      }
+
+      return serialized
+    },
+    catch: () => new Error('Failed to serialize payload'),
+  })
+
+const taggedPayload = (
+  name: string,
+  args: Option.Option<Record<string, unknown>>,
+): Record<string, unknown> =>
+  Option.match(args, {
+    onNone: () => ({ _tag: name }),
+    onSome: argsValue => ({ ...argsValue, _tag: name }),
+  })
 
 // UPDATE
 
@@ -538,6 +569,27 @@ export const Clear = Command.define('Clear', {
   }),
 })
 
+export const CopyPayloadToClipboard = Command.define('CopyPayloadToClipboard', {
+  args: { payload: Schema.Unknown },
+  messages: [
+    Message.SucceededCopyPayloadToClipboard,
+    Message.FailedCopyPayloadToClipboard,
+  ],
+  execute: ({ payload }) =>
+    serializePayload(payload).pipe(
+      Effect.flatMap(text =>
+        Effect.tryPromise({
+          try: () => navigator.clipboard.writeText(text),
+          catch: () => new Error('Failed to copy payload to clipboard'),
+        }),
+      ),
+      Effect.as(Message.SucceededCopyPayloadToClipboard()),
+      Effect.catch(() =>
+        Effect.succeed(Message.FailedCopyPayloadToClipboard()),
+      ),
+    ),
+})
+
 export const ScrollToTop = Command.define('ScrollToTop', {
   messages: [Message.CompletedScrollToTop],
   execute: Effect.gen(function* () {
@@ -699,6 +751,10 @@ const makeUpdate = (
               : HashSet.add(paths, path),
         }),
       }),
+      ClickedCopyPayload: ({ payload }) => ({
+        model,
+        commands: [CopyPayloadToClipboard({ payload })],
+      }),
       ReceivedStoreUpdate: ({
         entries,
         initCommands,
@@ -787,6 +843,8 @@ const makeUpdate = (
       CompletedLockScroll: () => ({ model }),
       CompletedUnlockScroll: () => ({ model }),
       CompletedScrollToTop: () => ({ model }),
+      SucceededCopyPayloadToClipboard: () => ({ model }),
+      FailedCopyPayloadToClipboard: () => ({ model }),
     })
 }
 
@@ -942,6 +1000,8 @@ const buildOverlayView = (
 
   const CHEVRON_RIGHT = 'M8.25 4.5l7.5 7.5-7.5 7.5'
   const CHEVRON_DOWN = 'M19.5 8.25l-7.5 7.5-7.5-7.5'
+  const COPY_ICON =
+    'M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184'
 
   const arrowView = (isExpanded: boolean): Html =>
     h.svg(
@@ -965,6 +1025,36 @@ const buildOverlayView = (
 
   const tagLabelView = (tag: string): Html =>
     h.span([h.Class('json-tag')], [tag])
+
+  const copyPayloadButtonView = (payload: unknown): Html =>
+    h.button(
+      [
+        h.Class('dt-copy-button shrink-0'),
+        h.AriaLabel('Copy payload as JSON'),
+        h.Title('Copy as JSON'),
+        h.OnClick(Message.ClickedCopyPayload({ payload })),
+      ],
+      [
+        h.svg(
+          [
+            h.AriaHidden(true),
+            h.Class('dt-copy-icon'),
+            h.Xmlns('http://www.w3.org/2000/svg'),
+            h.Fill('none'),
+            h.ViewBox('0 0 24 24'),
+            h.StrokeWidth('1.5'),
+            h.Stroke('currentColor'),
+          ],
+          [
+            h.path([
+              h.StrokeLinecap('round'),
+              h.StrokeLinejoin('round'),
+              h.D(COPY_ICON),
+            ]),
+          ],
+        ),
+      ],
+    )
 
   const previewView = (preview: string): Html =>
     h.span([h.Class('json-preview')], [preview])
@@ -1264,20 +1354,36 @@ const buildOverlayView = (
       ['init: no Message'],
     )
 
+  const payloadHeaderView = (label: string, payload: unknown): Html =>
+    h.div(
+      [
+        h.Class(
+          'flex items-center justify-between px-2 py-1 border-b text-2xs text-dt-muted font-mono shrink-0',
+        ),
+      ],
+      [h.span([], [label]), copyPayloadButtonView(payload)],
+    )
+
   const modelTabContent = (
     inspectedModel: unknown,
     expandedPaths: HashSet.HashSet<string>,
     changedPaths: HashSet.HashSet<string>,
     affectedPaths: HashSet.HashSet<string>,
   ): Html =>
-    treeView(
-      inspectedModel,
-      'root',
-      expandedPaths,
-      changedPaths,
-      affectedPaths,
-      Option.none(),
-      true,
+    h.div(
+      [h.Class('flex flex-col flex-1 min-h-0 min-w-0')],
+      [
+        payloadHeaderView('Model', inspectedModel),
+        treeView(
+          inspectedModel,
+          'root',
+          expandedPaths,
+          changedPaths,
+          affectedPaths,
+          Option.none(),
+          true,
+        ),
+      ],
     )
 
   const unwrapToLeaf = (message: unknown): unknown => {
@@ -1342,10 +1448,10 @@ const buildOverlayView = (
             h.div(
               [
                 h.Class(
-                  'px-2 py-1 border-b text-2xs text-dt-muted font-mono shrink-0',
+                  'flex items-center justify-between px-2 py-1 border-b text-2xs text-dt-muted font-mono shrink-0',
                 ),
               ],
-              [timestamp],
+              [h.span([], [timestamp]), copyPayloadButtonView(message)],
             ),
             h.div(
               [h.Class('flex flex-col flex-1 min-h-0 min-w-0 pt-1 pl-1')],
@@ -1403,10 +1509,7 @@ const buildOverlayView = (
     index: number,
     expandedPaths: HashSet.HashSet<string>,
   ): ReadonlyArray<FlatNode> => {
-    const taggedValue = Option.match(command.args, {
-      onNone: () => ({ _tag: command.name }),
-      onSome: argsValue => ({ ...argsValue, _tag: command.name }),
-    })
+    const taggedValue = taggedPayload(command.name, command.args)
     const rootPath = `command-${index}`
     const nodes: globalThis.Array<FlatNode> = []
     flattenTree({
@@ -1457,6 +1560,9 @@ const buildOverlayView = (
                     renderFlatNode,
                   ),
                 ),
+                copyPayloadButtonView(
+                  taggedPayload(command.name, command.args),
+                ),
               ],
             ),
           ),
@@ -1494,10 +1600,7 @@ const buildOverlayView = (
     index: number,
     expandedPaths: HashSet.HashSet<string>,
   ): ReadonlyArray<FlatNode> => {
-    const taggedValue = Option.match(mount.args, {
-      onNone: () => ({ _tag: mount.name }),
-      onSome: argsValue => ({ ...argsValue, _tag: mount.name }),
-    })
+    const taggedValue = taggedPayload(mount.name, mount.args)
     const rootPath = `mount-${sectionLabel}-${index}`
     const nodes: globalThis.Array<FlatNode> = []
     flattenTree({


### PR DESCRIPTION
Add copy controls for the inspected Model, Message, and displayed Command payloads. Serialize the underlying values as fully expanded, formatted JSON so copying does not depend on the inspector tree’s expanded state.

Run clipboard writes through a Command and turn both outcomes into Messages. Cover the interaction with a browser-DOM regression test.

Closes #357