### PR TITLE
feat(ui): add external-label support to remaining trigger components

### DIFF
--- a/.changeset/trigger-external-label-parity.md
+++ b/.changeset/trigger-external-label-parity.md
@@ -1,0 +1,20 @@
+---
+'foldkit': minor
+'@foldkit/ui': minor
+---
+
+Bring external-label support to the remaining trigger-based `@foldkit/ui`
+components, matching the `Ui.Listbox` trigger.
+
+`Ui.Combobox`, `Ui.Menu`, `Ui.DatePicker`, `Ui.Popover`, `Ui.Tooltip`, and
+`Ui.Disclosure` now accept optional `ariaLabel` and `ariaLabelledBy` on their
+view inputs. When provided, they are applied to the component's trigger
+element (the input for Combobox, the button for the rest), with `ariaLabel`
+taking precedence. Neither attribute is emitted when omitted, so a trigger
+never carries a dangling `aria-labelledby`.
+
+Each component also exposes a bare-id helper that mirrors its internal id
+convention, so a native `<label for=...>` can target the trigger without
+hardcoding the suffix: `Combobox.inputId(id)` (and `Combobox.Multi.inputId(id)`),
+`Menu.buttonId(id)`, `DatePicker.triggerId(id)`, `Popover.buttonId(id)`,
+`Tooltip.triggerId(id)`, and `Disclosure.buttonId(id)`.

--- a/examples/ui-showcase/src/ui/view/combobox.ts
+++ b/examples/ui-showcase/src/ui/view/combobox.ts
@@ -125,6 +125,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Single-Select'],
       ),
+      h.label(
+        [
+          h.For(Combobox.inputId(model.comboboxDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['City'],
+      ),
       h.div(
         [h.Class('relative')],
         [
@@ -132,7 +139,9 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
             slotId: model.comboboxDemo.id,
             model: model.comboboxDemo,
             view: CityCombobox.view,
-            viewInputs: comboboxInputs(model.comboboxDemo.inputValue),
+            viewInputs: {
+              ...comboboxInputs(model.comboboxDemo.inputValue),
+            },
             toParentMessage: message => GotComboboxDemoMessage({ message }),
           }),
         ],
@@ -142,6 +151,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Nullable'],
       ),
+      h.label(
+        [
+          h.For(Combobox.inputId(model.comboboxNullableDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['City'],
+      ),
       h.div(
         [h.Class('relative')],
         [
@@ -149,7 +165,9 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
             slotId: model.comboboxNullableDemo.id,
             model: model.comboboxNullableDemo,
             view: CityCombobox.view,
-            viewInputs: comboboxInputs(model.comboboxNullableDemo.inputValue),
+            viewInputs: {
+              ...comboboxInputs(model.comboboxNullableDemo.inputValue),
+            },
             toParentMessage: message =>
               GotComboboxNullableDemoMessage({ message }),
           }),
@@ -160,6 +178,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Select on Focus'],
       ),
+      h.label(
+        [
+          h.For(Combobox.inputId(model.comboboxSelectOnFocusDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['City'],
+      ),
       h.div(
         [h.Class('relative')],
         [
@@ -167,9 +192,9 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
             slotId: model.comboboxSelectOnFocusDemo.id,
             model: model.comboboxSelectOnFocusDemo,
             view: CityCombobox.view,
-            viewInputs: comboboxInputs(
-              model.comboboxSelectOnFocusDemo.inputValue,
-            ),
+            viewInputs: {
+              ...comboboxInputs(model.comboboxSelectOnFocusDemo.inputValue),
+            },
             toParentMessage: message =>
               GotComboboxSelectOnFocusDemoMessage({ message }),
           }),
@@ -179,6 +204,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
       h.h3(
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Multi-Select'],
+      ),
+      h.label(
+        [
+          h.For(Combobox.inputId(model.comboboxMultiDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Cities'],
       ),
       h.div(
         [h.Class('relative')],
@@ -199,7 +231,9 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
             slotId: model.comboboxMultiDemo.id,
             model: model.comboboxMultiDemo,
             view: CityMultiCombobox.view,
-            viewInputs: comboboxInputs(model.comboboxMultiDemo.inputValue),
+            viewInputs: {
+              ...comboboxInputs(model.comboboxMultiDemo.inputValue),
+            },
             toParentMessage: message =>
               GotComboboxMultiDemoMessage({ message }),
           }),

--- a/examples/ui-showcase/src/ui/view/datePicker.ts
+++ b/examples/ui-showcase/src/ui/view/datePicker.ts
@@ -95,6 +95,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
     [],
     [
       h.h2([h.Class('text-2xl font-bold text-gray-900 mb-6')], ['Date Picker']),
+      h.label(
+        [
+          h.For(DatePicker.triggerId(model.datePickerBasicDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Due date'],
+      ),
       h.submodel({
         slotId: model.datePickerBasicDemo.id,
         model: model.datePickerBasicDemo,

--- a/examples/ui-showcase/src/ui/view/disclosure.ts
+++ b/examples/ui-showcase/src/ui/view/disclosure.ts
@@ -72,6 +72,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
       h.h2([h.Class('text-2xl font-bold text-gray-900 mb-6')], ['Disclosure']),
 
       subheading('Basic'),
+      h.label(
+        [
+          h.For(Disclosure.buttonId(model.disclosureBasicDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Frequently asked'],
+      ),
       h.submodel({
         slotId: model.disclosureBasicDemo.id,
         model: model.disclosureBasicDemo,
@@ -98,6 +105,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
       }),
 
       subheading('Animated'),
+      h.label(
+        [
+          h.For(Disclosure.buttonId(model.disclosureAnimatedDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Frequently asked'],
+      ),
       h.submodel({
         slotId: model.disclosureAnimatedDemo.id,
         model: model.disclosureAnimatedDemo,

--- a/examples/ui-showcase/src/ui/view/menu.ts
+++ b/examples/ui-showcase/src/ui/view/menu.ts
@@ -120,6 +120,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Basic'],
       ),
+      h.label(
+        [
+          h.For(Menu.buttonId(model.menuBasicDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Row actions'],
+      ),
       h.div(
         [h.Class('relative')],
         [
@@ -127,7 +134,9 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
             slotId: model.menuBasicDemo.id,
             model: model.menuBasicDemo,
             view: ActionMenu.view,
-            viewInputs: menuViewConfig(basicItemsClassName),
+            viewInputs: {
+              ...menuViewConfig(basicItemsClassName),
+            },
             toParentMessage: message => GotMenuBasicDemoMessage({ message }),
           }),
         ],
@@ -137,6 +146,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Animated'],
       ),
+      h.label(
+        [
+          h.For(Menu.buttonId(model.menuAnimatedDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Row actions'],
+      ),
       h.div(
         [h.Class('relative')],
         [
@@ -144,7 +160,9 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
             slotId: model.menuAnimatedDemo.id,
             model: model.menuAnimatedDemo,
             view: ActionMenu.view,
-            viewInputs: menuViewConfig(animatedItemsClassName),
+            viewInputs: {
+              ...menuViewConfig(animatedItemsClassName),
+            },
             toParentMessage: message => GotMenuAnimatedDemoMessage({ message }),
           }),
         ],

--- a/examples/ui-showcase/src/ui/view/popover.ts
+++ b/examples/ui-showcase/src/ui/view/popover.ts
@@ -100,6 +100,7 @@ const nestedChildPopover = (childPopoverModel: Popover.Model): Html => {
     model: childPopoverModel,
     view: Popover.view,
     viewInputs: {
+      ariaLabel: 'Advanced settings',
       anchor: NESTED_POPOVER_ANCHOR,
       toView: ({ button, panel, backdrop, isVisible }) =>
         h.div(
@@ -204,6 +205,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Basic'],
       ),
+      h.label(
+        [
+          h.For(Popover.buttonId(model.popoverBasicDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Product menu'],
+      ),
       h.div(
         [h.Class('relative')],
         [
@@ -220,6 +228,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Animated'],
       ),
+      h.label(
+        [
+          h.For(Popover.buttonId(model.popoverAnimatedDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Product menu'],
+      ),
       h.div(
         [h.Class('relative')],
         [
@@ -235,6 +250,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
       h.h3(
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Nested'],
+      ),
+      h.label(
+        [
+          h.For(Popover.buttonId(model.popoverNestedParentDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Account'],
       ),
       nestedDemo(model.popoverNestedParentDemo, model.popoverNestedChildDemo),
     ],

--- a/examples/ui-showcase/src/ui/view/tooltip.ts
+++ b/examples/ui-showcase/src/ui/view/tooltip.ts
@@ -37,6 +37,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['Basic'],
       ),
+      h.label(
+        [
+          h.For(Tooltip.triggerId(model.tooltipBasicDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Tooltip trigger'],
+      ),
       h.div(
         [h.Class('relative')],
         [
@@ -73,6 +80,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model): Html => {
       h.h3(
         [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
         ['No delay'],
+      ),
+      h.label(
+        [
+          h.For(Tooltip.triggerId(model.tooltipNoDelayDemo.id)),
+          h.Class('block mb-1.5 text-sm font-medium text-gray-900'),
+        ],
+        ['Tooltip trigger'],
       ),
       h.div(
         [h.Class('relative')],

--- a/packages/examples-e2e/e2e/ui-showcase.spec.ts
+++ b/packages/examples-e2e/e2e/ui-showcase.spec.ts
@@ -33,6 +33,107 @@ test.describe('ui-showcase example', () => {
     await expect(trigger).toHaveAttribute('aria-expanded', 'true')
   })
 
+  test('opens the menu when its external label is clicked', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page.getByRole('link', { name: 'Menu', exact: true }).first().click()
+    await expect(page).toHaveURL(/\/menu$/)
+
+    const trigger = page.locator('#menu-basic-demo-button')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await page.locator('label[for="menu-basic-demo-button"]').click()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('opens the popover when its external label is clicked', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Popover', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/popover$/)
+
+    const trigger = page.locator('#popover-basic-demo-button')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await page.locator('label[for="popover-basic-demo-button"]').click()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('opens the date picker when its external label is clicked', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Date Picker', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/date-picker$/)
+
+    const trigger = page.locator('#date-picker-basic-demo-popover-button')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await page
+      .locator('label[for="date-picker-basic-demo-popover-button"]')
+      .click()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('opens the disclosure when its external label is clicked', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Disclosure', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/disclosure$/)
+
+    const trigger = page.locator('#disclosure-basic-demo-button')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await page.locator('label[for="disclosure-basic-demo-button"]').click()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('focuses the combobox input when its external label is clicked', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Combobox', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/combobox$/)
+
+    const trigger = page.locator('#combobox-demo-input')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await page.locator('label[for="combobox-demo-input"]').click()
+    await expect(trigger).toBeFocused()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('focuses the tooltip trigger when its external label is clicked', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Tooltip', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/tooltip$/)
+
+    const trigger = page.locator('#tooltip-basic-demo-trigger')
+
+    await page.locator('label[for="tooltip-basic-demo-trigger"]').click()
+    await expect(trigger).toBeFocused()
+  })
+
   test('releases the scroll lock when navigating away from an open dialog', async ({
     page,
   }) => {

--- a/packages/ui/src/combobox/multi.test.ts
+++ b/packages/ui/src/combobox/multi.test.ts
@@ -21,6 +21,7 @@ import {
   PortalComboboxBackdrop,
   ScrollIntoView,
   SelectedItem,
+  inputId,
 } from './shared.js'
 
 const TestCombobox = create<string>()
@@ -308,6 +309,66 @@ describe('Combobox.Multi', () => {
             )
           }),
         )
+      })
+    })
+
+    describe('input labeling', () => {
+      it('no aria-label or aria-labelledby on the input by default', () => {
+        Scene.scene(
+          { update, view: sceneView() },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const input = Scene.find(html, 'input[role="combobox"]')
+            expect(input).not.toHaveAttr('aria-label')
+            expect(input).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('applies aria-label to the input when ariaLabel is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabel: 'Fruit' }) },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const input = Scene.find(html, 'input[role="combobox"]')
+            expect(input).toHaveAttr('aria-label', 'Fruit')
+            expect(input).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('applies aria-labelledby to the input when ariaLabelledBy is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabelledBy: 'fruit-label' }) },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const input = Scene.find(html, 'input[role="combobox"]')
+            expect(input).toHaveAttr('aria-labelledby', 'fruit-label')
+            expect(input).not.toHaveAttr('aria-label')
+          }),
+        )
+      })
+
+      it('prefers aria-label over aria-labelledby when both are provided', () => {
+        Scene.scene(
+          {
+            update,
+            view: sceneView({
+              ariaLabel: 'Fruit',
+              ariaLabelledBy: 'fruit-label',
+            }),
+          },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const input = Scene.find(html, 'input[role="combobox"]')
+            expect(input).toHaveAttr('aria-label', 'Fruit')
+            expect(input).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('inputId derives the input id from the base id', () => {
+        expect(inputId('test')).toBe('test-input')
       })
     })
   })

--- a/packages/ui/src/combobox/multiPublic.ts
+++ b/packages/ui/src/combobox/multiPublic.ts
@@ -1,2 +1,3 @@
 export { init, create, Model } from './multi.js'
+export { inputId } from './shared.js'
 export type { InitConfig, ViewInputs } from './multi.js'

--- a/packages/ui/src/combobox/public.ts
+++ b/packages/ui/src/combobox/public.ts
@@ -1,5 +1,7 @@
 export { init, create, Model } from './single.js'
 
+export { inputId } from './shared.js'
+
 export {
   Message,
   OutMessage,

--- a/packages/ui/src/combobox/shared.ts
+++ b/packages/ui/src/combobox/shared.ts
@@ -258,6 +258,13 @@ export type OutMessage<Value extends string = string> = Selected<Value>
 
 // SELECTORS
 
+/** Returns the bare DOM id of the combobox input, derived from the
+ *  combobox's base id. Use this to associate an external label with the
+ *  input via a native `<label for={Combobox.inputId(id)}>` or an
+ *  `aria-labelledby` reference. Mirrors `inputSelector`, which returns the
+ *  CSS selector form (`#${id}-input`) rather than the bare id. */
+export const inputId = (id: string): string => `${id}-input`
+
 export const inputSelector = (id: string): string => idSelector(`${id}-input`)
 export const inputWrapperSelector = (id: string): string =>
   idSelector(`${id}-input-wrapper`)
@@ -826,6 +833,8 @@ export type BaseViewInputs<Item extends string> = Readonly<{
   separatorClassName?: string
   separatorAttributes?: ReadonlyArray<ChildAttribute>
   anchor?: AnchorConfig
+  ariaLabel?: string
+  ariaLabelledBy?: string
 }>
 
 // VIEW FACTORY
@@ -885,7 +894,21 @@ export const makeView = <Model extends BaseModel>(
         separatorClassName,
         separatorAttributes = [],
         anchor = {},
+        ariaLabel,
+        ariaLabelledBy,
       } = viewInputs
+
+      const resolveInputLabel = () => {
+        if (Predicate.isNotUndefined(ariaLabel)) {
+          return [h.AriaLabel(ariaLabel)]
+        } else if (Predicate.isNotUndefined(ariaLabelledBy)) {
+          return [h.AriaLabelledBy(ariaLabelledBy)]
+        } else {
+          return []
+        }
+      }
+
+      const inputLabelAttributes = resolveInputLabel()
 
       const isLeaving =
         transitionState === 'LeaveStart' || transitionState === 'LeaveAnimating'
@@ -1039,6 +1062,7 @@ export const makeView = <Model extends BaseModel>(
         h.AriaControls(`${id}-items`),
         h.Attribute('aria-autocomplete', 'list'),
         h.Attribute('aria-haspopup', 'listbox'),
+        ...inputLabelAttributes,
         h.Autocomplete('off'),
         h.Value(model.inputValue),
         ...maybeActiveDescendant,

--- a/packages/ui/src/combobox/single.test.ts
+++ b/packages/ui/src/combobox/single.test.ts
@@ -37,6 +37,7 @@ import {
   SelectedItem,
   UnlockScroll,
   UpdatedInputValue,
+  inputId,
 } from './shared.js'
 import { create, init, update } from './single.js'
 import type { Model, ViewInputs } from './single.js'
@@ -1418,6 +1419,66 @@ describe('Combobox', () => {
           acknowledgeAnchor,
           acknowledgeBackdrop,
         )
+      })
+    })
+
+    describe('input labeling', () => {
+      it('no aria-label or aria-labelledby on the input by default', () => {
+        Scene.scene(
+          { update, view: sceneView() },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const input = Scene.find(html, 'input[role="combobox"]')
+            expect(input).not.toHaveAttr('aria-label')
+            expect(input).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('applies aria-label to the input when ariaLabel is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabel: 'Fruit' }) },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const input = Scene.find(html, 'input[role="combobox"]')
+            expect(input).toHaveAttr('aria-label', 'Fruit')
+            expect(input).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('applies aria-labelledby to the input when ariaLabelledBy is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabelledBy: 'fruit-label' }) },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const input = Scene.find(html, 'input[role="combobox"]')
+            expect(input).toHaveAttr('aria-labelledby', 'fruit-label')
+            expect(input).not.toHaveAttr('aria-label')
+          }),
+        )
+      })
+
+      it('prefers aria-label over aria-labelledby when both are provided', () => {
+        Scene.scene(
+          {
+            update,
+            view: sceneView({
+              ariaLabel: 'Fruit',
+              ariaLabelledBy: 'fruit-label',
+            }),
+          },
+          Scene.with(closedModel()),
+          Scene.tap(({ html }) => {
+            const input = Scene.find(html, 'input[role="combobox"]')
+            expect(input).toHaveAttr('aria-label', 'Fruit')
+            expect(input).not.toHaveAttr('aria-labelledby')
+          }),
+        )
+      })
+
+      it('inputId derives the input id from the base id', () => {
+        expect(inputId('test')).toBe('test-input')
       })
     })
   })

--- a/packages/ui/src/datePicker/index.ts
+++ b/packages/ui/src/datePicker/index.ts
@@ -1,4 +1,4 @@
-import { Function, Match as M, Option, Schema as S } from 'effect'
+import { Function, Match as M, Option, Predicate, Schema as S } from 'effect'
 import * as Calendar from 'foldkit/calendar'
 import type { CalendarDate } from 'foldkit/calendar'
 import * as Command from 'foldkit/command'
@@ -395,6 +395,15 @@ export const reflectDisabledDaysOfWeek: Reflect<
     }),
 )
 
+// SELECTORS
+
+/** Returns the bare DOM id of the date picker trigger button, derived from
+ *  the date picker's base id. The trigger is the embedded Popover's button,
+ *  so the id is suffixed `-popover-button`. Use this to associate an external
+ *  label with the trigger via a native `<label for={DatePicker.triggerId(id)}>`
+ *  or an `aria-labelledby` reference. */
+export const triggerId = (id: string): string => `${id}-popover-button`
+
 // VIEW
 
 const encodeIsoDate = S.encodeSync(Calendar.CalendarDateFromIsoString)
@@ -423,6 +432,8 @@ export type ViewInputs = Readonly<{
   attributes?: ReadonlyArray<ChildAttribute>
   triggerClassName?: string
   triggerAttributes?: ReadonlyArray<ChildAttribute>
+  ariaLabel?: string
+  ariaLabelledBy?: string
   panelClassName?: string
   panelAttributes?: ReadonlyArray<ChildAttribute>
   backdropClassName?: string
@@ -448,11 +459,25 @@ export const view = defineView<Model, Message, ViewInputs>(
       attributes = [],
       triggerClassName,
       triggerAttributes = [],
+      ariaLabel,
+      ariaLabelledBy,
       panelClassName,
       panelAttributes = [],
       backdropClassName,
       backdropAttributes = [],
     } = viewInputs
+
+    const resolveTriggerLabel = () => {
+      if (Predicate.isNotUndefined(ariaLabel)) {
+        return [h.AriaLabel(ariaLabel)]
+      } else if (Predicate.isNotUndefined(ariaLabelledBy)) {
+        return [h.AriaLabelledBy(ariaLabelledBy)]
+      } else {
+        return []
+      }
+    }
+
+    const triggerLabelAttributes = resolveTriggerLabel()
 
     const calendarVNode = h.submodel({
       slotId: model.calendar.id,
@@ -477,6 +502,7 @@ export const view = defineView<Model, Message, ViewInputs>(
               h.button(
                 [
                   ...button,
+                  ...triggerLabelAttributes,
                   ...(triggerClassName !== undefined
                     ? [h.Class(triggerClassName)]
                     : []),

--- a/packages/ui/src/datePicker/public.ts
+++ b/packages/ui/src/datePicker/public.ts
@@ -2,6 +2,7 @@ export {
   init,
   update,
   view,
+  triggerId,
   open,
   close,
   selectDate,

--- a/packages/ui/src/datePicker/scene.test.ts
+++ b/packages/ui/src/datePicker/scene.test.ts
@@ -2,13 +2,21 @@ import { Match as M, Option } from 'effect'
 import * as Calendar from 'foldkit/calendar'
 import { html } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
+import { expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
 import * as UiCalendar from '../calendar/index.js'
 import * as Popover from '../popover/public.js'
 import type { Message, Model, ViewInputs } from './index.js'
-import { GotPopoverMessage, Opened, init, update, view } from './index.js'
+import {
+  GotPopoverMessage,
+  Opened,
+  init,
+  triggerId,
+  update,
+  view,
+} from './index.js'
 
 const acknowledgeAnchorPopover = Scene.Mount.resolve(
   Popover.AnchorPopover,
@@ -276,6 +284,54 @@ describe('DatePicker', () => {
         Scene.with(seeded),
         Scene.expect(hiddenInput).toHaveValue('2026-01-09'),
       )
+    })
+  })
+
+  describe('trigger labeling', () => {
+    it('no aria-label or aria-labelledby on the trigger by default', () => {
+      Scene.scene(
+        { update, view: sceneView() },
+        Scene.with(closedModel),
+        Scene.expect(trigger).not.toHaveAttr('aria-label'),
+        Scene.expect(trigger).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('applies aria-label to the trigger when ariaLabel is provided', () => {
+      Scene.scene(
+        { update, view: sceneView({ ariaLabel: 'Due date' }) },
+        Scene.with(closedModel),
+        Scene.expect(trigger).toHaveAttr('aria-label', 'Due date'),
+        Scene.expect(trigger).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('applies aria-labelledby to the trigger when ariaLabelledBy is provided', () => {
+      Scene.scene(
+        { update, view: sceneView({ ariaLabelledBy: 'due-label' }) },
+        Scene.with(closedModel),
+        Scene.expect(trigger).toHaveAttr('aria-labelledby', 'due-label'),
+        Scene.expect(trigger).not.toHaveAttr('aria-label'),
+      )
+    })
+
+    it('prefers aria-label over aria-labelledby when both are provided', () => {
+      Scene.scene(
+        {
+          update,
+          view: sceneView({
+            ariaLabel: 'Due date',
+            ariaLabelledBy: 'due-label',
+          }),
+        },
+        Scene.with(closedModel),
+        Scene.expect(trigger).toHaveAttr('aria-label', 'Due date'),
+        Scene.expect(trigger).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('triggerId derives the trigger id from the base id', () => {
+      expect(triggerId('picker')).toBe('picker-popover-button')
     })
   })
 })

--- a/packages/ui/src/disclosure/index.test.ts
+++ b/packages/ui/src/disclosure/index.test.ts
@@ -1,17 +1,42 @@
+import { html } from 'foldkit/html'
+import * as Scene from 'foldkit/scene'
 import * as Story from 'foldkit/story'
 import { expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
+import type { Message, Model, ViewInputs } from './index.js'
 import {
   Closed,
   CompletedFocusButton,
   FocusButton,
   Toggled,
+  buttonId,
   init,
   reflectOpenState,
   update,
+  view,
 } from './index.js'
+
+const sceneView =
+  (overrides: Omit<Partial<ViewInputs>, 'toView'> = {}) =>
+  (model: Model) => {
+    const h = html<Message>()
+
+    return view(model, {
+      ...overrides,
+      toView: ({ button, panel }) =>
+        h.div(
+          [],
+          [
+            h.keyed('button')('test-button', [...button], []),
+            h.keyed('div')('test-panel', [...panel], []),
+          ],
+        ),
+    })
+  }
+
+const button = Scene.selector('[key="test-button"]')
 
 describe('Disclosure', () => {
   describe('init', () => {
@@ -100,6 +125,54 @@ describe('Disclosure', () => {
       expect(
         reflectOpenState(init({ id: 'test', isOpen: true }), false).isOpen,
       ).toBe(false)
+    })
+  })
+
+  describe('button labeling', () => {
+    it('no aria-label or aria-labelledby on the button by default', () => {
+      Scene.scene(
+        { update, view: sceneView() },
+        Scene.with(init({ id: 'test' })),
+        Scene.expect(button).not.toHaveAttr('aria-label'),
+        Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('applies aria-label to the button when ariaLabel is provided', () => {
+      Scene.scene(
+        { update, view: sceneView({ ariaLabel: 'Details' }) },
+        Scene.with(init({ id: 'test' })),
+        Scene.expect(button).toHaveAttr('aria-label', 'Details'),
+        Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('applies aria-labelledby to the button when ariaLabelledBy is provided', () => {
+      Scene.scene(
+        { update, view: sceneView({ ariaLabelledBy: 'details-label' }) },
+        Scene.with(init({ id: 'test' })),
+        Scene.expect(button).toHaveAttr('aria-labelledby', 'details-label'),
+        Scene.expect(button).not.toHaveAttr('aria-label'),
+      )
+    })
+
+    it('prefers aria-label over aria-labelledby when both are provided', () => {
+      Scene.scene(
+        {
+          update,
+          view: sceneView({
+            ariaLabel: 'Details',
+            ariaLabelledBy: 'details-label',
+          }),
+        },
+        Scene.with(init({ id: 'test' })),
+        Scene.expect(button).toHaveAttr('aria-label', 'Details'),
+        Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('buttonId derives the trigger id from the base id', () => {
+      expect(buttonId('test')).toBe('test-button')
     })
   })
 })

--- a/packages/ui/src/disclosure/index.ts
+++ b/packages/ui/src/disclosure/index.ts
@@ -1,4 +1,11 @@
-import { Effect, Function, Match as M, Option, Schema as S } from 'effect'
+import {
+  Effect,
+  Function,
+  Match as M,
+  Option,
+  Predicate,
+  Schema as S,
+} from 'effect'
 import * as Command from 'foldkit/command'
 import * as Dom from 'foldkit/dom'
 import {
@@ -69,7 +76,11 @@ export const init = (config: InitConfig): Model => ({
 
 // UPDATE
 
-const buttonId = (id: string): string => `${id}-button`
+/** Returns the bare DOM id of the disclosure toggle button, derived from the
+ *  disclosure's base id. Use this to associate an external label with the
+ *  button via a native `<label for={Disclosure.buttonId(id)}>` or an
+ *  `aria-labelledby` reference. */
+export const buttonId = (id: string): string => `${id}-button`
 
 const buttonSelector = (id: string): string => idSelector(buttonId(id))
 
@@ -183,6 +194,8 @@ export type DisclosureAttributes = Readonly<{
 export type ViewInputs = Readonly<{
   toView: (attributes: DisclosureAttributes) => Html
   isDisabled?: boolean
+  ariaLabel?: string
+  ariaLabelledBy?: string
 }>
 
 /** Renders a headless disclosure component with accessible ARIA
@@ -198,7 +211,7 @@ export const view = defineView<Model, Message, ViewInputs>(
     const h = html<Message>()
 
     const { id, isOpen } = model
-    const { toView, isDisabled = false } = viewInputs
+    const { toView, isDisabled = false, ariaLabel, ariaLabelledBy } = viewInputs
 
     const handleKeyDown = (key: string): Option.Option<Toggled> =>
       M.value(key).pipe(
@@ -210,10 +223,23 @@ export const view = defineView<Model, Message, ViewInputs>(
       ? [h.AriaDisabled(true), h.DataAttribute('disabled', '')]
       : []
 
+    const resolveButtonLabel = () => {
+      if (Predicate.isNotUndefined(ariaLabel)) {
+        return [h.AriaLabel(ariaLabel)]
+      } else if (Predicate.isNotUndefined(ariaLabelledBy)) {
+        return [h.AriaLabelledBy(ariaLabelledBy)]
+      } else {
+        return []
+      }
+    }
+
+    const buttonLabelAttributes = resolveButtonLabel()
+
     const buttonAttributes = [
       h.Id(buttonId(id)),
       h.AriaExpanded(isOpen),
       h.AriaControls(panelId(id)),
+      ...buttonLabelAttributes,
       h.Tabindex(0),
       ...(isOpen ? [h.DataAttribute('open', '')] : []),
       ...disabledAttributes,

--- a/packages/ui/src/disclosure/public.ts
+++ b/packages/ui/src/disclosure/public.ts
@@ -5,6 +5,7 @@ export {
   close,
   reflectOpenState,
   view,
+  buttonId,
   Model,
   Message,
   OutMessage,

--- a/packages/ui/src/menu/index.ts
+++ b/packages/ui/src/menu/index.ts
@@ -294,6 +294,12 @@ const closedModel = (model: Model): Model =>
     maybePointerOrigin: () => Option.none(),
   })
 
+/** Returns the bare DOM id of the menu trigger button, derived from the
+ *  menu's base id. Use this to associate an external label with the trigger
+ *  via a native `<label for={Menu.buttonId(id)}>` or an `aria-labelledby`
+ *  reference. */
+export const buttonId = (id: string): string => `${id}-button`
+
 const buttonSelector = (id: string): string => idSelector(`${id}-button`)
 const itemsSelector = (id: string): string => idSelector(`${id}-items`)
 const itemSelector = (id: string, index: number): string =>
@@ -817,6 +823,8 @@ export type ViewInputs<Item extends string> = Readonly<{
   separatorClassName?: string
   separatorAttributes?: ReadonlyArray<ChildAttribute>
   anchor?: AnchorConfig
+  ariaLabel?: string
+  ariaLabelledBy?: string
 }>
 
 export { groupContiguous, resolveTypeaheadMatch }
@@ -873,6 +881,8 @@ const menuViewImpl = defineView<Model, Message, ViewInputs<string>>(
       separatorClassName,
       separatorAttributes = [],
       anchor = {},
+      ariaLabel,
+      ariaLabelledBy,
     } = viewInputs
 
     const dispatchSelectedItem = (item: string, index: number) =>
@@ -1047,12 +1057,25 @@ const menuViewImpl = defineView<Model, Message, ViewInputs<string>>(
         ReleasedPointerOnItems({ screenX, screenY, timeStamp }),
       )
 
+    const resolveButtonLabel = () => {
+      if (Predicate.isNotUndefined(ariaLabel)) {
+        return [h.AriaLabel(ariaLabel)]
+      } else if (Predicate.isNotUndefined(ariaLabelledBy)) {
+        return [h.AriaLabelledBy(ariaLabelledBy)]
+      } else {
+        return []
+      }
+    }
+
+    const buttonLabelAttributes = resolveButtonLabel()
+
     const resolvedButtonAttributes = [
       h.Id(`${id}-button`),
       h.Type('button'),
       h.AriaHasPopup('menu'),
       h.AriaExpanded(isVisible),
       h.AriaControls(`${id}-items`),
+      ...buttonLabelAttributes,
       ...(isButtonDisabled
         ? [h.AriaDisabled(true), h.DataAttribute('disabled', '')]
         : [

--- a/packages/ui/src/menu/public.ts
+++ b/packages/ui/src/menu/public.ts
@@ -1,6 +1,7 @@
 export {
   init,
   create,
+  buttonId,
   Model,
   Message,
   OutMessage,

--- a/packages/ui/src/menu/story.test.ts
+++ b/packages/ui/src/menu/story.test.ts
@@ -1,10 +1,12 @@
 import { Option, flow } from 'effect'
+import * as Scene from 'foldkit/scene'
 import * as Story from 'foldkit/story'
 import { expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
 import * as Animation from '../animation/index.js'
+import type { Model, ViewInputs } from './index.js'
 import {
   ActivatedItem,
   BlurredItems,
@@ -38,11 +40,32 @@ import {
   Searched,
   SelectedItem,
   UnlockScroll,
+  buttonId,
+  create,
   groupContiguous,
   init,
   resolveTypeaheadMatch,
   update,
 } from './index.js'
+
+const TestMenu = create<string>()
+
+const sceneView =
+  (
+    overrides: Pick<
+      Partial<ViewInputs<string>>,
+      'ariaLabel' | 'ariaLabelledBy'
+    > = {},
+  ) =>
+  (model: Model) =>
+    TestMenu.view(model, {
+      items: ['Edit', 'Duplicate', 'Delete'],
+      itemToConfig: item => ({ content: item }),
+      buttonContent: 'Actions',
+      ...overrides,
+    })
+
+const button = Scene.selector('#test-button')
 
 const animationToMenuMessage = (message: Animation.Message) =>
   GotAnimationMessage({ message })
@@ -1650,6 +1673,54 @@ describe('Menu', () => {
         { key: 'first', items: ['a', 'b'] },
         { key: 'second', items: ['c', 'd'] },
       ])
+    })
+  })
+
+  describe('button labeling', () => {
+    it('no aria-label or aria-labelledby on the button by default', () => {
+      Scene.scene(
+        { update, view: sceneView() },
+        Scene.with(init({ id: 'test' })),
+        Scene.expect(button).not.toHaveAttr('aria-label'),
+        Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('applies aria-label to the button when ariaLabel is provided', () => {
+      Scene.scene(
+        { update, view: sceneView({ ariaLabel: 'Actions' }) },
+        Scene.with(init({ id: 'test' })),
+        Scene.expect(button).toHaveAttr('aria-label', 'Actions'),
+        Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('applies aria-labelledby to the button when ariaLabelledBy is provided', () => {
+      Scene.scene(
+        { update, view: sceneView({ ariaLabelledBy: 'actions-label' }) },
+        Scene.with(init({ id: 'test' })),
+        Scene.expect(button).toHaveAttr('aria-labelledby', 'actions-label'),
+        Scene.expect(button).not.toHaveAttr('aria-label'),
+      )
+    })
+
+    it('prefers aria-label over aria-labelledby when both are provided', () => {
+      Scene.scene(
+        {
+          update,
+          view: sceneView({
+            ariaLabel: 'Actions',
+            ariaLabelledBy: 'actions-label',
+          }),
+        },
+        Scene.with(init({ id: 'test' })),
+        Scene.expect(button).toHaveAttr('aria-label', 'Actions'),
+        Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('buttonId derives the trigger id from the base id', () => {
+      expect(buttonId('test')).toBe('test-button')
     })
   })
 })

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -1,4 +1,12 @@
-import { Array, Effect, Equal, Match as M, Option, Schema as S } from 'effect'
+import {
+  Array,
+  Effect,
+  Equal,
+  Match as M,
+  Option,
+  Predicate,
+  Schema as S,
+} from 'effect'
 import * as Command from 'foldkit/command'
 import * as Dom from 'foldkit/dom'
 import {
@@ -177,6 +185,12 @@ const closedModel = (model: Model): Model =>
 
 const buttonSelector = (id: string): string => idSelector(`${id}-button`)
 const panelSelector = (id: string): string => idSelector(`${id}-panel`)
+
+/** Returns the bare DOM id of the popover trigger button, derived from the
+ *  popover's base id. Use this to associate an external label with the
+ *  trigger via a native `<label for={Popover.buttonId(id)}>` or an
+ *  `aria-labelledby` reference. */
+export const buttonId = (id: string): string => `${id}-button`
 
 type UpdateReturn = readonly [
   Model,
@@ -500,6 +514,8 @@ export type ViewInputs = Readonly<{
   toView: (render: RenderInfo) => Html
   isDisabled?: boolean
   focusSelector?: string
+  ariaLabel?: string
+  ariaLabelledBy?: string
 }>
 
 /** Renders a headless popover with a trigger button and a floating panel. */
@@ -514,7 +530,14 @@ export const view = defineView<Model, Message, ViewInputs>(
       animation: { transitionState },
       maybeLastButtonPointerType,
     } = model
-    const { anchor, toView, isDisabled, focusSelector } = viewInputs
+    const {
+      anchor,
+      toView,
+      isDisabled,
+      focusSelector,
+      ariaLabel,
+      ariaLabelledBy,
+    } = viewInputs
 
     const isLeaving =
       transitionState === 'LeaveStart' || transitionState === 'LeaveAnimating'
@@ -588,11 +611,24 @@ export const view = defineView<Model, Message, ViewInputs>(
         M.orElse(() => Option.none()),
       )
 
+    const resolveButtonLabel = () => {
+      if (Predicate.isNotUndefined(ariaLabel)) {
+        return [h.AriaLabel(ariaLabel)]
+      } else if (Predicate.isNotUndefined(ariaLabelledBy)) {
+        return [h.AriaLabelledBy(ariaLabelledBy)]
+      } else {
+        return []
+      }
+    }
+
+    const buttonLabelAttributes = resolveButtonLabel()
+
     const buttonAttributes = [
       h.Id(`${id}-button`),
       h.Type('button'),
       h.AriaExpanded(isVisible),
       h.AriaControls(`${id}-panel`),
+      ...buttonLabelAttributes,
       ...(isDisabled
         ? [h.AriaDisabled(true), h.DataAttribute('disabled', '')]
         : [

--- a/packages/ui/src/popover/public.ts
+++ b/packages/ui/src/popover/public.ts
@@ -4,6 +4,7 @@ export {
   open,
   close,
   view,
+  buttonId,
   Model,
   Message,
   OutMessage,

--- a/packages/ui/src/popover/scene.test.ts
+++ b/packages/ui/src/popover/scene.test.ts
@@ -1,5 +1,6 @@
 import { html } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
+import { expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
@@ -10,6 +11,7 @@ import {
   CompletedPortalPopoverBackdrop,
   PortalPopoverBackdrop,
   RequestedOpen,
+  buttonId,
   init,
   update,
   view,
@@ -173,6 +175,54 @@ describe('Popover', () => {
           acknowledgeAnchor,
           acknowledgeBackdrop,
         )
+      })
+    })
+
+    describe('button labeling', () => {
+      it('no aria-label or aria-labelledby on the button by default', () => {
+        Scene.scene(
+          { update, view: sceneView() },
+          Scene.with(closedModel),
+          Scene.expect(button).not.toHaveAttr('aria-label'),
+          Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+        )
+      })
+
+      it('applies aria-label to the button when ariaLabel is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabel: 'Options' }) },
+          Scene.with(closedModel),
+          Scene.expect(button).toHaveAttr('aria-label', 'Options'),
+          Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+        )
+      })
+
+      it('applies aria-labelledby to the button when ariaLabelledBy is provided', () => {
+        Scene.scene(
+          { update, view: sceneView({ ariaLabelledBy: 'options-label' }) },
+          Scene.with(closedModel),
+          Scene.expect(button).toHaveAttr('aria-labelledby', 'options-label'),
+          Scene.expect(button).not.toHaveAttr('aria-label'),
+        )
+      })
+
+      it('prefers aria-label over aria-labelledby when both are provided', () => {
+        Scene.scene(
+          {
+            update,
+            view: sceneView({
+              ariaLabel: 'Options',
+              ariaLabelledBy: 'options-label',
+            }),
+          },
+          Scene.with(closedModel),
+          Scene.expect(button).toHaveAttr('aria-label', 'Options'),
+          Scene.expect(button).not.toHaveAttr('aria-labelledby'),
+        )
+      })
+
+      it('buttonId derives the trigger id from the base id', () => {
+        expect(buttonId('test')).toBe('test-button')
       })
     })
   })

--- a/packages/ui/src/tooltip/index.ts
+++ b/packages/ui/src/tooltip/index.ts
@@ -6,6 +6,7 @@ import {
   Match as M,
   Number,
   Option,
+  Predicate,
   Schema as S,
 } from 'effect'
 import * as Command from 'foldkit/command'
@@ -111,6 +112,14 @@ export const OutMessage = S.Union([Shown, Hidden])
 export type Shown = typeof Shown.Type
 export type Hidden = typeof Hidden.Type
 export type OutMessage = typeof OutMessage.Type
+
+// SELECTORS
+
+/** Returns the bare DOM id of the tooltip trigger button, derived from the
+ *  tooltip's base id. Use this to associate an external label with the
+ *  trigger via a native `<label for={Tooltip.triggerId(id)}>` or an
+ *  `aria-labelledby` reference. */
+export const triggerId = (id: string): string => `${id}-trigger`
 
 // INIT
 
@@ -356,6 +365,8 @@ export type ViewInputs = Readonly<{
   anchor: AnchorConfig
   toView: (render: RenderInfo) => Html
   isDisabled?: boolean
+  ariaLabel?: string
+  ariaLabelledBy?: string
 }>
 
 /** Renders a headless tooltip with an anchored non-interactive panel.
@@ -367,7 +378,19 @@ export const view = defineView<Model, Message, ViewInputs>(
     const h = html<Message>()
 
     const { id, isOpen } = model
-    const { anchor, toView, isDisabled } = viewInputs
+    const { anchor, toView, isDisabled, ariaLabel, ariaLabelledBy } = viewInputs
+
+    const resolveTriggerLabel = () => {
+      if (Predicate.isNotUndefined(ariaLabel)) {
+        return [h.AriaLabel(ariaLabel)]
+      } else if (Predicate.isNotUndefined(ariaLabelledBy)) {
+        return [h.AriaLabelledBy(ariaLabelledBy)]
+      } else {
+        return []
+      }
+    }
+
+    const triggerLabelAttributes = resolveTriggerLabel()
 
     const handleTriggerKeyDown = (key: string): Option.Option<PressedEscape> =>
       M.value(key).pipe(
@@ -385,6 +408,7 @@ export const view = defineView<Model, Message, ViewInputs>(
       h.Id(`${id}-trigger`),
       h.Type('button'),
       h.AriaDescribedBy(`${id}-panel`),
+      ...triggerLabelAttributes,
       ...(isOpen ? [h.DataAttribute('open', '')] : []),
       ...(isDisabled
         ? [h.AriaDisabled(true), h.DataAttribute('disabled', '')]

--- a/packages/ui/src/tooltip/public.ts
+++ b/packages/ui/src/tooltip/public.ts
@@ -2,6 +2,7 @@ export {
   init,
   update,
   view,
+  triggerId,
   reflectShowDelay,
   Model,
   Message,

--- a/packages/ui/src/tooltip/scene.test.ts
+++ b/packages/ui/src/tooltip/scene.test.ts
@@ -1,5 +1,6 @@
 import { html, submodel } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
+import { expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
@@ -9,6 +10,7 @@ import {
   CompletedAnchorTooltip,
   FocusedTrigger,
   init,
+  triggerId,
   update,
   view,
 } from './index.js'
@@ -19,7 +21,13 @@ const acknowledgeAnchor = Scene.Mount.resolve(
 )
 
 const sceneView =
-  (overrides: { isDisabled?: boolean } = {}) =>
+  (
+    overrides: {
+      isDisabled?: boolean
+      ariaLabel?: string
+      ariaLabelledBy?: string
+    } = {},
+  ) =>
   (model: Model) => {
     const h = html<Message>()
 
@@ -30,6 +38,8 @@ const sceneView =
       viewInputs: {
         anchor: { placement: 'top' },
         isDisabled: overrides.isDisabled,
+        ariaLabel: overrides.ariaLabel,
+        ariaLabelledBy: overrides.ariaLabelledBy,
         toView: ({ trigger, panel, isVisible }) =>
           h.div(
             [],
@@ -111,6 +121,54 @@ describe('Tooltip', () => {
         Scene.expect(trigger).not.toHaveHandler('mouseenter'),
         Scene.expect(trigger).not.toHaveHandler('focus'),
       )
+    })
+  })
+
+  describe('trigger labeling', () => {
+    it('no aria-label or aria-labelledby on the trigger by default', () => {
+      Scene.scene(
+        { update, view: sceneView() },
+        Scene.with(hiddenModel),
+        Scene.expect(trigger).not.toHaveAttr('aria-label'),
+        Scene.expect(trigger).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('applies aria-label to the trigger when ariaLabel is provided', () => {
+      Scene.scene(
+        { update, view: sceneView({ ariaLabel: 'More info' }) },
+        Scene.with(hiddenModel),
+        Scene.expect(trigger).toHaveAttr('aria-label', 'More info'),
+        Scene.expect(trigger).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('applies aria-labelledby to the trigger when ariaLabelledBy is provided', () => {
+      Scene.scene(
+        { update, view: sceneView({ ariaLabelledBy: 'info-label' }) },
+        Scene.with(hiddenModel),
+        Scene.expect(trigger).toHaveAttr('aria-labelledby', 'info-label'),
+        Scene.expect(trigger).not.toHaveAttr('aria-label'),
+      )
+    })
+
+    it('prefers aria-label over aria-labelledby when both are provided', () => {
+      Scene.scene(
+        {
+          update,
+          view: sceneView({
+            ariaLabel: 'More info',
+            ariaLabelledBy: 'info-label',
+          }),
+        },
+        Scene.with(hiddenModel),
+        Scene.expect(trigger).toHaveAttr('aria-label', 'More info'),
+        Scene.expect(trigger).not.toHaveAttr('aria-labelledby'),
+      )
+    })
+
+    it('triggerId derives the trigger id from the base id', () => {
+      expect(triggerId('test')).toBe('test-trigger')
     })
   })
 })

--- a/packages/website/src/page/ui/combobox.ts
+++ b/packages/website/src/page/ui/combobox.ts
@@ -143,15 +143,29 @@ export const comboboxDemo = (comboboxModel: Combobox.Model) => {
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: comboboxModel.id,
-          model: comboboxModel,
-          view: CityCombobox.view,
-          viewInputs: comboboxViewInputs(comboboxModel.inputValue),
-          toParentMessage: message => GotComboboxDemoMessage({ message }),
-        }),
+        h.label(
+          [
+            h.For(Combobox.inputId(comboboxModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['City'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: comboboxModel.id,
+              model: comboboxModel,
+              view: CityCombobox.view,
+              viewInputs: {
+                ...comboboxViewInputs(comboboxModel.inputValue),
+              },
+              toParentMessage: message => GotComboboxDemoMessage({ message }),
+            }),
+          ],
+        ),
       ],
     ),
   ]
@@ -162,16 +176,30 @@ export const nullableDemo = (comboboxNullableModel: Combobox.Model) => {
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: comboboxNullableModel.id,
-          model: comboboxNullableModel,
-          view: CityCombobox.view,
-          viewInputs: comboboxViewInputs(comboboxNullableModel.inputValue),
-          toParentMessage: message =>
-            GotComboboxNullableDemoMessage({ message }),
-        }),
+        h.label(
+          [
+            h.For(Combobox.inputId(comboboxNullableModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['City'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: comboboxNullableModel.id,
+              model: comboboxNullableModel,
+              view: CityCombobox.view,
+              viewInputs: {
+                ...comboboxViewInputs(comboboxNullableModel.inputValue),
+              },
+              toParentMessage: message =>
+                GotComboboxNullableDemoMessage({ message }),
+            }),
+          ],
+        ),
       ],
     ),
   ]
@@ -189,16 +217,30 @@ export const selectOnFocusDemo = (
       ' to highlight the input text when the combobox receives focus. Typing immediately replaces the current value, making it easy to start a new search without manually clearing the input.',
     ),
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: comboboxSelectOnFocusModel.id,
-          model: comboboxSelectOnFocusModel,
-          view: CityCombobox.view,
-          viewInputs: comboboxViewInputs(comboboxSelectOnFocusModel.inputValue),
-          toParentMessage: message =>
-            GotComboboxSelectOnFocusDemoMessage({ message }),
-        }),
+        h.label(
+          [
+            h.For(Combobox.inputId(comboboxSelectOnFocusModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['City'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: comboboxSelectOnFocusModel.id,
+              model: comboboxSelectOnFocusModel,
+              view: CityCombobox.view,
+              viewInputs: {
+                ...comboboxViewInputs(comboboxSelectOnFocusModel.inputValue),
+              },
+              toParentMessage: message =>
+                GotComboboxSelectOnFocusDemoMessage({ message }),
+            }),
+          ],
+        ),
       ],
     ),
   ]
@@ -214,27 +256,42 @@ export const multiDemo = (comboboxMultiModel: Combobox.Multi.Model) => {
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.div(
-          [h.Class('flex flex-wrap gap-1.5 mb-2')],
-          Array.match(comboboxMultiModel.selectedItems, {
-            onEmpty: () => [
-              h.span([h.Class(emptyTagClassName)], ['No selection']),
-            ],
-            onNonEmpty: selectedItems =>
-              selectedItems.map(item =>
-                h.span([h.Class(tagClassName)], [item]),
-              ),
-          }),
+        h.label(
+          [
+            h.For(Combobox.inputId(comboboxMultiModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Cities'],
         ),
-        h.submodel({
-          slotId: comboboxMultiModel.id,
-          model: comboboxMultiModel,
-          view: CityMultiCombobox.view,
-          viewInputs: comboboxViewInputs(comboboxMultiModel.inputValue),
-          toParentMessage: message => GotComboboxMultiDemoMessage({ message }),
-        }),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.div(
+              [h.Class('flex flex-wrap gap-1.5 mb-2')],
+              Array.match(comboboxMultiModel.selectedItems, {
+                onEmpty: () => [
+                  h.span([h.Class(emptyTagClassName)], ['No selection']),
+                ],
+                onNonEmpty: selectedItems =>
+                  selectedItems.map(item =>
+                    h.span([h.Class(tagClassName)], [item]),
+                  ),
+              }),
+            ),
+            h.submodel({
+              slotId: comboboxMultiModel.id,
+              model: comboboxMultiModel,
+              view: CityMultiCombobox.view,
+              viewInputs: {
+                ...comboboxViewInputs(comboboxMultiModel.inputValue),
+              },
+              toParentMessage: message =>
+                GotComboboxMultiDemoMessage({ message }),
+            }),
+          ],
+        ),
       ],
     ),
   ]

--- a/packages/website/src/page/ui/comboboxPage.ts
+++ b/packages/website/src/page/ui/comboboxPage.ts
@@ -212,6 +212,18 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
     description:
       'Floating positioning config: placement, gap, offset, padding, and portal. The items panel is always anchored to the input wrapper; when omitted, the panel uses bottom-start placement. Portaled to the document body by default; pass portal: false to keep the panel inside the wrapper.',
   },
+  {
+    name: 'ariaLabel',
+    type: 'string',
+    description:
+      'Accessible name for the input. Use when there is no visible label. Applied as aria-label, and takes precedence over ariaLabelledBy.',
+  },
+  {
+    name: 'ariaLabelledBy',
+    type: 'string',
+    description:
+      'Id of an external element that labels the input, applied as aria-labelledby. Pair with a visible label element.',
+  },
 ]
 
 const outMessageProps: ReadonlyArray<PropEntry> = [
@@ -454,6 +466,30 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           ' with ',
           inlineCode('aria-selected'),
           '.',
+        ),
+        para(
+          'The input is a form field, so give it an accessible name. For a visible label, wire a native ',
+          inlineCode('<label for>'),
+          ' that targets the input id with ',
+          inlineCode('Combobox.inputId(id)'),
+          ' rather than hardcoding the ',
+          inlineCode('-input'),
+          ' convention. The ',
+          inlineCode('for'),
+          ' association makes the input properly labeled: assistive technology announces it by the visible label text, and clicking the label focuses the input. That is why it is the recommended pattern.',
+        ),
+        para(
+          'Two ViewInputs cover the cases a ',
+          inlineCode('<label for>'),
+          ' does not. Pass ',
+          inlineCode('ariaLabel'),
+          ' when there is no visible label, or ',
+          inlineCode('ariaLabelledBy'),
+          ' when the element that names the input is not a ',
+          inlineCode('<label>'),
+          ' you can point ',
+          inlineCode('for'),
+          ' at.',
         ),
         heading(
           apiReferenceHeader.level,

--- a/packages/website/src/page/ui/datePicker.ts
+++ b/packages/website/src/page/ui/datePicker.ts
@@ -94,187 +94,203 @@ export const basicDemo = (model: Model) => {
     )
 
   return [
-    h.submodel({
-      slotId: model.datePickerBasicDemo.id,
-      model: model.datePickerBasicDemo,
-      view: DatePicker.view,
-      viewInputs: {
-        anchor: DATE_PICKER_ANCHOR,
-        triggerContent,
-        triggerClassName,
-        panelClassName,
-        backdropClassName,
-        className: wrapperClassName,
-        toCalendarView: attributes =>
-          M.value(attributes).pipe(
-            M.tagsExhaustive({
-              Days: days =>
-                h.div(
-                  [...days.root, h.Class(calendarWrapperClassName)],
-                  [
+    h.div(
+      [h.Class('flex flex-col gap-1.5')],
+      [
+        h.label(
+          [
+            h.For(DatePicker.triggerId(model.datePickerBasicDemo.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Due date'],
+        ),
+        h.submodel({
+          slotId: model.datePickerBasicDemo.id,
+          model: model.datePickerBasicDemo,
+          view: DatePicker.view,
+          viewInputs: {
+            anchor: DATE_PICKER_ANCHOR,
+            triggerContent,
+            triggerClassName,
+            panelClassName,
+            backdropClassName,
+            className: wrapperClassName,
+            toCalendarView: attributes =>
+              M.value(attributes).pipe(
+                M.tagsExhaustive({
+                  Days: days =>
                     h.div(
-                      [h.Class(headerClassName)],
-                      [
-                        h.button(
-                          [
-                            ...days.previousMonthButton,
-                            h.Class(navButtonClassName),
-                          ],
-                          [Icon.chevronLeft('w-5 h-5')],
-                        ),
-                        h.button(
-                          [
-                            h.Id(days.heading.id),
-                            ...days.headingButton,
-                            h.Class(headingButtonClassName),
-                          ],
-                          [days.heading.text, Icon.chevronDown('w-3 h-3')],
-                        ),
-                        h.button(
-                          [
-                            ...days.nextMonthButton,
-                            h.Class(navButtonClassName),
-                          ],
-                          [Icon.chevronRight('w-5 h-5')],
-                        ),
-                      ],
-                    ),
-                    h.div(
-                      [...days.grid, h.Class(gridClassName)],
+                      [...days.root, h.Class(calendarWrapperClassName)],
                       [
                         h.div(
-                          [...days.headerRow, h.Class(headerRowClassName)],
-                          days.columnHeaders.map(header =>
-                            h.div(
+                          [h.Class(headerClassName)],
+                          [
+                            h.button(
                               [
-                                ...header.attributes,
-                                h.Class(columnHeaderClassName),
+                                ...days.previousMonthButton,
+                                h.Class(navButtonClassName),
                               ],
-                              [header.name],
+                              [Icon.chevronLeft('w-5 h-5')],
                             ),
-                          ),
+                            h.button(
+                              [
+                                h.Id(days.heading.id),
+                                ...days.headingButton,
+                                h.Class(headingButtonClassName),
+                              ],
+                              [days.heading.text, Icon.chevronDown('w-3 h-3')],
+                            ),
+                            h.button(
+                              [
+                                ...days.nextMonthButton,
+                                h.Class(navButtonClassName),
+                              ],
+                              [Icon.chevronRight('w-5 h-5')],
+                            ),
+                          ],
                         ),
-                        ...days.weeks.map(week =>
-                          h.div(
-                            [...week.attributes, h.Class(weekRowClassName)],
-                            week.cells.map(cell =>
-                              h.div(
-                                [
-                                  ...cell.cellAttributes,
-                                  h.Class(cellClassName),
-                                ],
-                                [
-                                  h.button(
-                                    [
-                                      ...cell.buttonAttributes,
-                                      h.Class(dayButtonClassName),
-                                    ],
-                                    [cell.label],
-                                  ),
-                                ],
+                        h.div(
+                          [...days.grid, h.Class(gridClassName)],
+                          [
+                            h.div(
+                              [...days.headerRow, h.Class(headerRowClassName)],
+                              days.columnHeaders.map(header =>
+                                h.div(
+                                  [
+                                    ...header.attributes,
+                                    h.Class(columnHeaderClassName),
+                                  ],
+                                  [header.name],
+                                ),
                               ),
                             ),
+                            ...days.weeks.map(week =>
+                              h.div(
+                                [...week.attributes, h.Class(weekRowClassName)],
+                                week.cells.map(cell =>
+                                  h.div(
+                                    [
+                                      ...cell.cellAttributes,
+                                      h.Class(cellClassName),
+                                    ],
+                                    [
+                                      h.button(
+                                        [
+                                          ...cell.buttonAttributes,
+                                          h.Class(dayButtonClassName),
+                                        ],
+                                        [cell.label],
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  Months: months =>
+                    h.div(
+                      [...months.root, h.Class(calendarWrapperClassName)],
+                      [
+                        h.div(
+                          [h.Class(`${headerClassName} justify-center`)],
+                          [
+                            h.button(
+                              [
+                                h.Id(months.heading.id),
+                                ...months.headingButton,
+                                h.Class(headingButtonClassName),
+                              ],
+                              [
+                                months.heading.text,
+                                Icon.chevronDown('w-3 h-3'),
+                              ],
+                            ),
+                          ],
+                        ),
+                        h.div(
+                          [...months.grid, h.Class(monthYearGridClassName)],
+                          months.cells.map(cell =>
+                            h.div(
+                              [
+                                ...cell.cellAttributes,
+                                h.Class(monthYearCellClassName),
+                              ],
+                              [
+                                h.button(
+                                  [
+                                    ...cell.buttonAttributes,
+                                    h.Class(monthYearButtonClassName),
+                                  ],
+                                  [cell.shortLabel],
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       ],
                     ),
-                  ],
-                ),
-              Months: months =>
-                h.div(
-                  [...months.root, h.Class(calendarWrapperClassName)],
-                  [
+                  Years: years =>
                     h.div(
-                      [h.Class(`${headerClassName} justify-center`)],
+                      [...years.root, h.Class(calendarWrapperClassName)],
                       [
-                        h.button(
-                          [
-                            h.Id(months.heading.id),
-                            ...months.headingButton,
-                            h.Class(headingButtonClassName),
-                          ],
-                          [months.heading.text, Icon.chevronDown('w-3 h-3')],
-                        ),
-                      ],
-                    ),
-                    h.div(
-                      [...months.grid, h.Class(monthYearGridClassName)],
-                      months.cells.map(cell =>
                         h.div(
-                          [
-                            ...cell.cellAttributes,
-                            h.Class(monthYearCellClassName),
-                          ],
+                          [h.Class(headerClassName)],
                           [
                             h.button(
                               [
-                                ...cell.buttonAttributes,
-                                h.Class(monthYearButtonClassName),
+                                ...years.previousPageButton,
+                                h.Class(navButtonClassName),
                               ],
-                              [cell.shortLabel],
+                              [Icon.chevronLeft('w-5 h-5')],
+                            ),
+                            h.h2(
+                              [
+                                h.Id(years.heading.id),
+                                h.Class(headingTextClassName),
+                              ],
+                              [years.heading.text],
+                            ),
+                            h.button(
+                              [
+                                ...years.nextPageButton,
+                                h.Class(navButtonClassName),
+                              ],
+                              [Icon.chevronRight('w-5 h-5')],
                             ),
                           ],
                         ),
-                      ),
-                    ),
-                  ],
-                ),
-              Years: years =>
-                h.div(
-                  [...years.root, h.Class(calendarWrapperClassName)],
-                  [
-                    h.div(
-                      [h.Class(headerClassName)],
-                      [
-                        h.button(
-                          [
-                            ...years.previousPageButton,
-                            h.Class(navButtonClassName),
-                          ],
-                          [Icon.chevronLeft('w-5 h-5')],
-                        ),
-                        h.h2(
-                          [
-                            h.Id(years.heading.id),
-                            h.Class(headingTextClassName),
-                          ],
-                          [years.heading.text],
-                        ),
-                        h.button(
-                          [
-                            ...years.nextPageButton,
-                            h.Class(navButtonClassName),
-                          ],
-                          [Icon.chevronRight('w-5 h-5')],
+                        h.div(
+                          [...years.grid, h.Class(monthYearGridClassName)],
+                          years.cells.map(cell =>
+                            h.div(
+                              [
+                                ...cell.cellAttributes,
+                                h.Class(monthYearCellClassName),
+                              ],
+                              [
+                                h.button(
+                                  [
+                                    ...cell.buttonAttributes,
+                                    h.Class(monthYearButtonClassName),
+                                  ],
+                                  [cell.label],
+                                ),
+                              ],
+                            ),
+                          ),
                         ),
                       ],
                     ),
-                    h.div(
-                      [...years.grid, h.Class(monthYearGridClassName)],
-                      years.cells.map(cell =>
-                        h.div(
-                          [
-                            ...cell.cellAttributes,
-                            h.Class(monthYearCellClassName),
-                          ],
-                          [
-                            h.button(
-                              [
-                                ...cell.buttonAttributes,
-                                h.Class(monthYearButtonClassName),
-                              ],
-                              [cell.label],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-            }),
-          ),
-      },
-      toParentMessage: message => GotDatePickerBasicDemoMessage({ message }),
-    }),
+                }),
+              ),
+          },
+          toParentMessage: message =>
+            GotDatePickerBasicDemoMessage({ message }),
+        }),
+      ],
+    ),
   ]
 }

--- a/packages/website/src/page/ui/datePickerPage.ts
+++ b/packages/website/src/page/ui/datePickerPage.ts
@@ -251,6 +251,18 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
       'Class name and additional attributes spread onto the trigger button.',
   },
   {
+    name: 'ariaLabel',
+    type: 'string',
+    description:
+      'Accessible name for the trigger button. Use for an icon-only trigger with no visible label. Applied as aria-label, and takes precedence over ariaLabelledBy.',
+  },
+  {
+    name: 'ariaLabelledBy',
+    type: 'string',
+    description:
+      'Id of an external element that labels the trigger button, applied as aria-labelledby. Pair with a visible label element.',
+  },
+  {
     name: 'panelClassName / panelAttributes',
     type: 'string / ReadonlyArray<Attribute<Message>>',
     description:
@@ -547,6 +559,30 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           ' prop, the selected date is encoded as an ISO string (',
           inlineCode('YYYY-MM-DD'),
           ') for native form submission.',
+        ),
+        para(
+          'Give the trigger an accessible name. For a visible label, wire a native ',
+          inlineCode('<label for>'),
+          ' that targets the trigger id with ',
+          inlineCode('DatePicker.triggerId(id)'),
+          ' rather than hardcoding the ',
+          inlineCode('-popover-button'),
+          ' convention. The ',
+          inlineCode('for'),
+          ' association makes the trigger properly labeled: assistive technology announces it by the visible label text, and clicking the label opens the date picker. That is why it is the recommended pattern.',
+        ),
+        para(
+          'Two ViewInputs cover the cases a ',
+          inlineCode('<label for>'),
+          ' does not. Pass ',
+          inlineCode('ariaLabel'),
+          ' for an icon-only trigger with no visible label, or ',
+          inlineCode('ariaLabelledBy'),
+          ' when the element that names the trigger is not a ',
+          inlineCode('<label>'),
+          ' you can point ',
+          inlineCode('for'),
+          ' at.',
         ),
         heading(
           apiReferenceHeader.level,

--- a/packages/website/src/page/ui/disclosure.ts
+++ b/packages/website/src/page/ui/disclosure.ts
@@ -33,8 +33,15 @@ export const disclosureDemo = (disclosureModel: Disclosure.Model) => {
 
   return [
     h.div(
-      [h.Class('w-full max-w-lg')],
+      [h.Class('flex w-full max-w-lg flex-col gap-1.5')],
       [
+        h.label(
+          [
+            h.For(Disclosure.buttonId('disclosure-demo')),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Frequently asked'],
+        ),
         h.submodel({
           slotId: 'disclosure-demo',
           model: disclosureModel,

--- a/packages/website/src/page/ui/disclosurePage.ts
+++ b/packages/website/src/page/ui/disclosurePage.ts
@@ -150,6 +150,18 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
     description:
       'When true, the button is not clickable, gets `aria-disabled` and a `data-disabled` attribute.',
   },
+  {
+    name: 'ariaLabel',
+    type: 'string',
+    description:
+      'Accessible name for the toggle button. Use for an icon-only trigger with no visible label. Applied as aria-label, and takes precedence over ariaLabelledBy.',
+  },
+  {
+    name: 'ariaLabelledBy',
+    type: 'string',
+    description:
+      'Id of an external element that labels the toggle button, applied as aria-labelledby. Pair with a visible label element.',
+  },
 ]
 
 const disclosureAttributesProps: ReadonlyArray<PropEntry> = [
@@ -305,6 +317,30 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           ' and ',
           inlineCode('aria-controls'),
           ' linking to the panel. When the disclosure closes, focus is returned to the toggle button automatically.',
+        ),
+        para(
+          'Give the toggle an accessible name when its content is not self-describing. For a visible label, wire a native ',
+          inlineCode('<label for>'),
+          ' that targets the toggle id with ',
+          inlineCode('Disclosure.buttonId(id)'),
+          ' rather than hardcoding the ',
+          inlineCode('-button'),
+          ' convention. The ',
+          inlineCode('for'),
+          ' association makes the toggle properly labeled: assistive technology announces it by the visible label text, and clicking the label opens the disclosure. That is why it is the recommended pattern.',
+        ),
+        para(
+          'Two ViewInputs cover the cases a ',
+          inlineCode('<label for>'),
+          ' does not. Pass ',
+          inlineCode('ariaLabel'),
+          ' for an icon-only toggle with no visible label, or ',
+          inlineCode('ariaLabelledBy'),
+          ' when the element that names the toggle is not a ',
+          inlineCode('<label>'),
+          ' you can point ',
+          inlineCode('for'),
+          ' at.',
         ),
         heading(
           apiReferenceHeader.level,

--- a/packages/website/src/page/ui/menu.ts
+++ b/packages/website/src/page/ui/menu.ts
@@ -128,15 +128,29 @@ export const basicDemo = (menuModel: Menu.Model) => {
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: menuModel.id,
-          model: menuModel,
-          view: DemoMenu.view,
-          viewInputs: menuViewConfig(basicItemsClassName),
-          toParentMessage: message => GotMenuBasicDemoMessage({ message }),
-        }),
+        h.label(
+          [
+            h.For(Menu.buttonId(menuModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Row actions'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: menuModel.id,
+              model: menuModel,
+              view: DemoMenu.view,
+              viewInputs: {
+                ...menuViewConfig(basicItemsClassName),
+              },
+              toParentMessage: message => GotMenuBasicDemoMessage({ message }),
+            }),
+          ],
+        ),
       ],
     ),
   ]
@@ -147,15 +161,30 @@ export const animatedDemo = (menuModel: Menu.Model) => {
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: menuModel.id,
-          model: menuModel,
-          view: DemoMenu.view,
-          viewInputs: menuViewConfig(animatedItemsClassName),
-          toParentMessage: message => GotMenuAnimatedDemoMessage({ message }),
-        }),
+        h.label(
+          [
+            h.For(Menu.buttonId(menuModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Row actions'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: menuModel.id,
+              model: menuModel,
+              view: DemoMenu.view,
+              viewInputs: {
+                ...menuViewConfig(animatedItemsClassName),
+              },
+              toParentMessage: message =>
+                GotMenuAnimatedDemoMessage({ message }),
+            }),
+          ],
+        ),
       ],
     ),
   ]

--- a/packages/website/src/page/ui/menuPage.ts
+++ b/packages/website/src/page/ui/menuPage.ts
@@ -254,6 +254,18 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
     type: 'ReadonlyArray<ChildAttribute> | undefined',
     description: 'Extra attributes spread onto the outer Menu root element.',
   },
+  {
+    name: 'ariaLabel',
+    type: 'string',
+    description:
+      'Accessible name for the trigger button. Use for an icon-only trigger with no visible label. Applied as aria-label, and takes precedence over ariaLabelledBy.',
+  },
+  {
+    name: 'ariaLabelledBy',
+    type: 'string',
+    description:
+      'Id of an external element that labels the trigger button, applied as aria-labelledby. Pair with a visible label element.',
+  },
 ]
 
 const outMessageProps: ReadonlyArray<PropEntry> = [
@@ -444,6 +456,30 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           '. Each item receives ',
           inlineCode('role="menuitem"'),
           '.',
+        ),
+        para(
+          'Give the trigger an accessible name. For a visible label, wire a native ',
+          inlineCode('<label for>'),
+          ' that targets the trigger id with ',
+          inlineCode('Menu.buttonId(id)'),
+          ' rather than hardcoding the ',
+          inlineCode('-button'),
+          ' convention. The ',
+          inlineCode('for'),
+          ' association makes the trigger properly labeled: assistive technology announces it by the visible label text, and clicking the label opens the menu. That is why it is the recommended pattern.',
+        ),
+        para(
+          'Two ViewInputs cover the cases a ',
+          inlineCode('<label for>'),
+          ' does not. Pass ',
+          inlineCode('ariaLabel'),
+          ' for an icon-only trigger with no visible label, or ',
+          inlineCode('ariaLabelledBy'),
+          ' when the element that names the trigger is not a ',
+          inlineCode('<label>'),
+          ' you can point ',
+          inlineCode('for'),
+          ' at.',
         ),
         heading(
           apiReferenceHeader.level,

--- a/packages/website/src/page/ui/popover.ts
+++ b/packages/website/src/page/ui/popover.ts
@@ -123,12 +123,24 @@ export const basicDemo = (popoverModel: Popover.Model) => {
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        popoverDemo(
-          popoverModel,
-          message => GotPopoverBasicDemoMessage({ message }),
-          basicPanelClassName,
+        h.label(
+          [
+            h.For(Popover.buttonId(popoverModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Product menu'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            popoverDemo(
+              popoverModel,
+              message => GotPopoverBasicDemoMessage({ message }),
+              basicPanelClassName,
+            ),
+          ],
         ),
       ],
     ),
@@ -140,12 +152,24 @@ export const animatedDemo = (popoverModel: Popover.Model) => {
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        popoverDemo(
-          popoverModel,
-          message => GotPopoverAnimatedDemoMessage({ message }),
-          animatedPanelClassName,
+        h.label(
+          [
+            h.For(Popover.buttonId(popoverModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Product menu'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            popoverDemo(
+              popoverModel,
+              message => GotPopoverAnimatedDemoMessage({ message }),
+              animatedPanelClassName,
+            ),
+          ],
         ),
       ],
     ),
@@ -160,6 +184,7 @@ const nestedChildPopover = (childPopoverModel: Popover.Model): Html => {
     model: childPopoverModel,
     view: Popover.view,
     viewInputs: {
+      ariaLabel: 'Advanced settings',
       anchor: NESTED_POPOVER_ANCHOR,
       toView: ({ button, panel, backdrop, isVisible }) =>
         h.div(
@@ -208,55 +233,70 @@ export const nestedDemo = (
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: parentPopoverModel.id,
-          model: parentPopoverModel,
-          view: Popover.view,
-          viewInputs: {
-            anchor: POPOVER_ANCHOR,
-            focusSelector: nestedChildButtonSelector,
-            toView: ({ button, panel, backdrop, isVisible }) =>
-              h.div(
-                [h.Class(wrapperClassName)],
-                [
-                  h.button(
-                    [...button, h.Class(triggerClassName)],
-                    [h.span([], ['Account'])],
-                  ),
-                  ...(isVisible
-                    ? [
-                        h.div([...backdrop, h.Class(backdropClassName)], []),
-                        h.div(
-                          [...panel, h.Class(basicPanelClassName)],
-                          [
+        h.label(
+          [
+            h.For(Popover.buttonId(parentPopoverModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Account'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: parentPopoverModel.id,
+              model: parentPopoverModel,
+              view: Popover.view,
+              viewInputs: {
+                anchor: POPOVER_ANCHOR,
+                focusSelector: nestedChildButtonSelector,
+                toView: ({ button, panel, backdrop, isVisible }) =>
+                  h.div(
+                    [h.Class(wrapperClassName)],
+                    [
+                      h.button(
+                        [...button, h.Class(triggerClassName)],
+                        [h.span([], ['Account'])],
+                      ),
+                      ...(isVisible
+                        ? [
                             h.div(
-                              [h.Class('flex flex-col gap-4')],
+                              [...backdrop, h.Class(backdropClassName)],
+                              [],
+                            ),
+                            h.div(
+                              [...panel, h.Class(basicPanelClassName)],
                               [
-                                h.p(
+                                h.div(
+                                  [h.Class('flex flex-col gap-4')],
                                   [
-                                    h.Class(
-                                      'text-sm text-gray-600 dark:text-gray-400',
+                                    h.p(
+                                      [
+                                        h.Class(
+                                          'text-sm text-gray-600 dark:text-gray-400',
+                                        ),
+                                      ],
+                                      [
+                                        'Manage account settings without leaving this panel.',
+                                      ],
                                     ),
-                                  ],
-                                  [
-                                    'Manage account settings without leaving this panel.',
+                                    nestedChildPopover(childPopoverModel),
                                   ],
                                 ),
-                                nestedChildPopover(childPopoverModel),
                               ],
                             ),
-                          ],
-                        ),
-                      ]
-                    : []),
-                ],
-              ),
-          },
-          toParentMessage: message =>
-            GotPopoverNestedParentDemoMessage({ message }),
-        }),
+                          ]
+                        : []),
+                    ],
+                  ),
+              },
+              toParentMessage: message =>
+                GotPopoverNestedParentDemoMessage({ message }),
+            }),
+          ],
+        ),
       ],
     ),
   ]

--- a/packages/website/src/page/ui/popoverPage.ts
+++ b/packages/website/src/page/ui/popoverPage.ts
@@ -171,6 +171,18 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
     description:
       'CSS selector for the element to focus after the panel is positioned. Defaults to the panel itself.',
   },
+  {
+    name: 'ariaLabel',
+    type: 'string',
+    description:
+      'Accessible name for the trigger button. Use for an icon-only trigger with no visible label. Applied as aria-label, and takes precedence over ariaLabelledBy.',
+  },
+  {
+    name: 'ariaLabelledBy',
+    type: 'string',
+    description:
+      'Id of an external element that labels the trigger button, applied as aria-labelledby. Pair with a visible label element.',
+  },
 ]
 
 const renderInfoProps: ReadonlyArray<PropEntry> = [
@@ -374,6 +386,30 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           ' and ',
           inlineCode('aria-controls'),
           ' linking to the panel. The panel has no role. Popover uses the disclosure pattern, not the menu pattern.',
+        ),
+        para(
+          'Give the trigger an accessible name. For a visible label, wire a native ',
+          inlineCode('<label for>'),
+          ' that targets the trigger id with ',
+          inlineCode('Popover.buttonId(id)'),
+          ' rather than hardcoding the ',
+          inlineCode('-button'),
+          ' convention. The ',
+          inlineCode('for'),
+          ' association makes the trigger properly labeled: assistive technology announces it by the visible label text, and clicking the label opens the popover. That is why it is the recommended pattern.',
+        ),
+        para(
+          'Two ViewInputs cover the cases a ',
+          inlineCode('<label for>'),
+          ' does not. Pass ',
+          inlineCode('ariaLabel'),
+          ' for an icon-only trigger with no visible label, or ',
+          inlineCode('ariaLabelledBy'),
+          ' when the element that names the trigger is not a ',
+          inlineCode('<label>'),
+          ' you can point ',
+          inlineCode('for'),
+          ' at.',
         ),
         heading(
           apiReferenceHeader.level,

--- a/packages/website/src/page/ui/tooltip.ts
+++ b/packages/website/src/page/ui/tooltip.ts
@@ -28,35 +28,47 @@ export const demo = (tooltipModel: Tooltip.Model) => {
 
   return [
     h.div(
-      [h.Class('relative')],
+      [h.Class('flex flex-col gap-1.5')],
       [
-        h.submodel({
-          slotId: tooltipModel.id,
-          model: tooltipModel,
-          view: Tooltip.view,
-          viewInputs: {
-            anchor: TOOLTIP_ANCHOR,
-            toView: ({ trigger, panel, isVisible }) =>
-              h.div(
-                [h.Class(wrapperClassName)],
-                [
-                  h.button(
-                    [...trigger, h.Class(triggerClassName)],
-                    [h.span([], ['Hover or focus me'])],
+        h.label(
+          [
+            h.For(Tooltip.triggerId(tooltipModel.id)),
+            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+          ],
+          ['Tooltip trigger'],
+        ),
+        h.div(
+          [h.Class('relative')],
+          [
+            h.submodel({
+              slotId: tooltipModel.id,
+              model: tooltipModel,
+              view: Tooltip.view,
+              viewInputs: {
+                anchor: TOOLTIP_ANCHOR,
+                toView: ({ trigger, panel, isVisible }) =>
+                  h.div(
+                    [h.Class(wrapperClassName)],
+                    [
+                      h.button(
+                        [...trigger, h.Class(triggerClassName)],
+                        [h.span([], ['Hover or focus me'])],
+                      ),
+                      ...(isVisible
+                        ? [
+                            h.div(
+                              [...panel, h.Class(panelClassName)],
+                              [h.span([], ['This is a tooltip'])],
+                            ),
+                          ]
+                        : []),
+                    ],
                   ),
-                  ...(isVisible
-                    ? [
-                        h.div(
-                          [...panel, h.Class(panelClassName)],
-                          [h.span([], ['This is a tooltip'])],
-                        ),
-                      ]
-                    : []),
-                ],
-              ),
-          },
-          toParentMessage: message => GotTooltipDemoMessage({ message }),
-        }),
+              },
+              toParentMessage: message => GotTooltipDemoMessage({ message }),
+            }),
+          ],
+        ),
       ],
     ),
   ]

--- a/packages/website/src/page/ui/tooltipPage.ts
+++ b/packages/website/src/page/ui/tooltipPage.ts
@@ -157,6 +157,18 @@ const viewConfigProps: ReadonlyArray<PropEntry> = [
     description:
       'Disables the trigger. Hover, focus, and keyboard events are ignored and the tooltip will not open.',
   },
+  {
+    name: 'ariaLabel',
+    type: 'string',
+    description:
+      'Accessible name for the trigger button. Use for an icon-only trigger with no visible label. Applied as aria-label, and takes precedence over ariaLabelledBy.',
+  },
+  {
+    name: 'ariaLabelledBy',
+    type: 'string',
+    description:
+      'Id of an external element that labels the trigger button, applied as aria-labelledby. Pair with a visible label element.',
+  },
 ]
 
 const renderInfoProps: ReadonlyArray<PropEntry> = [
@@ -302,6 +314,30 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           ' and the trigger is linked via ',
           inlineCode('aria-describedby'),
           '. Focus is never moved into the tooltip, so assistive technology announces the panel contents as a description of the trigger.',
+        ),
+        para(
+          'The tooltip describes the trigger but does not name it, so give the trigger an accessible name. For a visible label, wire a native ',
+          inlineCode('<label for>'),
+          ' that targets the trigger id with ',
+          inlineCode('Tooltip.triggerId(id)'),
+          ' rather than hardcoding the ',
+          inlineCode('-trigger'),
+          ' convention. The ',
+          inlineCode('for'),
+          ' association makes the trigger properly labeled: assistive technology announces it by the visible label text, and clicking the label focuses the trigger. That is why it is the recommended pattern.',
+        ),
+        para(
+          'Two ViewInputs cover the cases a ',
+          inlineCode('<label for>'),
+          ' does not. Pass ',
+          inlineCode('ariaLabel'),
+          ' for an icon-only trigger with no visible label, or ',
+          inlineCode('ariaLabelledBy'),
+          ' when the element that names the trigger is not a ',
+          inlineCode('<label>'),
+          ' you can point ',
+          inlineCode('for'),
+          ' at.',
         ),
         heading(
           apiReferenceHeader.level,

--- a/packages/website/src/snippet/uiComboboxBasic.ts
+++ b/packages/website/src/snippet/uiComboboxBasic.ts
@@ -83,38 +83,51 @@ const filteredCities =
         city.toLowerCase().includes(model.combobox.inputValue.toLowerCase()),
       )
 
-// Inside your view function, embed the Combobox via h.submodel:
+// Inside your view function, embed the Combobox via h.submodel. Give the
+// input an accessible name: target the input id with `Combobox.inputId('city')`
+// from a native `<label for>`, and pass `ariaLabelledBy` so the input is named
+// by the label. The attribute is only emitted when provided, so the input
+// never carries a dangling `aria-labelledby`.
 const view = () => {
   const h = html<Message>()
 
-  return h.submodel({
-    slotId: 'city',
-    model: model.combobox,
-    view: CityCombobox.view,
-    viewInputs: {
-      items: filteredCities,
-      itemToValue: city => city,
-      itemToDisplayText: city => city,
-      itemToConfig: (city, { isSelected }) => ({
-        className: 'px-3 py-2 cursor-pointer data-[active]:bg-blue-100',
-        content: h.div(
-          [h.Class('flex items-center gap-2')],
-          [
-            isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
-            h.span([], [city]),
-          ],
-        ),
+  const labelId = 'city-label'
+
+  return h.div(
+    [h.Class('flex flex-col gap-1.5')],
+    [
+      h.label([h.Id(labelId), h.For(Combobox.inputId('city'))], ['City']),
+      h.submodel({
+        slotId: 'city',
+        model: model.combobox,
+        view: CityCombobox.view,
+        viewInputs: {
+          ariaLabelledBy: labelId,
+          items: filteredCities,
+          itemToValue: city => city,
+          itemToDisplayText: city => city,
+          itemToConfig: (city, { isSelected }) => ({
+            className: 'px-3 py-2 cursor-pointer data-[active]:bg-blue-100',
+            content: h.div(
+              [h.Class('flex items-center gap-2')],
+              [
+                isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
+                h.span([], [city]),
+              ],
+            ),
+          }),
+          inputAttributes: childAttributes([
+            h.Class('w-full rounded-lg border px-3 py-2'),
+            h.Placeholder('Search cities...'),
+          ]),
+          itemsAttributes: childAttributes([
+            h.Class('rounded-lg border shadow-lg'),
+          ]),
+          backdropAttributes: childAttributes([h.Class('fixed inset-0')]),
+          anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
+        },
+        toParentMessage: message => GotComboboxMessage({ message }),
       }),
-      inputAttributes: childAttributes([
-        h.Class('w-full rounded-lg border px-3 py-2'),
-        h.Placeholder('Search cities...'),
-      ]),
-      itemsAttributes: childAttributes([
-        h.Class('rounded-lg border shadow-lg'),
-      ]),
-      backdropAttributes: childAttributes([h.Class('fixed inset-0')]),
-      anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
-    },
-    toParentMessage: message => GotComboboxMessage({ message }),
-  })
+    ],
+  )
 }

--- a/packages/website/src/snippet/uiComboboxMulti.ts
+++ b/packages/website/src/snippet/uiComboboxMulti.ts
@@ -88,38 +88,55 @@ const filteredCities =
           .includes(model.comboboxMulti.inputValue.toLowerCase()),
       )
 
-// Inside your view function, embed the Combobox.Multi via h.submodel:
+// Inside your view function, embed the Combobox.Multi via h.submodel. As with
+// the single-select Combobox, give the input an accessible name: target the
+// input id with `Combobox.Multi.inputId('cities-multi')` from a native
+// `<label for>`, and pass `ariaLabelledBy` so the input is named by the label.
+// The attribute is only emitted when provided, so the input never carries a
+// dangling `aria-labelledby`.
 const view = () => {
   const h = html<Message>()
 
-  return h.submodel({
-    slotId: 'cities-multi',
-    model: model.comboboxMulti,
-    view: CitiesCombobox.view,
-    viewInputs: {
-      items: filteredCities,
-      itemToValue: city => city,
-      itemToDisplayText: city => city,
-      itemToConfig: (city, { isSelected }) => ({
-        className: 'px-3 py-2 cursor-pointer data-[active]:bg-blue-100',
-        content: h.div(
-          [h.Class('flex items-center gap-2')],
-          [
-            isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
-            h.span([], [city]),
-          ],
-        ),
+  const labelId = 'cities-multi-label'
+
+  return h.div(
+    [h.Class('flex flex-col gap-1.5')],
+    [
+      h.label(
+        [h.Id(labelId), h.For(Combobox.Multi.inputId('cities-multi'))],
+        ['Cities'],
+      ),
+      h.submodel({
+        slotId: 'cities-multi',
+        model: model.comboboxMulti,
+        view: CitiesCombobox.view,
+        viewInputs: {
+          ariaLabelledBy: labelId,
+          items: filteredCities,
+          itemToValue: city => city,
+          itemToDisplayText: city => city,
+          itemToConfig: (city, { isSelected }) => ({
+            className: 'px-3 py-2 cursor-pointer data-[active]:bg-blue-100',
+            content: h.div(
+              [h.Class('flex items-center gap-2')],
+              [
+                isSelected ? h.span([], ['✓']) : h.span([h.Class('w-4')], []),
+                h.span([], [city]),
+              ],
+            ),
+          }),
+          inputAttributes: childAttributes([
+            h.Class('w-full rounded-lg border px-3 py-2'),
+            h.Placeholder('Search cities...'),
+          ]),
+          itemsAttributes: childAttributes([
+            h.Class('rounded-lg border shadow-lg'),
+          ]),
+          backdropAttributes: childAttributes([h.Class('fixed inset-0')]),
+          anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
+        },
+        toParentMessage: message => GotComboboxMultiMessage({ message }),
       }),
-      inputAttributes: childAttributes([
-        h.Class('w-full rounded-lg border px-3 py-2'),
-        h.Placeholder('Search cities...'),
-      ]),
-      itemsAttributes: childAttributes([
-        h.Class('rounded-lg border shadow-lg'),
-      ]),
-      backdropAttributes: childAttributes([h.Class('fixed inset-0')]),
-      anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
-    },
-    toParentMessage: message => GotComboboxMultiMessage({ message }),
-  })
+    ],
+  )
 }

--- a/packages/website/src/snippet/uiDatePickerBasic.ts
+++ b/packages/website/src/snippet/uiDatePickerBasic.ts
@@ -98,207 +98,238 @@ GotDatePickerMessage: ({ message }) => {
 // Inside your view function, embed the DatePicker via h.submodel. The
 // `toCalendarView` callback receives a discriminated `CalendarAttributes`
 // whose variant matches the calendar's current `viewMode`. Pattern-match
-// on `_tag` to render the day grid, the months grid, or the years grid:
+// on `_tag` to render the day grid, the months grid, or the years grid.
+//
+// The trigger is a form field, so give it an accessible name. Pass
+// `ariaLabelledBy` with the id of a visible label element, and render that
+// label targeting the trigger id with
+// `DatePicker.triggerId('date-picker-demo')` for a native `<label for>`. The
+// attribute is only emitted when provided, so the trigger never carries a
+// dangling `aria-labelledby`.
 const view = () => {
   const h = html<Message>()
 
-  return h.submodel({
-    slotId: 'date-picker-demo',
-    model: model.datePickerDemo,
-    view: DatePicker.view,
-    viewInputs: {
-      anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
-      triggerContent: maybeDate =>
-        Option.match(maybeDate, {
-          onNone: () => h.span([], ['Pick a date']),
-          onSome: date =>
-            h.span([], [`${date.year}-${date.month}-${date.day}`]),
-        }),
-      toCalendarView: attributes =>
-        M.value(attributes).pipe(
-          M.tagsExhaustive({
-            Days: days =>
-              h.div(
-                [...days.root, h.Class('flex flex-col gap-3 p-4')],
-                [
+  const labelId = 'date-picker-label'
+
+  return h.div(
+    [h.Class('flex flex-col gap-1.5')],
+    [
+      h.label(
+        [h.Id(labelId), h.For(DatePicker.triggerId('date-picker-demo'))],
+        ['Date'],
+      ),
+      h.submodel({
+        slotId: 'date-picker-demo',
+        model: model.datePickerDemo,
+        view: DatePicker.view,
+        viewInputs: {
+          ariaLabelledBy: labelId,
+          anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
+          triggerContent: maybeDate =>
+            Option.match(maybeDate, {
+              onNone: () => h.span([], ['Pick a date']),
+              onSome: date =>
+                h.span([], [`${date.year}-${date.month}-${date.day}`]),
+            }),
+          toCalendarView: attributes =>
+            M.value(attributes).pipe(
+              M.tagsExhaustive({
+                Days: days =>
                   h.div(
-                    [h.Class('flex items-center justify-between')],
-                    [
-                      h.button(
-                        [...days.previousMonthButton, h.Class('rounded px-2')],
-                        ['‹'],
-                      ),
-                      h.button(
-                        [
-                          h.Id(days.heading.id),
-                          ...days.headingButton,
-                          h.Class(
-                            'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                          ),
-                        ],
-                        [days.heading.text, ' ▾'],
-                      ),
-                      h.button(
-                        [...days.nextMonthButton, h.Class('rounded px-2')],
-                        ['›'],
-                      ),
-                    ],
-                  ),
-                  h.div(
-                    [...days.grid, h.Class('flex flex-col gap-1 outline-none')],
+                    [...days.root, h.Class('flex flex-col gap-3 p-4')],
                     [
                       h.div(
-                        [...days.headerRow, h.Class('grid grid-cols-7 gap-1')],
-                        days.columnHeaders.map(header =>
+                        [h.Class('flex items-center justify-between')],
+                        [
+                          h.button(
+                            [
+                              ...days.previousMonthButton,
+                              h.Class('rounded px-2'),
+                            ],
+                            ['‹'],
+                          ),
+                          h.button(
+                            [
+                              h.Id(days.heading.id),
+                              ...days.headingButton,
+                              h.Class(
+                                'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
+                              ),
+                            ],
+                            [days.heading.text, ' ▾'],
+                          ),
+                          h.button(
+                            [...days.nextMonthButton, h.Class('rounded px-2')],
+                            ['›'],
+                          ),
+                        ],
+                      ),
+                      h.div(
+                        [
+                          ...days.grid,
+                          h.Class('flex flex-col gap-1 outline-none'),
+                        ],
+                        [
                           h.div(
                             [
-                              ...header.attributes,
-                              h.Class('text-center text-xs uppercase'),
+                              ...days.headerRow,
+                              h.Class('grid grid-cols-7 gap-1'),
                             ],
-                            [header.name],
-                          ),
-                        ),
-                      ),
-                      ...days.weeks.map(week =>
-                        h.div(
-                          [
-                            ...week.attributes,
-                            h.Class('grid grid-cols-7 gap-1'),
-                          ],
-                          week.cells.map(cell =>
-                            h.div(
-                              [
-                                ...cell.cellAttributes,
-                                h.Class(
-                                  'group flex items-center justify-center',
-                                ),
-                              ],
-                              [
-                                h.button(
-                                  [
-                                    ...cell.buttonAttributes,
-                                    h.Class(
-                                      'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40',
-                                    ),
-                                  ],
-                                  [cell.label],
-                                ),
-                              ],
+                            days.columnHeaders.map(header =>
+                              h.div(
+                                [
+                                  ...header.attributes,
+                                  h.Class('text-center text-xs uppercase'),
+                                ],
+                                [header.name],
+                              ),
                             ),
                           ),
+                          ...days.weeks.map(week =>
+                            h.div(
+                              [
+                                ...week.attributes,
+                                h.Class('grid grid-cols-7 gap-1'),
+                              ],
+                              week.cells.map(cell =>
+                                h.div(
+                                  [
+                                    ...cell.cellAttributes,
+                                    h.Class(
+                                      'group flex items-center justify-center',
+                                    ),
+                                  ],
+                                  [
+                                    h.button(
+                                      [
+                                        ...cell.buttonAttributes,
+                                        h.Class(
+                                          'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40',
+                                        ),
+                                      ],
+                                      [cell.label],
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                // The months grid renders 12 cells (one per month). Clicking the
+                // heading again drills further into the years grid.
+                Months: months =>
+                  h.div(
+                    [...months.root, h.Class('flex flex-col gap-3 p-4')],
+                    [
+                      h.div(
+                        [h.Class('flex items-center justify-center')],
+                        [
+                          h.button(
+                            [
+                              h.Id(months.heading.id),
+                              ...months.headingButton,
+                              h.Class(
+                                'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
+                              ),
+                            ],
+                            [months.heading.text, ' ▾'],
+                          ),
+                        ],
+                      ),
+                      h.div(
+                        [
+                          ...months.grid,
+                          h.Class('grid grid-cols-3 gap-1 outline-none'),
+                        ],
+                        months.cells.map(cell =>
+                          h.div(
+                            [
+                              ...cell.cellAttributes,
+                              h.Class('group flex items-center justify-center'),
+                            ],
+                            [
+                              h.button(
+                                [
+                                  ...cell.buttonAttributes,
+                                  h.Class(
+                                    'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                                  ),
+                                ],
+                                [cell.shortLabel],
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ],
                   ),
-                ],
-              ),
-            // The months grid renders 12 cells (one per month). Clicking the
-            // heading again drills further into the years grid.
-            Months: months =>
-              h.div(
-                [...months.root, h.Class('flex flex-col gap-3 p-4')],
-                [
+                // The years grid renders 12 cells (one paged window). Prev/next
+                // page through 12-year windows; clicking a year drills back to
+                // the months grid for that year.
+                Years: years =>
                   h.div(
-                    [h.Class('flex items-center justify-center')],
+                    [...years.root, h.Class('flex flex-col gap-3 p-4')],
                     [
-                      h.button(
-                        [
-                          h.Id(months.heading.id),
-                          ...months.headingButton,
-                          h.Class(
-                            'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                          ),
-                        ],
-                        [months.heading.text, ' ▾'],
-                      ),
-                    ],
-                  ),
-                  h.div(
-                    [
-                      ...months.grid,
-                      h.Class('grid grid-cols-3 gap-1 outline-none'),
-                    ],
-                    months.cells.map(cell =>
                       h.div(
-                        [
-                          ...cell.cellAttributes,
-                          h.Class('group flex items-center justify-center'),
-                        ],
+                        [h.Class('flex items-center justify-between')],
                         [
                           h.button(
                             [
-                              ...cell.buttonAttributes,
-                              h.Class(
-                                'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
-                              ),
+                              ...years.previousPageButton,
+                              h.Class('rounded px-2'),
                             ],
-                            [cell.shortLabel],
+                            ['‹'],
+                          ),
+                          h.h2(
+                            [
+                              h.Id(years.heading.id),
+                              h.Class('text-sm font-semibold'),
+                            ],
+                            [years.heading.text],
+                          ),
+                          h.button(
+                            [...years.nextPageButton, h.Class('rounded px-2')],
+                            ['›'],
                           ),
                         ],
                       ),
-                    ),
-                  ),
-                ],
-              ),
-            // The years grid renders 12 cells (one paged window). Prev/next
-            // page through 12-year windows; clicking a year drills back to
-            // the months grid for that year.
-            Years: years =>
-              h.div(
-                [...years.root, h.Class('flex flex-col gap-3 p-4')],
-                [
-                  h.div(
-                    [h.Class('flex items-center justify-between')],
-                    [
-                      h.button(
-                        [...years.previousPageButton, h.Class('rounded px-2')],
-                        ['‹'],
-                      ),
-                      h.h2(
-                        [
-                          h.Id(years.heading.id),
-                          h.Class('text-sm font-semibold'),
-                        ],
-                        [years.heading.text],
-                      ),
-                      h.button(
-                        [...years.nextPageButton, h.Class('rounded px-2')],
-                        ['›'],
-                      ),
-                    ],
-                  ),
-                  h.div(
-                    [
-                      ...years.grid,
-                      h.Class('grid grid-cols-3 gap-1 outline-none'),
-                    ],
-                    years.cells.map(cell =>
                       h.div(
                         [
-                          ...cell.cellAttributes,
-                          h.Class('group flex items-center justify-center'),
+                          ...years.grid,
+                          h.Class('grid grid-cols-3 gap-1 outline-none'),
                         ],
-                        [
-                          h.button(
+                        years.cells.map(cell =>
+                          h.div(
                             [
-                              ...cell.buttonAttributes,
-                              h.Class(
-                                'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                              ...cell.cellAttributes,
+                              h.Class('group flex items-center justify-center'),
+                            ],
+                            [
+                              h.button(
+                                [
+                                  ...cell.buttonAttributes,
+                                  h.Class(
+                                    'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
+                                  ),
+                                ],
+                                [cell.label],
                               ),
                             ],
-                            [cell.label],
                           ),
-                        ],
+                        ),
                       ),
-                    ),
+                    ],
                   ),
-                ],
-              ),
-          }),
-        ),
-      // Optional: enable hidden form input for native <form> submission:
-      name: 'appointment-date',
-    },
-    toParentMessage: message => GotDatePickerMessage({ message }),
-  })
+              }),
+            ),
+          // Optional: enable hidden form input for native <form> submission:
+          name: 'appointment-date',
+        },
+        toParentMessage: message => GotDatePickerMessage({ message }),
+      }),
+    ],
+  )
 }

--- a/packages/website/src/snippet/uiDisclosureBasic.ts
+++ b/packages/website/src/snippet/uiDisclosureBasic.ts
@@ -63,7 +63,12 @@ GotDisclosureMessage: ({ message }) => {
   })
 }
 
-// Inside your view function, embed the disclosure via h.submodel:
+// Inside your view function, embed the disclosure via h.submodel. The toggle
+// text below names the button. When the toggle is icon-only, give it a name
+// with `ariaLabel`, or point `ariaLabelledBy` at a visible label element
+// (target the toggle id with `Disclosure.buttonId('faq-1')` for a native
+// `<label for>`). Either attribute is only emitted when provided, so the
+// toggle never carries a dangling `aria-labelledby`.
 const view = (model: Model) => {
   const h = html<Message>()
 
@@ -72,6 +77,7 @@ const view = (model: Model) => {
     model: model.disclosure,
     view: Disclosure.view,
     viewInputs: {
+      // ariaLabel: 'What is Foldkit?',
       toView: attributes =>
         h.div(
           [],

--- a/packages/website/src/snippet/uiMenuBasic.ts
+++ b/packages/website/src/snippet/uiMenuBasic.ts
@@ -69,7 +69,12 @@ GotMenuMessage: ({ message }) => {
   })
 }
 
-// Inside your view function, render the menu via the factory's view:
+// Inside your view function, render the menu via the factory's view. The
+// `buttonContent` below names the trigger. When the trigger is icon-only,
+// give it a name with `ariaLabel`, or point `ariaLabelledBy` at a visible
+// label element (target the trigger id with `Menu.buttonId('menu')` for a
+// native `<label for>`). Either attribute is only emitted when provided, so
+// the trigger never carries a dangling `aria-labelledby`.
 const view = () => {
   const h = html<Message>()
 
@@ -78,6 +83,7 @@ const view = () => {
     model: model.menu,
     view: ActionMenu.view,
     viewInputs: {
+      // ariaLabel: 'Options',
       items: actions,
       buttonContent: h.span([], ['Options']),
       buttonClassName: 'rounded-lg border px-3 py-2 cursor-pointer',

--- a/packages/website/src/snippet/uiPopoverBasic.ts
+++ b/packages/website/src/snippet/uiPopoverBasic.ts
@@ -69,20 +69,32 @@ GotPopoverMessage: ({ message }) => {
   })
 }
 
-// Inside your view function, embed the popover via h.submodel:
+// Inside your view function, embed the popover via h.submodel. Give the
+// trigger an accessible name: target the trigger id with
+// `Popover.buttonId('info')` from a native `<label for>`, and pass
+// `ariaLabelledBy` so the trigger is named by the label. The attribute is
+// only emitted when provided, so the trigger never carries a dangling
+// `aria-labelledby`.
 const view = () => {
   const h = html<Message>()
+
+  const labelId = 'info-label'
 
   return h.submodel({
     slotId: 'info',
     model: model.popover,
     view: Popover.view,
     viewInputs: {
+      ariaLabelledBy: labelId,
       anchor: { placement: 'bottom-start', gap: 4, padding: 8 },
       toView: ({ button, panel, backdrop, isVisible }) =>
         h.div(
           [h.Class('relative inline-block')],
           [
+            h.label(
+              [h.Id(labelId), h.For(Popover.buttonId('info'))],
+              ['Solutions'],
+            ),
             h.button(
               [
                 ...button,

--- a/packages/website/src/snippet/uiTooltipBasic.ts
+++ b/packages/website/src/snippet/uiTooltipBasic.ts
@@ -69,7 +69,11 @@ GotTooltipMessage: ({ message }) => {
   })
 }
 
-// Inside your view function, embed the tooltip via h.submodel:
+// Inside your view function, embed the tooltip via h.submodel. The tooltip
+// describes the trigger but does not name it, so give an icon-only trigger
+// an accessible name with `ariaLabel`. (Point `ariaLabelledBy` at a visible
+// label element instead when one exists.) The attribute is only emitted when
+// provided, so the trigger never carries a dangling `aria-labelledby`.
 const view = () => {
   const h = html<Message>()
 
@@ -78,6 +82,7 @@ const view = () => {
     model: model.tooltip,
     view: Tooltip.view,
     viewInputs: {
+      ariaLabel: 'Save',
       anchor: { placement: 'top', gap: 6, padding: 8 },
       toView: ({ trigger, panel, isVisible }) =>
         h.div(
@@ -88,7 +93,8 @@ const view = () => {
                 ...trigger,
                 h.Class('rounded-lg border px-3 py-2 cursor-pointer'),
               ],
-              [h.span([], ['Save'])],
+              // Icon-only content; `ariaLabel` above supplies the name.
+              [h.span([h.AriaHidden(true)], ['💾'])],
             ),
             ...(isVisible
               ? [


### PR DESCRIPTION
Closes #554

Brings the `Ui.Listbox` external-label pattern to the remaining six trigger-based `@foldkit/ui` components. Each accepts optional `ariaLabel` and `ariaLabelledBy` on its view inputs, resolved with an if/else where `ariaLabel` wins over `ariaLabelledBy` and neither attribute is emitted when both are absent, so a trigger never carries a dangling `aria-labelledby`. Each component also exposes a bare-id helper, matched to its actual internal id convention, so a native `<label for=...>` can target the trigger without hardcoding the suffix.

## Per-component changes

| Component | Trigger element | Helper | Bare id |
| --- | --- | --- | --- |
| Combobox | `input` (role combobox) | `Combobox.inputId` / `Combobox.Multi.inputId` | `${id}-input` |
| Menu | `button` | `Menu.buttonId` | `${id}-button` |
| DatePicker | `button` (embedded Popover trigger) | `DatePicker.triggerId` | `${id}-popover-button` |
| Popover | `button` | `Popover.buttonId` | `${id}-button` |
| Tooltip | `button` | `Tooltip.triggerId` | `${id}-trigger` |
| Disclosure | `button` | `Disclosure.buttonId` | `${id}-button` |

- **Combobox**: the label targets the `role="combobox"` input. The existing internal `aria-labelledby` wiring (listbox to input) is left untouched. `inputId` is exported on both the single and `Multi` public barrels.
- **DatePicker**: the trigger is the embedded Popover's button, so `triggerId` returns `${id}-popover-button` (verified against the actual rendered id, not assumed).
- **Tooltip**: the label names the trigger alongside the existing `aria-describedby` that describes it.
- **Disclosure**: promoted the previously private `buttonId` to a public TSDoc export.

## Tests

All six components assert the five cases at the unit level: default emits neither attribute; `ariaLabel` applies and suppresses `aria-labelledby`; `ariaLabelledBy` applies and suppresses `aria-label`; `ariaLabel` wins when both are set; the `*Id(id)` helper returns the expected bare id. The `@foldkit/ui` suite (891 tests) and the ui-showcase suite (11 tests) pass.

A ui-showcase Playwright spec (`packages/examples-e2e/e2e/ui-showcase.spec.ts`) locks in the label-click behavior, mirroring the merged Listbox label test. Clicking each component's visible label: opens the button-triggers (Menu, Popover, DatePicker, Disclosure) by flipping `aria-expanded` from `false` to `true`; focuses the Combobox input without force-opening the list (`aria-expanded` stays `false`, matching native input behavior); and focuses the Tooltip trigger. All ten ui-showcase e2e tests pass in real Chromium.

## Docs and live examples

Each component's website page gains the two prop entries plus a short accessibility note, and each component's snippet demonstrates the labeling pattern. A visible label is wired into every live demo on the component docs pages and into the matching demos in the ui-showcase example, so the rendered examples carry a real accessible name.

The live-demo and showcase labels use a native `<label for={Component.bareId(id)}>` rather than `aria-labelledby` on the trigger. The native `for`/`id` association supplies both the accessible name and click-to-focus, which `aria-labelledby` alone does not (and `aria-labelledby` without a native association also gets flagged by Chrome as an unlabeled form field). The icon-only nested Popover trigger keeps `ariaLabel`, which is the correct mechanism when there is no visible label.

## Changeset

`minor` bump for `foldkit` and `@foldkit/ui` (a fixed changeset group with `@foldkit/devtools`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