### PR TITLE
fix(ui-showcase): release scroll lock when navigating away from open dialogs

### DIFF
--- a/examples/ui-showcase/src/main.ts
+++ b/examples/ui-showcase/src/main.ts
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { Effect, Match as M, Schema as S, pipe } from 'effect'
+import { Array, Effect, Match as M, Schema as S, pipe } from 'effect'
 import {
   Calendar,
   Command,
@@ -21,7 +21,12 @@ import * as Icon from './icon'
 import { uiInit } from './ui/init'
 import {
   ClickedOpenMobileMenu,
+  GotDialogAnimatedDemoMessage,
+  GotDialogDemoMessage,
   GotMobileMenuDialogMessage,
+  GotNestedDialogChildDemoMessage,
+  GotNestedDialogParentDemoMessage,
+  GotOverlayDialogDemoMessage,
   UiMessage,
 } from './ui/message'
 import { UiModel } from './ui/model'
@@ -240,6 +245,78 @@ const toUiMessage = (message: typeof UiMessage.Type): Message =>
 const toMobileMenuDialogMessage = (message: Dialog.Message): Message =>
   GotUiMessage({ message: GotMobileMenuDialogMessage({ message }) })
 
+type ClosableDialog = Readonly<{
+  get: (uiModel: UiModel) => Dialog.Model
+  set: (uiModel: UiModel, closed: Dialog.Model) => UiModel
+  toParentMessage: (message: Dialog.Message) => Message
+}>
+
+const CLOSABLE_DIALOGS: ReadonlyArray<ClosableDialog> = [
+  {
+    get: uiModel => uiModel.mobileMenuDialog,
+    set: (uiModel, closed) => evo(uiModel, { mobileMenuDialog: () => closed }),
+    toParentMessage: toMobileMenuDialogMessage,
+  },
+  {
+    get: uiModel => uiModel.dialogDemo,
+    set: (uiModel, closed) => evo(uiModel, { dialogDemo: () => closed }),
+    toParentMessage: message =>
+      GotUiMessage({ message: GotDialogDemoMessage({ message }) }),
+  },
+  {
+    get: uiModel => uiModel.dialogAnimatedDemo,
+    set: (uiModel, closed) =>
+      evo(uiModel, { dialogAnimatedDemo: () => closed }),
+    toParentMessage: message =>
+      GotUiMessage({ message: GotDialogAnimatedDemoMessage({ message }) }),
+  },
+  {
+    get: uiModel => uiModel.overlayDialogDemo,
+    set: (uiModel, closed) => evo(uiModel, { overlayDialogDemo: () => closed }),
+    toParentMessage: message =>
+      GotUiMessage({ message: GotOverlayDialogDemoMessage({ message }) }),
+  },
+  {
+    get: uiModel => uiModel.nestedDialogParentDemo,
+    set: (uiModel, closed) =>
+      evo(uiModel, { nestedDialogParentDemo: () => closed }),
+    toParentMessage: message =>
+      GotUiMessage({ message: GotNestedDialogParentDemoMessage({ message }) }),
+  },
+  {
+    get: uiModel => uiModel.nestedDialogChildDemo,
+    set: (uiModel, closed) =>
+      evo(uiModel, { nestedDialogChildDemo: () => closed }),
+    toParentMessage: message =>
+      GotUiMessage({ message: GotNestedDialogChildDemoMessage({ message }) }),
+  },
+]
+
+type CloseAllDialogsReturn = readonly [
+  UiModel,
+  ReadonlyArray<Command.Command<Message>>,
+]
+
+const closeAllDialogs = (uiModel: UiModel): CloseAllDialogsReturn =>
+  Array.reduce(
+    CLOSABLE_DIALOGS,
+    [uiModel, []],
+    (
+      [accUiModel, accCommands]: CloseAllDialogsReturn,
+      dialog,
+    ): CloseAllDialogsReturn => {
+      const [nextDialog, dialogCommands] = Dialog.close(dialog.get(accUiModel))
+
+      return [
+        dialog.set(accUiModel, nextDialog),
+        [
+          ...accCommands,
+          ...Command.mapMessages(dialogCommands, dialog.toParentMessage),
+        ],
+      ]
+    },
+  )
+
 export const update = (
   model: Model,
   message: Message,
@@ -271,21 +348,16 @@ export const update = (
         ),
 
       ChangedUrl: ({ url }) => {
-        const [closedDialog, closeDialogCommands] = Dialog.close(
-          model.uiModel.mobileMenuDialog,
+        const [closedUiModel, closeDialogCommands] = closeAllDialogs(
+          model.uiModel,
         )
 
         return [
           evo(model, {
             route: () => urlToAppRoute(url),
-            uiModel: uiModel =>
-              evo(uiModel, {
-                mobileMenuDialog: () => closedDialog,
-              }),
+            uiModel: () => closedUiModel,
           }),
-          Command.mapMessages(closeDialogCommands, message =>
-            toMobileMenuDialogMessage(message),
-          ),
+          closeDialogCommands,
         ]
       },
 

--- a/packages/examples-e2e/e2e/ui-showcase.spec.ts
+++ b/packages/examples-e2e/e2e/ui-showcase.spec.ts
@@ -15,4 +15,25 @@ test.describe('ui-showcase example', () => {
       .click()
     await expect(page).toHaveURL(/\/button$/)
   })
+
+  test('releases the scroll lock when navigating away from an open dialog', async ({
+    page,
+  }) => {
+    const documentOverflow = () =>
+      page.evaluate(() => document.documentElement.style.overflow)
+
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Dialog', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/dialog$/)
+
+    await page.getByRole('button', { name: 'Open Dialog', exact: true }).click()
+    await expect.poll(documentOverflow).toBe('hidden')
+
+    await page.goBack()
+    await expect(page).toHaveURL(/\/$/)
+    await expect.poll(documentOverflow).not.toBe('hidden')
+  })
 })


### PR DESCRIPTION
## Problem

In the ui-showcase example, opening a demo dialog and then navigating away (for example via the browser back button) left page scroll locked permanently.

Two things combine to cause this:

- The main content is keyed by route (`h.keyed('div')(model.route._tag, ...)`), so navigating away unmounts the whole dialog section without ever closing the open dialog.
- The `ChangedUrl` handler closed only the mobile menu dialog (`mobileMenuDialog`). It never closed the demo dialogs, so `Dialog.close` (which releases the scroll lock) never fired for them. The scroll lock leaked.

## Fix (example only)

This change is scoped entirely to `examples/ui-showcase/`. The `ChangedUrl` handler now closes every dialog on navigation, not just the mobile menu. A small `CLOSABLE_DIALOGS` table pairs each `Dialog.Model` field in the UI model with its parent-message wrapper, and `closeAllDialogs` folds over it with `Dialog.close`, threading the updated UI model and accumulating the close Commands. This covers all six dialogs: `mobileMenuDialog`, `dialogDemo`, `dialogAnimatedDemo`, `overlayDialogDemo`, `nestedDialogParentDemo`, and `nestedDialogChildDemo`. Closing an already-closed dialog is a safe no-op, so the scroll lock is reliably released whenever the user navigates with a dialog open.

A Playwright test in `packages/examples-e2e/e2e/ui-showcase.spec.ts` opens the basic dialog, confirms the document scroll lock is applied, navigates back, and asserts the lock is released.

## Out of scope

The issue also raises a broader framework design question: should `ui.Dialog` (or the Mount / scroll-lock primitives) automatically release the scroll lock on unmount, so consumers do not have to remember to close dialogs on navigation? That architectural decision is intentionally left for the maintainer and is NOT addressed here. No library packages were modified.

Refs #545

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_