### PR TITLE
fix(foldkit): decode CustomElement event detail through its declared Schema

### DIFF
--- a/.changeset/customelement-decode-event-detail.md
+++ b/.changeset/customelement-decode-event-detail.md
@@ -1,0 +1,19 @@
+---
+'foldkit': minor
+---
+
+Decode a CustomElement event's `detail` through its declared Schema before
+dispatching. A CustomElement declares its events with Schema and the generated
+`On{Event}` factory is typed to hand your callback the decoded detail.
+Previously the runtime forwarded `event.detail` raw without decoding, so the
+type promised a validated value the runtime never checked. The factory now runs
+`Schema.decodeUnknownOption` on `event.detail` and dispatches a Message only on
+a successful decode, matching the decode-and-drop pattern used for a
+non-conforming Subscription event.
+
+This is a behavioral change: an event whose `detail` fails to decode (wrong
+shape, missing field, wrong type) is now dropped silently instead of
+dispatching a Message built from unchecked data. The `events` record passed to
+`CustomElement.define` is now typed as decodable schemas (`Schema.Codec`) so
+decoding requires no Effect services and stays synchronous inside event
+dispatch.

--- a/packages/foldkit/src/customElement/customElement.test.ts
+++ b/packages/foldkit/src/customElement/customElement.test.ts
@@ -144,12 +144,63 @@ describe('CustomElement.define', () => {
     element.dispatchEvent(
       new CustomEvent('change-rating', { detail: { value: 5 } }),
     )
-    element.dispatchEvent(new CustomEvent('clear-rating'))
+    element.dispatchEvent(new CustomEvent('clear-rating', { detail: {} }))
 
     expect(dispatched).toStrictEqual([
       RatingChanged({ value: 5 }),
       RatingCleared(),
     ])
+  })
+
+  it('decodes a conforming detail through the declared Schema before dispatching', () => {
+    const rating = emojiRating.withMessage<Message>()
+    const { dispatch, dispatched } = createCapturingDispatch()
+
+    const view = () =>
+      rating([
+        rating.OnChangeRating(detail => RatingChanged({ value: detail.value })),
+      ])
+    const element = patchInto(renderView(view, dispatch))
+
+    element.dispatchEvent(
+      new CustomEvent('change-rating', { detail: { value: 5 } }),
+    )
+
+    expect(dispatched).toStrictEqual([RatingChanged({ value: 5 })])
+  })
+
+  it('drops an event whose detail is the wrong type without dispatching', () => {
+    const rating = emojiRating.withMessage<Message>()
+    const { dispatch, dispatched } = createCapturingDispatch()
+
+    const view = () =>
+      rating([
+        rating.OnChangeRating(detail => RatingChanged({ value: detail.value })),
+      ])
+    const element = patchInto(renderView(view, dispatch))
+
+    element.dispatchEvent(
+      new CustomEvent('change-rating', { detail: { value: 'five' } }),
+    )
+
+    expect(dispatched).toStrictEqual([])
+  })
+
+  it('drops an event whose detail is missing a required field without dispatching', () => {
+    const rating = emojiRating.withMessage<Message>()
+    const { dispatch, dispatched } = createCapturingDispatch()
+
+    const view = () =>
+      rating([
+        rating.OnChangeRating(detail => RatingChanged({ value: detail.value })),
+      ])
+    const element = patchInto(renderView(view, dispatch))
+
+    element.dispatchEvent(
+      new CustomEvent('change-rating', { detail: { notValue: 5 } }),
+    )
+
+    expect(dispatched).toStrictEqual([])
   })
 
   it('preserves property updates across renders via the propsModule diff', () => {

--- a/packages/foldkit/src/customElement/index.ts
+++ b/packages/foldkit/src/customElement/index.ts
@@ -1,4 +1,4 @@
-import { Array, type Schema, String, pipe } from 'effect'
+import { Array, Option, Schema, String, pipe } from 'effect'
 
 import type { Attribute, Child, Html } from '../html/index.js'
 import {
@@ -33,7 +33,10 @@ type PropertyFactories<
 }
 
 /** @internal */
-type EventFactories<Message, Events extends Record<string, Schema.Top>> = {
+type EventFactories<
+  Message,
+  Events extends Record<string, Schema.Codec<any, any>>,
+> = {
   readonly [K in keyof Events as `On${KebabToPascal<string & K>}`]: EventFactory<
     Message,
     Schema.Schema.Type<Events[K]>
@@ -46,7 +49,7 @@ type EventFactories<Message, Events extends Record<string, Schema.Top>> = {
 export type ElementBuilder<
   Message,
   Properties extends Record<string, Schema.Top>,
-  Events extends Record<string, Schema.Top>,
+  Events extends Record<string, Schema.Codec<any, any>>,
 > = ((
   attributes?: ReadonlyArray<Attribute<Message>>,
   children?: ReadonlyArray<Child>,
@@ -58,7 +61,7 @@ export type ElementBuilder<
 export interface CustomElementConfig<
   Tag extends string,
   Properties extends Record<string, Schema.Top>,
-  Events extends Record<string, Schema.Top>,
+  Events extends Record<string, Schema.Codec<any, any>>,
 > {
   readonly tag: Tag
   readonly properties: Properties
@@ -72,7 +75,7 @@ export interface CustomElementConfig<
 export interface CustomElementSpec<
   Tag extends string,
   Properties extends Record<string, Schema.Top>,
-  Events extends Record<string, Schema.Top>,
+  Events extends Record<string, Schema.Codec<any, any>>,
 > {
   readonly tag: Tag
   readonly properties: Properties
@@ -157,7 +160,7 @@ const eventFactoryName = (eventName: string): string =>
 export const define = <
   Tag extends string,
   Properties extends Record<string, Schema.Top>,
-  Events extends Record<string, Schema.Top>,
+  Events extends Record<string, Schema.Codec<any, any>>,
 >(
   config: CustomElementConfig<Tag, Properties, Events>,
 ): CustomElementSpec<Tag, Properties, Events> => {
@@ -187,13 +190,14 @@ export const define = <
       ): Attribute<Message> => Prop({ key: propertyName, value })
     }
 
-    for (const eventName of eventNames) {
+    for (const [eventName, schema] of Object.entries(config.events)) {
+      const decodeDetail = Schema.decodeUnknownOption(schema)
       builder[eventFactoryName(eventName)] = (
         toMessage: (detail: unknown) => Message,
       ): Attribute<Message> =>
         OnCustomEvent({
           name: eventName,
-          f: event => toMessage(event.detail),
+          f: event => pipe(event.detail, decodeDetail, Option.map(toMessage)),
         })
     }
 

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -762,7 +762,7 @@ export type Attribute<Message> = Data.TaggedEnum<{
   Prop: { readonly key: string; readonly value: unknown }
   OnCustomEvent: {
     readonly name: string
-    readonly f: (event: CustomEvent<any>) => Message
+    readonly f: (event: CustomEvent<unknown>) => Option.Option<Message>
   }
   OnMount: {
     readonly action: MountAction<Message, any>
@@ -2633,7 +2633,10 @@ const attributeMatcher: (
         updateDataOn(ctx, {
           [name]: (event: Event) => {
             if (event instanceof CustomEvent) {
-              ctx.dispatch(f(event))
+              const maybeMessage = f(event)
+              if (Option.isSome(maybeMessage)) {
+                ctx.dispatch(maybeMessage.value)
+              }
             }
           },
         }),

--- a/packages/website/src/page/core/customElement.ts
+++ b/packages/website/src/page/core/customElement.ts
@@ -146,9 +146,9 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('OnColorChanged'),
         '. The factory takes a ',
         inlineCode('(detail) => Message'),
-        ' callback. When the element dispatches the CustomEvent, the runtime extracts ',
+        ' callback. When the element dispatches the CustomEvent, the runtime decodes ',
         inlineCode('event.detail'),
-        ', runs your callback, and dispatches the resulting Message just like any other handler.',
+        ' through the declared Schema, and only on success runs your callback and dispatches the resulting Message. A detail that fails to decode (wrong shape, missing field, wrong type) is dropped and no Message is dispatched, so the value your callback receives is always validated against the Schema you declared.',
       ),
       infoCallout(
         'Validation runs at define time',


### PR DESCRIPTION
Closes #573

## Problem

A `CustomElement` declares its events with Schema, and the generated `On{Event}` factory is typed to hand the callback the Schema-decoded detail. At runtime the declared Schema was never used: the factory forwarded `event.detail` raw. The public type promised a validated value the runtime never validated, an unsound cast at a DOM boundary. A custom element could dispatch a `detail` that did not match the declared Schema (wrong shape, missing field, wrong type) and the app would dispatch a Message built from unchecked data.

## Fix

The generated factory now decodes `event.detail` through the declared Schema with `Schema.decodeUnknownOption` and dispatches a Message only on a successful decode. This mirrors the decode-and-drop pattern used for a non-conforming Subscription event (#572): synchronous `decodeUnknownOption`, an `Option`-returning mapper, skip `None`.

## `OnCustomEvent` contract change

To support "skip on decode failure," `OnCustomEvent`'s handler `f` now returns `Option<Message>` instead of `Message`, the same shape the pointer and keydown-prevent-default handlers already use. The html dispatch site dispatches only when the result is `Some` and does nothing on `None`. With the detail now decoded rather than cast, the internal `CustomEvent<any>` is tightened to `CustomEvent<unknown>`. The `events` record accepted by `CustomElement.define` is typed as decodable schemas (`Schema.Codec`) so decoding requires no Effect services and stays synchronous inside event dispatch. No `as` cast was introduced; the unsound `any` is removed.

## Behavior change (drop on failure)

An event whose `detail` fails to decode is now dropped silently instead of dispatching a Message built from bad data. This matches how a non-conforming Subscription event is ignored today. No dev warning is emitted; silent drop is the recommendation in the issue. If a diagnostic is later wanted, it can layer on top of the drop without changing this contract.

## Tests

- Conforming `detail` decodes and dispatches the expected Message.
- Non-conforming `detail` (wrong type, and separately a missing required field) dispatches nothing.
- The existing name-conversion test now sends a conforming empty-object detail for the empty-struct `clear-rating` event.

## Changeset + docs

- Changeset at `minor` (pre-1.0 behavioral change), describing the drop-on-failure behavior. The fixed group (`foldkit`, `@foldkit/ui`, `@foldkit/devtools`) bumps together.
- CustomElement docs page notes that event detail is decoded through the declared Schema and non-conforming events are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_