### PR TITLE
docs(website): fix Settings namespace imports in Submodel snippets

### DIFF
--- a/packages/website/src/snippet/submodelParentModel.ts
+++ b/packages/website/src/snippet/submodelParentModel.ts
@@ -1,6 +1,6 @@
 import { Schema as S } from 'effect'
 
-import { Settings } from './page'
+import * as Settings from './page/settings'
 
 export const Model = S.Struct({
   username: S.String,

--- a/packages/website/src/snippet/submodelParentView.ts
+++ b/packages/website/src/snippet/submodelParentView.ts
@@ -3,7 +3,7 @@ import { type Document, html } from 'foldkit/html'
 
 import { GotSettingsMessage, type Message } from './message'
 import type { Model } from './model'
-import { Settings } from './page'
+import * as Settings from './page/settings'
 
 // The parent embeds the child via h.submodel. The slotId is unique within
 // the parent's view, view is the child's exported view function, model is the

--- a/packages/website/src/snippet/submodelWrapperMessage.ts
+++ b/packages/website/src/snippet/submodelWrapperMessage.ts
@@ -1,7 +1,7 @@
 import { Schema as S } from 'effect'
 import { m } from 'foldkit/message'
 
-import { Settings } from './page'
+import * as Settings from './page/settings'
 
 export const GotSettingsMessage = m('GotSettingsMessage', {
   message: Settings.Message,


### PR DESCRIPTION
This updates the Submodel docs snippets to import the `Settings` namespace directly from `./page/settings`, matching the child file shown earlier in the example.

Manually tested: `pnpm format`, rebuilt local packages, then ran `pnpm --filter website exec tsc --noEmit`.