### PR TITLE
fix(ui): keep tooltip visible when its trigger is clicked

### DIFF
--- a/.changeset/tooltip-click-behavior.md
+++ b/.changeset/tooltip-click-behavior.md
@@ -1,0 +1,13 @@
+---
+'@foldkit/ui': patch
+---
+
+`Ui.Tooltip` no longer hides when the trigger is pressed. Tooltips hide only
+on pointer-leave, blur, or Escape. Escape still suppresses re-opening until the
+user disengages.
+
+`PressedPointerOnTrigger` now carries only `pointerType`; the `button` field is
+removed, since it was only used to detect the left-click dismissal that was
+removed. The message still records the pointer type so the focus that follows a
+mouse press can be told apart from focus that affirms the tooltip (keyboard,
+touch, or pen).

--- a/packages/ui/src/tooltip/index.ts
+++ b/packages/ui/src/tooltip/index.ts
@@ -26,7 +26,7 @@ import * as OptionExt from '../internal/optionExtensions.js'
 
 // MODEL
 
-/** Schema for the tooltip component's state. `isOpen` is visibility; `isHovered` tracks pointer on trigger; `isFocused` tracks tooltip-affirming focus on the trigger (focus arriving without a preceding mouse press, like keyboard, touch, or pen; mouse-click-induced focus is excluded since it doesn't affirm the user wants the tooltip visible); `isDismissed` suppresses re-opening after the user dismissed the tooltip (via Escape or left-click) until they disengage (leave or blur). `showDelay` is the hover-to-show duration. `maybeLastPointerType` records the most recent pointer type that pressed the trigger, so a mouse-click-induced focus can be distinguished from other focus. */
+/** Schema for the tooltip component's state. `isOpen` is visibility; `isHovered` tracks pointer on trigger; `isFocused` tracks tooltip-affirming focus on the trigger (focus arriving without a preceding mouse press, like keyboard, touch, or pen; mouse-click-induced focus is excluded since it doesn't affirm the user wants the tooltip visible); `isDismissed` suppresses re-opening after the user dismissed the tooltip (via Escape) until they disengage (leave or blur). `showDelay` is the hover-to-show duration. `maybeLastPointerType` records the most recent pointer type that pressed the trigger, so a mouse-click-induced focus can be distinguished from other focus. */
 export const Model = S.Struct({
   id: S.String,
   isOpen: S.Boolean,
@@ -52,10 +52,11 @@ export const FocusedTrigger = m('FocusedTrigger')
 export const BlurredTrigger = m('BlurredTrigger')
 /** Sent when Escape is pressed while the tooltip is visible. */
 export const PressedEscape = m('PressedEscape')
-/** Sent when a pointer presses the trigger. */
+/** Sent when a pointer presses the trigger. Recorded so the focus that
+ *  follows a mouse press can be told apart from focus that affirms the
+ *  tooltip (keyboard, touch, or pen). */
 export const PressedPointerOnTrigger = m('PressedPointerOnTrigger', {
   pointerType: S.String,
-  button: S.Number,
 })
 /** Sent when the show-delay timer fires. */
 export const ElapsedShowDelay = m('ElapsedShowDelay', {
@@ -124,8 +125,6 @@ export const triggerId = (id: string): string => `${id}-trigger`
 // INIT
 
 const DEFAULT_SHOW_DELAY = Duration.millis(500)
-
-const LEFT_MOUSE_BUTTON = 0
 
 /** Configuration for creating a tooltip model with `init`. */
 export type InitConfig = Readonly<{
@@ -272,29 +271,12 @@ const computeUpdate = (model: Model, message: Message): InnerUpdateReturn =>
         [],
       ],
 
-      PressedPointerOnTrigger: ({ pointerType, button }) => {
-        const isLeftClickOnOpen = button === LEFT_MOUSE_BUTTON && model.isOpen
-
-        if (isLeftClickOnOpen) {
-          return [
-            evo(model, {
-              maybeLastPointerType: () => Option.some(pointerType),
-              isOpen: () => false,
-              isFocused: () => false,
-              isDismissed: () => true,
-              pendingShowVersion: Number.increment,
-            }),
-            [],
-          ]
-        }
-
-        return [
-          evo(model, {
-            maybeLastPointerType: () => Option.some(pointerType),
-          }),
-          [],
-        ]
-      },
+      PressedPointerOnTrigger: ({ pointerType }) => [
+        evo(model, {
+          maybeLastPointerType: () => Option.some(pointerType),
+        }),
+        [],
+      ],
 
       ElapsedShowDelay: ({ version }) => {
         if (version !== model.pendingShowVersion) {
@@ -371,8 +353,7 @@ export type ViewInputs = Readonly<{
 
 /** Renders a headless tooltip with an anchored non-interactive panel.
  *  Shows on hover (after delay) or focus (from keyboard, touch, or pen;
- *  mouse-click focus is excluded); hides on leave, blur, Escape, or
- *  left-click of the trigger. */
+ *  mouse-click focus is excluded). Hides on leave, blur, or Escape. */
 export const view = defineView<Model, Message, ViewInputs>(
   (model, viewInputs): Html => {
     const h = html<Message>()
@@ -400,9 +381,8 @@ export const view = defineView<Model, Message, ViewInputs>(
 
     const handleTriggerPointerDown = (
       pointerType: string,
-      button: number,
     ): Option.Option<PressedPointerOnTrigger> =>
-      Option.some(PressedPointerOnTrigger({ pointerType, button }))
+      Option.some(PressedPointerOnTrigger({ pointerType }))
 
     const triggerAttributes = [
       h.Id(`${id}-trigger`),

--- a/packages/ui/src/tooltip/story.test.ts
+++ b/packages/ui/src/tooltip/story.test.ts
@@ -371,9 +371,7 @@ describe('Tooltip', () => {
         Story.story(
           update,
           withHidden,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'mouse', button: 0 }),
-          ),
+          Story.message(PressedPointerOnTrigger({ pointerType: 'mouse' })),
           Story.Command.expectNone(),
           Story.model(model => {
             expect(model.maybeLastPointerType).toStrictEqual(
@@ -388,9 +386,7 @@ describe('Tooltip', () => {
         Story.story(
           update,
           withHidden,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'mouse', button: 0 }),
-          ),
+          Story.message(PressedPointerOnTrigger({ pointerType: 'mouse' })),
           Story.message(FocusedTrigger()),
           Story.model(model => {
             expect(model.isFocused).toBe(false)
@@ -404,9 +400,7 @@ describe('Tooltip', () => {
         Story.story(
           update,
           withHidden,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'touch', button: 0 }),
-          ),
+          Story.message(PressedPointerOnTrigger({ pointerType: 'touch' })),
           Story.message(FocusedTrigger()),
           Story.model(model => {
             expect(model.isFocused).toBe(true)
@@ -431,9 +425,7 @@ describe('Tooltip', () => {
         Story.story(
           update,
           withHidden,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'mouse', button: 0 }),
-          ),
+          Story.message(PressedPointerOnTrigger({ pointerType: 'mouse' })),
           Story.message(FocusedTrigger()),
           Story.message(BlurredTrigger()),
           Story.model(model => {
@@ -442,84 +434,60 @@ describe('Tooltip', () => {
         )
       })
 
-      it('dismisses an open tooltip on left-click of the trigger and clears focus so leave closes cleanly on next cycle', () => {
+      it('keeps an open tooltip visible when the trigger is pressed', () => {
         Story.story(
           update,
           withHoveredOpen,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'mouse', button: 0 }),
-          ),
-          Story.model(model => {
-            expect(model.isOpen).toBe(false)
-            expect(model.isDismissed).toBe(true)
-            expect(model.isFocused).toBe(false)
-            expect(model.isHovered).toBe(true)
-          }),
-        )
-      })
-
-      it('closes on leave after hover, click, leave, and re-hover', () => {
-        Story.story(
-          update,
-          withHoveredOpen,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'mouse', button: 0 }),
-          ),
-          Story.message(FocusedTrigger()),
-          Story.message(LeftTrigger()),
-          Story.message(EnteredTrigger()),
-          Story.Command.resolve(
-            ShowAfterDelay,
-            ElapsedShowDelay({ version: 4 }),
-          ),
-          Story.model(model => {
-            expect(model.isOpen).toBe(true)
-          }),
-          Story.message(LeftTrigger()),
-          Story.model(model => {
-            expect(model.isOpen).toBe(false)
-            expect(model.isFocused).toBe(false)
-          }),
-        )
-      })
-
-      it('does not dismiss the tooltip on right-click', () => {
-        Story.story(
-          update,
-          withHoveredOpen,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'mouse', button: 2 }),
-          ),
+          Story.message(PressedPointerOnTrigger({ pointerType: 'mouse' })),
+          Story.Command.expectNone(),
+          Story.expectNoOutMessage(),
           Story.model(model => {
             expect(model.isOpen).toBe(true)
             expect(model.isDismissed).toBe(false)
+            expect(model.isHovered).toBe(true)
+            expect(model.maybeLastPointerType).toStrictEqual(
+              Option.some('mouse'),
+            )
           }),
         )
       })
 
-      it('stays dismissed after click until the pointer leaves', () => {
+      it('stays open across the focus that follows a press while hovering', () => {
         Story.story(
           update,
           withHoveredOpen,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'mouse', button: 0 }),
-          ),
-          Story.message(EnteredTrigger()),
-          Story.Command.expectNone(),
+          Story.message(PressedPointerOnTrigger({ pointerType: 'mouse' })),
+          Story.message(FocusedTrigger()),
+          Story.model(model => {
+            expect(model.isOpen).toBe(true)
+            expect(model.isFocused).toBe(false)
+            expect(model.isHovered).toBe(true)
+            expect(model.maybeLastPointerType).toStrictEqual(Option.none())
+          }),
+        )
+      })
+
+      it('still hides on leave after the trigger is pressed while hovering', () => {
+        Story.story(
+          update,
+          withHoveredOpen,
+          Story.message(PressedPointerOnTrigger({ pointerType: 'mouse' })),
+          Story.message(FocusedTrigger()),
+          Story.message(LeftTrigger()),
+          Story.expectOutMessage(Hidden()),
           Story.model(model => {
             expect(model.isOpen).toBe(false)
-            expect(model.isDismissed).toBe(true)
+            expect(model.isHovered).toBe(false)
+            expect(model.isFocused).toBe(false)
           }),
         )
       })
 
-      it('re-enables show after leave and re-hover following a click', () => {
+      it('does not dismiss, so a re-hover after leaving still schedules a show', () => {
         Story.story(
           update,
           withHoveredOpen,
-          Story.message(
-            PressedPointerOnTrigger({ pointerType: 'mouse', button: 0 }),
-          ),
+          Story.message(PressedPointerOnTrigger({ pointerType: 'mouse' })),
           Story.message(LeftTrigger()),
           Story.message(EnteredTrigger()),
           Story.Command.expectHas(ShowAfterDelay),

--- a/packages/website/src/page/ui/tooltipPage.ts
+++ b/packages/website/src/page/ui/tooltipPage.ts
@@ -249,7 +249,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
         pageTitle('ui/tooltip', 'Tooltip'),
         tableOfContentsEntryToHeader(overviewHeader),
         para(
-          'A non-interactive floating label anchored to a trigger. Tooltips appear on hover after a short delay, or immediately on keyboard focus. They hide on pointer-leave, blur, Escape, or left-click of the trigger. Use tooltips for short hints about a control. For rich content or interactive panels, use ',
+          'A non-interactive floating label anchored to a trigger. Tooltips appear on hover after a short delay, or immediately on keyboard focus. They hide on pointer-leave, blur, or Escape. Use tooltips for short hints about a control. Because they rely on hover and keyboard focus, don’t use them for content that must be reachable on touch; for that, or for rich or interactive content, use ',
           inlineCode('Popover'),
           ' instead.',
         ),


### PR DESCRIPTION
## What

`Ui.Tooltip` no longer hides when its trigger is pressed. Previously a left-click on an open tooltip dismissed it (setting `isDismissed`), which is not standard tooltip behavior. Standard tooltips stay visible while the pointer hovers the trigger, regardless of clicks.

After this change the tooltip hides only on pointer-leave, blur, or Escape. Escape still hides it and suppresses re-opening until the user disengages (leaves or blurs).

## Why

A tooltip is a hover/focus affordance. Dismissing it on click conflates the tooltip with the trigger's action and surprises users who are still hovering. Removing the click-dismiss brings the component in line with how tooltips are expected to behave.

## Changes

- `packages/ui/src/tooltip/index.ts`: removed the `isLeftClickOnOpen` dismissal branch from the `PressedPointerOnTrigger` handler. The message now records only `pointerType` (the `button` field and the `LEFT_MOUSE_BUTTON` constant are gone, since button distinction only ever existed to detect the left-click dismissal). The message still records the pointer type so the focus that follows a mouse press can be told apart from focus that affirms the tooltip (keyboard, touch, or pen). Model and view TSDoc updated.
- `packages/ui/src/tooltip/story.test.ts`: rewrote the `PressedPointerOnTrigger` test block for the new behavior (a press keeps an open tooltip open and emits no `Hidden`; leave still closes and emits `Hidden`; the mouse-focus suppression still holds; a press no longer sets `isDismissed`, so a re-hover after leaving still schedules a show).
- `packages/website/src/page/ui/tooltipPage.ts`: overview prose updated to match.
- Added a `@foldkit/ui` patch changeset.

## Verification

- `pnpm --filter @foldkit/ui test tooltip` — 44 passed.
- `pnpm --filter @foldkit/ui typecheck`, `lint`, and workspace dead-code check clean.
- Full pre-push suite (build, typecheck, test across the workspace) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNn57AQHAq7Nm3rnXkFGRZ)_