### PR TITLE
feat(ui): add external-label support to the Listbox trigger

### DIFF
--- a/.changeset/listbox-trigger-label.md
+++ b/.changeset/listbox-trigger-label.md
@@ -1,0 +1,16 @@
+---
+'foldkit': minor
+'@foldkit/ui': minor
+---
+
+Add a first-class way to associate an external label with the `Ui.Listbox`
+trigger button.
+
+`ViewInputs` now accepts optional `ariaLabel` and `ariaLabelledBy`. When
+provided, they are applied to the trigger button, with `ariaLabel` taking
+precedence. Neither attribute is rendered when omitted, so the trigger never
+carries a dangling `aria-labelledby`. `Listbox.buttonId(id)` (and
+`Listbox.Multi.buttonId(id)`) returns the bare id of the trigger button,
+mirroring the existing `buttonSelector`, so a native
+`<label for={Listbox.buttonId(id)}>` can drive click-to-focus without
+hardcoding the internal `-button` convention.

--- a/packages/ui/src/listbox/multi.test.ts
+++ b/packages/ui/src/listbox/multi.test.ts
@@ -20,6 +20,7 @@ import {
   PortalListboxBackdrop,
   ScrollIntoView,
   SelectedItem,
+  buttonId,
 } from './shared.js'
 
 const TestListbox = create<string>()
