### PR TITLE
feat(devtools): persist panel open state across page reloads

### DIFF
--- a/.changeset/devtools-persist-panel-open.md
+++ b/.changeset/devtools-persist-panel-open.md
@@ -1,0 +1,20 @@
+---
+'@foldkit/devtools': minor
+---
+
+Persist the DevTools panel's open state across page reloads.
+
+The overlay previously booted closed unconditionally, so every reload
+(including every dev-server full reload) meant clicking the badge again to
+reopen the panel. The open state now survives reloads: it is read at overlay
+boot and written on each badge toggle. Booting with the panel open also
+replays the open side effects, locking page scroll when the mobile breakpoint
+matches.
+
+DevTools persisted state (panel open and flatten-to-leaf) now lives under a
+single `foldkit-devtools` localStorage key, decoded with per-field defaults so
+a missing field falls back on its own. The previous `foldkit-devtools-flatten`
+key is no longer read, so that toggle resets once.
+
+A first-ever load still starts closed, and storage that is blocked or throws
+(for example private browsing) falls back to closed.

--- a/packages/devtools/src/overlay.ts
+++ b/packages/devtools/src/overlay.ts
@@ -157,6 +157,7 @@ const Model = S.Struct({
 type Model = typeof Model.Type
 
 const Flags = S.Struct({
+  isOpen: S.Boolean,
   isMobile: S.Boolean,
   isFlattened: S.Boolean,
   entries: S.Array(DisplayEntry),
@@ -174,7 +175,7 @@ const ClickedSettingsToggle = m('ClickedSettingsToggle')
 const GotFlattenSwitchMessage = m('GotFlattenSwitchMessage', {
   message: Switch.Message,
 })
-const CompletedPersistFlatten = m('CompletedPersistFlatten')
+const CompletedPersistDevToolsState = m('CompletedPersistDevToolsState')
 const ClickedRow = m('ClickedRow', { index: S.Number })
 const ClickedResume = m('ClickedResume')
 const ClickedClear = m('ClickedClear')
@@ -220,7 +221,7 @@ const Message = S.Union([
   ClickedToggle,
   ClickedSettingsToggle,
   GotFlattenSwitchMessage,
-  CompletedPersistFlatten,
+  CompletedPersistDevToolsState,
   ClickedRow,
   ClickedResume,
   ClickedClear,
@@ -251,8 +252,7 @@ const MOBILE_BREAKPOINT_QUERY = `(max-width: ${MOBILE_BREAKPOINT}px)`
 const TREE_INDENT_PX = 12
 const MAX_PREVIEW_KEYS = 3
 const ALL_MESSAGES_VALUE = ''
-const FLATTEN_STORAGE_KEY = 'foldkit-devtools-flatten'
-const BooleanJsonString = S.fromJsonString(S.Boolean)
+const DEVTOOLS_STORAGE_KEY = 'foldkit-devtools'
 const NO_COMMANDS: ReadonlyArray<typeof DisplayCommand.Type> = []
 const NO_MOUNTS: ReadonlyArray<typeof DisplayMount.Type> = []
 
@@ -384,29 +384,51 @@ export const UnlockScroll = Command.define(
   UnlockedScroll,
 )(unlockScroll.pipe(Effect.as(UnlockedScroll())))
 
-const readPersistedFlatten: Effect.Effect<boolean> = Effect.gen(function* () {
-  const store = yield* KeyValueStore.KeyValueStore
-  const json = yield* Effect.fromOption(
-    Option.fromNullishOr(yield* store.get(FLATTEN_STORAGE_KEY)),
-  )
-  return yield* S.decodeEffect(BooleanJsonString)(json)
-}).pipe(
-  Effect.catch(() => Effect.succeed(false)),
+const maybeToggleScrollLock = (isEnabled: boolean, shouldLock: boolean) =>
+  OptionExt.when(isEnabled, shouldLock ? LockScroll() : UnlockScroll())
+
+const maybeLockScroll = (isOpen: boolean, isMobile: boolean) =>
+  OptionExt.when(isOpen && isMobile, LockScroll())
+
+const DevToolsPersistedState = S.Struct({
+  isOpen: S.Boolean.pipe(S.withDecodingDefault(Effect.succeed(false))),
+  isFlattened: S.Boolean.pipe(S.withDecodingDefault(Effect.succeed(false))),
+})
+type DevToolsPersistedState = typeof DevToolsPersistedState.Type
+const DevToolsPersistedStateJson = S.fromJsonString(DevToolsPersistedState)
+const DEFAULT_PERSISTED_STATE: DevToolsPersistedState = {
+  isOpen: false,
+  isFlattened: false,
+}
+
+const readPersistedState: Effect.Effect<DevToolsPersistedState> = Effect.gen(
+  function* () {
+    const store = yield* KeyValueStore.KeyValueStore
+    const json = yield* Effect.fromOption(
+      Option.fromNullishOr(yield* store.get(DEVTOOLS_STORAGE_KEY)),
+    )
+    return yield* S.decodeEffect(DevToolsPersistedStateJson)(json)
+  },
+).pipe(
+  Effect.catch(() => Effect.succeed(DEFAULT_PERSISTED_STATE)),
   Effect.provide(BrowserKeyValueStore.layerLocalStorage),
 )
 
-export const PersistFlatten = Command.define(
-  'PersistFlatten',
-  { isFlattened: S.Boolean },
-  CompletedPersistFlatten,
-)(({ isFlattened }) =>
+export const PersistDevToolsState = Command.define(
+  'PersistDevToolsState',
+  { isOpen: S.Boolean, isFlattened: S.Boolean },
+  CompletedPersistDevToolsState,
+)(({ isOpen, isFlattened }) =>
   Effect.gen(function* () {
     const store = yield* KeyValueStore.KeyValueStore
-    const json = yield* S.encodeEffect(BooleanJsonString)(isFlattened)
-    yield* store.set(FLATTEN_STORAGE_KEY, json)
-    return CompletedPersistFlatten()
+    const json = yield* S.encodeEffect(DevToolsPersistedStateJson)({
+      isOpen,
+      isFlattened,
+    })
+    yield* store.set(DEVTOOLS_STORAGE_KEY, json)
+    return CompletedPersistDevToolsState()
   }).pipe(
-    Effect.catch(() => Effect.succeed(CompletedPersistFlatten())),
+    Effect.catch(() => Effect.succeed(CompletedPersistDevToolsState())),
     Effect.provide(BrowserKeyValueStore.layerLocalStorage),
   ),
 )
@@ -520,9 +542,6 @@ const makeUpdate = (
   const inspectState = (index: number) =>
     Command.mapEffect(InspectState({ index }), provideContext)
 
-  const toggleScrollLock = (shouldLock: boolean) =>
-    shouldLock ? LockScroll() : UnlockScroll()
-
   return (model: Model, message: Message): UpdateReturn =>
     M.value(message).pipe(
       M.withReturnType<UpdateReturn>(),
@@ -531,9 +550,15 @@ const makeUpdate = (
           const nextIsOpen = !model.isOpen
           return [
             evo(model, { isOpen: () => nextIsOpen }),
-            OptionExt.when(model.isMobile, toggleScrollLock(nextIsOpen)).pipe(
-              Option.toArray,
-            ),
+            [
+              ...Option.toArray(
+                maybeToggleScrollLock(model.isMobile, nextIsOpen),
+              ),
+              PersistDevToolsState({
+                isOpen: nextIsOpen,
+                isFlattened: model.flattenSwitch.isChecked,
+              }),
+            ],
           ]
         },
         ClickedSettingsToggle: () => [
@@ -568,7 +593,10 @@ const makeUpdate = (
                   evo(model, { flattenSwitch: () => nextFlattenSwitch }),
                   [
                     ...mappedCommands,
-                    PersistFlatten({ isFlattened: isChecked }),
+                    PersistDevToolsState({
+                      isOpen: model.isOpen,
+                      isFlattened: isChecked,
+                    }),
                   ],
                 ],
               }),
@@ -577,9 +605,7 @@ const makeUpdate = (
         },
         CrossedMobileBreakpoint: ({ isMobile }) => [
           evo(model, { isMobile: () => isMobile }),
-          OptionExt.when(model.isOpen, toggleScrollLock(isMobile)).pipe(
-            Option.toArray,
-          ),
+          Option.toArray(maybeToggleScrollLock(model.isOpen, isMobile)),
         ],
         ClickedRow: ({ index }) =>
           M.value(mode).pipe(
@@ -832,7 +858,7 @@ const makeUpdate = (
       M.tag(
         'CompletedResume',
         'CompletedClear',
-        'CompletedPersistFlatten',
+        'CompletedPersistDevToolsState',
         'LockedScroll',
         'UnlockedScroll',
         'ScrolledToTop',
@@ -2474,8 +2500,9 @@ export const createOverlay = (
 
     const flags: Effect.Effect<typeof Flags.Type> = Effect.gen(function* () {
       const storeState = yield* SubscriptionRef.get(store.stateRef)
-      const isFlattened = yield* readPersistedFlatten
+      const { isOpen, isFlattened } = yield* readPersistedState
       return {
+        isOpen,
         isMobile: window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches,
         isFlattened,
         ...toDisplayState(storeState),
@@ -2491,7 +2518,6 @@ export const createOverlay = (
 
       return [
         {
-          isOpen: false,
           screen: 'Messages',
           ...displayFlags,
           flattenSwitch: Switch.init({
@@ -2522,7 +2548,7 @@ export const createOverlay = (
             initialValue: initialSliderValue,
           }),
         },
-        [],
+        Option.toArray(maybeLockScroll(flags.isOpen, flags.isMobile)),
       ]
     }
 


### PR DESCRIPTION
## What

Persist the DevTools panel's open state across page reloads. The overlay
previously booted with `isOpen: false` unconditionally, so every reload
(including every dev-server full reload while iterating on an app) meant
clicking the badge again to reopen the panel.

## How

DevTools persisted state now lives under a single `foldkit-devtools`
localStorage key, scoped to `packages/devtools/src/overlay.ts`:

- A `DevToolsPersistedState` struct (`isOpen`, `isFlattened`) is read at
  overlay boot into `Flags` and applied in `init`. Each field uses
  `S.withDecodingDefault`, so a missing field falls back on its own, and the
  whole read falls back to closed on absent or corrupt storage.
- Toggling either setting dispatches a single `PersistDevToolsState` Command
  that writes the whole record from the current model, so each toggle
  preserves the other field. Acknowledged by a `CompletedPersistDevToolsState`
  Message.
- Booting with the panel open replays the open side effects: `init` returns a
  `LockScroll` boot Command when the mobile breakpoint matches, matching what
  `ClickedToggle` produces on mobile.

The previous `foldkit-devtools-flatten` key is no longer read, so the
flatten-to-leaf toggle resets once. A first-ever load still starts closed: the
badge remains the opt-in, and the open state never appears in any settings
surface.

## Verification

Drove a devtools-enabled example app (counter) with Playwright against the
edited source (19 checks):

- First load with clean storage starts closed; opening writes
  `{isOpen:true,isFlattened:false}`; reload boots open; closing persists
  `isOpen:false`; reload stays closed.
- Cross-preservation both ways: toggling the panel open preserves a stored
  `isFlattened:true`, and toggling the flatten switch preserves `isOpen:true`.
  The flatten toggle round-trips through a reload.
- A partial blob (`isOpen` absent), a garbage string, and a wrong-typed field
  all boot closed.
- Mobile viewport booting open locks page scroll at boot and unlocks on close;
  desktop booting open does not lock.

## Note on a pre-existing dispose gap

While reviewing this change I traced a pre-existing asymmetry it makes easier
to reach: no overlay teardown path releases the scroll lock. `createOverlay`'s
release only removes the shadow host, and `embed().dispose()` interrupts the
scope without unlocking, so a dispose while the panel is open on mobile leaks a
count in `foldkit/dom`'s ref-counted lock. That was already true on main for a
user-opened panel; with persistence, an embed host that disposes and re-embeds
can now hit it at boot without interaction. Fixing it needs teardown machinery
that knows whether the overlay currently holds the lock, which the issue
explicitly scoped out of this change, so this PR leaves it alone. Happy to file
a follow-up issue if useful.

Fixes #604.
