### PR TITLE
feat(oxlint-plugin): add no-module-level-mutable-state rule

### DIFF
--- a/packages/oxlint-plugin-foldkit/src/index.ts
+++ b/packages/oxlint-plugin-foldkit/src/index.ts
@@ -152,6 +152,39 @@ const innerCommandDefineCall = (
   return callee
 }
 
+const isProgram = (node: ESTree.Node): node is ESTree.Program =>
+  node.type === 'Program'
+
+const isVariableDeclaration = (
+  node: unknown,
+): node is ESTree.VariableDeclaration =>
+  typeof node === 'object' &&
+  node !== null &&
+  'type' in node &&
+  node.type === 'VariableDeclaration'
+
+const isMutableDeclaration = (node: ESTree.VariableDeclaration): boolean =>
+  (node.kind === 'let' || node.kind === 'var') && node.declare !== true
+
+// The mutable `let`/`var` declarations at module scope, including any re-exported
+// via `export let`. `declare let` (ambient) is left alone.
+const topLevelMutableDeclarations = (
+  program: ESTree.Program,
+): ReadonlyArray<ESTree.VariableDeclaration> =>
+  program.body.flatMap(statement => {
+    if (isVariableDeclaration(statement)) {
+      return isMutableDeclaration(statement) ? [statement] : []
+    }
+    if (
+      statement.type === 'ExportNamedDeclaration' &&
+      isVariableDeclaration(statement.declaration) &&
+      isMutableDeclaration(statement.declaration)
+    ) {
+      return [statement.declaration]
+    }
+    return []
+  })
+
 // RULES
 
 export const noNoopMessage = Rule.define({
@@ -411,6 +444,35 @@ export const commandBindingMatchesName = Rule.define({
   },
 })
 
+export const noModuleLevelMutableState = Rule.define({
+  name: 'no-module-level-mutable-state',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Keep mutable state in the Model tree; avoid module-scope let/var in Foldkit files.',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return {
+      Program: (node: ESTree.Node) => {
+        if (!isProgram(node)) return Effect.void
+        return Effect.forEach(
+          topLevelMutableDeclarations(node),
+          declaration =>
+            ctx.report(
+              Diagnostic.make({
+                node: declaration,
+                message:
+                  'Module-level let/var is hidden state outside the single Model tree. Keep mutable state in the Model, or reach for an explicit runtime primitive.',
+              }),
+            ),
+          { concurrency: 1, discard: true },
+        )
+      },
+    }
+  },
+})
+
 export default Plugin.define({
   name: 'foldkit',
   rules: {
@@ -419,6 +481,7 @@ export default Plugin.define({
     'got-submodel-message-name': gotSubmodelMessageName,
     'message-binding-matches-tag': messageBindingMatchesTag,
     'no-empty-object-tagged-call': noEmptyObjectTaggedCall,
+    'no-module-level-mutable-state': noModuleLevelMutableState,
     'no-noop-message': noNoopMessage,
     'prefer-callable-message-constructor': preferCallableMessageConstructor,
   },

--- a/packages/oxlint-plugin-foldkit/test/index.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/index.test.ts
@@ -7,6 +7,7 @@ import {
   gotSubmodelMessageName,
   messageBindingMatchesTag,
   noEmptyObjectTaggedCall,
+  noModuleLevelMutableState,
   noNoopMessage,
   preferCallableMessageConstructor,
 } from '../src/index.ts'
@@ -57,6 +58,17 @@ const tsAsExpression = (expression: unknown) => ({
   type: 'TSAsExpression',
   expression,
 })
+
+const variableDeclaration = (kind: string, name: string) => ({
+  type: 'VariableDeclaration',
+  kind,
+  declare: false,
+  declarations: [
+    { type: 'VariableDeclarator', id: Testing.id(name), init: null },
+  ],
+})
+
+const program = (body: ReadonlyArray<unknown>) => ({ type: 'Program', body })
 
 describe('@foldkit/oxlint-plugin', () => {
   it('flags generic NoOp Messages', () => {
@@ -264,5 +276,41 @@ describe('@foldkit/oxlint-plugin', () => {
     )
 
     expect(result).toHaveLength(0)
+  })
+
+  it('flags module-level let/var state', () => {
+    const result = Testing.runRule(
+      noModuleLevelMutableState,
+      'Program',
+      program([variableDeclaration('let', 'cache')]),
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('single Model tree')
+  })
+
+  it('allows module-level const', () => {
+    const result = Testing.runRule(
+      noModuleLevelMutableState,
+      'Program',
+      program([variableDeclaration('const', 'config')]),
+    )
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags an exported module-level let', () => {
+    const result = Testing.runRule(
+      noModuleLevelMutableState,
+      'Program',
+      program([
+        {
+          type: 'ExportNamedDeclaration',
+          declaration: variableDeclaration('let', 'counter'),
+        },
+      ]),
+    )
+
+    expect(result).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## What

Adds `no-module-level-mutable-state`: it flags module-scope `let`/`var` (including `export let`) in Foldkit files, where a hidden mutable binding lives outside the single Model tree. Ambient `declare let` is left alone. The rule visits `Program` and reports each offending declaration.

```ts
let cache = new Map()        // flagged
export let counter = 0       // flagged
const config = loadConfig()  // fine
declare let __DEV__: boolean  // fine (ambient)
```

## Why

The current 7 rules all live in the Message / Command-shape family. The one class most worth adding for real apps (and the one an LLM-assisted contributor most easily violates) is the purity boundary: module-level mutable state is exactly the kind of hidden side channel The Elm Architecture is meant to make impossible, and a linter catches it where review does not.

## Attribution

This is ported from the purity-boundary family in [`@mpsuesser/oxlint-plugin-foldkit`](https://github.com/mpsuesser/oxlint-plugin-foldkit) (MIT, by Marc Suesser, who sponsors Foldkit). That plugin is a 45-rule superset built on the same `effect-oxlint` SDK, and its author deliberately reserved the `foldkit/*` namespace for this project. I reimplemented the rule in this plugin's inline-guard style rather than copying, so it reads like the existing rules here. If it is useful, the broader purity and view/lifecycle families there are good candidates to bring upstream too, and Marc's plugin is worth a mention on the Foldkit site as the community superset.

## Tests

- Added three cases (flags a module-level `let`, allows `const`, flags an exported `let`).
- Full suite passes (19 tests) and `tsc --noEmit` is clean.
