### PR TITLE
docs(website): document dialog scroll-lock lifecycle on navigation

### DIFF
--- a/packages/website/src/page/ui/dialogPage.ts
+++ b/packages/website/src/page/ui/dialogPage.ts
@@ -12,6 +12,7 @@ import {
   pageTitle,
   para,
   tableOfContentsEntryToHeader,
+  warningCallout,
 } from '../../prose'
 import { uiAnimationRouter } from '../../route'
 import * as Snippet from '../../snippet'
@@ -262,6 +263,24 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           'Check out how Dialog is wired up in a ',
           link(uiShowcaseViewSourceHref('dialog'), 'real Foldkit app'),
           '.',
+        ),
+        para(
+          'A dialog is open or closed because the Model says so. ',
+          inlineCode('Dialog.open'),
+          ' returns a Command that locks page scroll and traps focus; ',
+          inlineCode('Dialog.close'),
+          ' returns a Command that releases both. Routing these effects through Commands keeps DevTools time-travel clean, since replay reconstructs the Model without re-running Commands, so scrubbing the timeline never locks your page.',
+        ),
+        warningCallout(
+          'Close dialogs when you navigate away',
+          'The release runs from the close Command, so the dialog must actually be closed for scroll to unlock. If your view is keyed by route and the dialog Model lives somewhere that persists across routes, such as a top-level UI Submodel, then navigating away unmounts the dialog element without dispatching a close. The release Command never fires and page scroll stays locked.',
+        ),
+        para(
+          'Treat open-state as something that must not outlive the context that renders it. In the handler for your route-change Message (commonly ',
+          inlineCode('ChangedUrl'),
+          '), call ',
+          inlineCode('Dialog.close'),
+          ' on each dialog Model and dispatch the resulting close Commands as you swap the route. Closing an already-closed dialog is a safe no-op, so it is cheap to do unconditionally. Equivalently, co-locate dialog state with the route so navigating discards it. The fix is keeping the Model accurate, not relocating the effect.',
         ),
         heading(examplesHeader.level, examplesHeader.id, examplesHeader.text),
         heading(


### PR DESCRIPTION
## Summary

Adds a warning callout and short prose to the Dialog UI docs page (`packages/website/src/page/ui/dialogPage.ts`) describing a real lifecycle pitfall and the recommended pattern. This covers the documentation half of #545.

## The pitfall

A dialog's open/closed status is Model state. Opening runs a Command that locks page scroll, traps focus, and marks sibling content inert; closing runs a Command that releases all of it. Because the cleanup runs from the close Command, the dialog must actually be closed for scroll to unlock. If the view is keyed by route so navigating away unmounts the dialog, but the dialog's Model lives somewhere that persists across routes (for example a top-level UI Submodel), then navigating away removes the dialog element without dispatching a close. The release Command never fires and page scroll stays locked.

## The pattern

Treat open-state as something that must not outlive the context that renders it. In the route-change Message handler (commonly `ChangedUrl`), call `Dialog.close` on each dialog Model and dispatch the resulting close Commands as the route swaps. Closing an already-closed dialog is a safe no-op, so it is cheap to do unconditionally. Equivalently, co-locate dialog state with the route so navigating discards it.

The Command-based design is intentional. Routing these effects through Commands keeps DevTools time-travel replay safe, since replay reconstructs the Model without re-running Commands. The fix is keeping the Model accurate, not relocating the effect to a Subscription or Mount.

## Notes

- Docs-only change. `website` is a private package, so no changeset.
- Uses the page's existing `warningCallout` and prose helpers; placed in the Overview where scroll locking is already discussed.
- Technical claims (replay discards Commands; `Dialog.close` on an already-closed model is a no-op) verified against `packages/foldkit/src/runtime/runtime.ts` and `packages/ui/src/dialog/index.ts`.

Refs #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_