### PR TITLE
chore(release): unwrap changeset summaries

### DIFF
--- a/.changeset/no-module-level-mutable-state.md
+++ b/.changeset/no-module-level-mutable-state.md
@@ -3,10 +3,6 @@
 'create-foldkit-app': minor
 ---
 
-Add `foldkit/no-module-level-mutable-state`, a lint rule that flags module-level
-`let` and `var` declarations (including `export let`), which hold state outside
-the Model. Ambient `declare let` declarations are not flagged. Scaffolded
-projects enable the rule in their generated `.oxlintrc.json`.
+Add `foldkit/no-module-level-mutable-state`, a lint rule that flags module-level `let` and `var` declarations (including `export let`), which hold state outside the Model. Ambient `declare let` declarations are not flagged. Scaffolded projects enable the rule in their generated `.oxlintrc.json`.
 
-Ported from the purity-boundary rule family in `@mpsuesser/oxlint-plugin-foldkit`
-by Marc Suesser.
+Ported from the purity-boundary rule family in `@mpsuesser/oxlint-plugin-foldkit` by Marc Suesser.

--- a/.changeset/typecheck-test-files.md
+++ b/.changeset/typecheck-test-files.md
@@ -5,6 +5,4 @@
 'create-foldkit-app': patch
 ---
 
-Typecheck test files. Each package's `typecheck` script now checks the
-project that includes tests instead of the build project that excludes
-them. No runtime changes.
+Typecheck test files. Each package's `typecheck` script now checks the project that includes tests instead of the build project that excludes them. No runtime changes.


### PR DESCRIPTION
The Version Packages PR (#596) shows jagged line wrapping in two of its release entries. The cause is the changeset files themselves: `no-module-level-mutable-state.md` and `typecheck-test-files.md` were written with hard line breaks at roughly 80 columns, and GitHub renders PR bodies with comment-style markdown, where a single newline inside a paragraph becomes a real line break.

This unwraps both summaries so each paragraph is a single line. The changesets action will regenerate the Version Packages PR body cleanly on its next run after this merges. No content changes, only whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAWbvnzLuqcTREawHww2cd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAWbvnzLuqcTREawHww2cd)_