### PR TITLE
feat(foldkit): add Subscription.fromEventFilterMap

### DIFF
--- a/.changeset/subscription-from-event-filter-map.md
+++ b/.changeset/subscription-from-event-filter-map.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `Subscription.fromEventFilterMap`, a filtered variant of `fromEvent` whose mapper returns `Option<Message>` so a listener can ignore events while still calling `preventDefault()` synchronously.

--- a/examples/slow-warnings/src/main.ts
+++ b/examples/slow-warnings/src/main.ts
@@ -1,10 +1,8 @@
 import {
   Array,
-  Effect,
   Match as M,
   Number,
   Option,
-  Queue,
   Schema as S,
   Stream,
   pipe,
@@ -250,32 +248,19 @@ export const init: Runtime.ApplicationInit<Model, Message> = () => [
 
 export const subscriptions = Subscription.make<Model, Message>()(entry => ({
   slowWarnings: Subscription.persistent(
-    Stream.callback<typeof RecordedSlowWarning.Type>(queue =>
-      Effect.acquireRelease(
-        Effect.sync(() => {
-          const handler = (event: Event) => {
-            if (event instanceof CustomEvent) {
-              pipe(
-                event.detail,
-                S.decodeUnknownOption(SlowWarningReport),
-                Option.match({
-                  onNone: () => undefined,
-                  onSome: report =>
-                    Queue.offerUnsafe(queue, RecordedSlowWarning({ report })),
-                }),
-              )
-            }
-          }
-
-          slowWarningTarget.addEventListener(SLOW_WARNING_EVENT, handler)
-          return handler
-        }),
-        handler =>
-          Effect.sync(() =>
-            slowWarningTarget.removeEventListener(SLOW_WARNING_EVENT, handler),
-          ),
-      ).pipe(Effect.flatMap(() => Effect.never)),
-    ),
+    Subscription.fromEventFilterMap<
+      CustomEvent,
+      typeof RecordedSlowWarning.Type
+    >({
+      target: slowWarningTarget,
+      type: SLOW_WARNING_EVENT,
+      toMessage: event =>
+        pipe(
+          event.detail,
+          S.decodeUnknownOption(SlowWarningReport),
+          Option.map(report => RecordedSlowWarning({ report })),
+        ),
+    }),
   ),
   burnCpuDuringDependencyExtraction: entry(
     {

--- a/packages/foldkit/src/subscription/fromEvent.test.ts
+++ b/packages/foldkit/src/subscription/fromEvent.test.ts
@@ -1,7 +1,7 @@
-import { Effect, Fiber, Stream } from 'effect'
+import { Effect, Fiber, Option, Stream } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { fromEvent } from './fromEvent.js'
+import { fromEvent, fromEventFilterMap } from './fromEvent.js'
 
 const tick = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0))
 
@@ -116,6 +116,88 @@ describe('fromEvent', () => {
     await tick()
     await Effect.runPromise(Fiber.interrupt(fiber))
 
+    expect(received).toEqual(['a'])
+  })
+})
+
+describe('fromEventFilterMap', () => {
+  it('emits only for events the mapper keeps and skips the rest', async () => {
+    const target = new EventTarget()
+    const received: Array<string> = []
+
+    const fiber = Effect.runFork(
+      drain(
+        fromEventFilterMap<CustomEvent<string>, string>({
+          target,
+          type: 'ping',
+          toMessage: event =>
+            event.detail === 'skip' ? Option.none() : Option.some(event.detail),
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'a' }))
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'skip' }))
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'b' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual(['a', 'b'])
+  })
+
+  it('removes the listener when the scope closes', async () => {
+    const target = new EventTarget()
+    const received: Array<string> = []
+
+    const fiber = Effect.runFork(
+      drain(
+        fromEventFilterMap<CustomEvent<string>, string>({
+          target,
+          type: 'ping',
+          toMessage: event => Option.some(event.detail),
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'a' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    target.dispatchEvent(new CustomEvent('ping', { detail: 'b' }))
+    await tick()
+
+    expect(received).toEqual(['a'])
+  })
+
+  it('runs preventDefault synchronously inside the mapper', async () => {
+    const target = new EventTarget()
+    const received: Array<string> = []
+
+    const fiber = Effect.runFork(
+      drain(
+        fromEventFilterMap<CustomEvent<string>, string>({
+          target,
+          type: 'ping',
+          toMessage: event => {
+            event.preventDefault()
+            return Option.some(event.detail)
+          },
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    const event = new CustomEvent('ping', { detail: 'a', cancelable: true })
+    target.dispatchEvent(event)
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(event.defaultPrevented).toBe(true)
     expect(received).toEqual(['a'])
   })
 })

--- a/packages/foldkit/src/subscription/fromEvent.ts
+++ b/packages/foldkit/src/subscription/fromEvent.ts
@@ -1,4 +1,4 @@
-import { Effect, Queue, Stream } from 'effect'
+import { Effect, Option, Queue, Stream } from 'effect'
 
 /**
  * Configuration for the `fromEvent` Stream helper.
@@ -25,6 +25,109 @@ const resolveTarget = (
 ): EventTarget => (typeof target === 'function' ? target() : target)
 
 /**
+ * Configuration for the `fromEventFilterMap` Stream helper.
+ *
+ * `target` is read inside the acquire Effect, never before it, so the
+ * resolved `EventTarget` is captured at the moment the Subscription's scope
+ * opens. Pass a thunk when the target may not exist until the scope opens, or
+ * pass the `EventTarget` directly for always-present globals like `window` or
+ * `document`.
+ *
+ * `toMessage(event)` returns `Option.some(message)` to emit a Message for the
+ * event, or `Option.none()` to ignore it. The mapper runs synchronously in the
+ * same call stack as the browser's event dispatch, so calling
+ * `event.preventDefault()` inside it works as expected.
+ */
+export type FromEventFilterMapConfig<
+  EventType extends Event,
+  Message,
+> = Readonly<{
+  target: EventTarget | (() => EventTarget)
+  type: string
+  toMessage: (event: EventType) => Option.Option<Message>
+  options?: AddEventListenerOptions
+}>
+
+/**
+ * Build a Stream that emits a Message for the dispatches of a DOM event the
+ * mapper chooses to keep, registering the listener when the Stream's scope
+ * opens and removing it when the scope closes.
+ *
+ * This is the filtered variant of `fromEvent`. Its `toMessage` returns
+ * `Option.some(message)` to emit and `Option.none()` to ignore the event, so a
+ * single listener can react to some dispatches while passing on the rest.
+ *
+ * Reach for this over a downstream `Stream.filterMap` whenever the decision to
+ * keep an event is paired with `event.preventDefault()`. The mapper runs
+ * synchronously inside the browser's event dispatch, so `preventDefault()`
+ * takes effect, while a downstream filter would run on a later turn after the
+ * default action has already happened.
+ *
+ * The listener lifecycle uses `Effect.acquireRelease`. The `addEventListener`
+ * call happens inside the acquire Effect, and the matching
+ * `removeEventListener` is registered only after acquire completes, so the
+ * listener never leaks on interruption.
+ *
+ * This is a Stream, not a Subscription entry. Wrap it with
+ * `Subscription.persistent` for a listener whose lifetime spans the whole
+ * Subscriptions record, or plug it into a `Subscription.make` entry's
+ * `dependenciesToStream` (typically behind `Stream.when`) to gate it on a
+ * Model condition.
+ *
+ * @example
+ * ```typescript
+ * const subscriptions = Subscription.make<Model, Message>()(entry => ({
+ *   searchShortcut: entry(
+ *     { isListening: S.Boolean },
+ *     {
+ *       modelToDependencies: model => ({ isListening: model.isListening }),
+ *       dependenciesToStream: ({ isListening }) =>
+ *         Stream.when(
+ *           Subscription.fromEventFilterMap<KeyboardEvent, Message>({
+ *             target: window,
+ *             type: 'keydown',
+ *             toMessage: event => {
+ *               if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+ *                 event.preventDefault()
+ *                 return Option.some(OpenedSearch())
+ *               }
+ *               return Option.none()
+ *             },
+ *           }),
+ *           Effect.sync(() => isListening),
+ *         ),
+ *     },
+ *   ),
+ * }))
+ * ```
+ */
+export const fromEventFilterMap = <EventType extends Event, Message>(
+  config: FromEventFilterMapConfig<EventType, Message>,
+): Stream.Stream<Message> =>
+  Stream.callback<Message>(queue =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        const target = resolveTarget(config.target)
+
+        const handleEvent = (event: Event): void => {
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+          const maybeMessage = config.toMessage(event as EventType)
+          if (Option.isSome(maybeMessage)) {
+            Queue.offerUnsafe(queue, maybeMessage.value)
+          }
+        }
+
+        target.addEventListener(config.type, handleEvent, config.options)
+        return { target, handleEvent }
+      }),
+      ({ target, handleEvent }) =>
+        Effect.sync(() => {
+          target.removeEventListener(config.type, handleEvent, config.options)
+        }),
+    ).pipe(Effect.flatMap(() => Effect.never)),
+  )
+
+/**
  * Build a Stream that emits a Message for every dispatch of a DOM event,
  * registering the listener when the Stream's scope opens and removing it when
  * the scope closes.
@@ -39,6 +142,9 @@ const resolveTarget = (
  * Subscriptions record, or plug it into a `Subscription.make` entry's
  * `dependenciesToStream` (typically behind `Stream.when`) to gate it on a
  * Model condition.
+ *
+ * For a listener that reacts to only some events, reach for
+ * `fromEventFilterMap`, whose mapper returns `Option<Message>`.
  *
  * @example
  * ```typescript
@@ -64,22 +170,7 @@ const resolveTarget = (
 export const fromEvent = <EventType extends Event, Message>(
   config: FromEventConfig<EventType, Message>,
 ): Stream.Stream<Message> =>
-  Stream.callback<Message>(queue =>
-    Effect.acquireRelease(
-      Effect.sync(() => {
-        const target = resolveTarget(config.target)
-
-        const handleEvent = (event: Event): void => {
-          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-          Queue.offerUnsafe(queue, config.toMessage(event as EventType))
-        }
-
-        target.addEventListener(config.type, handleEvent, config.options)
-        return { target, handleEvent }
-      }),
-      ({ target, handleEvent }) =>
-        Effect.sync(() => {
-          target.removeEventListener(config.type, handleEvent, config.options)
-        }),
-    ).pipe(Effect.flatMap(() => Effect.never)),
-  )
+  fromEventFilterMap<EventType, Message>({
+    ...config,
+    toMessage: event => Option.some(config.toMessage(event)),
+  })

--- a/packages/foldkit/src/subscription/public.ts
+++ b/packages/foldkit/src/subscription/public.ts
@@ -10,6 +10,6 @@ export { animationFrame } from './animationFrame.js'
 
 export type { AnimationFrameConfig } from './animationFrame.js'
 
-export { fromEvent } from './fromEvent.js'
+export { fromEvent, fromEventFilterMap } from './fromEvent.js'
 
-export type { FromEventConfig } from './fromEvent.js'
+export type { FromEventConfig, FromEventFilterMapConfig } from './fromEvent.js'

--- a/packages/website/src/page/core/subscriptions.ts
+++ b/packages/website/src/page/core/subscriptions.ts
@@ -381,6 +381,17 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         link(coreMountRouter(), 'Mount'),
         ' instead, which hands you the element directly.',
       ),
+      para(
+        'When only some events should become Messages, use ',
+        inlineCode('Subscription.fromEventFilterMap'),
+        '. Its ',
+        inlineCode('toMessage'),
+        ' returns ',
+        inlineCode('Option.some(message)'),
+        ' to emit a Message or ',
+        inlineCode('Option.none()'),
+        ' to ignore the event.',
+      ),
 
       // ADVANCED
 

--- a/packages/website/src/subscription/searchShortcut.ts
+++ b/packages/website/src/subscription/searchShortcut.ts
@@ -1,4 +1,4 @@
-import { Effect, Queue, Schema as S, Stream } from 'effect'
+import { Effect, Option, Schema as S, Stream } from 'effect'
 import { Subscription } from 'foldkit'
 
 import type { Model } from '../main'
@@ -15,29 +15,22 @@ export const subscriptions = Subscription.make<Model, Message>()(entry => ({
       }),
       dependenciesToStream: ({ isDocsPage }) =>
         Stream.when(
-          Stream.callback<typeof GotSearchMessage.Type>(queue =>
-            Effect.acquireRelease(
-              Effect.sync(() => {
-                const handler = (event: KeyboardEvent) => {
-                  if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
-                    event.preventDefault()
-                    Queue.offerUnsafe(
-                      queue,
-                      GotSearchMessage({
-                        message: PressedSearchShortcut(),
-                      }),
-                    )
-                  }
-                }
-                document.addEventListener('keydown', handler)
-                return handler
-              }),
-              handler =>
-                Effect.sync(() =>
-                  document.removeEventListener('keydown', handler),
-                ),
-            ).pipe(Effect.flatMap(() => Effect.never)),
-          ),
+          Subscription.fromEventFilterMap<
+            KeyboardEvent,
+            typeof GotSearchMessage.Type
+          >({
+            target: document,
+            type: 'keydown',
+            toMessage: event => {
+              if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+                event.preventDefault()
+                return Option.some(
+                  GotSearchMessage({ message: PressedSearchShortcut() }),
+                )
+              }
+              return Option.none()
+            },
+          }),
           Effect.sync(() => isDocsPage),
         ),
     },


### PR DESCRIPTION
Re-files the `Subscription.fromEventFilterMap` work against `main`. It was originally #572, which was stacked on #542 (`fromEvent`) and got merged into that stacking branch (`claude/issue-534-subscription-from-event`) rather than `main`, so the work never landed on `main`. #542 is merged; this replays the same commit (`32810de`) cleanly on top of it. The commit is unchanged.

## What

Adds `Subscription.fromEventFilterMap`, a filtered variant of `fromEvent` whose `toMessage` returns `Option<Message>`. `Option.some(message)` emits, `Option.none()` ignores the event, so a single DOM listener can react to some dispatches while passing on the rest.

## Why the Option-returning mapper

`fromEvent`'s `toMessage` emits a Message for every dispatch (1:1). Some DOM subscriptions only want to emit for some events, and they must filter synchronously inside the listener because `event.preventDefault()` has to run during the browser's event dispatch. A downstream `Stream.filterMap` would run on a later turn, after the default action already happened, so the event would be lost. Putting the filter inside the listener keeps `preventDefault()` working. `fromEvent` is now defined in terms of `fromEventFilterMap`, so the `addEventListener` / `removeEventListener` lifecycle lives in one place.

## Changes

- `packages/foldkit/src/subscription/fromEvent.ts`: the new helper and config type with TSDoc, and `fromEvent` delegating to it.
- `packages/foldkit/src/subscription/public.ts`: barrel re-export of `fromEventFilterMap` and `FromEventFilterMapConfig`.
- `packages/foldkit/src/subscription/fromEvent.test.ts`: filtered emission, listener removal on scope close (no-leak), synchronous `preventDefault()`.
- Two in-repo subscriptions migrated to the helper: the website Cmd/Ctrl+K search shortcut and the `slow-warnings` example (which decodes the `CustomEvent` detail with `S.decodeUnknownOption`).
- `packages/website/src/page/core/subscriptions.ts`: a note in the DOM Events section.
- `.changeset/subscription-from-event-filter-map.md`: minor bump for `foldkit` (fixed group).

## Verification

Cherry-picked cleanly onto latest `main`. Locally green: `changeset status --since=origin/main`, `prettier --check`, `pnpm lint`, `foldkit` typecheck, and the subscription tests (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8dbyXo8QMLz85FtKtePAZ)_