### PR TITLE
docs(website): match Submodel snippet import style for the Collapsible child

### DIFF
--- a/packages/website/src/snippet/submodelParentViewInputs.ts
+++ b/packages/website/src/snippet/submodelParentViewInputs.ts
@@ -3,7 +3,7 @@ import { type Document, html } from 'foldkit/html'
 
 import { GotCollapsibleMessage, type Message } from './message'
 import type { Model } from './model'
-import { Collapsible } from './page'
+import * as Collapsible from './page/collapsible'
 
 // The parent passes `viewInputs` alongside model/view/toParentMessage.
 // `summary` and `content` are Html the parent builds; the child slots


### PR DESCRIPTION
Follow-up to #562.

#562 converted the Settings example snippets on the Submodel docs page to import the child namespace directly (`import * as Settings from './page/settings'`), since the Submodel lesson is not the place to teach the barrel export pattern. The same page also renders `submodelParentViewInputs`, which still imported its child via `import { Collapsible } from './page'`, so the page showed two import styles for the same concept side by side.

This aligns the Collapsible snippet to the direct namespace import, matching #562, so the Submodel page teaches one consistent style. The path `./page/collapsible` matches the child snippet's `// page/collapsible.ts` header.

Out of scope (intentionally left as-is):
- `informingSubmodelsParent` (People) on the Informing Submodels page: its child snippet has no `// page/...` path header, so a direct import would invent a path rather than align an existing one. It is also a different page with no internal inconsistency.
- `indexUsage` on the File Organization page, where the barrel is the lesson.

Display-only snippet change (loaded as raw text for the highlighted code block), so there is no compile impact. `prettier --check` is clean. No changeset (`website` is private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_