### PR TITLE
Add no-route-query-constructor-default lint rule

### DIFF
--- a/.changeset/no-route-query-constructor-default.md
+++ b/.changeset/no-route-query-constructor-default.md
@@ -1,0 +1,14 @@
+---
+'@foldkit/oxlint-plugin': minor
+'create-foldkit-app': patch
+---
+
+Add the `foldkit/no-route-query-constructor-default` rule, which flags
+`Schema.withConstructorDefault` on `Route.query` fields. A field that carries a
+constructor default becomes optional in the tagged struct's constructor-input
+type, and `Route.mapTo` consumes that type on its encode side. It no longer
+matches the required field that `Route.query` parses, so the `Route.query` plus
+`Route.mapTo` pipe stops typechecking with an opaque error. The rule reports the
+offending `withConstructorDefault` call directly so the fix is obvious: drop the
+default and model the missing parameter with `Option`. Scaffolded apps enable
+the rule alongside the other Foldkit rules.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -30,6 +30,7 @@
     "foldkit/message-binding-matches-tag": "error",
     "foldkit/got-prefix-requires-submodel-payload": "error",
     "foldkit/no-empty-object-tagged-call": "error",
+    "foldkit/no-route-query-constructor-default": "error",
     "foldkit/prefer-callable-message-constructor": "error",
     "foldkit/command-binding-matches-name": "error"
   },

--- a/packages/create-foldkit-app/templates/base/.oxlintrc.json
+++ b/packages/create-foldkit-app/templates/base/.oxlintrc.json
@@ -30,6 +30,7 @@
     "foldkit/message-binding-matches-tag": "error",
     "foldkit/got-prefix-requires-submodel-payload": "error",
     "foldkit/no-empty-object-tagged-call": "error",
+    "foldkit/no-route-query-constructor-default": "error",
     "foldkit/prefer-callable-message-constructor": "error",
     "foldkit/command-binding-matches-name": "error"
   },

--- a/packages/oxlint-plugin-foldkit/src/index.ts
+++ b/packages/oxlint-plugin-foldkit/src/index.ts
@@ -90,6 +90,39 @@ const isMemberCall = (
   node.callee.type === 'MemberExpression' &&
   isStaticMember(node.callee, objectName, propertyNames)
 
+const calleePropertyName = (
+  node: ESTree.CallExpression,
+): string | undefined => {
+  const callee = node.callee
+  if (isIdentifier(callee)) {
+    return callee.name
+  }
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    isIdentifier(callee.property)
+  ) {
+    return callee.property.name
+  }
+  return undefined
+}
+
+const isWithConstructorDefaultCall = (node: unknown): boolean => {
+  if (
+    typeof node !== 'object' ||
+    node === null ||
+    !('type' in node) ||
+    node.type !== 'CallExpression' ||
+    !('callee' in node)
+  ) {
+    return false
+  }
+  return (
+    calleePropertyName(node as ESTree.CallExpression) ===
+    'withConstructorDefault'
+  )
+}
+
 const hasTagPropertyWithStringLiteral = (
   node: ESTree.ObjectExpression,
 ): boolean =>
@@ -150,6 +183,24 @@ const innerCommandDefineCall = (
   if (callee.type !== 'CallExpression') return undefined
   if (!isMemberCall(callee, 'Command', ['define'])) return undefined
   return callee
+}
+
+const collectWithConstructorDefaultCalls = (
+  node: unknown,
+): ReadonlyArray<ESTree.CallExpression> => {
+  if (typeof node !== 'object' || node === null) {
+    return []
+  }
+  if (Array.isArray(node)) {
+    return node.flatMap(collectWithConstructorDefaultCalls)
+  }
+  const matches = isWithConstructorDefaultCall(node)
+    ? [node as ESTree.CallExpression]
+    : []
+  const nested = Object.entries(node).flatMap(([key, value]) =>
+    key === 'parent' ? [] : collectWithConstructorDefaultCalls(value),
+  )
+  return [...matches, ...nested]
 }
 
 // RULES
@@ -329,6 +380,46 @@ export const noEmptyObjectTaggedCall = Rule.define({
   },
 })
 