@@ -187,6 +188,66 @@ describe('Listbox.Multi', () => {
           acknowledgeAnchor,
           acknowledgeBackdrop,
         )
+      })
+    })
+
+    describe('button labeling', () => {
+      it('no aria-label or aria-labelledby on the trigger by default', () => {
+        Scene.scene(
+          { update, view: sceneView() },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const button = Scene.find(html, '[key="test-button"]')
+            expect(button).not.toHaveAttr('aria-label')
+            expect(button).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('applies aria-label to the trigger when ariaLabel is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabel: 'Fruit' }) },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const button = Scene.find(html, '[key="test-button"]')
+            expect(button).toHaveAttr('aria-label', 'Fruit')
+            expect(button).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('applies aria-labelledby to the trigger when ariaLabelledBy is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabelledBy: 'fruit-label' }) },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const button = Scene.find(html, '[key="test-button"]')
+            expect(button).toHaveAttr('aria-labelledby', 'fruit-label')
+            expect(button).not.toHaveAttr('aria-label')
+          }),
+        )
+      })
+
+      it('prefers aria-label over aria-labelledby when both are provided', () => {
+        Scene.scene(
+          {
+            update,
+            view: sceneView({
+              ariaLabel: 'Fruit',
+              ariaLabelledBy: 'fruit-label',
+            }),
+          },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const button = Scene.find(html, '[key="test-button"]')
+            expect(button).toHaveAttr('aria-label', 'Fruit')
+            expect(button).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('buttonId derives the trigger id from the base id', () => {
+        expect(buttonId('test')).toBe('test-button')
       })
     })
 

--- a/packages/ui/src/listbox/multiPublic.ts
+++ b/packages/ui/src/listbox/multiPublic.ts
@@ -1,2 +1,3 @@
 export { init, create, Model } from './multi.js'
+export { buttonId } from './shared.js'
 export type { InitConfig, ViewInputs } from './multi.js'

--- a/packages/ui/src/listbox/public.ts
+++ b/packages/ui/src/listbox/public.ts
@@ -1,5 +1,7 @@
 export { init, create, Model } from './single.js'
 
+export { buttonId } from './shared.js'
+
 export {
   Message,
   OutMessage,

--- a/packages/ui/src/listbox/shared.ts
+++ b/packages/ui/src/listbox/shared.ts
@@ -270,6 +270,14 @@ export const LEFT_MOUSE_BUTTON = 0
 // SELECTORS
 
 export const buttonSelector = (id: string): string => idSelector(`${id}-button`)
+
+/** Returns the bare DOM id of the listbox trigger button, derived from the
+ *  listbox's base id. Use this to associate an external label with the
+ *  trigger via a native `<label for={Listbox.buttonId(id)}>` or an
+ *  `aria-labelledby` reference. Mirrors `buttonSelector`, which returns the
+ *  CSS selector form (`#${id}-button`) rather than the bare id. */
+export const buttonId = (id: string): string => `${id}-button`
+
 export const itemsSelector = (id: string): string => idSelector(`${id}-items`)
 export const itemSelector = (id: string, index: number): string =>
   idSelector(`${id}-item-${index}`)
@@ -813,6 +821,8 @@ type BaseViewInputsCommon<Item> = Readonly<{
   form?: string
   isDisabled?: boolean
   isInvalid?: boolean
+  ariaLabel?: string
+  ariaLabelledBy?: string
 }>
 
 /** Per-render view inputs for a Listbox view. The `itemToValue` extractor
@@ -883,6 +893,8 @@ export const makeView = <Model extends BaseModel>(
         form,
         isDisabled,
         isInvalid,
+        ariaLabel,
+        ariaLabelledBy,
       } = viewInputs
 
       const itemToValue =
@@ -1069,12 +1081,25 @@ export const makeView = <Model extends BaseModel>(
           M.orElse(() => Option.none()),
         )
 
+      const resolveButtonLabel = () => {
+        if (Predicate.isNotUndefined(ariaLabel)) {
+          return [h.AriaLabel(ariaLabel)]
+        } else if (Predicate.isNotUndefined(ariaLabelledBy)) {
+          return [h.AriaLabelledBy(ariaLabelledBy)]
+        } else {
+          return []
+        }
+      }
+
+      const buttonLabelAttributes = resolveButtonLabel()
+
       const resolvedButtonAttributes = [
         h.Id(`${id}-button`),
         h.Type('button'),
         h.AriaHasPopup('listbox'),
         h.AriaExpanded(isVisible),
         h.AriaControls(`${id}-items`),
+        ...buttonLabelAttributes,
         ...(isButtonEffectivelyDisabled
           ? [h.AriaDisabled(true), h.DataAttribute('disabled', '')]
           : [

--- a/packages/ui/src/listbox/single.test.ts
+++ b/packages/ui/src/listbox/single.test.ts
@@ -43,6 +43,7 @@ import {
   SelectedItem,
   SuppressedSpaceScroll,
   UnlockScroll,
+  buttonId,
 } from './shared.js'
 import { create, init, update } from './single.js'
 import type { Model, ViewInputs } from './single.js'
@@ -1467,6 +1468,66 @@ describe('Listbox', () => {
             )
           }),
         )
+      })
+    })
+
+    describe('button labeling', () => {
+      it('no aria-label or aria-labelledby on the trigger by default', () => {
+        Scene.scene(
+          { update, view: sceneView() },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const button = Scene.find(html, '[key="test-button"]')
+            expect(button).not.toHaveAttr('aria-label')
+            expect(button).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('applies aria-label to the trigger when ariaLabel is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabel: 'Fruit' }) },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const button = Scene.find(html, '[key="test-button"]')
+            expect(button).toHaveAttr('aria-label', 'Fruit')
+            expect(button).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('applies aria-labelledby to the trigger when ariaLabelledBy is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabelledBy: 'fruit-label' }) },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const button = Scene.find(html, '[key="test-button"]')
+            expect(button).toHaveAttr('aria-labelledby', 'fruit-label')
+            expect(button).not.toHaveAttr('aria-label')
+          }),
+        )
+      })
+
+      it('prefers aria-label over aria-labelledby when both are provided', () => {
+        Scene.scene(
+          {
+            update,
+            view: sceneView({
+              ariaLabel: 'Fruit',
+              ariaLabelledBy: 'fruit-label',
+            }),
+          },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const button = Scene.find(html, '[key="test-button"]')
+            expect(button).toHaveAttr('aria-label', 'Fruit')
+            expect(button).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('buttonId derives the trigger id from the base id', () => {
+        expect(buttonId('test')).toBe('test-button')
       })
     })
 

--- a/packages/website/src/page/ui/listbox.ts
+++ b/packages/website/src/page/ui/listbox.ts
@@ -116,40 +116,57 @@ export const basicDemo = (listboxModel: Listbox.Model) => {
     () => 'Select a Bluth',
   )
 
+  const labelId = `${listboxModel.id}-label`
+
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: 'listbox-basic',
-          model: listboxModel,
-          view: ItemListbox.view,
-          viewInputs: {
-            anchor: LISTBOX_ANCHOR,
-            items: LISTBOX_ITEMS,
-            itemToConfig: item => ({
-              className: itemClassName,
-              content: h.div(
-                [h.Class('flex items-center gap-2')],
-                [
-                  Icon.check(
-                    'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900 dark:text-white',
+        h.label(
+          [
+            h.Id(labelId),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Family member'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: 'listbox-basic',
+              model: listboxModel,
+              view: ItemListbox.view,
+              viewInputs: {
+                ariaLabelledBy: labelId,
+                anchor: LISTBOX_ANCHOR,
+                items: LISTBOX_ITEMS,
+                itemToConfig: item => ({
+                  className: itemClassName,
+                  content: h.div(
+                    [h.Class('flex items-center gap-2')],
+                    [
+                      Icon.check(
+                        'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900 dark:text-white',
+                      ),
+                      h.span([], [item]),
+                    ],
                   ),
-                  h.span([], [item]),
-                ],
-              ),
+                }),
+                buttonContent: h.div(
+                  [h.Class('flex w-full items-center justify-between gap-4')],
+                  [h.span([], [buttonLabel]), Icon.chevronDown('w-4 h-4')],
+                ),
+                buttonAttributes: childAttributes([h.Class(triggerClassName)]),
+                itemsAttributes: childAttributes([h.Class(itemsClassName)]),
+                backdropAttributes: childAttributes([
+                  h.Class(backdropClassName),
+                ]),
+                attributes: childAttributes([h.Class(wrapperClassName)]),
+              },
+              toParentMessage: message => GotListboxDemoMessage({ message }),
             }),
-            buttonContent: h.div(
-              [h.Class('flex w-full items-center justify-between gap-4')],
-              [h.span([], [buttonLabel]), Icon.chevronDown('w-4 h-4')],
-            ),
-            buttonAttributes: childAttributes([h.Class(triggerClassName)]),
-            itemsAttributes: childAttributes([h.Class(itemsClassName)]),
-            backdropAttributes: childAttributes([h.Class(backdropClassName)]),
-            attributes: childAttributes([h.Class(wrapperClassName)]),
-          },
-          toParentMessage: message => GotListboxDemoMessage({ message }),
-        }),
+          ],
+        ),
       ],
     ),
   ]
@@ -165,40 +182,58 @@ export const multiSelectDemo = (listboxModel: Listbox.Multi.Model) => {
       items.length === 1 ? items[0] : `${items.length} selected`,
   })
 
+  const labelId = `${listboxModel.id}-label`
+
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: 'listbox-multi',
-          model: listboxModel,
-          view: ItemMultiListbox.view,
-          viewInputs: {
-            anchor: LISTBOX_ANCHOR,
-            items: LISTBOX_ITEMS,
-            itemToConfig: item => ({
-              className: itemClassName,
-              content: h.div(
-                [h.Class('flex items-center gap-2')],
-                [
-                  Icon.check(
-                    'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900 dark:text-white',
+        h.label(
+          [
+            h.Id(labelId),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Family members'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: 'listbox-multi',
+              model: listboxModel,
+              view: ItemMultiListbox.view,
+              viewInputs: {
+                ariaLabelledBy: labelId,
+                anchor: LISTBOX_ANCHOR,
+                items: LISTBOX_ITEMS,
+                itemToConfig: item => ({
+                  className: itemClassName,
+                  content: h.div(
+                    [h.Class('flex items-center gap-2')],
+                    [
+                      Icon.check(
+                        'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900 dark:text-white',
+                      ),
+                      h.span([], [item]),
+                    ],
                   ),
-                  h.span([], [item]),
-                ],
-              ),
+                }),
+                buttonContent: h.div(
+                  [h.Class('flex w-full items-center justify-between gap-4')],
+                  [h.span([], [buttonLabel]), Icon.chevronDown('w-4 h-4')],
+                ),
+                buttonAttributes: childAttributes([h.Class(triggerClassName)]),
+                itemsAttributes: childAttributes([h.Class(itemsClassName)]),
+                backdropAttributes: childAttributes([
+                  h.Class(backdropClassName),
+                ]),
+                attributes: childAttributes([h.Class(wrapperClassName)]),
+              },
+              toParentMessage: message =>
+                GotListboxMultiDemoMessage({ message }),
             }),
-            buttonContent: h.div(
-              [h.Class('flex w-full items-center justify-between gap-4')],
-              [h.span([], [buttonLabel]), Icon.chevronDown('w-4 h-4')],
-            ),
-            buttonAttributes: childAttributes([h.Class(triggerClassName)]),
-            itemsAttributes: childAttributes([h.Class(itemsClassName)]),
-            backdropAttributes: childAttributes([h.Class(backdropClassName)]),
-            attributes: childAttributes([h.Class(wrapperClassName)]),
-          },
-          toParentMessage: message => GotListboxMultiDemoMessage({ message }),
-        }),
+          ],
+        ),
       ],
     ),
   ]
@@ -212,47 +247,67 @@ export const groupedDemo = (listboxModel: Listbox.Model) => {
     () => 'Select a character',
   )
 
+  const labelId = `${listboxModel.id}-label`
+
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: 'listbox-grouped',
-          model: listboxModel,
-          view: CharacterListbox.view,
-          viewInputs: {
-            anchor: LISTBOX_ANCHOR,
-            items: GROUPED_CHARACTERS,
-            itemToValue: characterName,
-            itemGroupKey: character => character.lastName,
-            groupToHeading: lastName => ({
-              content: h.span([], [`${lastName}s`]),
-              className: groupHeadingClassName,
-            }),
-            separatorAttributes: childAttributes([h.Class(separatorClassName)]),
-            itemToConfig: character => ({
-              className: groupedItemClassName,
-              content: h.div(
-                [h.Class('flex items-center gap-2')],
-                [
-                  Icon.check(
-                    'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900 dark:text-white',
+        h.label(
+          [
+            h.Id(labelId),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Character'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: 'listbox-grouped',
+              model: listboxModel,
+              view: CharacterListbox.view,
+              viewInputs: {
+                ariaLabelledBy: labelId,
+                anchor: LISTBOX_ANCHOR,
+                items: GROUPED_CHARACTERS,
+                itemToValue: characterName,
+                itemGroupKey: character => character.lastName,
+                groupToHeading: lastName => ({
+                  content: h.span([], [`${lastName}s`]),
+                  className: groupHeadingClassName,
+                }),
+                separatorAttributes: childAttributes([
+                  h.Class(separatorClassName),
+                ]),
+                itemToConfig: character => ({
+                  className: groupedItemClassName,
+                  content: h.div(
+                    [h.Class('flex items-center gap-2')],
+                    [
+                      Icon.check(
+                        'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900 dark:text-white',
+                      ),
+                      h.span([], [characterName(character)]),
+                    ],
                   ),
-                  h.span([], [characterName(character)]),
-                ],
-              ),
+                }),
+                buttonContent: h.div(
+                  [h.Class('flex w-full items-center justify-between gap-4')],
+                  [h.span([], [buttonLabel]), Icon.chevronDown('w-4 h-4')],
+                ),
+                buttonAttributes: childAttributes([h.Class(triggerClassName)]),
+                itemsAttributes: childAttributes([h.Class(itemsClassName)]),
+                backdropAttributes: childAttributes([
+                  h.Class(backdropClassName),
+                ]),
+                attributes: childAttributes([h.Class(wrapperClassName)]),
+              },
+              toParentMessage: message =>
+                GotListboxGroupedDemoMessage({ message }),
             }),
-            buttonContent: h.div(
-              [h.Class('flex w-full items-center justify-between gap-4')],
-              [h.span([], [buttonLabel]), Icon.chevronDown('w-4 h-4')],
-            ),
-            buttonAttributes: childAttributes([h.Class(triggerClassName)]),
-            itemsAttributes: childAttributes([h.Class(itemsClassName)]),
-            backdropAttributes: childAttributes([h.Class(backdropClassName)]),
-            attributes: childAttributes([h.Class(wrapperClassName)]),
-          },
-          toParentMessage: message => GotListboxGroupedDemoMessage({ message }),
-        }),
+          ],
+        ),
       ],
     ),
   ]

--- a/packages/website/src/page/ui/listboxPage.ts
+++ b/packages/website/src/page/ui/listboxPage.ts
@@ -208,6 +208,18 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
     default: 'false',
     description: 'Marks the listbox as invalid for validation styling.',
   },
+  {
+    name: 'ariaLabel',
+    type: 'string',
+    description:
+      'Accessible name for the trigger button. Use for an icon-only trigger with no visible label. Applied as aria-label, and takes precedence over ariaLabelledBy.',
+  },
+  {
+    name: 'ariaLabelledBy',
+    type: 'string',
+    description:
+      'Id of an external element that labels the trigger button, applied as aria-labelledby. Pair with a visible label element.',
+  },
 ]
 
 const outMessageProps: ReadonlyArray<PropEntry> = [
@@ -459,6 +471,19 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           ' with ',
           inlineCode('aria-selected'),
           '.',
+        ),
+        para(
+          'The trigger is a form field, so give it an accessible name. Pass ',
+          inlineCode('ariaLabelledBy'),
+          ' with the id of a visible label element, or ',
+          inlineCode('ariaLabel'),
+          ' for an icon-only trigger. To wire a native ',
+          inlineCode('<label for>'),
+          ' for click-to-focus, target the trigger id with ',
+          inlineCode('Listbox.buttonId(id)'),
+          ' rather than hardcoding the ',
+          inlineCode('-button'),
+          ' convention.',
         ),
         heading(
           apiReferenceHeader.level,

--- a/packages/website/src/snippet/uiListboxBasic.ts
+++ b/packages/website/src/snippet/uiListboxBasic.ts
@@ -71,36 +71,48 @@ GotListboxMessage: ({ message }) => {
 const plans: ReadonlyArray<Plan> = ['Free', 'Pro', 'Enterprise']
 
 // Inside your view function, embed the Listbox via h.submodel using
-// `PlanListbox.view`:
+// `PlanListbox.view`. Associate an external label with the trigger: target
+// the trigger id with `Listbox.buttonId('plan')` from a native `<label for>`
+// for click-to-focus, and pass `ariaLabelledBy` so the trigger has an
+// accessible name.
 const view = (model: Model) => {
   const h = html<Message>()
 
-  return h.submodel({
-    slotId: 'plan',
-    model: model.listbox,
-    view: PlanListbox.view,
-    viewInputs: {
-      // `items` must be ReadonlyArray<Plan>. The factory's <Plan> parameter constrains the shape.
-      items: plans,
-      buttonContent: h.span(
-        [],
-        [Option.getOrElse(model.maybePlan, () => 'Select a plan')],
-      ),
-      buttonClassName: 'w-full rounded-lg border px-3 py-2 text-left',
-      itemsClassName: 'rounded-lg border shadow-lg',
-      itemToConfig: (plan, { isSelected, isActive }) => ({
-        className: isActive ? 'bg-blue-100' : '',
-        content: h.div(
-          [h.Class('flex items-center gap-2 px-3 py-2')],
-          [
-            isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
-            h.span([], [plan]),
-          ],
-        ),
+  const labelId = 'plan-label'
+
+  return h.div(
+    [],
+    [
+      h.label([h.Id(labelId), h.For(Listbox.buttonId('plan'))], ['Plan']),
+      h.submodel({
+        slotId: 'plan',
+        model: model.listbox,
+        view: PlanListbox.view,
+        viewInputs: {
+          ariaLabelledBy: labelId,
+          // `items` must be ReadonlyArray<Plan>. The factory's <Plan> parameter constrains the shape.
+          items: plans,
+          buttonContent: h.span(
+            [],
+            [Option.getOrElse(model.maybePlan, () => 'Select a plan')],
+          ),
+          buttonClassName: 'w-full rounded-lg border px-3 py-2 text-left',
+          itemsClassName: 'rounded-lg border shadow-lg',
+          itemToConfig: (plan, { isSelected, isActive }) => ({
+            className: isActive ? 'bg-blue-100' : '',
+            content: h.div(
+              [h.Class('flex items-center gap-2 px-3 py-2')],
+              [
+                isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
+                h.span([], [plan]),
+              ],
+            ),
+          }),
+          backdropClassName: 'fixed inset-0',
+          anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+        },
+        toParentMessage: message => GotListboxMessage({ message }),
       }),
-      backdropClassName: 'fixed inset-0',
-      anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-    },
-    toParentMessage: message => GotListboxMessage({ message }),
-  })
+    ],
+  )
 }


### PR DESCRIPTION
## What

The `Ui.Listbox` trigger renders as a `<button>` and is framed as a form field (`ViewInputs` already carry `name`, `form`, `isInvalid`, `isDisabled`), but there was no first-class way to give that trigger an accessible name from an external label. Consumers had to hardcode the internal `#${id}-button` id convention or hand-manage `aria-labelledby` through `buttonAttributes`, and a11y checkers flagged the trigger as an unlabeled form field.

This adds a supported labeling path that mirrors the existing sibling form-field components.

## New public surface

- `ViewInputs.ariaLabel?: string` and `ViewInputs.ariaLabelledBy?: string` (shared across single and multi). Applied to the trigger button. `ariaLabel` takes precedence over `ariaLabelledBy`, and **neither attribute is emitted when both are absent**, so the trigger never carries a dangling `aria-labelledby` (the issue #528 class of bug). This matches the `Ui.Slider` shape, which already exposes `ariaLabel` / `ariaLabelledBy` on its `ViewInputs`.
- `Listbox.buttonId(id)` and `Listbox.Multi.buttonId(id)`: a bare-id helper returning `${id}-button`, mirroring the existing `buttonSelector(id)` (which returns the CSS selector form). This matches `Ui.Dialog`'s `titleId` / `descriptionId` bare-id helper convention.

## Recommended external-label pattern

```ts
const labelId = `${model.id}-label`

h.div([], [
  h.label([h.Id(labelId), h.For(Listbox.buttonId('plan'))], ['Plan']),
  h.submodel({
    slotId: 'plan',
    model: model.listbox,
    view: PlanListbox.view,
    viewInputs: {
      ariaLabelledBy: labelId,
      // ...rest
    },
    toParentMessage: message => GotListboxMessage({ message }),
  }),
])
```

Use `ariaLabel` for an icon-only trigger with no visible label. Use `ariaLabelledBy` plus `Listbox.buttonId(id)` on a native `<label for>` to get both an accessible name and click-to-focus.

## Why this shape

The chosen surface matches the established sibling form-field patterns rather than inventing a new one. `Ui.Slider` already establishes `ariaLabel` / `ariaLabelledBy` on `ViewInputs` for a non-natively-labelable widget, and `Ui.Dialog` / `Ui.Slider` establish bare-id helpers. The Listbox trigger is a `<button>` with no implicit `<label for>` association, so it needs both: the framework-applied ARIA path and the bare id for native `<label>`.

## Tests

`single.test.ts` and `multi.test.ts` assert, against the existing scene harness, that the trigger:
- has no `aria-label` or `aria-labelledby` by default (no dangling reference),
- gets `aria-label` when `ariaLabel` is provided,
- gets `aria-labelledby` when `ariaLabelledBy` is provided,
- prefers `aria-label` when both are provided,
- and that `buttonId('test')` derives `test-button`.

## Docs

Updated the Listbox docs page (ViewInputs prop table and Accessibility section), the live demo (wires a visible `<label>` via `ariaLabelledBy`), and the copyable snippet to show the supported external-label pattern.

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_