### PR TITLE
refactor(dom)!: rename showModal/closeModal to showDialog/closeDialog

### DIFF
--- a/.changeset/rename-show-dialog.md
+++ b/.changeset/rename-show-dialog.md
@@ -1,0 +1,17 @@
+---
+'foldkit': minor
+'@foldkit/ui': minor
+---
+
+Rename `Dom.showModal` to `Dom.showDialog` and `Dom.closeModal` to
+`Dom.closeDialog`.
+
+The old names implied native `HTMLDialogElement.showModal()` semantics, but
+`Dom.showModal` deliberately calls `element.show()` plus a manual focus trap
+and a high z-index so DevTools and other overlays stay interactive above the
+dialog. `Dom.closeModal` wraps native `.close()`. The new names drop the
+misnomer and match the already-`Dialog`-flavored internals and the `Ui.Dialog`
+Commands.
+
+Migration: rename `Dom.showModal` to `Dom.showDialog` and `Dom.closeModal` to
+`Dom.closeDialog` at every call site. Behavior is unchanged.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/packages/foldkit/src/dom/dom.ts
+++ b/packages/foldkit/src/dom/dom.ts
@@ -110,16 +110,16 @@ export const focus = (
  *
  * Pass `focusSelector` to focus an element inside the dialog when it opens.
  *
- * Records the element that had focus when the dialog opened so `closeModal`
+ * Records the element that had focus when the dialog opened so `closeDialog`
  * can return focus there, the way `showModal()` would natively.
  *
  * @example
  * ```typescript
- * Dom.showModal('#my-dialog')
- * Dom.showModal('#my-dialog', { focusSelector: '#search-input' })
+ * Dom.showDialog('#my-dialog')
+ * Dom.showDialog('#my-dialog', { focusSelector: '#search-input' })
  * ```
  */
-export const showModal = (
+export const showDialog = (
   selector: string,
   options?: Readonly<{ focusSelector?: string }>,
 ): Effect.Effect<void, ElementNotFound> =>
@@ -220,17 +220,17 @@ const trapFocusWithinDialog = (
 
 /**
  * Closes a dialog element using `.close()`.
- * Cleans up the keyboard handlers installed by `showModal` and restores focus to
+ * Cleans up the keyboard handlers installed by `showDialog` and restores focus to
  * the element that was focused before the dialog opened (the trigger, or the
  * dialog beneath it when closing a stacked dialog).
  * Fails with `ElementNotFound` if the selector does not match an `HTMLDialogElement`.
  *
  * @example
  * ```typescript
- * Dom.closeModal('#my-dialog')
+ * Dom.closeDialog('#my-dialog')
  * ```
  */
-export const closeModal = (
+export const closeDialog = (
   selector: string,
 ): Effect.Effect<void, ElementNotFound> =>
   Effect.suspend(() => {
@@ -268,13 +268,13 @@ const releaseDialogHygieneById = (id: string): boolean => {
  * z-index counter, and one page scroll lock. Use this as a backstop for the
  * case where a dialog's element is removed from the DOM without a purposeful
  * close, the classic example being navigation away from a route-keyed subtree
- * that contains the dialog. The normal close path (`closeModal` plus the
+ * that contains the dialog. The normal close path (`closeDialog` plus the
  * Dialog component's `unlockScroll` Command) already releases these, so this
  * is the missing teardown when no close Message ever flows through `update`.
  *
  * Addressed by the dialog's id, not a selector, because the element is
  * typically already gone from the DOM by the time this runs (that is the whole
- * point of the backstop). The hygiene installed by `showModal` is tracked by
+ * point of the backstop). The hygiene installed by `showDialog` is tracked by
  * id so it can be reclaimed without a live element handle. The id must be
  * non-empty and unique within the document, since it keys this cleanup
  * accounting; a duplicate or empty id would release the wrong dialog's hygiene.

--- a/packages/foldkit/src/dom/index.test.ts
+++ b/packages/foldkit/src/dom/index.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from '@effect/vitest'
 
 import {
   ElementNotFound,
-  closeModal,
+  closeDialog,
   focus,
   inertOthers,
   lockScroll,
@@ -13,7 +13,7 @@ import {
   restoreInert,
   scrollIntoView,
   scrollIntoViewAfterPaint,
-  showModal,
+  showDialog,
   unlockScroll,
 } from './index.js'
 
@@ -354,7 +354,7 @@ describe('restoreInert', () => {
   )
 })
 
-describe('showModal', () => {
+describe('showDialog', () => {
   const makeDialog = (id: string): HTMLDialogElement => {
     const dialog = document.createElement('dialog')
     dialog.id = id
@@ -393,12 +393,12 @@ describe('showModal', () => {
         .querySelector('#solo')
         ?.addEventListener('cancel', () => cancelled.push('solo'))
 
-      yield* showModal('#solo')
+      yield* showDialog('#solo')
       pressEscape()
 
       expect(cancelled).toEqual(['solo'])
 
-      yield* closeModal('#solo')
+      yield* closeDialog('#solo')
       document.body.innerHTML = ''
     }),
   )
@@ -417,17 +417,17 @@ describe('showModal', () => {
           .querySelector('#child')
           ?.addEventListener('cancel', () => cancelled.push('child'))
 
-        yield* showModal('#parent')
-        yield* showModal('#child')
+        yield* showDialog('#parent')
+        yield* showDialog('#child')
 
         pressEscape()
         expect(cancelled).toEqual(['child'])
 
-        yield* closeModal('#child')
+        yield* closeDialog('#child')
         pressEscape()
         expect(cancelled).toEqual(['child', 'parent'])
 
-        yield* closeModal('#parent')
+        yield* closeDialog('#parent')
         document.body.innerHTML = ''
       }),
   )
@@ -440,7 +440,7 @@ describe('showModal', () => {
         .querySelector('#solo')
         ?.addEventListener('cancel', () => cancelled.push('solo'))
 
-      yield* showModal('#solo')
+      yield* showDialog('#solo')
 
       const event = new KeyboardEvent('keydown', {
         key: 'Escape',
@@ -452,7 +452,7 @@ describe('showModal', () => {
 
       expect(cancelled).toEqual([])
 
-      yield* closeModal('#solo')
+      yield* closeDialog('#solo')
       document.body.innerHTML = ''
     }),
   )
@@ -462,8 +462,8 @@ describe('showModal', () => {
       const parent = makeDialog('parent')
       const child = makeDialog('child')
 
-      yield* showModal('#parent')
-      yield* showModal('#child')
+      yield* showDialog('#parent')
+      yield* showDialog('#child')
 
       child.querySelector<HTMLButtonElement>('button')?.focus()
       expect(pressTab().defaultPrevented).toBe(true)
@@ -471,8 +471,8 @@ describe('showModal', () => {
       parent.querySelector<HTMLButtonElement>('button')?.focus()
       expect(pressTab().defaultPrevented).toBe(false)
 
-      yield* closeModal('#child')
-      yield* closeModal('#parent')
+      yield* closeDialog('#child')
+      yield* closeDialog('#parent')
       document.body.innerHTML = ''
     }),
   )
@@ -485,8 +485,8 @@ describe('showModal', () => {
       makeDialog('solo')
 
       trigger.focus()
-      yield* showModal('#solo')
-      yield* closeModal('#solo')
+      yield* showDialog('#solo')
+      yield* closeDialog('#solo')
 
       expect(document.activeElement).toBe(trigger)
       document.body.innerHTML = ''
@@ -501,14 +501,14 @@ describe('showModal', () => {
         makeDialog('child')
         const parentButton = parent.querySelector<HTMLButtonElement>('button')
 
-        yield* showModal('#parent')
+        yield* showDialog('#parent')
         parentButton?.focus()
-        yield* showModal('#child')
-        yield* closeModal('#child')
+        yield* showDialog('#child')
+        yield* closeDialog('#child')
 
         expect(document.activeElement).toBe(parentButton)
 
-        yield* closeModal('#parent')
+        yield* closeDialog('#parent')
         document.body.innerHTML = ''
       }),
   )
@@ -553,7 +553,7 @@ describe('releaseDialogResources', () => {
 
         trigger.focus()
         yield* lockScroll
-        yield* showModal('#solo')
+        yield* showDialog('#solo')
         expect(document.documentElement.style.overflow).toBe('hidden')
 
         // The real unmount scenario: the element is gone before the backstop
@@ -586,7 +586,7 @@ describe('releaseDialogResources', () => {
 
         trigger.focus()
         yield* lockScroll
-        yield* showModal('#solo')
+        yield* showDialog('#solo')
         expect(document.documentElement.style.overflow).toBe('hidden')
 
         const cancelled: Array<string> = []
@@ -613,7 +613,7 @@ describe('releaseDialogResources', () => {
     Effect.gen(function* () {
       makeDialog('solo')
       yield* lockScroll
-      yield* showModal('#solo')
+      yield* showDialog('#solo')
 
       const first = yield* releaseDialogResources('solo')
       const second = yield* releaseDialogResources('solo')
@@ -630,9 +630,9 @@ describe('releaseDialogResources', () => {
     Effect.gen(function* () {
       makeDialog('solo')
       yield* lockScroll
-      yield* showModal('#solo')
+      yield* showDialog('#solo')
 
-      yield* closeModal('#solo')
+      yield* closeDialog('#solo')
       yield* unlockScroll
       expect(document.documentElement.style.overflow).toBe('')
 
@@ -648,7 +648,7 @@ describe('releaseDialogResources', () => {
     Effect.gen(function* () {
       makeDialog('solo')
       yield* lockScroll
-      yield* showModal('#solo')
+      yield* showDialog('#solo')
 
       // A second, unrelated holder takes the shared scroll lock.
       yield* lockScroll
@@ -678,9 +678,9 @@ describe('releaseDialogResources', () => {
         parent.addEventListener('cancel', () => cancelled.push('parent'))
 
         yield* lockScroll
-        yield* showModal('#parent')
+        yield* showDialog('#parent')
         yield* lockScroll
-        yield* showModal('#child')
+        yield* showDialog('#child')
 
         const released = yield* releaseDialogResources('child')
         expect(released).toBe(true)

--- a/packages/foldkit/src/dom/index.ts
+++ b/packages/foldkit/src/dom/index.ts
@@ -2,13 +2,13 @@ export { ElementNotFound } from './error.js'
 export {
   advanceFocus,
   clickElement,
-  closeModal,
+  closeDialog,
   focus,
   releaseDialogResources,
   scrollIntoView,
   scrollIntoViewAfterPaint,
   scrollIntoViewIfNotVisible,
-  showModal,
+  showDialog,
 } from './dom.js'
 export type { FocusDirection } from './dom.js'
 export { detectElementMovement } from './elementMovement.js'

--- a/packages/foldkit/src/dom/public.ts
+++ b/packages/foldkit/src/dom/public.ts
@@ -2,7 +2,7 @@ export {
   ElementNotFound,
   advanceFocus,
   clickElement,
-  closeModal,
+  closeDialog,
   detectElementMovement,
   focus,
   inertOthers,
@@ -12,7 +12,7 @@ export {
   scrollIntoView,
   scrollIntoViewAfterPaint,
   scrollIntoViewIfNotVisible,
-  showModal,
+  showDialog,
   unlockScroll,
   waitForAnimationSettled,
 } from './index.js'

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -163,7 +163,7 @@ export const ShowDialog = Command.define(
 )(({ id, maybeFocusSelector }) =>
   Dom.lockScroll.pipe(
     Effect.andThen(() =>
-      Dom.showModal(
+      Dom.showDialog(
         dialogSelector(id),
         Option.match(maybeFocusSelector, {
           onNone: () => undefined,
@@ -182,7 +182,7 @@ export const CloseDialog = Command.define(
   { id: S.String },
   CompletedCloseDialog,
 )(({ id }) =>
-  Dom.closeModal(dialogSelector(id)).pipe(
+  Dom.closeDialog(dialogSelector(id)).pipe(
     Effect.andThen(() => Dom.unlockScroll),
     Effect.ignore,
     Effect.as(CompletedCloseDialog()),

--- a/skills/generate-program/SKILL.md
+++ b/skills/generate-program/SKILL.md
@@ -315,7 +315,7 @@ For each Foldkit module you plan to use, read the `.d.ts` at the paths below. Re
 
 # If using async / side effects
 <project>/node_modules/foldkit/dist/command/index.d.ts  # Command.define: result schemas are required
-<project>/node_modules/foldkit/dist/dom/index.d.ts      # focus, advanceFocus, scrollIntoView, showModal, closeModal, clickElement, lockScroll, unlockScroll, inertOthers, restoreInert, detectElementMovement, waitForAnimationSettled. For time/random/uuid/delay use Effect's Clock, Random, Effect.uuid, Effect.sleep + Duration directly.
+<project>/node_modules/foldkit/dist/dom/index.d.ts      # focus, advanceFocus, scrollIntoView, showDialog, closeDialog, clickElement, lockScroll, unlockScroll, inertOthers, restoreInert, detectElementMovement, waitForAnimationSettled. For time/random/uuid/delay use Effect's Clock, Random, Effect.uuid, Effect.sleep + Duration directly.
 
 # If using subscriptions
 <project>/node_modules/foldkit/dist/subscription/index.d.ts # Subscription.make<Model, Message>, Subscription.lift, Subscription.aggregate
@@ -456,7 +456,7 @@ Every message must carry meaning. No `NoOp`.
 - Use `Effect.provide` for services
 - Factory functions named by action: `fetchWeather`, not `fetchWeatherCommand`
 - Fire-and-forget Commands return `Completed*` Messages
-- Use Foldkit's `Dom` module for DOM operations (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showModal`, `Dom.lockScroll`, etc.) and Effect built-ins for everything else (`Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep(Duration.millis(...))`). See DOM and Effect Helpers in [architecture.md](architecture.md)
+- Use Foldkit's `Dom` module for DOM operations (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showDialog`, `Dom.lockScroll`, etc.) and Effect built-ins for everything else (`Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep(Duration.millis(...))`). See DOM and Effect Helpers in [architecture.md](architecture.md)
 - For HTTP requests, use `HttpClient` from `@effect/platform`. See the weather example for the pattern
 
 ### Form Validation

--- a/skills/generate-program/architecture.md
+++ b/skills/generate-program/architecture.md
@@ -287,8 +287,8 @@ Import as `import { Dom } from 'foldkit'` (or `import * as Dom from 'foldkit/dom
 | `Dom.focus(selector)`              | Focus a DOM element by CSS selector                          |
 | `Dom.advanceFocus(direction)`      | Move focus to the next/previous focusable element            |
 | `Dom.scrollIntoView(selector)`     | Scroll an element into view                                  |
-| `Dom.showModal(selector)`          | Show a `<dialog>` element as a modal                         |
-| `Dom.closeModal(selector)`         | Close a `<dialog>` element                                   |
+| `Dom.showDialog(selector)`         | Open a `<dialog>` element with `show()`                      |
+| `Dom.closeDialog(selector)`        | Close a `<dialog>` element                                   |
 | `Dom.clickElement(selector)`       | Programmatically click an element                            |
 | `Dom.lockScroll` / `unlockScroll`  | Prevent / restore page scroll (e.g. behind modals)           |
 | `Dom.inertOthers` / `restoreInert` | Toggle `inert` on siblings of an element (focus containment) |

--- a/skills/generate-program/conventions.md
+++ b/skills/generate-program/conventions.md
@@ -455,7 +455,7 @@ import {
 Notes:
 
 - Only import what you actually use in the file. The lint pass catches unused imports.
-- Module-by-module reminders, for example: `Calendar` for `Calendar.CalendarDate`, `Calendar.today.local`, `Calendar.make`, `Calendar.addDays` etc., paired with `Ui.Calendar` or `Ui.DatePicker`. `Dom` for DOM-side-effect helpers (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showModal`, `Dom.closeModal`, `Dom.lockScroll`, `Dom.unlockScroll`, `Dom.waitForAnimationSettled`, etc.). `File` for file upload primitives paired with `Ui.FileDrop`. `foldkit/fieldValidation` for form validation.
+- Module-by-module reminders, for example: `Calendar` for `Calendar.CalendarDate`, `Calendar.today.local`, `Calendar.make`, `Calendar.addDays` etc., paired with `Ui.Calendar` or `Ui.DatePicker`. `Dom` for DOM-side-effect helpers (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showDialog`, `Dom.closeDialog`, `Dom.lockScroll`, `Dom.unlockScroll`, `Dom.waitForAnimationSettled`, etc.). `File` for file upload primitives paired with `Ui.FileDrop`. `foldkit/fieldValidation` for form validation.
 - For time, randomness, UUIDs, or delays, use Effect's built-ins directly rather than reaching for a Foldkit module: `Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep(Duration.millis(...))`.
 - When an Effect module name collides with a global, alias the Effect import with a trailing underscore: `String as String_`, `Array as Array_`, `Number as Number_`.
 - `Match as M` is Effect's Match module. Foldkit re-exports `M.value`, `M.tagsExhaustive`, `M.withReturnType` etc. through Effect's `Match`.


### PR DESCRIPTION
## What

Rename the public DOM helpers `Dom.showModal` to `Dom.showDialog` and `Dom.closeModal` to `Dom.closeDialog`.

## Why

This is an accuracy fix, not just consistency. `Dom.showModal` deliberately calls native `element.show()`, NOT native `HTMLDialogElement.showModal()`. It pairs `show()` with a manual focus trap and a high z-index so that DevTools and any other high z-index overlay stay interactive above the dialog. `Dom.closeModal` wraps native `.close()`.

Because the helper avoids native modal/top-layer semantics on purpose, the name `showModal` wrongly implies behavior it does not provide. That was the source of the confusion in #533. The new names drop the misnomer and align the public functions with the already-`Dialog`-flavored internals (`openDialogStack`, `dialogCleanups`, `dialogReturnFocus`, `dialogSelector`) and the `Ui.Dialog` `ShowDialog`/`CloseDialog` Commands.

## Migration

Rename at every call site. Behavior is unchanged.

- `Dom.showModal(selector, options?)` becomes `Dom.showDialog(selector, options?)`
- `Dom.closeModal(selector)` becomes `Dom.closeDialog(selector)`

A changeset marks this as a breaking rename: `'foldkit': minor` and `'@foldkit/ui': minor` (pre-1.0, so a breaking change is a minor bump). The fixed release group pulls `@foldkit/devtools` along at minor too.

## Scope

- Renamed the function definitions in `packages/foldkit/src/dom/dom.ts` and the barrel re-exports in `packages/foldkit/src/dom/index.ts` and `packages/foldkit/src/dom/public.ts`.
- Updated the `@foldkit/ui` Dialog Commands (`packages/ui/src/dialog/index.ts`) to call the new names. Internal `Dialog`-flavored names (`ShowDialog`/`CloseDialog` Commands, `dialogSelector`, `releaseDialogResources`, etc.) are left as-is.
- Updated the dom tests (`packages/foldkit/src/dom/index.test.ts`), including the `releaseDialogResources` tests, and the skills docs.
- Updated TSDoc and prose that referenced the old public names, including the `releaseDialogResources` TSDoc. References to the NATIVE browser `showModal()` API (the rationale for using `show()` instead) are intentionally kept.

A repo-wide grep confirms no stale references to the Foldkit `Dom.showModal`/`Dom.closeModal` functions remain. The only remaining `showModal`/`closeModal` hits are the immutable CHANGELOG history, the migration prose in the changeset, and TSDoc/docs about the native browser API.

## Rebased on top of #549

This was rebased onto `main` after #549 (dialog auto-cleanup on unmount) landed. #549 added new `Dom.showModal`/`Dom.closeModal` call sites (its `releaseDialogResources` TSDoc and tests); those are renamed here too, so the sweep covers the post-#549 surface.

Closes #551