+export const noRouteQueryConstructorDefault = Rule.define({
+  name: 'no-route-query-constructor-default',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Avoid Schema.withConstructorDefault on Route.query fields; it breaks Route.query plus Route.mapTo composition.',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return {
+      CallExpression: (node: ESTree.Node) => {
+        if (
+          !isCallExpression(node) ||
+          !isMemberCall(node, 'Route', ['query'])
+        ) {
+          return Effect.void
+        }
+        const offendingCalls = node.arguments.flatMap(
+          collectWithConstructorDefaultCalls,
+        )
+        if (offendingCalls.length === 0) {
+          return Effect.void
+        }
+        return Effect.forEach(
+          offendingCalls,
+          offendingCall =>
+            ctx.report(
+              Diagnostic.make({
+                node: offendingCall,
+                message:
+                  'Schema.withConstructorDefault on a Route.query field makes it optional in the constructor-input type that Route.mapTo encodes, so the Route.query plus Route.mapTo pipe stops typechecking. Drop the default.',
+              }),
+            ),
+          { discard: true },
+        )
+      },
+    }
+  },
+})
+
 export const preferCallableMessageConstructor = Rule.define({
   name: 'prefer-callable-message-constructor',
   meta: Rule.meta({
@@ -420,6 +511,7 @@ export default Plugin.define({
     'message-binding-matches-tag': messageBindingMatchesTag,
     'no-empty-object-tagged-call': noEmptyObjectTaggedCall,
     'no-noop-message': noNoopMessage,
+    'no-route-query-constructor-default': noRouteQueryConstructorDefault,
     'prefer-callable-message-constructor': preferCallableMessageConstructor,
   },
 })

--- a/packages/oxlint-plugin-foldkit/test/index.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/index.test.ts
@@ -8,6 +8,7 @@ import {
   messageBindingMatchesTag,
   noEmptyObjectTaggedCall,
   noNoopMessage,
+  noRouteQueryConstructorDefault,
   preferCallableMessageConstructor,
 } from '../src/index.ts'
 
@@ -57,6 +58,17 @@ const tsAsExpression = (expression: unknown) => ({
   type: 'TSAsExpression',
   expression,
 })
+
+const withConstructorDefaultCall = (object: string) =>
+  Testing.callOfMember(object, 'withConstructorDefault', [Testing.arrowFn()])
+
+const structFields = (
+  fields: ReadonlyArray<{ readonly key: string; readonly value?: unknown }>,
+) => Testing.callOfMember('S', 'Struct', [Testing.objectExpr(fields)])
+
+const routeQuery = (
+  fields: ReadonlyArray<{ readonly key: string; readonly value?: unknown }>,
+) => Testing.callOfMember('Route', 'query', [structFields(fields)])
 
 describe('@foldkit/oxlint-plugin', () => {
   it('flags generic NoOp Messages', () => {
@@ -261,6 +273,73 @@ describe('@foldkit/oxlint-plugin', () => {
       noEmptyObjectTaggedCall,
       'CallExpression',
       Testing.callOfMember('S', 'Struct', [Testing.objectExpr([])]),
+    )
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags Schema.withConstructorDefault on a Route.query field', () => {
+    const result = Testing.runRule(
+      noRouteQueryConstructorDefault,
+      'CallExpression',
+      routeQuery([
+        { key: 'page', value: withConstructorDefaultCall('Schema') },
+      ]),
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Route.mapTo')
+  })
+
+  it('flags a bare withConstructorDefault on a Route.query field', () => {
+    const result = Testing.runRule(
+      noRouteQueryConstructorDefault,
+      'CallExpression',
+      routeQuery([
+        {
+          key: 'page',
+          value: Testing.callExpr('withConstructorDefault', [
+            Testing.arrowFn(),
+          ]),
+        },
+      ]),
+    )
+
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags every Route.query field that carries a default', () => {
+    const result = Testing.runRule(
+      noRouteQueryConstructorDefault,
+      'CallExpression',
+      routeQuery([
+        { key: 'page', value: withConstructorDefaultCall('Schema') },
+        { key: 'sort', value: withConstructorDefaultCall('S') },
+      ]),
+    )
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('allows Route.query fields without a constructor default', () => {
+    const result = Testing.runRule(
+      noRouteQueryConstructorDefault,
+      'CallExpression',
+      routeQuery([
+        { key: 'page', value: Testing.memberExpr('S', 'FiniteFromString') },
+      ]),
+    )
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('ignores withConstructorDefault outside Route.query', () => {
+    const result = Testing.runRule(
+      noRouteQueryConstructorDefault,
+      'CallExpression',
+      structFields([
+        { key: 'name', value: withConstructorDefaultCall('Schema') },
+      ]),
     )
 
     expect(result).toHaveLength(0)

--- a/packages/website/src/page/routing.ts
+++ b/packages/website/src/page/routing.ts
@@ -15,6 +15,7 @@ import {
   bestPracticesKeyingRouter,
   exampleDetailRouter,
   patternsInformingSubmodelsRouter,
+  toolingLintingRouter,
 } from '../route'
 import * as Snippet from '../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../view/codeBlock'
@@ -335,6 +336,25 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         '. ',
         inlineCode('S.FiniteFromString'),
         ' automatically parses string query values into numbers.',
+      ),
+      warningCallout(
+        'Don’t put Schema.withConstructorDefault on route fields.',
+        'A field that carries ',
+        inlineCode('Schema.withConstructorDefault'),
+        ' becomes optional in the tagged struct’s constructor-input type, and ',
+        inlineCode('Route.mapTo'),
+        ' consumes that constructor-input type on its encode side. It no longer matches the required field that ',
+        inlineCode('Route.query'),
+        ' parses, so the ',
+        inlineCode('Route.query'),
+        ' plus ',
+        inlineCode('Route.mapTo'),
+        ' pipe stops typechecking. Drop the default and the router composes again. The ',
+        link(
+          `${toolingLintingRouter()}#no-route-query-constructor-default`,
+          'foldkit/no-route-query-constructor-default',
+        ),
+        ' lint rule catches this.',
       ),
       para(
         'For a complete routing example, see the ',

--- a/packages/website/src/page/toolingLinting.ts
+++ b/packages/website/src/page/toolingLinting.ts
@@ -116,6 +116,17 @@ const foldkitRuleExamples: ReadonlyArray<RuleExample> = [
     raw: Snippet.lintCommandBindingMatchesNameRaw,
     highlighted: Snippet.lintCommandBindingMatchesNameHighlighted,
   },
+  {
+    heading: {
+      level: 'h3',
+      id: 'no-route-query-constructor-default',
+      text: 'foldkit/no-route-query-constructor-default',
+    },
+    description:
+      'Flags Schema.withConstructorDefault on Route.query fields. The default makes the field optional in the constructor-input type that Route.mapTo encodes, so the Route.query plus Route.mapTo pipe stops typechecking. Model the missing parameter with Option instead.',
+    raw: Snippet.lintNoRouteQueryConstructorDefaultRaw,
+    highlighted: Snippet.lintNoRouteQueryConstructorDefaultHighlighted,
+  },
 ]
 
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
@@ -191,7 +202,9 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('message'),
         ' payload, matching ',
         inlineCode('m()'),
-        ' tags, no-field Message constructors, and Command names.',
+        ' tags, no-field Message constructors, Command names, and constructor defaults on ',
+        inlineCode('Route.query'),
+        ' fields.',
       ),
       ...foldkitRuleExamples.map(ruleExampleView(copiedSnippets)),
     ],

--- a/packages/website/src/snippet/index.ts
+++ b/packages/website/src/snippet/index.ts
@@ -74,6 +74,8 @@ export { default as lintGotPrefixRequiresSubmodelPayloadRaw } from './lintGotPre
 export { default as lintGotPrefixRequiresSubmodelPayloadHighlighted } from './lintGotPrefixRequiresSubmodelPayload.ts?highlighted'
 export { default as lintNoEmptyObjectTaggedCallRaw } from './lintNoEmptyObjectTaggedCall.ts?raw'
 export { default as lintNoEmptyObjectTaggedCallHighlighted } from './lintNoEmptyObjectTaggedCall.ts?highlighted'
+export { default as lintNoRouteQueryConstructorDefaultRaw } from './lintNoRouteQueryConstructorDefault.ts?raw'
+export { default as lintNoRouteQueryConstructorDefaultHighlighted } from './lintNoRouteQueryConstructorDefault.ts?highlighted'
 export { default as lintPreferCallableMessageConstructorRaw } from './lintPreferCallableMessageConstructor.ts?raw'
 export { default as lintPreferCallableMessageConstructorHighlighted } from './lintPreferCallableMessageConstructor.ts?highlighted'
 export { default as lintCommandBindingMatchesNameRaw } from './lintCommandBindingMatchesName.ts?raw'

--- a/packages/website/src/snippet/lintNoRouteQueryConstructorDefault.ts
+++ b/packages/website/src/snippet/lintNoRouteQueryConstructorDefault.ts
@@ -1,0 +1,28 @@
+import { Schema as S, pipe } from 'effect'
+import { Route } from 'foldkit'
+import { literal } from 'foldkit/route'
+
+// ❌ Bad: the default makes page optional in the constructor-input type that
+// Route.mapTo encodes, so the Route.query plus Route.mapTo pipe stops
+// typechecking.
+const badSearchRouter = pipe(
+  literal('search'),
+  Route.query(
+    S.Struct({
+      page: S.FiniteFromString.pipe(S.withConstructorDefault(() => 1)),
+    }),
+  ),
+  Route.mapTo(SearchRoute),
+)
+
+// ✅ Good: model the missing parameter with Option and supply the default where
+// the value is read.
+const goodSearchRouter = pipe(
+  literal('search'),
+  Route.query(
+    S.Struct({
+      page: S.OptionFromOptional(S.FiniteFromString),
+    }),
+  ),
+  Route.mapTo(SearchRoute),
+)

--- a/packages/website/src/snippet/oxlintConfig.json
+++ b/packages/website/src/snippet/oxlintConfig.json
@@ -32,6 +32,7 @@
     "foldkit/message-binding-matches-tag": "error",
     "foldkit/got-prefix-requires-submodel-payload": "error",
     "foldkit/no-empty-object-tagged-call": "error",
+    "foldkit/no-route-query-constructor-default": "error",
     "foldkit/prefer-callable-message-constructor": "error",
     "foldkit/command-binding-matches-name": "error"
   },


### PR DESCRIPTION
Adds a new Foldkit lint rule that flags `Schema.withConstructorDefault` on `Route.query` fields, which breaks the `Route.query` plus `Route.mapTo` composition.

## Summary

When a field carries `Schema.withConstructorDefault`, it becomes optional in the tagged struct's constructor-input type. Since `Route.mapTo` consumes that constructor-input type on its encode side, it no longer matches the required field that `Route.query` parses, causing the pipe to fail typechecking with an opaque error. This rule reports the offending `withConstructorDefault` call directly so the fix is obvious: drop the default and model the missing parameter with `Option` instead.

## Changes

- **Rule implementation** (`packages/oxlint-plugin-foldkit/src/index.ts`):
  - Added `calleePropertyName()` helper to extract the property name from a call expression's callee
  - Added `isWithConstructorDefaultCall()` predicate to identify `withConstructorDefault` calls
  - Added `collectWithConstructorDefaultCalls()` to recursively find all `withConstructorDefault` calls within a node tree
  - Added `noRouteQueryConstructorDefault` rule that checks `Route.query()` calls and reports any nested `withConstructorDefault` calls
  - Registered the rule in the plugin exports

- **Tests** (`packages/oxlint-plugin-foldkit/test/index.test.ts`):
  - Added test helpers for constructing `withConstructorDefault` calls, struct fields, and `Route.query` expressions
  - Added five test cases covering: member calls, bare calls, multiple offending fields, allowed fields without defaults, and ignoring `withConstructorDefault` outside `Route.query`

- **Documentation and configuration**:
  - Added example snippet (`packages/website/src/snippet/lintNoRouteQueryConstructorDefault.ts`) showing bad and good patterns
  - Added rule documentation to the linting guide (`packages/website/src/page/toolingLinting.ts`)
  - Added warning callout to the routing guide (`packages/website/src/page/routing.ts`)
  - Enabled the rule in all `.oxlintrc.json` files (root, create-foldkit-app template, website)
  - Added changeset entry documenting the new rule

## Implementation Details

The rule uses a recursive tree traversal (`collectWithConstructorDefaultCalls`) to find all `withConstructorDefault` calls within the arguments to `Route.query()`, regardless of nesting depth. This handles both direct calls (`withConstructorDefault(...)`) and member calls (`Schema.withConstructorDefault(...)`). The rule reports each offending call individually so developers see exactly which fields need fixing.

https://claude.ai/code/session_01PL8dgnD85nfyqhWebdB5N1