### PR TITLE
feat(oxlint-plugin): port 38 convention rules from @mpsuesser/oxlint-plugin-foldkit

### DIFF
--- a/.changeset/port-mpsuesser-convention-rules.md
+++ b/.changeset/port-mpsuesser-convention-rules.md
@@ -1,0 +1,19 @@
+---
+'@foldkit/oxlint-plugin': minor
+---
+
+Add 38 convention rules ported from [`@mpsuesser/oxlint-plugin-foldkit`](https://github.com/mpsuesser/oxlint-plugin-foldkit) (MIT, © Marc Suesser), bringing the plugin from 8 to 46 rules. They extend the existing message/command-naming checks into Foldkit's other convention surfaces:
+
+- **Routing** — `route-union-parser-registration`, `route-oneof-shadowing-order`, `no-hardcoded-route-strings`
+- **View keying & accessibility** — `no-array-index-view-keys`, `keyed-required-for-mapped-rows`, `label-requires-for`, `require-rel-for-external-link`, `no-hand-rolled-form-controls`, `no-raw-dom-event-attributes`
+- **The `evo`/Model update idiom** — `prefer-evo-over-model-spread`, `no-spread-in-evo`, `prefer-option-match-over-map-getorelse`
+- **Command shape** — `command-define-pascal-const`, `command-failed-result-requires-catch`, `no-hand-rolled-command-struct`, `no-explicit-command-type-annotation`, `require-succeeded-failed-pair`, `require-completed-mirrors-command`
+- **Purity boundaries** — `no-impure-calls-in-pure-layer`, `no-disabling-dev-guardrails`
+- **Submodel wiring** — `wrap-child-output-in-got-message`, `got-wrapper-carries-only-routing`, `no-child-message-construction-in-root`, `selection-submodel-factory-at-module-scope`
+- **Lifecycle handles** — `managed-resource-for-stateful-handles`, `mount-factory-must-use-element`, `no-duplicate-onmount-per-element`
+- **DOM & UI helpers** — `prefer-dom-helpers-for-element-ops`, `prefer-empty-over-empty-element`, `ui-toview-must-spread-attribute-bundles`, `lazy-view-stable-references`
+- **Message naming** — `require-past-tense-message-names`, `no-changed-message-prefix`, `foldkit-primitives-declared-in-role-files`
+- **Test shape** — `subscription-file-canonical-shape`, `prefer-story-command-matchers`, `scene-tests-run-from-root`
+- **Type shape** — `no-array-shorthand-type`
+
+Each new rule lives in `src/rules/` (one per file) with co-located tests. The eight existing rules are unchanged. None of the new rules are enabled in the scaffold preset — enabling them per app stays opt-in, so this is additive and non-breaking for existing projects.

--- a/packages/oxlint-plugin-foldkit/src/index.ts
+++ b/packages/oxlint-plugin-foldkit/src/index.ts
@@ -7,6 +7,45 @@ import {
   RuleContext,
 } from 'effect-oxlint'
 
+import commandDefinePascalConst from './rules/command-define-pascal-const.ts'
+import commandFailedResultRequiresCatch from './rules/command-failed-result-requires-catch.ts'
+import foldkitPrimitivesDeclaredInRoleFiles from './rules/foldkit-primitives-declared-in-role-files.ts'
+import gotWrapperCarriesOnlyRouting from './rules/got-wrapper-carries-only-routing.ts'
+import keyedRequiredForMappedRows from './rules/keyed-required-for-mapped-rows.ts'
+import labelRequiresFor from './rules/label-requires-for.ts'
+import lazyViewStableReferences from './rules/lazy-view-stable-references.ts'
+import managedResourceForStatefulHandles from './rules/managed-resource-for-stateful-handles.ts'
+import mountFactoryMustUseElement from './rules/mount-factory-must-use-element.ts'
+import noArrayIndexViewKeys from './rules/no-array-index-view-keys.ts'
+import noArrayShorthandType from './rules/no-array-shorthand-type.ts'
+import noChangedMessagePrefix from './rules/no-changed-message-prefix.ts'
+import noChildMessageConstructionInRoot from './rules/no-child-message-construction-in-root.ts'
+import noDisablingDevGuardrails from './rules/no-disabling-dev-guardrails.ts'
+import noDuplicateOnmountPerElement from './rules/no-duplicate-onmount-per-element.ts'
+import noExplicitCommandTypeAnnotation from './rules/no-explicit-command-type-annotation.ts'
+import noHandRolledCommandStruct from './rules/no-hand-rolled-command-struct.ts'
+import noHandRolledFormControls from './rules/no-hand-rolled-form-controls.ts'
+import noHardcodedRouteStrings from './rules/no-hardcoded-route-strings.ts'
+import noImpureCallsInPureLayer from './rules/no-impure-calls-in-pure-layer.ts'
+import noRawDomEventAttributes from './rules/no-raw-dom-event-attributes.ts'
+import noSpreadInEvo from './rules/no-spread-in-evo.ts'
+import preferDomHelpersForElementOps from './rules/prefer-dom-helpers-for-element-ops.ts'
+import preferEmptyOverEmptyElement from './rules/prefer-empty-over-empty-element.ts'
+import preferEvoOverModelSpread from './rules/prefer-evo-over-model-spread.ts'
+import preferOptionMatchOverMapGetorelse from './rules/prefer-option-match-over-map-getorelse.ts'
+import preferStoryCommandMatchers from './rules/prefer-story-command-matchers.ts'
+import requireCompletedMirrorsCommand from './rules/require-completed-mirrors-command.ts'
+import requirePastTenseMessageNames from './rules/require-past-tense-message-names.ts'
+import requireRelForExternalLink from './rules/require-rel-for-external-link.ts'
+import requireSucceededFailedPair from './rules/require-succeeded-failed-pair.ts'
+import routeOneofShadowingOrder from './rules/route-oneof-shadowing-order.ts'
+import routeUnionParserRegistration from './rules/route-union-parser-registration.ts'
+import sceneTestsRunFromRoot from './rules/scene-tests-run-from-root.ts'
+import selectionSubmodelFactoryAtModuleScope from './rules/selection-submodel-factory-at-module-scope.ts'
+import subscriptionFileCanonicalShape from './rules/subscription-file-canonical-shape.ts'
+import uiToviewMustSpreadAttributeBundles from './rules/ui-toview-must-spread-attribute-bundles.ts'
+import wrapChildOutputInGotMessage from './rules/wrap-child-output-in-got-message.ts'
+
 // GUARDS
 
 const isIdentifier = (
@@ -471,6 +510,47 @@ export const noModuleLevelMutableState = Rule.define({
 export default Plugin.define({
   name: 'foldkit',
   rules: {
+    'command-define-pascal-const': commandDefinePascalConst,
+    'command-failed-result-requires-catch': commandFailedResultRequiresCatch,
+    'foldkit-primitives-declared-in-role-files':
+      foldkitPrimitivesDeclaredInRoleFiles,
+    'got-wrapper-carries-only-routing': gotWrapperCarriesOnlyRouting,
+    'keyed-required-for-mapped-rows': keyedRequiredForMappedRows,
+    'label-requires-for': labelRequiresFor,
+    'lazy-view-stable-references': lazyViewStableReferences,
+    'managed-resource-for-stateful-handles': managedResourceForStatefulHandles,
+    'mount-factory-must-use-element': mountFactoryMustUseElement,
+    'no-array-index-view-keys': noArrayIndexViewKeys,
+    'no-array-shorthand-type': noArrayShorthandType,
+    'no-changed-message-prefix': noChangedMessagePrefix,
+    'no-child-message-construction-in-root': noChildMessageConstructionInRoot,
+    'no-disabling-dev-guardrails': noDisablingDevGuardrails,
+    'no-duplicate-onmount-per-element': noDuplicateOnmountPerElement,
+    'no-explicit-command-type-annotation': noExplicitCommandTypeAnnotation,
+    'no-hand-rolled-command-struct': noHandRolledCommandStruct,
+    'no-hand-rolled-form-controls': noHandRolledFormControls,
+    'no-hardcoded-route-strings': noHardcodedRouteStrings,
+    'no-impure-calls-in-pure-layer': noImpureCallsInPureLayer,
+    'no-raw-dom-event-attributes': noRawDomEventAttributes,
+    'no-spread-in-evo': noSpreadInEvo,
+    'prefer-dom-helpers-for-element-ops': preferDomHelpersForElementOps,
+    'prefer-empty-over-empty-element': preferEmptyOverEmptyElement,
+    'prefer-evo-over-model-spread': preferEvoOverModelSpread,
+    'prefer-option-match-over-map-getorelse': preferOptionMatchOverMapGetorelse,
+    'prefer-story-command-matchers': preferStoryCommandMatchers,
+    'require-completed-mirrors-command': requireCompletedMirrorsCommand,
+    'require-past-tense-message-names': requirePastTenseMessageNames,
+    'require-rel-for-external-link': requireRelForExternalLink,
+    'require-succeeded-failed-pair': requireSucceededFailedPair,
+    'route-oneof-shadowing-order': routeOneofShadowingOrder,
+    'route-union-parser-registration': routeUnionParserRegistration,
+    'scene-tests-run-from-root': sceneTestsRunFromRoot,
+    'selection-submodel-factory-at-module-scope':
+      selectionSubmodelFactoryAtModuleScope,
+    'subscription-file-canonical-shape': subscriptionFileCanonicalShape,
+    'ui-toview-must-spread-attribute-bundles':
+      uiToviewMustSpreadAttributeBundles,
+    'wrap-child-output-in-got-message': wrapChildOutputInGotMessage,
     'command-binding-matches-name': commandBindingMatchesName,
     'got-prefix-requires-submodel-payload': gotPrefixRequiresSubmodelPayload,
     'got-submodel-message-name': gotSubmodelMessageName,

--- a/packages/oxlint-plugin-foldkit/src/rules/command-define-pascal-const.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/command-define-pascal-const.ts
@@ -1,0 +1,169 @@
+import { Match, pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Schema from 'effect/Schema'
+
+const PascalCase = Schema.String.check(
+  Schema.isPattern(/^[A-Z][A-Za-z0-9]*$/, {
+    identifier: 'PascalCase',
+    title: 'PascalCase Identifier',
+    description: 'A non-empty PascalCase identifier (e.g. `FetchWeather`).',
+  }),
+)
+
+const isPascalCase = Schema.is(PascalCase)
+
+interface Diagnosis {
+  readonly node: ESTree.CallExpression
+  readonly message: string
+}
+
+const stringLiteralValue = (arg: ESTree.Argument): Option.Option<string> =>
+  arg.type === 'Literal' && P.isString(arg.value)
+    ? Option.some(arg.value)
+    : Option.none()
+
+/** Walk the typed parent chain to find the enclosing `VariableDeclarator`. */
+const walkUpForDeclarator = (
+  node: Option.Option<ESTree.Node>,
+): Option.Option<ESTree.VariableDeclarator> =>
+  Option.match(node, {
+    onNone: () => Option.none(),
+    onSome: n =>
+      n.type === 'VariableDeclarator'
+        ? Option.some(n)
+        : walkUpForDeclarator(Option.fromNullishOr(n.parent)),
+  })
+
+const declaratorOf = (
+  node: ESTree.CallExpression,
+): Option.Option<ESTree.VariableDeclarator> =>
+  walkUpForDeclarator(Option.fromNullishOr(node.parent))
+
+const declaratorName = (
+  declarator: ESTree.VariableDeclarator,
+): Option.Option<string> =>
+  declarator.id.type === 'Identifier'
+    ? Option.some(declarator.id.name)
+    : Option.none()
+
+/**
+ * Find the `Command.define(...)` call that heads a declarator's init,
+ * descending through any curried application calls. Foldkit's canonical
+ * signature is curried — `Command.define(name, payload, SuccessCtor)(handler)`
+ * — so the declarator's `init` is the outermost application call, not the
+ * `Command.define(...)` call itself.
+ */
+const initCommandDefineCall = (
+  init: ESTree.Node | null | undefined,
+): Option.Option<ESTree.CallExpression> => {
+  if (init === null || init === undefined || init.type !== 'CallExpression') {
+    return Option.none()
+  }
+  if (AST.isCallOf(init, 'Command', 'define')) return Option.some(init)
+  return init.callee.type === 'CallExpression'
+    ? initCommandDefineCall(init.callee)
+    : Option.none()
+}
+
+/**
+ * True when `node` is the `Command.define(...)` call that heads `declarator`'s
+ * init — whether assigned directly (`const X = Command.define(...)`) or through
+ * curried application (`const X = Command.define(...)(handler)`).
+ */
+const isImmediateInitOf = (
+  declarator: ESTree.VariableDeclarator,
+  node: ESTree.CallExpression,
+): boolean =>
+  Option.match(initCommandDefineCall(declarator.init), {
+    onNone: () => false,
+    onSome: call => call === node,
+  })
+
+const diagnoseFromName = (
+  node: ESTree.CallExpression,
+  name: string,
+): Option.Option<Diagnosis> =>
+  Match.value(name).pipe(
+    Match.when(
+      n => !isPascalCase(n),
+      () =>
+        Option.some<Diagnosis>({
+          node,
+          message: `\`Command.define('${name}', ...)\` must use a PascalCase name (e.g. \`FetchWeather\`, \`FocusInput\`). (FK-2)`,
+        }),
+    ),
+    Match.orElse(() =>
+      pipe(
+        declaratorOf(node),
+        Option.filter(d => isImmediateInitOf(d, node)),
+        Option.match({
+          onNone: () =>
+            Option.some<Diagnosis>({
+              node,
+              message: `\`Command.define('${name}', ...)\` must be assigned to a PascalCase \`const\` — never inline in a pipe or expression. Write \`const ${name} = Command.define('${name}', ...)\`. (FK-2)`,
+            }),
+          onSome: d =>
+            pipe(
+              declaratorName(d),
+              Option.flatMap(got =>
+                got === name
+                  ? Option.none<Diagnosis>()
+                  : Option.some<Diagnosis>({
+                      node,
+                      message: `\`Command.define('${name}', ...)\` should be assigned to a const named \`${name}\` — got \`${got}\`. The const name must mirror the Command identity. (FK-2)`,
+                    }),
+              ),
+            ),
+        }),
+      ),
+    ),
+  )
+
+const diagnose = (node: ESTree.CallExpression): Option.Option<Diagnosis> => {
+  const arg = node.arguments[0]
+  if (arg === undefined) {
+    return Option.some({
+      node,
+      message:
+        '`Command.define` requires a literal string name as its first argument. (FK-2)',
+    })
+  }
+  return pipe(
+    stringLiteralValue(arg),
+    Option.match({
+      onNone: () =>
+        Option.some<Diagnosis>({
+          node,
+          message:
+            '`Command.define` requires a literal string name as its first argument. (FK-2)',
+        }),
+      onSome: name => diagnoseFromName(node, name),
+    }),
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'command-define-pascal-const',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      '`Command.define(...)` must be assigned to a PascalCase const matching the first argument (FK-2)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node => {
+      if (!AST.isCallOf(node, 'Command', 'define')) return Effect.void
+      return Option.match(diagnose(node), {
+        onNone: () => Effect.void,
+        onSome: d => ctx.report(Diagnostic.make(d)),
+      })
+    })
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/command-failed-result-requires-catch.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/command-failed-result-requires-catch.ts
@@ -1,0 +1,386 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+import * as Schema from 'effect/Schema'
+
+const FailedResultName = Schema.String.check(
+  Schema.isPattern(/^Failed[A-Z]/, {
+    identifier: 'FailedResultName',
+    title: 'Failed-prefixed Command Result',
+    description:
+      'A Command result constructor whose name starts with `Failed` followed by an uppercase letter.',
+  }),
+)
+const isFailedResultName = Schema.is(FailedResultName)
+
+const CATCH_METHODS = HashSet.make(
+  'catch',
+  'catchAll',
+  'catchCause',
+  'catchIf',
+  'catchTag',
+  'catchTags',
+  'match',
+  'matchCause',
+)
+
+const isCommandDefineCall = (node: ESTree.CallExpression): boolean =>
+  AST.isCallOf(node, 'Command', 'define')
+
+const appliedCommandDefine = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.CallExpression> =>
+  call.callee.type === 'CallExpression' && isCommandDefineCall(call.callee)
+    ? Option.some(call.callee)
+    : Option.none()
+
+const resultArgs = (
+  defineCall: ESTree.CallExpression,
+): ReadonlyArray<ESTree.Argument> => {
+  const withoutName = Arr.drop(defineCall.arguments, 1)
+  return pipe(
+    Arr.head(withoutName),
+    Option.match({
+      onNone: () => withoutName,
+      onSome: arg =>
+        arg.type === 'ObjectExpression'
+          ? Arr.drop(withoutName, 1)
+          : withoutName,
+    }),
+  )
+}
+
+const argumentName = (arg: ESTree.Argument): Option.Option<string> => {
+  if (arg.type === 'Identifier') return Option.some(arg.name)
+  if (arg.type === 'MemberExpression') {
+    return pipe(AST.memberPath(arg), Option.map(Arr.lastNonEmpty))
+  }
+  return Option.none()
+}
+
+const failedResultNames = (
+  defineCall: ESTree.CallExpression,
+): ReadonlyArray<string> =>
+  pipe(
+    resultArgs(defineCall),
+    Arr.filterMap(arg =>
+      pipe(
+        argumentName(arg),
+        Option.filter(isFailedResultName),
+        Result.fromOption(() => undefined),
+      ),
+    ),
+  )
+
+const hasFailedResult = (defineCall: ESTree.CallExpression): boolean =>
+  Arr.isReadonlyArrayNonEmpty(failedResultNames(defineCall))
+
+const parentOf = (node: {
+  readonly parent?: unknown
+}): Option.Option<{
+  readonly type: string
+  readonly callee?: unknown
+  readonly parent?: unknown
+}> =>
+  pipe(
+    Option.fromNullishOr(node.parent),
+    Option.filter(
+      (
+        parent,
+      ): parent is {
+        readonly type: string
+        readonly callee?: unknown
+        readonly parent?: unknown
+      } => P.isObject(parent) && 'type' in parent && P.isString(parent.type),
+    ),
+  )
+
+const isImmediatelyApplied = (defineCall: ESTree.CallExpression): boolean =>
+  pipe(
+    parentOf(defineCall),
+    Option.match({
+      onNone: () => false,
+      onSome: parent =>
+        parent.type === 'CallExpression' && parent.callee === defineCall,
+    }),
+  )
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type MemberExpressionLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly object?: unknown
+  readonly property?: unknown
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpressionLike = (
+  value: unknown,
+): value is MemberExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const memberPath = (
+  value: unknown,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  if (isIdentifierLike(value)) return Option.some([value.name])
+  if (!isMemberExpressionLike(value) || value.computed === true) {
+    return Option.none()
+  }
+  const property = value.property
+  if (!isIdentifierLike(property)) return Option.none()
+  return pipe(
+    memberPath(value.object),
+    Option.map(path => [...path, property.name]),
+  )
+}
+
+const isEffectCatchCall = (value: unknown): boolean => {
+  if (!P.isObject(value)) return false
+  if (!('type' in value) || value.type !== 'CallExpression') return false
+  if (!('callee' in value)) return false
+  return pipe(
+    memberPath(value.callee),
+    Option.match({
+      onNone: () => false,
+      onSome: path => {
+        const method = Arr.lastNonEmpty(path)
+        return (
+          path.length === 2 &&
+          Arr.headNonEmpty(path) === 'Effect' &&
+          HashSet.has(CATCH_METHODS, method)
+        )
+      },
+    }),
+  )
+}
+
+const containsCatch = (root: unknown): boolean => {
+  if (isEffectCatchCall(root)) return true
+  if (!P.isObject(root)) return false
+  return pipe(
+    Object.entries(root),
+    Arr.some(([key, child]) =>
+      key === 'parent'
+        ? false
+        : Array.isArray(child)
+          ? pipe(child, Arr.some(containsCatch))
+          : containsCatch(child),
+    ),
+  )
+}
+
+const appliedArgumentContainsCatch = (call: ESTree.CallExpression): boolean =>
+  pipe(call.arguments, Arr.some(containsCatch))
+
+type ProgramLike = {
+  readonly type: string
+  readonly body: ReadonlyArray<unknown>
+}
+
+const isProgramLike = (value: unknown): value is ProgramLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Program' &&
+  'body' in value &&
+  Array.isArray(value.body)
+
+/** Walk `parent` links from a node up to the enclosing `Program`, if reachable. */
+const findProgram = (node: unknown): Option.Option<ProgramLike> => {
+  let current: unknown = node
+  for (let depth = 0; depth < 1000; depth += 1) {
+    if (isProgramLike(current)) return Option.some(current)
+    if (!P.isObject(current) || !('parent' in current)) return Option.none()
+    current = current.parent
+  }
+  return Option.none()
+}
+
+/** Collect the names of every identifier-callee call within an AST subtree. */
+const collectCalledIdentifierNames = (
+  root: unknown,
+  acc: Set<string>,
+): void => {
+  if (!P.isObject(root)) return
+  if (
+    'type' in root &&
+    root.type === 'CallExpression' &&
+    'callee' in root &&
+    isIdentifierLike(root.callee)
+  ) {
+    acc.add(root.callee.name)
+  }
+  pipe(
+    Object.entries(root),
+    Arr.forEach(([key, child]) => {
+      if (key === 'parent') return
+      if (Array.isArray(child)) {
+        pipe(
+          child,
+          Arr.forEach(c => collectCalledIdentifierNames(c, acc)),
+        )
+      } else {
+        collectCalledIdentifierNames(child, acc)
+      }
+    }),
+  )
+}
+
+const declaratorLike = (value: unknown): Option.Option<unknown> => {
+  if (!P.isObject(value) || !('type' in value)) return Option.none()
+  // Unwrap `export const/function …`.
+  if (value.type === 'ExportNamedDeclaration' && 'declaration' in value) {
+    return declaratorLike(value.declaration)
+  }
+  return Option.some(value)
+}
+
+/**
+ * Resolve a top-level `function name(){}` or `const name = (…) => …` body from
+ * the module Program, so one level of local-function indirection can be
+ * inspected for a catch.
+ */
+const topLevelDeclBody = (
+  program: ProgramLike,
+  name: string,
+): Option.Option<unknown> =>
+  pipe(
+    program.body,
+    Arr.findFirst(statement =>
+      pipe(
+        declaratorLike(statement),
+        Option.flatMap(decl => {
+          if (!P.isObject(decl) || !('type' in decl)) {
+            return Option.none()
+          }
+          if (
+            decl.type === 'FunctionDeclaration' &&
+            'id' in decl &&
+            isIdentifierLike(decl.id) &&
+            decl.id.name === name &&
+            'body' in decl
+          ) {
+            return Option.some(decl.body)
+          }
+          if (
+            decl.type === 'VariableDeclaration' &&
+            'declarations' in decl &&
+            Array.isArray(decl.declarations)
+          ) {
+            return pipe(
+              decl.declarations,
+              Arr.findFirst(
+                (d): d is { readonly init: unknown } =>
+                  P.isObject(d) &&
+                  'id' in d &&
+                  isIdentifierLike(d.id) &&
+                  d.id.name === name &&
+                  'init' in d &&
+                  d.init !== null,
+              ),
+              Option.map(d => d.init),
+            )
+          }
+          return Option.none()
+        }),
+      ),
+    ),
+  )
+
+/**
+ * True when the applied Effect body calls a locally-defined function whose own
+ * body contains an `Effect.catch*`/`Effect.match*` — i.e. the catch is extracted
+ * into a helper instead of inlined. Follows one level of indirection; if the
+ * helper can't be resolved in this Program, returns false (keep flagging).
+ */
+const appliedCallsLocalCatcher = (call: ESTree.CallExpression): boolean => {
+  const names = new Set<string>()
+  pipe(
+    call.arguments,
+    Arr.forEach(arg => collectCalledIdentifierNames(arg, names)),
+  )
+  if (names.size === 0) return false
+  return pipe(
+    findProgram(call),
+    Option.match({
+      onNone: () => false,
+      onSome: program =>
+        pipe(
+          Array.from(names),
+          Arr.some(name =>
+            pipe(
+              topLevelDeclBody(program, name),
+              Option.match({
+                onNone: () => false,
+                onSome: containsCatch,
+              }),
+            ),
+          ),
+        ),
+    }),
+  )
+}
+
+const failedList = (defineCall: ESTree.CallExpression): string =>
+  pipe(failedResultNames(defineCall), Arr.join(', '))
+
+const rule: CreateRule = Rule.define({
+  name: 'command-failed-result-requires-catch',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Commands declaring Failed* results must catch failures into those result messages',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node => {
+      if (isCommandDefineCall(node)) {
+        return hasFailedResult(node) && !isImmediatelyApplied(node)
+          ? ctx.report(
+              Diagnostic.make({
+                node,
+                message: `\`Command.define\` declares ${failedList(node)} but is not immediately applied to an Effect factory. Apply it in-place and catch failures into the Failed result. (FK commands)`,
+              }),
+            )
+          : Effect.void
+      }
+      return pipe(
+        appliedCommandDefine(node),
+        Option.filter(hasFailedResult),
+        Option.filter(
+          () =>
+            !appliedArgumentContainsCatch(node) &&
+            !appliedCallsLocalCatcher(node),
+        ),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: defineCall =>
+            ctx.report(
+              Diagnostic.make({
+                node,
+                message: `\`Command.define\` declares ${failedList(defineCall)} but the applied Effect does not contain \`Effect.catch*\` or \`Effect.match*\`. Catch failures and return the Failed result so the Foldkit runtime receives a Message instead of a defect. (FK commands)`,
+              }),
+            ),
+        }),
+      )
+    })
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/foldkit-primitives-declared-in-role-files.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/foldkit-primitives-declared-in-role-files.ts
@@ -1,0 +1,175 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+import * as Str from 'effect/String'
+
+const normalizedPath = (filename: string): string =>
+  Str.replaceAll('\\', '/')(filename)
+
+const pathSegments = (filename: string): ReadonlyArray<string> =>
+  Str.split('/')(normalizedPath(filename))
+
+const basename = (filename: string): string =>
+  pipe(
+    pathSegments(filename),
+    Arr.last,
+    Option.getOrElse(() => filename),
+  )
+
+const parentDirectory = (filename: string): Option.Option<string> =>
+  pipe(pathSegments(filename), Arr.dropRight(1), Arr.last)
+
+const isRoleFile = (filename: string, role: string): boolean =>
+  basename(filename) === `${role}.ts` ||
+  pipe(
+    parentDirectory(filename),
+    Option.match({
+      onNone: () => false,
+      onSome: dir => dir === role,
+    }),
+  )
+
+const isMessageRoleFile = (filename: string): boolean =>
+  isRoleFile(filename, 'message')
+
+const isCommandRoleFile = (filename: string): boolean =>
+  isRoleFile(filename, 'command')
+
+const isSubscriptionRoleFile = (filename: string): boolean =>
+  isRoleFile(filename, 'subscription')
+
+const importSource = (node: ESTree.ImportDeclaration): string =>
+  node.source.value
+
+const isImportSpecifier = (
+  specifier: ESTree.ImportDeclaration['specifiers'][number],
+): specifier is ESTree.ImportSpecifier => specifier.type === 'ImportSpecifier'
+
+const importedName = (
+  specifier: ESTree.ImportSpecifier,
+): Option.Option<string> => {
+  const imported = specifier.imported
+  if (imported.type === 'Identifier') return Option.some(imported.name)
+  return imported.type === 'Literal' && P.isString(imported.value)
+    ? Option.some(imported.value)
+    : Option.none()
+}
+
+const mSchemaImportSpecifiers = (
+  importNode: ESTree.ImportDeclaration,
+): ReadonlyArray<ESTree.Node> =>
+  importSource(importNode) === 'foldkit/schema'
+    ? pipe(
+        importNode.specifiers,
+        Arr.filterMap(specifier =>
+          isImportSpecifier(specifier)
+            ? pipe(
+                importedName(specifier),
+                Option.filter(name => name === 'm'),
+                Option.map(() => specifier),
+                Result.fromOption(() => undefined),
+              )
+            : Result.failVoid,
+        ),
+      )
+    : []
+
+const subscriptionMethod = (
+  call: ESTree.CallExpression,
+): Option.Option<string> =>
+  pipe(
+    AST.matchCallOf(call, 'Subscription', [
+      'make',
+      'lift',
+      'aggregate',
+      'persistent',
+    ]),
+    Option.flatMap(matched =>
+      matched.callee.type === 'MemberExpression' &&
+      matched.callee.property.type === 'Identifier'
+        ? Option.some(matched.callee.property.name)
+        : Option.none(),
+    ),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'foldkit-primitives-declared-in-role-files',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Keep Foldkit primitive declarations in their role files: message.ts, command.ts, and subscription.ts',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+
+    return Visitor.merge(
+      Visitor.on('ImportDeclaration', node => {
+        if (isMessageRoleFile(ctx.filename)) return Effect.void
+        const foldkitMessage =
+          importSource(node) === 'foldkit/message'
+            ? [
+                ctx.report(
+                  Diagnostic.make({
+                    node,
+                    message:
+                      'Foldkit Message primitives must be declared from a `message.ts` file or `message/` role folder. Move this `foldkit/message` import into the role file and re-export helpers from there. (FK role files)',
+                  }),
+                ),
+              ]
+            : []
+        const schemaMImports = pipe(
+          mSchemaImportSpecifiers(node),
+          Arr.map(specifier =>
+            ctx.report(
+              Diagnostic.make({
+                node: specifier,
+                message:
+                  'Foldkit Message constructors (`m`) must be declared from a `message.ts` file or `message/` role folder. Move this `m` import into the role file and export the Message API from there. (FK role files)',
+              }),
+            ),
+          ),
+        )
+        return Effect.all([...foldkitMessage, ...schemaMImports], {
+          concurrency: 1,
+          discard: true,
+        })
+      }),
+      Visitor.on('CallExpression', node => {
+        if (
+          !isCommandRoleFile(ctx.filename) &&
+          AST.isCallOf(node, 'Command', 'define')
+        ) {
+          return ctx.report(
+            Diagnostic.make({
+              node,
+              message:
+                '`Command.define(...)` belongs in a `command.ts` file or `command/` role folder. Keep the Command catalog centralized and import the exported command instead. (FK role files)',
+            }),
+          )
+        }
+        return pipe(
+          subscriptionMethod(node),
+          Option.filter(() => !isSubscriptionRoleFile(ctx.filename)),
+          Option.match({
+            onNone: () => Effect.void,
+            onSome: method =>
+              ctx.report(
+                Diagnostic.make({
+                  node,
+                  message: `\`Subscription.${method}(...)\` belongs in a \`subscription.ts\` file or \`subscription/\` role folder. Keep subscription declarations centralized and lift/aggregate them from the role file. (FK role files)`,
+                }),
+              ),
+          }),
+        )
+      }),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/got-wrapper-carries-only-routing.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/got-wrapper-carries-only-routing.ts
@@ -1,0 +1,208 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+
+const gotWrapperPrefixPattern = /^Got[A-Z]/
+const gotWrapperFullNamePattern = /^Got[A-Z][A-Za-z0-9]*Message$/
+const allowedRoutingFieldPattern = /Id$/
+
+interface GotWrapperCall {
+  readonly tag: string
+  readonly tagNode: ESTree.Node
+  readonly callNode: ESTree.CallExpression
+}
+
+const isMCall = (call: ESTree.CallExpression): boolean =>
+  call.callee.type === 'Identifier' && call.callee.name === 'm'
+
+const stringLiteralArg = (arg: ESTree.Argument): Option.Option<string> =>
+  arg.type === 'Literal' && P.isString(arg.value)
+    ? Option.some(arg.value)
+    : Option.none()
+
+const gotWrapperCall = (
+  call: ESTree.CallExpression,
+): Option.Option<GotWrapperCall> =>
+  isMCall(call)
+    ? pipe(
+        Option.fromNullishOr(call.arguments[0]),
+        Option.flatMap(arg =>
+          pipe(
+            stringLiteralArg(arg),
+            Option.filter(tag => gotWrapperPrefixPattern.test(tag)),
+            Option.map(tag => ({
+              tag,
+              tagNode: arg,
+              callNode: call,
+            })),
+          ),
+        ),
+      )
+    : Option.none()
+
+const propertyKeyName = (
+  property: ESTree.ObjectProperty,
+): Option.Option<string> => {
+  if (property.computed) return Option.none()
+  const key = property.key
+  if (key.type === 'Identifier') return Option.some(key.name)
+  return key.type === 'Literal' && P.isString(key.value)
+    ? Option.some(key.value)
+    : Option.none()
+}
+
+const objectArg = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.ObjectExpression> =>
+  pipe(
+    Option.fromNullishOr(call.arguments[1]),
+    Option.filter(
+      (arg): arg is ESTree.ObjectExpression => arg.type === 'ObjectExpression',
+    ),
+  )
+
+const hasProperty = (object: ESTree.ObjectExpression, name: string): boolean =>
+  pipe(
+    object.properties,
+    Arr.some(property =>
+      property.type === 'Property'
+        ? pipe(
+            propertyKeyName(property),
+            Option.match({
+              onNone: () => false,
+              onSome: key => key === name,
+            }),
+          )
+        : false,
+    ),
+  )
+
+interface ExtraField {
+  readonly key: string
+  readonly node: ESTree.Node
+}
+
+const extraFields = (
+  object: ESTree.ObjectExpression,
+): ReadonlyArray<ExtraField> =>
+  pipe(
+    object.properties,
+    Arr.filterMap(property => {
+      if (property.type !== 'Property') return Result.failVoid
+      return pipe(
+        propertyKeyName(property),
+        Option.filter(
+          key =>
+            key !== 'message' &&
+            key !== 'id' &&
+            !allowedRoutingFieldPattern.test(key),
+        ),
+        Option.map(key => ({ key, node: property.key })),
+        Result.fromOption(() => undefined),
+      )
+    }),
+  )
+
+const nameDiagnostic = (wrapper: GotWrapperCall) => {
+  const base = Diagnostic.make({
+    node: wrapper.tagNode,
+    message: `Got-wrapper Message tag \`${wrapper.tag}\` must use the full \`Got*Message\` name so DevTools can identify submodel wrappers. Rename it to \`${wrapper.tag}Message\` when it is a wrapper. (FK messages)`,
+  })
+  return wrapper.tag.endsWith('Message')
+    ? base
+    : Diagnostic.withSuggestions(base, [
+        {
+          desc: `Rename to ${wrapper.tag}Message`,
+          fix: Diagnostic.replaceText(
+            wrapper.tagNode,
+            `'${wrapper.tag}Message'`,
+          ),
+        },
+      ])
+}
+
+const analyzeWrapper = (
+  ctx: RuleContext['Service'],
+  wrapper: GotWrapperCall,
+): Effect.Effect<void, never, RuleContext> => {
+  const nameCheck = gotWrapperFullNamePattern.test(wrapper.tag)
+    ? Effect.void
+    : ctx.report(nameDiagnostic(wrapper))
+
+  const fieldsArg = Option.fromNullishOr(wrapper.callNode.arguments[1])
+  const missingFields = Option.isNone(fieldsArg)
+    ? ctx.report(
+        Diagnostic.make({
+          node: wrapper.callNode,
+          message: `Got-wrapper \`${wrapper.tag}\` must declare fields with at least a \`message\` property. Wrappers carry child output plus routing context only. (FK messages)`,
+        }),
+      )
+    : Effect.void
+
+  const fieldsCheck = pipe(
+    objectArg(wrapper.callNode),
+    Option.match({
+      onNone: () => Effect.void,
+      onSome: fields =>
+        Effect.all(
+          [
+            hasProperty(fields, 'message')
+              ? Effect.void
+              : ctx.report(
+                  Diagnostic.make({
+                    node: fields,
+                    message: `Got-wrapper \`${wrapper.tag}\` must include a \`message\` property for the child Message it wraps. (FK messages)`,
+                  }),
+                ),
+            Effect.forEach(
+              extraFields(fields),
+              field =>
+                ctx.report(
+                  Diagnostic.make({
+                    node: field.node,
+                    message: `Got-wrapper \`${wrapper.tag}\` has extra field \`${field.key}\`. Wrappers may carry only \`message\`, \`id\`, or routing keys ending in \`Id\`. (FK messages)`,
+                  }),
+                ),
+              { concurrency: 1, discard: true },
+            ),
+          ],
+          { concurrency: 1, discard: true },
+        ),
+    }),
+  )
+
+  return Effect.all([nameCheck, missingFields, fieldsCheck], {
+    concurrency: 1,
+    discard: true,
+  })
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'got-wrapper-carries-only-routing',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Got-wrapper Messages must be named `Got*Message` and carry only `{ message, id?, *Id? }` routing context',
+    hasSuggestions: true,
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        gotWrapperCall(node),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: wrapper => analyzeWrapper(ctx, wrapper),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/keyed-required-for-mapped-rows.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/keyed-required-for-mapped-rows.ts
@@ -1,0 +1,178 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Schema from 'effect/Schema'
+
+/**
+ * `.map(...)` callbacks that return a row element (`li`, `div`, `tr`, ...)
+ * tied to a domain entity's identity must wrap with `keyed('tag')(item.id, ...)`.
+ * Otherwise snabbdom can patch the wrong row's event handlers into surviving
+ * rows when the list mutates (delete-mid-list, reorder, filter).
+ *
+ * To reduce false positives over static literal lists, the rule only fires
+ * when the callback body references `<param>.id` — i.e. the row is
+ * identity-bearing. Stateless rows over literals are passed through.
+ *
+ * Escape hatch: `// oxlint-disable-next-line @mpsuesser/foldkit/keyed-required-for-mapped-rows`.
+ *
+ * @since 0.4.0
+ */
+
+const ROW_ELEMENT_TAGS = HashSet.make('li', 'div', 'tr', 'article', 'section')
+
+const isRowElementCall = (
+  node: ESTree.Node,
+): Option.Option<{ readonly tag: string; readonly node: ESTree.Node }> => {
+  if (node.type !== 'CallExpression') return Option.none()
+  if (node.callee.type !== 'Identifier') return Option.none()
+  const name = node.callee.name
+  return HashSet.has(ROW_ELEMENT_TAGS, name)
+    ? Option.some({ tag: name, node })
+    : Option.none()
+}
+
+/**
+ * Pattern: `keyed('li')(id, attrs, children)` — outer CallExpression whose
+ * callee is itself a CallExpression on `keyed`.
+ */
+const isKeyedWrapped = (node: ESTree.Node): boolean =>
+  node.type === 'CallExpression' &&
+  node.callee.type === 'CallExpression' &&
+  node.callee.callee.type === 'Identifier' &&
+  node.callee.callee.name === 'keyed'
+
+/**
+ * Recognise both `Array.map(items, fn)` and `items.map(fn)`. Returns the
+ * arrow-function callback if the shape matches. Function expressions
+ * (`function (item) { ... }`) are deliberately not supported — Foldkit
+ * row renderers are uniformly arrow functions.
+ */
+const mapCallback = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.ArrowFunctionExpression> => {
+  if (call.callee.type !== 'MemberExpression') return Option.none()
+  if (call.callee.property.type !== 'Identifier') return Option.none()
+  if (call.callee.property.name !== 'map') return Option.none()
+  const isArrayMapCall =
+    call.callee.object.type === 'Identifier' &&
+    call.callee.object.name === 'Array'
+  const callback = isArrayMapCall ? call.arguments[1] : call.arguments[0]
+  if (callback === undefined) return Option.none()
+  if (callback.type !== 'ArrowFunctionExpression') return Option.none()
+  return Option.some(callback)
+}
+
+const callbackReturnExpression = (
+  fn: ESTree.ArrowFunctionExpression,
+): Option.Option<ESTree.Node> => {
+  const body = fn.body
+  if (body.type !== 'BlockStatement') {
+    return Option.some<ESTree.Node>(body)
+  }
+  return pipe(
+    body.body,
+    Arr.findLast(
+      (s): s is ESTree.ReturnStatement => s.type === 'ReturnStatement',
+    ),
+    Option.flatMap(ret =>
+      ret.argument === null
+        ? Option.none()
+        : Option.some<ESTree.Node>(ret.argument),
+    ),
+  )
+}
+
+// ── `<param>.id` reference walker ──────────────────────────────────────────
+//
+// Recursively walks the callback body looking for a MemberExpression of shape
+// `<paramName>.id`. The shape check is Schema-validated so we never need to
+// cast back to `ESTree.Node` during the walk.
+
+const buildIsParamIdAccess = (paramName: string) =>
+  Schema.is(
+    Schema.Struct({
+      type: Schema.Literal('MemberExpression'),
+      object: Schema.Struct({
+        type: Schema.Literal('Identifier'),
+        name: Schema.Literal(paramName),
+      }),
+      property: Schema.Struct({
+        type: Schema.Literal('Identifier'),
+        name: Schema.Literal('id'),
+      }),
+    }),
+  )
+
+const referencesParamId = (paramName: string, root: unknown): boolean => {
+  const matches = buildIsParamIdAccess(paramName)
+  const walk = (n: unknown): boolean => {
+    if (matches(n)) return true
+    if (!P.isObject(n)) return false
+    return pipe(
+      Object.values(n),
+      Arr.some(child =>
+        Array.isArray(child) ? pipe(child, Arr.some(walk)) : walk(child),
+      ),
+    )
+  }
+  return walk(root)
+}
+
+const callbackBodyReferencesId = (
+  fn: ESTree.ArrowFunctionExpression,
+): boolean => {
+  const param = fn.params[0]
+  if (param === undefined) return false
+  // Destructured params (`({ id }) => ...`) — assume identity-bearing.
+  if (param.type !== 'Identifier') return true
+  return referencesParamId(param.name, fn.body)
+}
+
+// ── Rule ───────────────────────────────────────────────────────────────────
+
+const rule: CreateRule = Rule.define({
+  name: 'keyed-required-for-mapped-rows',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Row renderers in `.map` over domain entities must wrap their element in `keyed(...)` to avoid snabbdom patching bugs (FK-5)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        mapCallback(node),
+        Option.flatMap(cb =>
+          pipe(
+            callbackReturnExpression(cb),
+            Option.flatMap(ret =>
+              pipe(
+                isRowElementCall(ret),
+                Option.filter(() => !isKeyedWrapped(ret)),
+                Option.filter(() => callbackBodyReferencesId(cb)),
+              ),
+            ),
+          ),
+        ),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: ({ tag, node: rowNode }) =>
+            ctx.report(
+              Diagnostic.make({
+                node: rowNode,
+                message: `Row renderer returns \`${tag}(...)\` without a \`keyed(...)\` wrapper. When the list is reordered or pruned, snabbdom may patch the wrong row's handlers onto surviving rows. Wrap with \`keyed('${tag}')(item.id, attrs, children)\`. (FK-5)`,
+              }),
+            ),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/label-requires-for.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/label-requires-for.ts
@@ -1,0 +1,72 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+
+/**
+ * `label([attrs], children)` calls that omit a `For(id)` attribute do not
+ * associate with any input, breaking assistive tech and keyboard navigation.
+ *
+ * @since 0.4.0
+ */
+
+const isLabelCall = (node: ESTree.Node): boolean =>
+  node.type === 'CallExpression' &&
+  node.callee.type === 'Identifier' &&
+  node.callee.name === 'label'
+
+const isForCall = (node: ESTree.Node): boolean =>
+  node.type === 'CallExpression' &&
+  node.callee.type === 'Identifier' &&
+  node.callee.name === 'For'
+
+const attributeArray = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.ArrayExpression> => {
+  const arg0 = call.arguments[0]
+  return arg0 !== undefined && arg0.type === 'ArrayExpression'
+    ? Option.some(arg0)
+    : Option.none()
+}
+
+const hasFor = (arr: ESTree.ArrayExpression): boolean =>
+  pipe(
+    arr.elements,
+    Arr.some(el => P.isNotNull(el) && isForCall(el)),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'label-requires-for',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      '`label([attrs], children)` must include a `For(id)` attribute to associate with its input (FK-5)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node => {
+      if (!isLabelCall(node)) return Effect.void
+      return pipe(
+        attributeArray(node),
+        Option.filter(arr => !hasFor(arr)),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: () =>
+            ctx.report(
+              Diagnostic.make({
+                node,
+                message:
+                  '`label([...])` is missing a `For(id)` attribute. Pair it with `Id(id)` on the matching input, or use `Ui.Input.view` which wires the association for you. (FK-5)',
+              }),
+            ),
+        }),
+      )
+    })
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/lazy-view-stable-references.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/lazy-view-stable-references.ts
@@ -1,0 +1,405 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+
+type LazySlotKind = 'lazy' | 'keyed'
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type ExpressionWrapperLike = {
+  readonly type: string
+  readonly expression?: unknown
+}
+
+type FunctionLike = ESTree.ArrowFunctionExpression | ESTree.Function
+
+interface LazySlot {
+  readonly name: string
+  readonly kind: LazySlotKind
+  readonly initCall: ESTree.CallExpression
+}
+
+interface Offense {
+  readonly node: ESTree.Node
+  readonly message: string
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isEstreeNode = (value: unknown): value is ESTree.Node =>
+  P.isObject(value) && 'type' in value && P.isString(value.type)
+
+const isCallExpressionNode = (value: unknown): value is ESTree.CallExpression =>
+  isEstreeNode(value) && value.type === 'CallExpression'
+
+const isVariableDeclarator = (
+  value: unknown,
+): value is ESTree.VariableDeclarator =>
+  isEstreeNode(value) && value.type === 'VariableDeclarator'
+
+const isFunctionLike = (value: unknown): value is FunctionLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  (value.type === 'ArrowFunctionExpression' ||
+    value.type === 'FunctionDeclaration' ||
+    value.type === 'FunctionExpression') &&
+  'params' in value &&
+  Array.isArray(value.params) &&
+  'body' in value
+
+const isExpressionWrapperLike = (
+  value: unknown,
+): value is ExpressionWrapperLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  P.isString(value.type) &&
+  'expression' in value &&
+  (value.type === 'ParenthesizedExpression' ||
+    value.type === 'TSAsExpression' ||
+    value.type === 'TSSatisfiesExpression' ||
+    value.type === 'TSTypeAssertion' ||
+    value.type === 'TSNonNullExpression' ||
+    value.type === 'TSInstantiationExpression' ||
+    value.type === 'ChainExpression')
+
+const unwrapExpression = (value: unknown): unknown =>
+  isExpressionWrapperLike(value) ? unwrapExpression(value.expression) : value
+
+const createLazyKind = (
+  call: ESTree.CallExpression,
+): Option.Option<LazySlotKind> => {
+  const callee = unwrapExpression(call.callee)
+  if (!isIdentifierLike(callee)) return Option.none()
+  if (callee.name === 'createLazy') return Option.some('lazy')
+  if (callee.name === 'createKeyedLazy') return Option.some('keyed')
+  return Option.none()
+}
+
+const exportedVariableDeclaration = (
+  statement: ESTree.Program['body'][number],
+): Option.Option<ESTree.VariableDeclaration> => {
+  if (statement.type === 'VariableDeclaration') return Option.some(statement)
+  if (statement.type !== 'ExportNamedDeclaration') return Option.none()
+  return pipe(
+    Option.fromNullishOr(statement.declaration),
+    Option.filter(declaration => declaration.type === 'VariableDeclaration'),
+  )
+}
+
+const topLevelVariableDeclarations = (
+  program: ESTree.Program,
+): ReadonlyArray<ESTree.VariableDeclaration> =>
+  pipe(
+    program.body,
+    Arr.filterMap(statement =>
+      pipe(
+        exportedVariableDeclaration(statement),
+        Result.fromOption(() => undefined),
+      ),
+    ),
+  )
+
+const declaratorName = (
+  declarator: ESTree.VariableDeclarator,
+): Option.Option<string> =>
+  isIdentifierLike(declarator.id)
+    ? Option.some(declarator.id.name)
+    : Option.none()
+
+const directLazySlot = (
+  declarator: ESTree.VariableDeclarator,
+): Option.Option<LazySlot> =>
+  pipe(
+    declaratorName(declarator),
+    Option.flatMap(name =>
+      pipe(
+        Option.fromNullishOr(declarator.init),
+        Option.map(unwrapExpression),
+        Option.filter(isCallExpressionNode),
+        Option.flatMap(initCall =>
+          pipe(
+            createLazyKind(initCall),
+            Option.map(kind => ({ name, kind, initCall })),
+          ),
+        ),
+      ),
+    ),
+  )
+
+const moduleLazySlots = (program: ESTree.Program): ReadonlyArray<LazySlot> =>
+  pipe(
+    topLevelVariableDeclarations(program),
+    Arr.filter(declaration => declaration.kind === 'const'),
+    Arr.flatMap(declaration =>
+      pipe(
+        declaration.declarations,
+        Arr.filterMap(declarator =>
+          pipe(
+            directLazySlot(declarator),
+            Result.fromOption(() => undefined),
+          ),
+        ),
+      ),
+    ),
+  )
+
+const walkChildren = <A>(
+  value: object,
+  visit: (child: unknown) => ReadonlyArray<A>,
+): ReadonlyArray<A> =>
+  pipe(
+    Object.entries(value),
+    Arr.flatMap(([key, child]) =>
+      key === 'parent'
+        ? []
+        : Array.isArray(child)
+          ? pipe(child, Arr.flatMap(visit))
+          : visit(child),
+    ),
+  )
+
+const createLazyCallsIn = (
+  root: unknown,
+): ReadonlyArray<ESTree.CallExpression> => {
+  const self =
+    isCallExpressionNode(root) && Option.isSome(createLazyKind(root))
+      ? [root]
+      : []
+  return P.isObject(root)
+    ? [...self, ...walkChildren(root, createLazyCallsIn)]
+    : self
+}
+
+const isAllowedCreateCall = (
+  call: ESTree.CallExpression,
+  slots: ReadonlyArray<LazySlot>,
+): boolean =>
+  pipe(
+    slots,
+    Arr.some(slot => slot.initCall === call),
+  )
+
+const createCallOffenses = (
+  program: ESTree.Program,
+  slots: ReadonlyArray<LazySlot>,
+): ReadonlyArray<Offense> =>
+  pipe(
+    createLazyCallsIn(program),
+    Arr.filter(call => !isAllowedCreateCall(call, slots)),
+    Arr.map(call => ({
+      node: call,
+      message:
+        '`createLazy()` and `createKeyedLazy()` slots must be direct module-scope `const` initializers. Recreating lazy slots in views or functions keeps the cache permanently cold. (FK lazy view)',
+    })),
+  )
+
+const slotForCall = (
+  call: ESTree.CallExpression,
+  slots: ReadonlyArray<LazySlot>,
+): Option.Option<LazySlot> => {
+  const callee = unwrapExpression(call.callee)
+  if (!isIdentifierLike(callee)) return Option.none()
+  return pipe(
+    slots,
+    Arr.findFirst(slot => slot.name === callee.name),
+  )
+}
+
+const argumentAt = (
+  call: ESTree.CallExpression,
+  index: number,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    Arr.get(call.arguments, index),
+    Option.filter(argument => argument.type !== 'SpreadElement'),
+  )
+
+const viewFunctionArgument = (
+  call: ESTree.CallExpression,
+  slot: LazySlot,
+): Option.Option<ESTree.Node> => argumentAt(call, slot.kind === 'lazy' ? 0 : 1)
+
+const paramNames = (fn: FunctionLike): ReadonlyArray<string> =>
+  pipe(
+    fn.params,
+    Arr.filterMap(param =>
+      isIdentifierLike(param) ? Result.succeed(param.name) : Result.failVoid,
+    ),
+  )
+
+const functionName = (fn: FunctionLike): Option.Option<string> =>
+  fn.type === 'FunctionDeclaration'
+    ? pipe(
+        Option.fromNullishOr(fn.id),
+        Option.filter(isIdentifierLike),
+        Option.map(id => id.name),
+      )
+    : Option.none()
+
+const bindingNamesIn = (root: unknown): ReadonlyArray<string> => {
+  if (isFunctionLike(root)) {
+    return pipe(
+      functionName(root),
+      Option.match({
+        onNone: () => [],
+        onSome: name => [name],
+      }),
+    )
+  }
+  const self =
+    isVariableDeclarator(root) && isIdentifierLike(root.id)
+      ? [root.id.name]
+      : []
+  return P.isObject(root)
+    ? [...self, ...walkChildren(root, bindingNamesIn)]
+    : self
+}
+
+const functionScopeBindings = (fn: FunctionLike): HashSet.HashSet<string> =>
+  pipe(
+    [
+      ...paramNames(fn),
+      ...pipe(
+        functionName(fn),
+        Option.match({
+          onNone: () => [],
+          onSome: name => [name],
+        }),
+      ),
+      ...bindingNamesIn(fn.body),
+    ],
+    HashSet.fromIterable,
+  )
+
+const isFunctionScopedName = (
+  name: string,
+  scopes: ReadonlyArray<HashSet.HashSet<string>>,
+): boolean =>
+  pipe(
+    scopes,
+    Arr.some(scope => HashSet.has(scope, name)),
+  )
+
+const viewReferenceOffense = (
+  slot: LazySlot,
+  argument: ESTree.Node,
+  scopes: ReadonlyArray<HashSet.HashSet<string>>,
+): Option.Option<Offense> => {
+  const unwrapped = unwrapExpression(argument)
+  if (isFunctionLike(unwrapped)) {
+    return Option.some({
+      node: argument,
+      message: `Lazy slot \`${slot.name}\` must receive a stable module-scope view function, not an inline function. Define the view function at module scope and pass the identifier. (FK lazy view)`,
+    })
+  }
+  if (!isIdentifierLike(unwrapped)) return Option.none()
+  return isFunctionScopedName(unwrapped.name, scopes)
+    ? Option.some({
+        node: argument,
+        message: `Lazy slot \`${slot.name}\` receives function-scoped view reference \`${unwrapped.name}\`. Lazy view functions must be module-scope identifiers so referential equality can hit the cache. (FK lazy view)`,
+      })
+    : Option.none()
+}
+
+const slotCallOffense = (
+  call: ESTree.CallExpression,
+  slots: ReadonlyArray<LazySlot>,
+  scopes: ReadonlyArray<HashSet.HashSet<string>>,
+): Option.Option<Offense> =>
+  pipe(
+    slotForCall(call, slots),
+    Option.flatMap(slot =>
+      pipe(
+        viewFunctionArgument(call, slot),
+        Option.flatMap(argument =>
+          viewReferenceOffense(slot, argument, scopes),
+        ),
+      ),
+    ),
+  )
+
+const slotCallOffensesIn = (
+  root: unknown,
+  slots: ReadonlyArray<LazySlot>,
+  scopes: ReadonlyArray<HashSet.HashSet<string>>,
+): ReadonlyArray<Offense> => {
+  if (isFunctionLike(root)) {
+    return P.isObject(root)
+      ? walkChildren(root, child =>
+          slotCallOffensesIn(child, slots, [
+            ...scopes,
+            functionScopeBindings(root),
+          ]),
+        )
+      : []
+  }
+  const self = isCallExpressionNode(root)
+    ? pipe(
+        slotCallOffense(root, slots, scopes),
+        Option.match({
+          onNone: () => [],
+          onSome: offense => [offense],
+        }),
+      )
+    : []
+  return P.isObject(root)
+    ? [
+        ...self,
+        ...walkChildren(root, child =>
+          slotCallOffensesIn(child, slots, scopes),
+        ),
+      ]
+    : self
+}
+
+const analyze = (
+  ctx: RuleContext['Service'],
+  program: ESTree.Program,
+): Effect.Effect<void, never, RuleContext> => {
+  const slots = moduleLazySlots(program)
+  const offenses = [
+    ...createCallOffenses(program, slots),
+    ...slotCallOffensesIn(program, slots, []),
+  ]
+  return Effect.forEach(
+    offenses,
+    offense =>
+      ctx.report(
+        Diagnostic.make({
+          node: offense.node,
+          message: offense.message,
+        }),
+      ),
+    { concurrency: 1, discard: true },
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'lazy-view-stable-references',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Require Foldkit lazy slots and lazy view functions to be stable module-scope references',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('Program:exit', node => analyze(ctx, node))
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/managed-resource-for-stateful-handles.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/managed-resource-for-stateful-handles.ts
@@ -1,0 +1,186 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import {
+  AST,
+  Diagnostic,
+  Rule,
+  RuleContext,
+  SourceCode,
+  Visitor,
+} from 'effect-oxlint'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Schema from 'effect/Schema'
+
+const StatefulHandleConstructor = Schema.Literals([
+  'WebSocket',
+  'MediaRecorder',
+  'Worker',
+  'SharedWorker',
+  'RTCPeerConnection',
+])
+const isStatefulHandleConstructor = Schema.is(StatefulHandleConstructor)
+
+const StatefulMediaDevicesPath = Schema.Tuple([
+  Schema.Literal('navigator'),
+  Schema.Literal('mediaDevices'),
+  Schema.Literals(['getUserMedia', 'getDisplayMedia']),
+])
+const isStatefulMediaDevicesPath = Schema.is(StatefulMediaDevicesPath)
+
+const STATEFUL_CONSTRUCTORS = HashSet.make(
+  'WebSocket',
+  'MediaRecorder',
+  'Worker',
+  'SharedWorker',
+  'RTCPeerConnection',
+)
+
+const basename = (filename: string): string => filename.replace(/^.*[\\/]/, '')
+
+const isExemptFilename = (filename: string): boolean => {
+  const normalized = filename.replaceAll('\\', '/')
+  const base = basename(normalized)
+  return (
+    /^managed-?[rR]esources?.*\.tsx?$/.test(base) ||
+    /^subscription.*\.tsx?$/.test(base) ||
+    normalized.includes('/src/client/')
+  )
+}
+
+const isIdentifier = (
+  node: ESTree.Node,
+): node is ESTree.Node & {
+  readonly type: 'Identifier'
+  readonly name: string
+} => node.type === 'Identifier' && 'name' in node && P.isString(node.name)
+
+const calleeIdentifier = (
+  node: ESTree.NewExpression,
+): Option.Option<
+  ESTree.Node & { readonly type: 'Identifier'; readonly name: string }
+> => (isIdentifier(node.callee) ? Option.some(node.callee) : Option.none())
+
+const rootIdentifier = (
+  node: ESTree.Node,
+): Option.Option<
+  ESTree.Node & { readonly type: 'Identifier'; readonly name: string }
+> => {
+  if (isIdentifier(node)) return Option.some(node)
+  if (node.type !== 'MemberExpression') return Option.none()
+  return rootIdentifier(node.object)
+}
+
+const memberPath = (
+  call: ESTree.CallExpression,
+): Option.Option<ReadonlyArray<string>> =>
+  call.callee.type === 'MemberExpression'
+    ? AST.memberPath(call.callee)
+    : Option.none()
+
+const statefulMediaDevicesCall = (
+  call: ESTree.CallExpression,
+): Option.Option<{
+  readonly member: ESTree.MemberExpression
+  readonly method: 'getUserMedia' | 'getDisplayMedia'
+}> => {
+  if (call.callee.type !== 'MemberExpression') return Option.none()
+  const member = call.callee
+  return pipe(
+    memberPath(call),
+    Option.filter(isStatefulMediaDevicesPath),
+    Option.map(path => ({
+      member,
+      method: path[2],
+    })),
+  )
+}
+
+const reportConstructor = (
+  ctx: RuleContext['Service'],
+  node: ESTree.NewExpression,
+  name: string,
+): Effect.Effect<void> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message: `Stateful browser handle \`new ${name}(...)\` must be acquired through \`ManagedResource.tag\` + \`ManagedResource.make\`, not constructed directly in model-tied code. (FK side-effect boundaries)`,
+    }),
+  )
+
+const reportMediaDevices = (
+  ctx: RuleContext['Service'],
+  node: ESTree.MemberExpression,
+  method: 'getUserMedia' | 'getDisplayMedia',
+): Effect.Effect<void> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message: `Stateful media handle \`navigator.mediaDevices.${method}(...)\` must be acquired through \`ManagedResource.tag\` + \`ManagedResource.make\`, with release owned by the resource lifecycle. (FK side-effect boundaries)`,
+    }),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'managed-resource-for-stateful-handles',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Require ManagedResource for stateful browser handles such as WebSocket, MediaRecorder, Worker, and media streams',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const visitor = Visitor.merge(
+      Visitor.on('NewExpression', node =>
+        pipe(
+          calleeIdentifier(node),
+          Option.filter(callee =>
+            HashSet.has(STATEFUL_CONSTRUCTORS, callee.name),
+          ),
+          Option.match({
+            onNone: () => Effect.void,
+            onSome: callee =>
+              SourceCode.isGlobalReference(callee).pipe(
+                Effect.flatMap(isGlobal =>
+                  isGlobal && isStatefulHandleConstructor(callee.name)
+                    ? reportConstructor(ctx, node, callee.name)
+                    : Effect.void,
+                ),
+              ),
+          }),
+        ),
+      ),
+      Visitor.on('CallExpression', node =>
+        pipe(
+          statefulMediaDevicesCall(node),
+          Option.match({
+            onNone: () => Effect.void,
+            onSome: ({ member, method }) =>
+              pipe(
+                rootIdentifier(member),
+                Option.match({
+                  onNone: () => Effect.void,
+                  onSome: root =>
+                    SourceCode.isGlobalReference(root).pipe(
+                      Effect.flatMap(isGlobal =>
+                        isGlobal
+                          ? reportMediaDevices(ctx, member, method)
+                          : Effect.void,
+                      ),
+                    ),
+                }),
+              ),
+          }),
+        ),
+      ),
+    )
+    return yield* Visitor.filter(
+      filename => !isExemptFilename(filename),
+      visitor,
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/mount-factory-must-use-element.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/mount-factory-must-use-element.ts
@@ -1,0 +1,200 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+
+type FunctionLike = ESTree.ArrowFunctionExpression | ESTree.Function
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type ObjectPropertyLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly key?: unknown
+  readonly value?: unknown
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isFunctionLike = (value: unknown): value is FunctionLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  (value.type === 'ArrowFunctionExpression' ||
+    value.type === 'FunctionExpression') &&
+  'params' in value &&
+  Array.isArray(value.params) &&
+  'body' in value
+
+const isObjectPropertyLike = (value: unknown): value is ObjectPropertyLike =>
+  P.isObject(value) && 'type' in value && value.type === 'Property'
+
+const mountDefineCall = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.CallExpression> => {
+  if (AST.isCallOf(call, 'Mount', ['define', 'defineStream'])) {
+    return Option.some(call)
+  }
+  return call.callee.type === 'CallExpression'
+    ? mountDefineCall(call.callee)
+    : Option.none()
+}
+
+const appliedMountFactory = (
+  call: ESTree.CallExpression,
+): Option.Option<FunctionLike> => {
+  if (call.callee.type !== 'CallExpression') return Option.none()
+  return pipe(
+    mountDefineCall(call.callee),
+    Option.flatMap(() => Arr.head(call.arguments)),
+    Option.filter(arg => arg.type !== 'SpreadElement'),
+    Option.filter(isFunctionLike),
+  )
+}
+
+const returnedFunction = (fn: FunctionLike): Option.Option<FunctionLike> =>
+  pipe(
+    Option.fromNullishOr(fn.body),
+    Option.flatMap(body => {
+      if (isFunctionLike(body)) return Option.some(body)
+      if (body.type !== 'BlockStatement') return Option.none()
+      return pipe(
+        body.body,
+        Arr.filterMap(stmt => {
+          if (stmt.type !== 'ReturnStatement') return Result.failVoid
+          return pipe(
+            Option.fromNullishOr(stmt.argument),
+            Option.filter(isFunctionLike),
+            Result.fromOption(() => undefined),
+          )
+        }),
+        Arr.head,
+      )
+    }),
+  )
+
+const elementFactory = (factory: FunctionLike): FunctionLike =>
+  pipe(
+    returnedFunction(factory),
+    Option.getOrElse(() => factory),
+  )
+
+const paramNames = (value: unknown): ReadonlyArray<string> => {
+  if (!isFunctionLike(value)) return []
+  return pipe(
+    value.params,
+    Arr.filterMap(param =>
+      isIdentifierLike(param) ? Result.succeed(param.name) : Result.failVoid,
+    ),
+  )
+}
+
+const containsIdentifier = (
+  root: unknown,
+  activeNames: ReadonlyArray<string>,
+): boolean => {
+  if (Arr.isReadonlyArrayEmpty(activeNames)) return false
+  if (isIdentifierLike(root)) return Arr.contains(activeNames, root.name)
+  if (isObjectPropertyLike(root)) {
+    return (
+      (root.computed === true && containsIdentifier(root.key, activeNames)) ||
+      containsIdentifier(root.value, activeNames)
+    )
+  }
+  if (!P.isObject(root)) return false
+  const nextNames = isFunctionLike(root)
+    ? pipe(
+        activeNames,
+        Arr.filter(name => !Arr.contains(paramNames(root), name)),
+      )
+    : activeNames
+  return pipe(
+    Object.entries(root),
+    Arr.some(([key, child]) =>
+      key === 'parent'
+        ? false
+        : Array.isArray(child)
+          ? pipe(
+              child,
+              Arr.some(item => containsIdentifier(item, nextNames)),
+            )
+          : containsIdentifier(child, nextNames),
+    ),
+  )
+}
+
+interface Offense {
+  readonly fn: FunctionLike
+  readonly message: string
+}
+
+const elementParamName = (fn: FunctionLike): Option.Option<string> =>
+  pipe(
+    Arr.head(fn.params),
+    Option.filter(isIdentifierLike),
+    Option.map(param => param.name),
+  )
+
+const diagnose = (factory: FunctionLike): Option.Option<Offense> => {
+  const fn = elementFactory(factory)
+  return pipe(
+    elementParamName(fn),
+    Option.match({
+      onNone: () =>
+        Option.some({
+          fn,
+          message:
+            'Mount factories must accept and use the live element parameter. If the work does not need the element, use a Command, Subscription, or ManagedResource instead. (FK mount)',
+        }),
+      onSome: name =>
+        name.startsWith('_')
+          ? Option.some({
+              fn,
+              message: `Mount factory element parameter \`${name}\` is explicitly ignored. A Mount must use its live element; choose another primitive when the element is irrelevant. (FK mount)`,
+            })
+          : containsIdentifier(fn.body, [name])
+            ? Option.none()
+            : Option.some({
+                fn,
+                message: `Mount factory element parameter \`${name}\` is never used. If the work is not element-caused and element-targeted, use a Command, Subscription, or ManagedResource instead. (FK mount)`,
+              }),
+    }),
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'mount-factory-must-use-element',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Require Mount.define / Mount.defineStream factories to use their live element parameter',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        appliedMountFactory(node),
+        Option.flatMap(diagnose),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: ({ fn, message }) =>
+            ctx.report(Diagnostic.make({ node: fn, message })),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-array-index-view-keys.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-array-index-view-keys.ts
@@ -1,0 +1,380 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Ref from 'effect/Ref'
+import * as Result from 'effect/Result'
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+  readonly parent?: unknown
+}
+
+type MemberExpressionLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly object?: unknown
+  readonly property?: unknown
+}
+
+type CallExpressionLike = {
+  readonly type: string
+  readonly callee?: unknown
+  readonly arguments?: ReadonlyArray<unknown>
+  readonly parent?: unknown
+}
+
+type VariableDeclaratorLike = {
+  readonly type: string
+  readonly id?: unknown
+  readonly init?: unknown
+}
+
+type ObjectPropertyLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly shorthand?: unknown
+  readonly key?: unknown
+  readonly value?: unknown
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpressionLike = (
+  value: unknown,
+): value is MemberExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isCallExpressionLike = (value: unknown): value is CallExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'CallExpression'
+
+const isVariableDeclaratorLike = (
+  value: unknown,
+): value is VariableDeclaratorLike =>
+  P.isObject(value) && 'type' in value && value.type === 'VariableDeclarator'
+
+const isObjectPropertyLike = (value: unknown): value is ObjectPropertyLike =>
+  P.isObject(value) && 'type' in value && value.type === 'Property'
+
+const memberPath = (
+  value: unknown,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  if (isIdentifierLike(value)) return Option.some([value.name])
+  if (!isMemberExpressionLike(value) || value.computed === true) {
+    return Option.none()
+  }
+  const property = value.property
+  if (!isIdentifierLike(property)) return Option.none()
+  return pipe(
+    memberPath(value.object),
+    Option.map(path => [...path, property.name]),
+  )
+}
+
+const pathEquals = (
+  path: ReadonlyArray<string>,
+  expected: ReadonlyArray<string>,
+): boolean =>
+  path.length === expected.length &&
+  pipe(
+    Arr.zip(path, expected),
+    Arr.every(([left, right]) => left === right),
+  )
+
+const callPath = (
+  call: CallExpressionLike,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => memberPath(call.callee)
+
+const isArrMapCall = (call: CallExpressionLike): boolean =>
+  pipe(
+    callPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path => pathEquals(path, ['Arr', 'map']),
+    }),
+  )
+
+const isMapMethodCall = (call: CallExpressionLike): boolean =>
+  pipe(
+    callPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path => Arr.lastNonEmpty(path) === 'map',
+    }),
+  ) && !isArrMapCall(call)
+
+const isMapCallback = (fn: ESTree.ArrowFunctionExpression): boolean => {
+  const parent = fn.parent
+  if (!isCallExpressionLike(parent)) return false
+  const args = parent.arguments ?? []
+  return isMapMethodCall(parent)
+    ? args[0] === fn
+    : isArrMapCall(parent) && (args[0] === fn || args[1] === fn)
+}
+
+const secondParamName = (
+  fn: ESTree.ArrowFunctionExpression,
+): Option.Option<string> => {
+  const param = fn.params[1]
+  return param !== undefined && isIdentifierLike(param)
+    ? Option.some(param.name)
+    : Option.none()
+}
+
+const isCreateKeyedLazyCall = (value: unknown): boolean =>
+  isCallExpressionLike(value) &&
+  pipe(
+    callPath(value),
+    Option.match({
+      onNone: () => false,
+      onSome: path => Arr.lastNonEmpty(path) === 'createKeyedLazy',
+    }),
+  )
+
+const keyedLazyDeclaratorName = (
+  node: ESTree.VariableDeclarator,
+): Option.Option<string> =>
+  isVariableDeclaratorLike(node) &&
+  isIdentifierLike(node.id) &&
+  isCreateKeyedLazyCall(node.init)
+    ? Option.some(node.id.name)
+    : Option.none()
+
+const objectValue = (
+  object: ESTree.ObjectExpression,
+  key: string,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    object.properties,
+    Arr.findFirst((property): property is ESTree.ObjectProperty => {
+      if (property.type !== 'Property' || property.computed) return false
+      if (property.key.type === 'Identifier') {
+        return property.key.name === key
+      }
+      return property.key.type === 'Literal' && property.key.value === key
+    }),
+    Option.map(property => property.value),
+  )
+
+const isKeyedFactoryCall = (value: unknown): boolean =>
+  isCallExpressionLike(value) &&
+  pipe(
+    callPath(value),
+    Option.match({
+      onNone: () => false,
+      onSome: path =>
+        pathEquals(path, ['h', 'keyed']) || pathEquals(path, ['keyed']),
+    }),
+  )
+
+const firstNodeArgument = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.Node> => {
+  const arg = call.arguments[0]
+  return arg !== undefined && arg.type !== 'SpreadElement'
+    ? Option.some(arg)
+    : Option.none()
+}
+
+const keyedCallKeyArgument = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.Node> =>
+  isCallExpressionLike(call.callee) && isKeyedFactoryCall(call.callee)
+    ? firstNodeArgument(call)
+    : Option.none()
+
+const hKeyArgument = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    callPath(call),
+    Option.filter(
+      path => pathEquals(path, ['h', 'Key']) || pathEquals(path, ['Key']),
+    ),
+    Option.flatMap(() => firstNodeArgument(call)),
+  )
+
+const submodelSlotIdArgument = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    callPath(call),
+    Option.filter(
+      path =>
+        pathEquals(path, ['h', 'submodel']) || pathEquals(path, ['submodel']),
+    ),
+    Option.flatMap(() => {
+      const arg = call.arguments[0]
+      return arg !== undefined && arg.type === 'ObjectExpression'
+        ? objectValue(arg, 'slotId')
+        : Option.none()
+    }),
+  )
+
+const keyedLazySlotArgument = (
+  call: ESTree.CallExpression,
+  keyedLazySlots: HashSet.HashSet<string>,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    callPath(call),
+    Option.filter(
+      path =>
+        path.length === 1 &&
+        HashSet.has(keyedLazySlots, Arr.headNonEmpty(path)),
+    ),
+    Option.flatMap(() => firstNodeArgument(call)),
+  )
+
+const keySinkArgument = (
+  call: ESTree.CallExpression,
+  keyedLazySlots: HashSet.HashSet<string>,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    keyedCallKeyArgument(call),
+    Option.orElse(() => hKeyArgument(call)),
+    Option.orElse(() => submodelSlotIdArgument(call)),
+    Option.orElse(() => keyedLazySlotArgument(call, keyedLazySlots)),
+  )
+
+const paramNames = (value: unknown): ReadonlyArray<string> => {
+  if (
+    !P.isObject(value) ||
+    !('params' in value) ||
+    !Array.isArray(value.params)
+  ) {
+    return []
+  }
+  return pipe(
+    value.params,
+    Arr.filterMap(param =>
+      isIdentifierLike(param) ? Result.succeed(param.name) : Result.failVoid,
+    ),
+  )
+}
+
+const containsIndexIdentifier = (
+  root: unknown,
+  activeNames: ReadonlyArray<string>,
+): boolean => {
+  if (Arr.isReadonlyArrayEmpty(activeNames)) return false
+  if (isIdentifierLike(root)) return Arr.contains(activeNames, root.name)
+  if (isObjectPropertyLike(root)) {
+    return (
+      (root.computed === true &&
+        containsIndexIdentifier(root.key, activeNames)) ||
+      containsIndexIdentifier(root.value, activeNames)
+    )
+  }
+  if (!P.isObject(root)) return false
+  const nextNames =
+    'type' in root && root.type === 'ArrowFunctionExpression'
+      ? pipe(
+          activeNames,
+          Arr.filter(name => !Arr.contains(paramNames(root), name)),
+        )
+      : activeNames
+  return pipe(
+    Object.entries(root),
+    Arr.some(([key, child]) =>
+      key === 'parent'
+        ? false
+        : Array.isArray(child)
+          ? pipe(
+              child,
+              Arr.some(item => containsIndexIdentifier(item, nextNames)),
+            )
+          : containsIndexIdentifier(child, nextNames),
+    ),
+  )
+}
+
+const reportIndexKey = (
+  ctx: RuleContext['Service'],
+  node: ESTree.Node,
+  indexName: string,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message: `Do not use array index parameter \`${indexName}\` as a Foldkit view key. Key rows and submodels from stable model ids instead. (FK view keys)`,
+    }),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'no-array-index-view-keys',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Disallow array index parameters in Foldkit keyed view sinks; use stable model ids instead',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const indexStack = yield* Ref.make<ReadonlyArray<string>>([])
+    const keyedLazySlots = yield* Ref.make<HashSet.HashSet<string>>(
+      HashSet.empty(),
+    )
+
+    const enterFunction = (node: ESTree.ArrowFunctionExpression) =>
+      pipe(
+        secondParamName(node),
+        Option.filter(() => isMapCallback(node)),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: name => Ref.update(indexStack, stack => [...stack, name]),
+        }),
+      )
+
+    const exitFunction = (node: ESTree.ArrowFunctionExpression) =>
+      pipe(
+        secondParamName(node),
+        Option.filter(() => isMapCallback(node)),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: () => Ref.update(indexStack, Arr.dropRight(1)),
+        }),
+      )
+
+    return Visitor.merge(
+      Visitor.on('VariableDeclarator', node =>
+        pipe(
+          keyedLazyDeclaratorName(node),
+          Option.match({
+            onNone: () => Effect.void,
+            onSome: name => Ref.update(keyedLazySlots, HashSet.add(name)),
+          }),
+        ),
+      ),
+      Visitor.on('ArrowFunctionExpression', enterFunction),
+      Visitor.onExit('ArrowFunctionExpression', exitFunction),
+      Visitor.on('CallExpression', node =>
+        Effect.gen(function* () {
+          const stack = yield* Ref.get(indexStack)
+          if (Arr.isReadonlyArrayEmpty(stack)) return
+          const slots = yield* Ref.get(keyedLazySlots)
+          const sink = keySinkArgument(node, slots)
+          if (Option.isNone(sink)) return
+          const offender = pipe(
+            stack,
+            Arr.findFirst(name => containsIndexIdentifier(sink.value, [name])),
+          )
+          if (Option.isSome(offender)) {
+            yield* reportIndexKey(ctx, sink.value, offender.value)
+          }
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-array-shorthand-type.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-array-shorthand-type.ts
@@ -1,0 +1,9 @@
+import type { CreateRule } from 'effect-oxlint'
+import { Rule } from 'effect-oxlint'
+
+const rule: CreateRule = Rule.banStatement('TSArrayType', {
+  message:
+    'Avoid `T[]` array-type syntax. Use `Array<T>` for mutable arrays or `ReadonlyArray<T>` for read-only — the form used throughout Foldkit exemplars. (FK-6)',
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-changed-message-prefix.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-changed-message-prefix.ts
@@ -1,0 +1,66 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Schema from 'effect/Schema'
+
+const ChangedPrefixedTag = Schema.String.check(
+  Schema.isPattern(/^Changed([A-Z]|$)/, {
+    identifier: 'ChangedPrefixedTag',
+    title: 'Changed-prefixed Message Tag',
+    description:
+      "A Message tag using the non-idiomatic `Changed*` prefix; Foldkit's convention is `Updated*`.",
+  }),
+)
+
+const isChangedPrefixedTag = Schema.is(ChangedPrefixedTag)
+
+const allowedChangedTags = new Set(['ChangedRoute', 'ChangedUrl'])
+
+const shouldReportChangedTag = (tag: string): boolean =>
+  isChangedPrefixedTag(tag) && !allowedChangedTags.has(tag)
+
+const mTagFromCall = (call: ESTree.CallExpression): Option.Option<string> => {
+  if (call.callee.type !== 'Identifier' || call.callee.name !== 'm') {
+    return Option.none()
+  }
+  const arg = call.arguments[0]
+  return arg !== undefined && arg.type === 'Literal' && P.isString(arg.value)
+    ? Option.some(arg.value)
+    : Option.none()
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'no-changed-message-prefix',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Disallow Message tags prefixed with `Changed*` — use `Updated*` instead, except route/url change events (FK-1)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        mTagFromCall(node),
+        Option.filter(shouldReportChangedTag),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: tag =>
+            ctx.report(
+              Diagnostic.make({
+                node,
+                message: `Message tag \`${tag}\` uses the \`Changed*\` prefix. Foldkit's convention is \`Updated*\` for both user input changes and external state updates. Rename to \`Updated${tag.slice(
+                  'Changed'.length,
+                )}\`. (FK-1)`,
+              }),
+            ),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-child-message-construction-in-root.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-child-message-construction-in-root.ts
@@ -1,0 +1,82 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as Schema from 'effect/Schema'
+
+const PascalIdentifier = Schema.String.check(
+  Schema.isPattern(/^[A-Z][A-Za-z0-9]*$/, {
+    identifier: 'PascalIdentifier',
+    title: 'Pascal Identifier',
+    description: 'A PascalCase identifier segment.',
+  }),
+)
+
+const isPascalIdentifier = Schema.is(PascalIdentifier)
+
+interface ChildMessageConstruction {
+  readonly namespace: string
+  readonly constructor: string
+  readonly node: ESTree.CallExpression
+}
+
+const childMessageConstruction = (
+  call: ESTree.CallExpression,
+): Option.Option<ChildMessageConstruction> => {
+  if (call.callee.type !== 'MemberExpression') return Option.none()
+  return pipe(
+    AST.memberPath(call.callee),
+    Option.filter(path => path.length === 3),
+    Option.flatMap(path =>
+      Option.all({
+        namespace: Arr.get(path, 0),
+        messageSegment: Arr.get(path, 1),
+        constructor: Arr.get(path, 2),
+      }),
+    ),
+    Option.filter(
+      ({ namespace, messageSegment, constructor }) =>
+        isPascalIdentifier(namespace) &&
+        messageSegment === 'Message' &&
+        isPascalIdentifier(constructor) &&
+        constructor !== 'Message',
+    ),
+    Option.map(({ namespace, constructor }) => ({
+      namespace,
+      constructor,
+      node: call,
+    })),
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'no-child-message-construction-in-root',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Disallow constructing child Message variants through `Child.Message.Variant(...)`; use child helper verbs and Got* wrappers instead',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        childMessageConstruction(node),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: ({ namespace, constructor, node: call }) =>
+            ctx.report(
+              Diagnostic.make({
+                node: call,
+                message: `Do not construct child Message \`${namespace}.Message.${constructor}(...)\` directly. Parents should call child-exported helper functions and route child output through Got*Message wrappers. (FK submodel)`,
+              }),
+            ),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-disabling-dev-guardrails.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-disabling-dev-guardrails.ts
@@ -1,0 +1,82 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+
+const guardedKeys = ['slowView', 'freezeModel'] as const
+
+const propertyKeyName = (
+  property: ESTree.ObjectProperty,
+): Option.Option<string> => {
+  if (property.computed) return Option.none()
+  const key = property.key
+  if (key.type === 'Identifier') return Option.some(key.name)
+  return key.type === 'Literal' && P.isString(key.value)
+    ? Option.some(key.value)
+    : Option.none()
+}
+
+const isGuardrailKey = (key: string): key is (typeof guardedKeys)[number] =>
+  Arr.contains(guardedKeys, key)
+
+const isFalseLiteral = (node: ESTree.Node): boolean =>
+  node.type === 'Literal' && node.value === false
+
+interface GuardrailDisabled {
+  readonly key: (typeof guardedKeys)[number]
+  readonly node: ESTree.ObjectProperty
+}
+
+const disabledGuardrails = (
+  object: ESTree.ObjectExpression,
+): ReadonlyArray<GuardrailDisabled> =>
+  pipe(
+    object.properties,
+    Arr.filterMap(property => {
+      if (property.type !== 'Property') return Result.failVoid
+      if (!isFalseLiteral(property.value)) return Result.failVoid
+      return pipe(
+        propertyKeyName(property),
+        Option.filter(isGuardrailKey),
+        Option.map(key => ({ key, node: property })),
+        Result.fromOption(() => undefined),
+      )
+    }),
+  )
+
+const reportDisabledGuardrail = (
+  ctx: RuleContext['Service'],
+  finding: GuardrailDisabled,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node: finding.node,
+      message: `Do not set Foldkit dev guardrail \`${finding.key}\` to false. Fix the slow view or model mutation instead of disabling runtime feedback. (FK dev guardrails)`,
+    }),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'no-disabling-dev-guardrails',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Disallow setting Foldkit dev guardrails `slowView` or `freezeModel` to false',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('ObjectExpression', node =>
+      Effect.forEach(
+        disabledGuardrails(node),
+        finding => reportDisabledGuardrail(ctx, finding),
+        { concurrency: 1, discard: true },
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-duplicate-onmount-per-element.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-duplicate-onmount-per-element.ts
@@ -1,0 +1,66 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+
+const memberEndsWithOnMount = (member: ESTree.MemberExpression): boolean =>
+  pipe(
+    AST.memberPath(member),
+    Option.match({
+      onNone: () => false,
+      onSome: path => Arr.lastNonEmpty(path) === 'OnMount',
+    }),
+  )
+
+const isOnMountCall = (node: ESTree.Node): boolean => {
+  if (node.type !== 'CallExpression') return false
+  if (node.callee.type === 'Identifier') return node.callee.name === 'OnMount'
+  return node.callee.type === 'MemberExpression'
+    ? memberEndsWithOnMount(node.callee)
+    : false
+}
+
+const isPresentOnMountCall = (
+  element: ESTree.ArrayExpression['elements'][number],
+): element is ESTree.CallExpression =>
+  pipe(
+    Option.fromNullishOr(element),
+    Option.match({
+      onNone: () => false,
+      onSome: isOnMountCall,
+    }),
+  )
+
+const topLevelOnMountCalls = (
+  array: ESTree.ArrayExpression,
+): ReadonlyArray<ESTree.CallExpression> =>
+  pipe(array.elements, Arr.filter(isPresentOnMountCall))
+
+const rule: CreateRule = Rule.define({
+  name: 'no-duplicate-onmount-per-element',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Disallow multiple top-level OnMount attributes on a single Foldkit element',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('ArrayExpression', node => {
+      const calls = topLevelOnMountCalls(node)
+      return calls.length >= 2
+        ? ctx.report(
+            Diagnostic.make({
+              node,
+              message:
+                'Only one `OnMount` can attach per Foldkit element; Snabbdom keeps a single insert/destroy hook and later mounts overwrite earlier ones. Bundle multiple lifetime-scoped behaviors into one Mount. (FK mount)',
+            }),
+          )
+        : Effect.void
+    })
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-explicit-command-type-annotation.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-explicit-command-type-annotation.ts
@@ -1,0 +1,34 @@
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Effect from 'effect/Effect'
+
+const isCommandTypeRefWithArguments = (node: ESTree.TSTypeReference): boolean =>
+  node.typeName.type === 'Identifier' &&
+  node.typeName.name === 'Command' &&
+  node.typeArguments !== null
+
+const rule: CreateRule = Rule.define({
+  name: 'no-explicit-command-type-annotation',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Disallow explicit `Command<...>` type annotations on Command factories — let TypeScript infer (FK-2)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('TSTypeReference', node =>
+      isCommandTypeRefWithArguments(node)
+        ? ctx.report(
+            Diagnostic.make({
+              node,
+              message:
+                "Avoid explicit `Command<...>` type annotations. The Command identity (`Command.define(...)`) already constrains the Effect's return type at the type level — let TypeScript infer the rest. (FK-2)",
+            }),
+          )
+        : Effect.void,
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-hand-rolled-command-struct.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-hand-rolled-command-struct.ts
@@ -1,0 +1,95 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+
+const commandShapeKeys = HashSet.make('name', 'effect')
+const commandShapeWithArgsKeys = HashSet.make('name', 'args', 'effect')
+
+const propertyKeyName = (
+  property: ESTree.ObjectProperty,
+): Option.Option<string> => {
+  if (property.computed) return Option.none()
+  if (property.key.type === 'Identifier') return Option.some(property.key.name)
+  return property.key.type === 'Literal' && P.isString(property.key.value)
+    ? Option.some(property.key.value)
+    : Option.none()
+}
+
+const staticKeys = (node: ESTree.ObjectExpression): HashSet.HashSet<string> =>
+  pipe(
+    node.properties,
+    Arr.filterMap(property =>
+      property.type === 'Property'
+        ? Result.fromOption(propertyKeyName(property), () => undefined)
+        : Result.failVoid,
+    ),
+    HashSet.fromIterable,
+  )
+
+const sameKeySet = (
+  left: HashSet.HashSet<string>,
+  right: HashSet.HashSet<string>,
+): boolean =>
+  HashSet.size(left) === HashSet.size(right) &&
+  pipe(
+    left,
+    HashSet.every(key => HashSet.has(right, key)),
+  )
+
+const hasSpread = (node: ESTree.ObjectExpression): boolean =>
+  pipe(
+    node.properties,
+    Arr.some(property => property.type === 'SpreadElement'),
+  )
+
+const hasEffectProperty = (node: ESTree.ObjectExpression): boolean =>
+  pipe(staticKeys(node), HashSet.has('effect'))
+
+const hasHandRolledCommandShape = (node: ESTree.ObjectExpression): boolean => {
+  const keys = staticKeys(node)
+  return (
+    sameKeySet(keys, commandShapeKeys) ||
+    sameKeySet(keys, commandShapeWithArgsKeys)
+  )
+}
+
+const messageFor = (node: ESTree.ObjectExpression): string =>
+  hasSpread(node)
+    ? 'Do not rebuild Foldkit Command structs with object spread plus an `effect` property. Use `Command.mapEffect`, `Command.mapMessage`, or `Command.mapMessages` so command identity and args are preserved. (FK commands)'
+    : 'Do not hand-roll Foldkit Command structs with `{ name, effect }` or `{ name, args, effect }`. Create Commands with `Command.define(...)` so identity, args, and tracing metadata stay canonical. (FK commands)'
+
+const shouldReport = (node: ESTree.ObjectExpression): boolean =>
+  hasSpread(node) && hasEffectProperty(node)
+    ? true
+    : hasHandRolledCommandShape(node)
+
+const rule: CreateRule = Rule.define({
+  name: 'no-hand-rolled-command-struct',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Disallow hand-rolled Foldkit Command structs; use Command.define or Command.map* helpers',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('ObjectExpression', node =>
+      shouldReport(node)
+        ? ctx.report(
+            Diagnostic.make({
+              node,
+              message: messageFor(node),
+            }),
+          )
+        : Effect.void,
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-hand-rolled-form-controls.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-hand-rolled-form-controls.ts
@@ -1,0 +1,84 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as Str from 'effect/String'
+
+/**
+ * Bare `input`, `textarea`, and `button` calls skip the accessibility wiring
+ * that `Ui.Input`, `Ui.Textarea`, and `Ui.Button` provide (label association,
+ * focus management, ARIA state, keyboard handling).
+ *
+ * The escape hatch is oxlint's native disable directive:
+ * `// oxlint-disable-next-line @mpsuesser/foldkit/no-hand-rolled-form-controls -- <reason>`.
+ *
+ * @since 0.4.0
+ */
+
+const FORM_CONTROL_TAGS = HashSet.make('input', 'textarea', 'button')
+
+const formControlName = (call: ESTree.CallExpression): Option.Option<string> =>
+  call.callee.type === 'Identifier' &&
+  HashSet.has(FORM_CONTROL_TAGS, call.callee.name)
+    ? Option.some(call.callee.name)
+    : Option.none()
+
+/**
+ * `Ui.Button({ toView: ({ attributes }) => button([...attributes.button, ...]) })`
+ * is the blessed escape from a `Ui.*` component to a custom-rendered control.
+ * Spreading `attributes.<tag>` into the attribute array is the marker for that
+ * hand-off and must not trigger this rule.
+ */
+const isUiAttributesSpread = (
+  el: ESTree.ArrayExpression['elements'][number],
+): boolean =>
+  el !== null &&
+  el.type === 'SpreadElement' &&
+  el.argument.type === 'MemberExpression' &&
+  el.argument.object.type === 'Identifier' &&
+  el.argument.object.name === 'attributes'
+
+const looksLikeUiToViewCallback = (call: ESTree.CallExpression): boolean => {
+  const arg0 = call.arguments[0]
+  if (arg0 === undefined || arg0.type !== 'ArrayExpression') return false
+  return pipe(arg0.elements, Arr.some(isUiAttributesSpread))
+}
+
+const messageFor = (tag: string): string =>
+  tag === 'button'
+    ? 'Bare `button([...])` skips accessibility wiring. Use `Ui.Button` (which exposes a `toView` callback for custom looks), or add a `// oxlint-disable-next-line @mpsuesser/foldkit/no-hand-rolled-form-controls -- <reason>` directive to opt out. (FK-5)'
+    : `Bare \`${tag}([...])\` skips label association, validation hooks, and ARIA states. Use \`Ui.${Str.capitalize(tag)}.view\`, or add a \`// oxlint-disable-next-line @mpsuesser/foldkit/no-hand-rolled-form-controls -- <reason>\` directive to opt out. (FK-5)`
+
+const rule: CreateRule = Rule.define({
+  name: 'no-hand-rolled-form-controls',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Disallow bare `input`/`textarea`/`button` calls; use `Ui.*` components (FK-5)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        formControlName(node),
+        Option.filter(() => !looksLikeUiToViewCallback(node)),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: tag =>
+            ctx.report(
+              Diagnostic.make({
+                node,
+                message: messageFor(tag),
+              }),
+            ),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-hardcoded-route-strings.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-hardcoded-route-strings.ts
@@ -1,0 +1,116 @@
+import { Match, pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Schema from 'effect/Schema'
+
+const ROUTING_FNS = HashSet.make('Href', 'navigateInternal', 'loadExternalUrl')
+
+const RouteLiteral = Schema.String.check(
+  Schema.isPattern(/^(\/|https?:\/\/)/, {
+    identifier: 'RouteLiteral',
+    title: 'Route Literal',
+    description:
+      'A string that begins with `/`, `http://`, or `https://` — i.e. looks like a route or URL.',
+  }),
+)
+const isRouteLiteral = Schema.is(RouteLiteral)
+
+const routingFnName = (call: ESTree.CallExpression): Option.Option<string> =>
+  call.callee.type === 'Identifier' &&
+  HashSet.has(ROUTING_FNS, call.callee.name)
+    ? Option.some(call.callee.name)
+    : Option.none()
+
+interface RouteArg {
+  readonly fn: string
+  readonly preview: string
+  readonly kind: 'literal' | 'template'
+}
+
+const firstTemplateQuasi = (
+  tpl: ESTree.TemplateLiteral,
+): Option.Option<string> =>
+  pipe(
+    Arr.head(tpl.quasis),
+    Option.flatMap(q => Option.fromNullishOr(q.value.cooked)),
+  )
+
+const classifyArg = (
+  fn: string,
+  arg: ESTree.Node | ESTree.SpreadElement,
+): Option.Option<RouteArg> => {
+  if (
+    arg.type === 'Literal' &&
+    P.isString(arg.value) &&
+    isRouteLiteral(arg.value)
+  ) {
+    return Option.some<RouteArg>({
+      fn,
+      preview: arg.value,
+      kind: 'literal',
+    })
+  }
+  if (arg.type === 'TemplateLiteral') {
+    return pipe(
+      firstTemplateQuasi(arg),
+      Option.filter(isRouteLiteral),
+      Option.map(head => ({
+        fn,
+        preview: `${head}...`,
+        kind: 'template' as const,
+      })),
+    )
+  }
+  return Option.none()
+}
+
+const messageFor = (arg: RouteArg): string =>
+  Match.value(arg.kind).pipe(
+    Match.when(
+      'literal',
+      () =>
+        `Avoid hard-coded route literal in \`${arg.fn}('${arg.preview}')\`. Routers are bidirectional — call them as printers: \`${arg.fn}(homeRouter())\`, \`${arg.fn}(tagFilterRouter({ tag }))\`. (FK-4)`,
+    ),
+    Match.when(
+      'template',
+      () =>
+        `Avoid hard-coded route template in \`${arg.fn}(\\\`${arg.preview}\\\`)\`. Routers are bidirectional — call them as printers with named parameters. (FK-4)`,
+    ),
+    Match.exhaustive,
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'no-hardcoded-route-strings',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Disallow hard-coded route strings in `Href` / `navigateInternal` / `loadExternalUrl` — call the bidirectional route printer instead (FK-4)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        routingFnName(node),
+        Option.flatMap(fn =>
+          pipe(
+            Arr.head(node.arguments),
+            Option.flatMap(arg => classifyArg(fn, arg)),
+          ),
+        ),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: arg =>
+            ctx.report(Diagnostic.make({ node, message: messageFor(arg) })),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-impure-calls-in-pure-layer.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-impure-calls-in-pure-layer.ts
@@ -1,0 +1,314 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import {
+  AST,
+  Diagnostic,
+  Rule,
+  RuleContext,
+  SourceCode,
+  Visitor,
+} from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Str from 'effect/String'
+
+const PURE_BASENAMES = HashSet.make(
+  'init.ts',
+  'model.ts',
+  'message.ts',
+  'update.ts',
+  'view.ts',
+)
+
+const GLOBALS = HashSet.make(
+  'alert',
+  'cancelAnimationFrame',
+  'clearInterval',
+  'clearTimeout',
+  'confirm',
+  'console',
+  'crypto',
+  'document',
+  'fetch',
+  'history',
+  'localStorage',
+  'location',
+  'navigator',
+  'performance',
+  'prompt',
+  'requestAnimationFrame',
+  'sessionStorage',
+  'setInterval',
+  'setTimeout',
+  'window',
+)
+
+const normalizedPath = (filename: string): string =>
+  Str.replaceAll('\\', '/')(filename)
+
+const basename = (filename: string): string => {
+  const parts = Str.split('/')(normalizedPath(filename))
+  return pipe(
+    Arr.last(parts),
+    Option.getOrElse(() => filename),
+  )
+}
+
+const isPureLayerFile = (filename: string): boolean => {
+  const path = normalizedPath(filename)
+  return (
+    HashSet.has(PURE_BASENAMES, basename(path)) ||
+    Str.includes('/update/')(path) ||
+    Str.includes('/view/')(path)
+  )
+}
+
+const pathEquals = (
+  path: ReadonlyArray<string>,
+  expected: ReadonlyArray<string>,
+): boolean =>
+  path.length === expected.length &&
+  pipe(
+    Arr.zip(path, expected),
+    Arr.every(([left, right]) => left === right),
+  )
+
+const memberPathFromCallee = (
+  callee: ESTree.CallExpression['callee'],
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  if (callee.type === 'MemberExpression') return AST.memberPath(callee)
+  if (callee.type === 'CallExpression') {
+    return memberPathFromCallee(callee.callee)
+  }
+  return Option.none()
+}
+
+const callMemberPath = (
+  call: ESTree.CallExpression,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> =>
+  memberPathFromCallee(call.callee)
+
+const isExemptFactoryCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    callMemberPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path =>
+        pathEquals(path, ['Command', 'define']) ||
+        pathEquals(path, ['Mount', 'define']) ||
+        pathEquals(path, ['Mount', 'defineStream']) ||
+        pathEquals(path, ['Subscription', 'make']),
+    }),
+  )
+
+const parentOf = (node: {
+  readonly parent?: unknown
+}): Option.Option<{
+  readonly type: string
+  readonly parent?: unknown
+}> =>
+  pipe(
+    Option.fromNullishOr(node.parent),
+    Option.filter(
+      (
+        parent,
+      ): parent is { readonly type: string; readonly parent?: unknown } =>
+        P.isObject(parent) && 'type' in parent && P.isString(parent.type),
+    ),
+  )
+
+const isCallExpression = (node: {
+  readonly type: string
+  readonly parent?: unknown
+}): node is ESTree.CallExpression => node.type === 'CallExpression'
+
+const isWithinExemptFactory = (node: {
+  readonly parent?: unknown
+}): boolean => {
+  const walk = (
+    current: Option.Option<{
+      readonly type: string
+      readonly parent?: unknown
+    }>,
+  ): boolean =>
+    Option.match(current, {
+      onNone: () => false,
+      onSome: ancestor =>
+        isCallExpression(ancestor) && isExemptFactoryCall(ancestor)
+          ? true
+          : walk(parentOf(ancestor)),
+    })
+  return walk(parentOf(node))
+}
+
+type Identifier = ESTree.IdentifierName | ESTree.IdentifierReference
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+  readonly parent?: unknown
+}
+
+const isStaticMemberProperty = (node: IdentifierLike): boolean =>
+  pipe(
+    parentOf(node),
+    Option.match({
+      onNone: () => false,
+      onSome: parent =>
+        parent.type === 'MemberExpression' &&
+        'computed' in parent &&
+        parent.computed === false &&
+        'property' in parent &&
+        parent.property === node,
+    }),
+  )
+
+const isStaticObjectKey = (node: IdentifierLike): boolean =>
+  pipe(
+    parentOf(node),
+    Option.match({
+      onNone: () => false,
+      onSome: parent =>
+        parent.type === 'Property' &&
+        'computed' in parent &&
+        parent.computed === false &&
+        'key' in parent &&
+        parent.key === node &&
+        'value' in parent &&
+        parent.value !== node,
+    }),
+  )
+
+const shouldSkipIdentifier = (node: IdentifierLike): boolean =>
+  isWithinExemptFactory(node) ||
+  isStaticMemberProperty(node) ||
+  isStaticObjectKey(node)
+
+const impureMemberName = (call: ESTree.CallExpression): Option.Option<string> =>
+  pipe(
+    callMemberPath(call),
+    Option.flatMap(path => {
+      if (pathEquals(path, ['Date', 'now'])) return Option.some('Date.now')
+      if (pathEquals(path, ['Math', 'random']))
+        return Option.some('Math.random')
+      if (pathEquals(path, ['performance', 'now']))
+        return Option.some('performance.now')
+      if (pathEquals(path, ['crypto', 'randomUUID']))
+        return Option.some('crypto.randomUUID')
+      if (pathEquals(path, ['crypto', 'getRandomValues'])) {
+        return Option.some('crypto.getRandomValues')
+      }
+      return Option.none()
+    }),
+  )
+
+const isAddEventListenerCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    callMemberPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path => Arr.lastNonEmpty(path) === 'addEventListener',
+    }),
+  )
+
+const objectIdentifier = (
+  call: ESTree.CallExpression,
+): Option.Option<Identifier> =>
+  call.callee.type === 'MemberExpression' &&
+  call.callee.object.type === 'Identifier'
+    ? Option.some(call.callee.object)
+    : Option.none()
+
+const newDateWithoutArgs = (node: ESTree.NewExpression): boolean =>
+  node.callee.type === 'Identifier' &&
+  node.callee.name === 'Date' &&
+  node.arguments.length === 0
+
+const reportImpureMember = (
+  ctx: RuleContext['Service'],
+  node: ESTree.CallExpression,
+  name: string,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message: `Do not call \`${name}\` in Foldkit's pure layer. Move time, randomness, DOM, and browser effects into Command, Mount, or Subscription factories. (FK purity)`,
+    }),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'no-impure-calls-in-pure-layer',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Disallow time, randomness, DOM, and browser side effects in Foldkit pure-layer files',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return yield* Visitor.filter(
+      isPureLayerFile,
+      Visitor.merge(
+        Visitor.on('CallExpression', node => {
+          if (isWithinExemptFactory(node)) return Effect.void
+          if (isAddEventListenerCall(node)) {
+            return reportImpureMember(ctx, node, '.addEventListener')
+          }
+          return pipe(
+            impureMemberName(node),
+            Option.match({
+              onNone: () => Effect.void,
+              onSome: name =>
+                pipe(
+                  objectIdentifier(node),
+                  Option.match({
+                    onNone: () => reportImpureMember(ctx, node, name),
+                    onSome: object =>
+                      SourceCode.isGlobalReference(object).pipe(
+                        Effect.flatMap(isGlobal =>
+                          isGlobal
+                            ? reportImpureMember(ctx, node, name)
+                            : Effect.void,
+                        ),
+                      ),
+                  }),
+                ),
+            }),
+          )
+        }),
+        Visitor.on('NewExpression', node =>
+          newDateWithoutArgs(node) && !isWithinExemptFactory(node)
+            ? ctx.report(
+                Diagnostic.make({
+                  node,
+                  message:
+                    "Do not call `new Date()` in Foldkit's pure layer. Request time through Commands and store it in the Model. (FK purity)",
+                }),
+              )
+            : Effect.void,
+        ),
+        Visitor.on('Identifier', node =>
+          HashSet.has(GLOBALS, node.name) && !shouldSkipIdentifier(node)
+            ? SourceCode.isGlobalReference(node).pipe(
+                Effect.flatMap(isGlobal =>
+                  isGlobal
+                    ? ctx.report(
+                        Diagnostic.make({
+                          node,
+                          message: `Do not read browser/global \`${node.name}\` in Foldkit's pure layer. Move side effects into Command, Mount, or Subscription factories. (FK purity)`,
+                        }),
+                      )
+                    : Effect.void,
+                ),
+              )
+            : Effect.void,
+        ),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-raw-dom-event-attributes.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-raw-dom-event-attributes.ts
@@ -1,0 +1,145 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Str from 'effect/String'
+
+const rawDomEventPattern = /^on[a-zA-Z]+$/i
+
+const normalizedPath = (filename: string): string =>
+  Str.replaceAll('\\', '/')(filename)
+
+const basename = (filename: string): string =>
+  pipe(
+    Str.split('/')(normalizedPath(filename)),
+    Arr.last,
+    Option.getOrElse(() => filename),
+  )
+
+const isCrashViewFile = (filename: string): boolean =>
+  basename(filename) === 'crash-view.ts'
+
+const calleePath = (
+  callee: ESTree.CallExpression['callee'],
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  if (callee.type === 'Identifier') return Option.some([callee.name])
+  if (callee.type === 'MemberExpression' && !callee.computed) {
+    const property = callee.property
+    if (property.type !== 'Identifier') return Option.none()
+    return pipe(
+      calleePath(callee.object),
+      Option.map(path => [...path, property.name]),
+    )
+  }
+  return Option.none()
+}
+
+const lastPathSegment = (call: ESTree.CallExpression): Option.Option<string> =>
+  pipe(calleePath(call.callee), Option.map(Arr.lastNonEmpty))
+
+const isAttributeOrPropCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    lastPathSegment(call),
+    Option.match({
+      onNone: () => false,
+      onSome: name => name === 'Attribute' || name === 'Prop',
+    }),
+  )
+
+const staticTemplateString = (
+  template: ESTree.TemplateLiteral,
+): Option.Option<string> =>
+  template.expressions.length === 0
+    ? pipe(
+        Arr.head(template.quasis),
+        Option.flatMap(quasi => Option.fromNullishOr(quasi.value.cooked)),
+      )
+    : Option.none()
+
+const staticStringArg = (arg: ESTree.Argument): Option.Option<string> => {
+  if (arg.type === 'Literal' && P.isString(arg.value)) {
+    return Option.some(arg.value)
+  }
+  return arg.type === 'TemplateLiteral'
+    ? staticTemplateString(arg)
+    : Option.none()
+}
+
+const rawEventAttributeName = (
+  call: ESTree.CallExpression,
+): Option.Option<string> =>
+  isAttributeOrPropCall(call)
+    ? pipe(
+        Arr.head(call.arguments),
+        Option.flatMap(staticStringArg),
+        Option.filter(name => rawDomEventPattern.test(name)),
+      )
+    : Option.none()
+
+const isHtmlCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    calleePath(call.callee),
+    Option.match({
+      onNone: () => false,
+      onSome: path => path.length === 1 && Arr.headNonEmpty(path) === 'html',
+    }),
+  )
+
+const hasNeverTypeArgument = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    Option.fromNullishOr(call.typeArguments),
+    Option.flatMap(typeArguments =>
+      typeArguments.params.length === 1
+        ? Arr.get(typeArguments.params, 0)
+        : Option.none(),
+    ),
+    Option.match({
+      onNone: () => false,
+      onSome: param => param.type === 'TSNeverKeyword',
+    }),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'no-raw-dom-event-attributes',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Disallow raw DOM event Attribute/Prop calls outside crash-view.ts; crash views must bind html<never>()',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const crashView = isCrashViewFile(ctx.filename)
+    return Visitor.on('CallExpression', node => {
+      if (crashView) {
+        return isHtmlCall(node) && !hasNeverTypeArgument(node)
+          ? ctx.report(
+              Diagnostic.make({
+                node,
+                message:
+                  'Crash views that use raw DOM event attributes must bind `html<never>()` so no application Messages can be dispatched from the crash renderer. (FK crash view)',
+              }),
+            )
+          : Effect.void
+      }
+      return pipe(
+        rawEventAttributeName(node),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: name =>
+            ctx.report(
+              Diagnostic.make({
+                node,
+                message: `Do not create raw DOM event attribute \`${name}\`. Foldkit events must go through typed On* constructors that dispatch Messages; raw event attributes are only allowed in crash-view.ts. (FK events)`,
+              }),
+            ),
+        }),
+      )
+    })
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/no-spread-in-evo.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-spread-in-evo.ts
@@ -1,0 +1,127 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as Result from 'effect/Result'
+
+const objectExprHasSpread = (obj: ESTree.ObjectExpression): boolean =>
+  pipe(
+    obj.properties,
+    Arr.some(p => p.type === 'SpreadElement'),
+  )
+
+/**
+ * A computed property (`{ [key]: v }`) can't be expressed by a static
+ * nested-`evo` rewrite, so `{ ...x, [key]: v }` is a legitimate dynamic
+ * record update rather than the plain static-key merge this rule replaces.
+ */
+const objectExprHasComputedKey = (obj: ESTree.ObjectExpression): boolean =>
+  pipe(
+    obj.properties,
+    Arr.some(p => p.type === 'Property' && p.computed === true),
+  )
+
+const arrowBodyObject = (
+  arrow: ESTree.ArrowFunctionExpression,
+): Option.Option<ESTree.ObjectExpression> => {
+  if (arrow.body.type === 'ObjectExpression') {
+    return Option.some(arrow.body)
+  }
+  if (arrow.body.type === 'BlockStatement') {
+    return pipe(
+      arrow.body.body,
+      Arr.findFirst(stmt =>
+        stmt.type === 'ReturnStatement' ? Option.some(stmt) : Option.none(),
+      ),
+      Option.flatMap(ret =>
+        ret.argument !== null && ret.argument.type === 'ObjectExpression'
+          ? Option.some(ret.argument)
+          : Option.none(),
+      ),
+    )
+  }
+  return Option.none()
+}
+
+interface SpreadFinding {
+  readonly fieldName: string
+  readonly node: ESTree.ObjectExpression
+}
+
+const propertyKeyName = (prop: ESTree.ObjectProperty): string =>
+  prop.key.type === 'Identifier' ? prop.key.name : '<key>'
+
+const extractFindings = (
+  updates: ESTree.ObjectExpression,
+): ReadonlyArray<SpreadFinding> =>
+  pipe(
+    updates.properties,
+    Arr.filterMap(prop => {
+      if (prop.type !== 'Property') return Result.failVoid
+      if (prop.value.type !== 'ArrowFunctionExpression') return Result.failVoid
+      return pipe(
+        arrowBodyObject(prop.value),
+        Option.filter(
+          obj => objectExprHasSpread(obj) && !objectExprHasComputedKey(obj),
+        ),
+        Option.match({
+          onNone: () => Result.failVoid,
+          onSome: obj =>
+            Result.succeed<SpreadFinding>({
+              fieldName: propertyKeyName(prop),
+              node: obj,
+            }),
+        }),
+      )
+    }),
+  )
+
+const evoUpdatesArg = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.ObjectExpression> => {
+  if (call.callee.type !== 'Identifier' || call.callee.name !== 'evo') {
+    return Option.none()
+  }
+  const arg1 = call.arguments[1]
+  return arg1 !== undefined && arg1.type === 'ObjectExpression'
+    ? Option.some(arg1)
+    : Option.none()
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'no-spread-in-evo',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Disallow `{ ...x, ... }` inside `evo()` updater arrows — use a nested `evo()` instead (FK-2)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        evoUpdatesArg(node),
+        Option.map(extractFindings),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: findings =>
+            Effect.forEach(
+              findings,
+              ({ fieldName, node: innerObj }) =>
+                ctx.report(
+                  Diagnostic.make({
+                    node: innerObj,
+                    message: `Spread (\`...\`) inside an \`evo\` updater for field \`${fieldName}\` bypasses the canonical update path. Use a nested \`evo\`: \`${fieldName}: () => evo(model.${fieldName}, { ... })\`. (FK-2)`,
+                  }),
+                ),
+              { concurrency: 1, discard: true },
+            ),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/prefer-dom-helpers-for-element-ops.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/prefer-dom-helpers-for-element-ops.ts
@@ -1,0 +1,508 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import {
+  AST,
+  Diagnostic,
+  Rule,
+  RuleContext,
+  SourceCode,
+  Visitor,
+} from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Str from 'effect/String'
+
+const TARGET_METHODS = HashSet.make(
+  'click',
+  'close',
+  'focus',
+  'scrollIntoView',
+  'showModal',
+)
+
+const QUERY_METHODS = HashSet.make('getElementById', 'querySelector')
+
+const normalizedPath = (filename: string): string =>
+  Str.replaceAll('\\', '/')(filename)
+
+const basename = (filename: string): string =>
+  pipe(
+    Str.split('/')(normalizedPath(filename)),
+    Arr.last,
+    Option.getOrElse(() => filename),
+  )
+
+const isScopedFile = (filename: string): boolean => {
+  const base = basename(filename)
+  return /^command.*\.tsx?$/.test(base) || /^subscription.*\.tsx?$/.test(base)
+}
+
+type IdentifierNode = ESTree.IdentifierName | ESTree.IdentifierReference
+
+type NodeWithParent = {
+  readonly type: string
+  readonly parent?: unknown
+}
+
+const isNodeWithParent = (value: unknown): value is NodeWithParent =>
+  P.isObject(value) && 'type' in value && P.isString(value.type)
+
+const parentOf = (node: {
+  readonly parent?: unknown
+}): Option.Option<NodeWithParent> =>
+  pipe(Option.fromNullishOr(node.parent), Option.filter(isNodeWithParent))
+
+const isIdentifier = (value: unknown): value is IdentifierNode =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpression = (value: unknown): value is ESTree.MemberExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isCallExpression = (value: unknown): value is ESTree.CallExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'CallExpression'
+
+const isVariableDeclaration = (
+  value: unknown,
+): value is ESTree.VariableDeclaration =>
+  P.isObject(value) && 'type' in value && value.type === 'VariableDeclaration'
+
+const isIfStatementLike = (
+  value: unknown,
+): value is NodeWithParent & { readonly test: unknown } =>
+  isNodeWithParent(value) && value.type === 'IfStatement' && 'test' in value
+
+const isConditionalExpressionLike = (
+  value: unknown,
+): value is NodeWithParent & { readonly test: unknown } =>
+  isNodeWithParent(value) &&
+  value.type === 'ConditionalExpression' &&
+  'test' in value
+
+const isWhileStatementLike = (
+  value: unknown,
+): value is NodeWithParent & { readonly test: unknown } =>
+  isNodeWithParent(value) &&
+  (value.type === 'WhileStatement' || value.type === 'DoWhileStatement') &&
+  'test' in value
+
+const isUnaryExpressionLike = (
+  value: unknown,
+): value is NodeWithParent & {
+  readonly operator: string
+  readonly argument: unknown
+} =>
+  isNodeWithParent(value) &&
+  value.type === 'UnaryExpression' &&
+  'operator' in value &&
+  P.isString(value.operator) &&
+  'argument' in value
+
+const isBinaryExpressionLike = (
+  value: unknown,
+): value is NodeWithParent & {
+  readonly operator: string
+  readonly left: unknown
+  readonly right: unknown
+} =>
+  isNodeWithParent(value) &&
+  value.type === 'BinaryExpression' &&
+  'operator' in value &&
+  P.isString(value.operator) &&
+  'left' in value &&
+  'right' in value
+
+const isLogicalExpressionLike = (
+  value: unknown,
+): value is NodeWithParent & {
+  readonly operator: string
+  readonly left: unknown
+  readonly right: unknown
+} =>
+  isNodeWithParent(value) &&
+  value.type === 'LogicalExpression' &&
+  'operator' in value &&
+  P.isString(value.operator) &&
+  'left' in value &&
+  'right' in value
+
+const isNullishLiteral = (value: unknown): boolean =>
+  (P.isObject(value) &&
+    'type' in value &&
+    value.type === 'Literal' &&
+    'value' in value &&
+    value.value === null) ||
+  (isIdentifier(value) && value.name === 'undefined')
+
+const unwrapExpression = (value: unknown): unknown => {
+  if (!P.isObject(value) || !('type' in value)) return value
+  if (
+    (value.type === 'ChainExpression' ||
+      value.type === 'ParenthesizedExpression' ||
+      value.type === 'TSNonNullExpression' ||
+      value.type === 'TSAsExpression' ||
+      value.type === 'TSSatisfiesExpression' ||
+      value.type === 'TSTypeAssertion' ||
+      value.type === 'TSInstantiationExpression') &&
+    'expression' in value
+  ) {
+    return unwrapExpression(value.expression)
+  }
+  return value
+}
+
+const staticPropertyName = (
+  member: ESTree.MemberExpression,
+): Option.Option<string> =>
+  member.computed
+    ? Option.none()
+    : isIdentifier(member.property)
+      ? Option.some(member.property.name)
+      : Option.none()
+
+const rootIdentifier = (value: unknown): Option.Option<IdentifierNode> => {
+  const unwrapped = unwrapExpression(value)
+  if (isIdentifier(unwrapped)) return Option.some(unwrapped)
+  if (isMemberExpression(unwrapped)) return rootIdentifier(unwrapped.object)
+  return Option.none()
+}
+
+interface DomQueryCall {
+  readonly call: ESTree.CallExpression
+  readonly document: IdentifierNode
+  readonly method: string
+}
+
+const domQueryCall = (value: unknown): Option.Option<DomQueryCall> => {
+  const unwrapped = unwrapExpression(value)
+  if (!isCallExpression(unwrapped)) return Option.none()
+  const callee = unwrapExpression(unwrapped.callee)
+  if (!isMemberExpression(callee)) return Option.none()
+  return pipe(
+    AST.memberPath(callee),
+    Option.flatMap(path => {
+      if (path.length !== 2 || path[0] !== 'document') {
+        return Option.none()
+      }
+      return pipe(
+        Arr.get(path, 1),
+        Option.filter(method => HashSet.has(QUERY_METHODS, method)),
+        Option.flatMap(method =>
+          pipe(
+            rootIdentifier(callee),
+            Option.map(document => ({
+              call: unwrapped,
+              document,
+              method,
+            })),
+          ),
+        ),
+      )
+    }),
+  )
+}
+
+interface TargetMethodCall {
+  readonly member: ESTree.MemberExpression
+  readonly method: string
+  readonly receiver: unknown
+}
+
+const targetMethodCall = (
+  call: ESTree.CallExpression,
+): Option.Option<TargetMethodCall> => {
+  const callee = unwrapExpression(call.callee)
+  if (!isMemberExpression(callee)) return Option.none()
+  return pipe(
+    staticPropertyName(callee),
+    Option.filter(method => HashSet.has(TARGET_METHODS, method)),
+    Option.map(method => ({
+      member: callee,
+      method,
+      receiver: unwrapExpression(callee.object),
+    })),
+  )
+}
+
+const directQueryTarget = (
+  call: ESTree.CallExpression,
+): Option.Option<DomQueryCall & { readonly method: string }> =>
+  pipe(
+    targetMethodCall(call),
+    Option.flatMap(target =>
+      pipe(
+        domQueryCall(target.receiver),
+        Option.map(query => ({ ...query, method: target.method })),
+      ),
+    ),
+  )
+
+const isCalleeOfCall = (member: ESTree.MemberExpression): boolean =>
+  pipe(
+    parentOf(member),
+    Option.match({
+      onNone: () => false,
+      onSome: parent => {
+        if (
+          isCallExpression(parent) &&
+          unwrapExpression(parent.callee) === member
+        ) {
+          return true
+        }
+        return (
+          parent.type === 'ChainExpression' &&
+          'expression' in parent &&
+          parent.expression === member &&
+          pipe(
+            parentOf(parent),
+            Option.match({
+              onNone: () => false,
+              onSome: callParent =>
+                isCallExpression(callParent) &&
+                unwrapExpression(callParent.callee) === parent,
+            }),
+          )
+        )
+      },
+    }),
+  )
+
+const isTargetReceiverReference = (identifier: IdentifierNode): boolean =>
+  pipe(
+    parentOf(identifier),
+    Option.match({
+      onNone: () => false,
+      onSome: parent => {
+        if (!isMemberExpression(parent) || parent.object !== identifier) {
+          return false
+        }
+        return pipe(
+          staticPropertyName(parent),
+          Option.match({
+            onNone: () => false,
+            onSome: method =>
+              HashSet.has(TARGET_METHODS, method) && isCalleeOfCall(parent),
+          }),
+        )
+      },
+    }),
+  )
+
+const isControlTest = (value: unknown): boolean =>
+  pipe(
+    Option.fromNullishOr(value),
+    Option.flatMap(node =>
+      isNodeWithParent(node) ? parentOf(node) : Option.none(),
+    ),
+    Option.match({
+      onNone: () => false,
+      onSome: parent =>
+        (isIfStatementLike(parent) && parent.test === value) ||
+        (isConditionalExpressionLike(parent) && parent.test === value) ||
+        (isWhileStatementLike(parent) && parent.test === value),
+    }),
+  )
+
+const isNullishComparisonGuard = (
+  binary: NodeWithParent & {
+    readonly operator: string
+    readonly left: unknown
+    readonly right: unknown
+  },
+  identifier: IdentifierNode,
+): boolean =>
+  (binary.operator === '==' ||
+    binary.operator === '===' ||
+    binary.operator === '!=' ||
+    binary.operator === '!==') &&
+  ((binary.left === identifier && isNullishLiteral(binary.right)) ||
+    (binary.right === identifier && isNullishLiteral(binary.left))) &&
+  isControlTest(binary)
+
+const isExistenceGuardReference = (identifier: IdentifierNode): boolean =>
+  pipe(
+    parentOf(identifier),
+    Option.match({
+      onNone: () => false,
+      onSome: parent => {
+        if (isControlTest(identifier)) return true
+        if (
+          isUnaryExpressionLike(parent) &&
+          parent.operator === '!' &&
+          parent.argument === identifier
+        ) {
+          return isControlTest(parent)
+        }
+        if (isBinaryExpressionLike(parent)) {
+          return isNullishComparisonGuard(parent, identifier)
+        }
+        return (
+          isLogicalExpressionLike(parent) &&
+          parent.operator === '&&' &&
+          parent.left === identifier
+        )
+      },
+    }),
+  )
+
+type ReferenceUse = 'guard' | 'other' | 'target'
+
+const referenceUse = (identifier: IdentifierNode): ReferenceUse => {
+  if (isTargetReceiverReference(identifier)) return 'target'
+  if (isExistenceGuardReference(identifier)) return 'guard'
+  return 'other'
+}
+
+const shouldReportQueryVariable = (
+  references: ReadonlyArray<{
+    readonly identifier: unknown
+    readonly init: boolean
+  }>,
+): boolean => {
+  const uses = pipe(
+    references,
+    Arr.filter(reference => !reference.init),
+    Arr.map(reference =>
+      isIdentifier(reference.identifier)
+        ? referenceUse(reference.identifier)
+        : 'other',
+    ),
+  )
+  return (
+    pipe(
+      uses,
+      Arr.some(use => use === 'target'),
+    ) &&
+    pipe(
+      uses,
+      Arr.every(use => use === 'target' || use === 'guard'),
+    )
+  )
+}
+
+const constQueryVariable = (
+  node: ESTree.VariableDeclarator,
+): Option.Option<{ readonly name: string; readonly query: DomQueryCall }> => {
+  const id = node.id
+  if (!isIdentifier(id)) return Option.none()
+  return pipe(
+    domQueryCall(node.init),
+    Option.map(query => ({ name: id.name, query })),
+  )
+}
+
+const reportDirectMethod = (
+  ctx: RuleContext['Service'],
+  node: ESTree.CallExpression,
+  method: string,
+): Effect.Effect<void> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message: `Use Foldkit \`Dom\` helpers instead of calling \`${method}\` directly on a \`document.getElementById/querySelector\` result. Dom helpers wait for the next render commit and report typed missing-element failures. (FK Dom)`,
+    }),
+  )
+
+const reportQueryVariable = (
+  ctx: RuleContext['Service'],
+  node: ESTree.VariableDeclarator,
+  name: string,
+  queryMethod: string,
+): Effect.Effect<void> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message: `Variable \`${name}\` is initialized from \`document.${queryMethod}(...)\` and only used to call DOM element methods. Use Foldkit \`Dom\` helpers instead so the operation runs after render commit and fails in the typed channel. (FK Dom)`,
+    }),
+  )
+
+const analyzeQueryVariable = (
+  ctx: RuleContext['Service'],
+  node: ESTree.VariableDeclarator,
+  name: string,
+  query: DomQueryCall,
+): Effect.Effect<void, never, RuleContext> =>
+  SourceCode.getDeclaredVariables(node).pipe(
+    Effect.flatMap(variables =>
+      pipe(
+        variables,
+        Arr.findFirst(variable => variable.name === name),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: variable =>
+            shouldReportQueryVariable(variable.references)
+              ? reportQueryVariable(ctx, node, name, query.method)
+              : Effect.void,
+        }),
+      ),
+    ),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'prefer-dom-helpers-for-element-ops',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Prefer Foldkit Dom helpers over direct focus, scroll, click, and dialog operations on queried elements',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return yield* Visitor.filter(
+      isScopedFile,
+      Visitor.merge(
+        Visitor.on('CallExpression', node =>
+          pipe(
+            directQueryTarget(node),
+            Option.match({
+              onNone: () => Effect.void,
+              onSome: ({ document, method }) =>
+                SourceCode.isGlobalReference(document).pipe(
+                  Effect.flatMap(isGlobal =>
+                    isGlobal
+                      ? reportDirectMethod(ctx, node, method)
+                      : Effect.void,
+                  ),
+                ),
+            }),
+          ),
+        ),
+        Visitor.on('VariableDeclarator', node =>
+          pipe(
+            constQueryVariable(node),
+            Option.match({
+              onNone: () => Effect.void,
+              onSome: ({ name, query }) =>
+                pipe(
+                  parentOf(node),
+                  Option.filter(
+                    parent =>
+                      isVariableDeclaration(parent) && parent.kind === 'const',
+                  ),
+                  Option.match({
+                    onNone: () => Effect.void,
+                    onSome: () =>
+                      SourceCode.isGlobalReference(query.document).pipe(
+                        Effect.flatMap(isGlobal =>
+                          isGlobal
+                            ? analyzeQueryVariable(ctx, node, name, query)
+                            : Effect.void,
+                        ),
+                      ),
+                  }),
+                ),
+            }),
+          ),
+        ),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/prefer-empty-over-empty-element.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/prefer-empty-over-empty-element.ts
@@ -1,0 +1,90 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+
+/** Hyperscript element helpers most often left empty. */
+const EMPTY_ABLE_ELEMENTS = HashSet.make(
+  'span',
+  'div',
+  'p',
+  'section',
+  'article',
+)
+
+interface CalleeInfo {
+  readonly element: string
+  readonly viaHelper: boolean
+}
+
+const isEmptyArrayLiteral = (n: ESTree.Node): boolean =>
+  n.type === 'ArrayExpression' && n.elements.length === 0
+
+const calleeInfo = (call: ESTree.CallExpression): Option.Option<CalleeInfo> => {
+  if (
+    call.callee.type === 'MemberExpression' &&
+    !call.callee.computed &&
+    call.callee.object.type === 'Identifier' &&
+    call.callee.property.type === 'Identifier' &&
+    HashSet.has(EMPTY_ABLE_ELEMENTS, call.callee.property.name)
+  ) {
+    return Option.some({
+      element: call.callee.property.name,
+      viaHelper: true,
+    })
+  }
+  if (
+    call.callee.type === 'Identifier' &&
+    HashSet.has(EMPTY_ABLE_ELEMENTS, call.callee.name)
+  ) {
+    return Option.some({ element: call.callee.name, viaHelper: false })
+  }
+  return Option.none()
+}
+
+const hasTwoEmptyArrayArgs = (call: ESTree.CallExpression): boolean => {
+  if (call.arguments.length !== 2) return false
+  const [attrs, children] = call.arguments
+  return (
+    !!attrs &&
+    !!children &&
+    isEmptyArrayLiteral(attrs) &&
+    isEmptyArrayLiteral(children)
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'prefer-empty-over-empty-element',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Use `empty` / `h.empty` instead of empty hyperscript elements like `span([], [])` (FK-5)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        calleeInfo(node),
+        Option.filter(() => hasTwoEmptyArrayArgs(node)),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: ({ element, viaHelper }) => {
+            const suggested = viaHelper ? 'h.empty' : 'empty'
+            const prefix = viaHelper ? 'h.' : ''
+            return ctx.report(
+              Diagnostic.make({
+                node,
+                message: `Empty element \`${prefix}${element}([], [])\` is non-idiomatic. Use \`${suggested}\` instead. (FK-5)`,
+              }),
+            )
+          },
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/prefer-evo-over-model-spread.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/prefer-evo-over-model-spread.ts
@@ -1,0 +1,123 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Ref from 'effect/Ref'
+import * as Result from 'effect/Result'
+import * as Str from 'effect/String'
+
+type FunctionLike = {
+  readonly params: ReadonlyArray<unknown>
+}
+
+const normalizedPath = (filename: string): string =>
+  Str.replaceAll('\\', '/')(filename)
+
+const basename = (filename: string): string => {
+  const parts = Str.split('/')(normalizedPath(filename))
+  return pipe(
+    Arr.last(parts),
+    Option.getOrElse(() => filename),
+  )
+}
+
+const isUpdateFile = (filename: string): boolean => {
+  const path = normalizedPath(filename)
+  return basename(path) === 'update.ts' || Str.includes('/update/')(path)
+}
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const hasModelParameter = (fn: FunctionLike): boolean =>
+  pipe(
+    fn.params,
+    Arr.some(param => isIdentifierLike(param) && param.name === 'model'),
+  )
+
+const modelSpreadElements = (
+  object: ESTree.ObjectExpression,
+): ReadonlyArray<ESTree.SpreadElement> =>
+  pipe(
+    object.properties,
+    Arr.filterMap(property =>
+      property.type === 'SpreadElement' &&
+      isIdentifierLike(property.argument) &&
+      property.argument.name === 'model'
+        ? Result.succeed(property)
+        : Result.failVoid,
+    ),
+  )
+
+const reportModelSpread = (
+  ctx: RuleContext['Service'],
+  node: ESTree.SpreadElement,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message:
+        'Use `evo(model, { ... })` to evolve Foldkit Models instead of object-spreading `model`. `evo` keeps updates strict and preserves references. (FK model evolution)',
+    }),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'prefer-evo-over-model-spread',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Disallow object-spreading update function `model` parameters; use `evo(model, ...)` for Foldkit Model evolution',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const modelParameterDepth = yield* Ref.make(0)
+
+    const enterFunction = (node: FunctionLike): Effect.Effect<void> =>
+      hasModelParameter(node)
+        ? Ref.update(modelParameterDepth, depth => depth + 1)
+        : Effect.void
+
+    const exitFunction = (node: FunctionLike): Effect.Effect<void> =>
+      hasModelParameter(node)
+        ? Ref.update(modelParameterDepth, depth => depth - 1)
+        : Effect.void
+
+    return yield* Visitor.filter(
+      isUpdateFile,
+      Visitor.merge(
+        Visitor.on('ArrowFunctionExpression', enterFunction),
+        Visitor.onExit('ArrowFunctionExpression', exitFunction),
+        Visitor.on('FunctionDeclaration', enterFunction),
+        Visitor.onExit('FunctionDeclaration', exitFunction),
+        Visitor.on('FunctionExpression', enterFunction),
+        Visitor.onExit('FunctionExpression', exitFunction),
+        Visitor.on('ObjectExpression', node =>
+          Effect.gen(function* () {
+            const depth = yield* Ref.get(modelParameterDepth)
+            if (depth <= 0) return
+            yield* Effect.forEach(
+              modelSpreadElements(node),
+              spread => reportModelSpread(ctx, spread),
+              { concurrency: 1, discard: true },
+            )
+          }),
+        ),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/prefer-option-match-over-map-getorelse.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/prefer-option-match-over-map-getorelse.ts
@@ -1,0 +1,73 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+
+const isOptionMapCall = (node: ESTree.Node): boolean =>
+  node.type === 'CallExpression' && AST.isCallOf(node, 'Option', 'map')
+
+const isOptionGetOrElseCall = (node: ESTree.Node): boolean =>
+  node.type === 'CallExpression' && AST.isCallOf(node, 'Option', 'getOrElse')
+
+/**
+ * `<Option.map(...)>.pipe(..., Option.getOrElse(...), ...)`
+ */
+const matchesMethodPipeForm = (call: ESTree.CallExpression): boolean =>
+  call.callee.type === 'MemberExpression' &&
+  call.callee.property.type === 'Identifier' &&
+  call.callee.property.name === 'pipe' &&
+  isOptionMapCall(call.callee.object) &&
+  pipe(
+    call.arguments,
+    Arr.some(arg => arg.type !== 'SpreadElement' && isOptionGetOrElseCall(arg)),
+  )
+
+/**
+ * `pipe(value, Option.map(...), Option.getOrElse(...))` —
+ * any two consecutive arguments matching the pattern.
+ */
+const matchesFreestandingPipeForm = (call: ESTree.CallExpression): boolean => {
+  if (call.callee.type !== 'Identifier' || call.callee.name !== 'pipe') {
+    return false
+  }
+  const args = call.arguments
+  return pipe(
+    Arr.range(0, Math.max(args.length - 2, -1)),
+    Arr.some(i => {
+      const a = args[i]
+      const b = args[i + 1]
+      if (!a || !b) return false
+      if (a.type === 'SpreadElement' || b.type === 'SpreadElement') return false
+      return isOptionMapCall(a) && isOptionGetOrElseCall(b)
+    }),
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'prefer-option-match-over-map-getorelse',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Prefer `Option.match` over `Option.map(...).pipe(Option.getOrElse(...))` (FK-3)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node => {
+      const matches =
+        matchesMethodPipeForm(node) || matchesFreestandingPipeForm(node)
+      return matches
+        ? ctx.report(
+            Diagnostic.make({
+              node,
+              message:
+                'Prefer `Option.match(value, { onNone: ..., onSome: ... })` over `Option.map(...).pipe(Option.getOrElse(...))`. The labeled branches are self-documenting. (FK-3)',
+            }),
+          )
+        : Effect.void
+    })
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/prefer-story-command-matchers.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/prefer-story-command-matchers.ts
@@ -1,0 +1,294 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+import * as Schema from 'effect/Schema'
+import * as Str from 'effect/String'
+
+const PascalCommandName = Schema.String.check(
+  Schema.isPattern(/^[A-Z][A-Za-z0-9]*$/, {
+    identifier: 'PascalCommandName',
+    title: 'Pascal Command Name',
+    description: 'A PascalCase Foldkit command name.',
+  }),
+)
+const isPascalCommandName = Schema.is(PascalCommandName)
+
+const CommandCollectionName = Schema.String.check(
+  Schema.isPattern(/commands?$/i, {
+    identifier: 'CommandCollectionName',
+    title: 'Command Collection Name',
+    description: 'An identifier ending in command or commands.',
+  }),
+)
+const isCommandCollectionName = Schema.is(CommandCollectionName)
+
+const COMMAND_MATCH_KEYS = HashSet.make('args', 'name')
+
+const normalizedPath = (filename: string): string =>
+  Str.replaceAll('\\', '/')(filename)
+
+const isTestFile = (filename: string): boolean => {
+  const normalized = normalizedPath(filename)
+  return (
+    Str.includes('/apps/ui/test/')(normalized) && /\.tsx?$/.test(normalized)
+  )
+}
+
+const isIdentifier = (
+  value: unknown,
+): value is ESTree.IdentifierName | ESTree.IdentifierReference =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpression = (value: unknown): value is ESTree.MemberExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isCallExpression = (value: unknown): value is ESTree.CallExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'CallExpression'
+
+const isObjectExpression = (value: unknown): value is ESTree.ObjectExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'ObjectExpression'
+
+const isObjectProperty = (value: unknown): value is ESTree.ObjectProperty =>
+  P.isObject(value) && 'type' in value && value.type === 'Property'
+
+const unwrapExpression = (value: unknown): unknown => {
+  if (!P.isObject(value) || !('type' in value)) return value
+  if (
+    (value.type === 'ChainExpression' ||
+      value.type === 'ParenthesizedExpression' ||
+      value.type === 'TSNonNullExpression' ||
+      value.type === 'TSAsExpression' ||
+      value.type === 'TSSatisfiesExpression' ||
+      value.type === 'TSTypeAssertion' ||
+      value.type === 'TSInstantiationExpression') &&
+    'expression' in value
+  ) {
+    return unwrapExpression(value.expression)
+  }
+  return value
+}
+
+const staticPropertyName = (
+  member: ESTree.MemberExpression,
+): Option.Option<string> =>
+  member.computed
+    ? Option.none()
+    : isIdentifier(member.property)
+      ? Option.some(member.property.name)
+      : Option.none()
+
+const staticKeyName = (
+  property: ESTree.ObjectProperty,
+): Option.Option<string> => {
+  if (property.computed) return Option.none()
+  if (isIdentifier(property.key)) return Option.some(property.key.name)
+  return property.key.type === 'Literal' && P.isString(property.key.value)
+    ? Option.some(property.key.value)
+    : Option.none()
+}
+
+const stringLiteralValue = (value: unknown): Option.Option<string> =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Literal' &&
+  'value' in value &&
+  P.isString(value.value)
+    ? Option.some(value.value)
+    : Option.none()
+
+const firstExpressionArg = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.Node> => {
+  const arg = call.arguments[0]
+  return arg !== undefined && arg.type !== 'SpreadElement'
+    ? Option.some(arg)
+    : Option.none()
+}
+
+const expectArgument = (value: unknown): Option.Option<ESTree.Node> => {
+  const unwrapped = unwrapExpression(value)
+  if (!isCallExpression(unwrapped)) return Option.none()
+  const callee = unwrapExpression(unwrapped.callee)
+  return isIdentifier(callee) && callee.name === 'expect'
+    ? firstExpressionArg(unwrapped)
+    : Option.none()
+}
+
+const matcherExpectArgument = (
+  call: ESTree.CallExpression,
+  matcher: string,
+): Option.Option<ESTree.Node> => {
+  const callee = unwrapExpression(call.callee)
+  if (!isMemberExpression(callee)) return Option.none()
+  return pipe(
+    staticPropertyName(callee),
+    Option.filter(name => name === matcher),
+    Option.flatMap(() => expectArgument(callee.object)),
+  )
+}
+
+const isCommandElementAccess = (value: unknown): boolean => {
+  const unwrapped = unwrapExpression(value)
+  return (
+    isMemberExpression(unwrapped) &&
+    unwrapped.computed === true &&
+    pipe(
+      Option.fromNullishOr(unwrapExpression(unwrapped.object)),
+      Option.filter(isIdentifier),
+      Option.match({
+        onNone: () => false,
+        onSome: identifier => isCommandCollectionName(identifier.name),
+      }),
+    )
+  )
+}
+
+const isCommandElementNameAccess = (value: unknown): boolean => {
+  const unwrapped = unwrapExpression(value)
+  return (
+    isMemberExpression(unwrapped) &&
+    pipe(
+      staticPropertyName(unwrapped),
+      Option.match({
+        onNone: () => false,
+        onSome: name =>
+          name === 'name' && isCommandElementAccess(unwrapped.object),
+      }),
+    )
+  )
+}
+
+interface CommandMatcherProperty {
+  readonly key: string
+  readonly value: ESTree.Node
+}
+
+const commandMatcherProperties = (
+  object: ESTree.ObjectExpression,
+): Option.Option<ReadonlyArray<CommandMatcherProperty>> => {
+  const properties = pipe(
+    object.properties,
+    Arr.filterMap(property => {
+      if (!isObjectProperty(property)) return Result.failVoid
+      return pipe(
+        staticKeyName(property),
+        Option.map(key => ({ key, value: property.value })),
+        Result.fromOption(() => undefined),
+      )
+    }),
+  )
+  return Arr.length(properties) === Arr.length(object.properties)
+    ? Option.some(properties)
+    : Option.none()
+}
+
+const isCommandMatcherObject = (object: ESTree.ObjectExpression): boolean =>
+  pipe(
+    commandMatcherProperties(object),
+    Option.match({
+      onNone: () => false,
+      onSome: properties => {
+        const keys = pipe(
+          properties,
+          Arr.map(property => property.key),
+        )
+        return (
+          Arr.isReadonlyArrayNonEmpty(keys) &&
+          pipe(
+            keys,
+            Arr.every(key => HashSet.has(COMMAND_MATCH_KEYS, key)),
+          ) &&
+          pipe(
+            properties,
+            Arr.findFirst(property => property.key === 'name'),
+            Option.flatMap(property => stringLiteralValue(property.value)),
+            Option.match({
+              onNone: () => false,
+              onSome: isPascalCommandName,
+            }),
+          )
+        )
+      },
+    }),
+  )
+
+const toMatchObjectOffense = (call: ESTree.CallExpression): boolean => {
+  const objectArg = pipe(
+    firstExpressionArg(call),
+    Option.filter(isObjectExpression),
+  )
+  return (
+    Option.isSome(objectArg) &&
+    isCommandMatcherObject(objectArg.value) &&
+    pipe(
+      matcherExpectArgument(call, 'toMatchObject'),
+      Option.match({
+        onNone: () => false,
+        onSome: isCommandElementAccess,
+      }),
+    )
+  )
+}
+
+const toBeNameOffense = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    firstExpressionArg(call),
+    Option.flatMap(stringLiteralValue),
+    Option.filter(isPascalCommandName),
+    Option.match({
+      onNone: () => false,
+      onSome: () =>
+        pipe(
+          matcherExpectArgument(call, 'toBe'),
+          Option.match({
+            onNone: () => false,
+            onSome: isCommandElementNameAccess,
+          }),
+        ),
+    }),
+  )
+
+const report = (
+  ctx: RuleContext['Service'],
+  node: ESTree.CallExpression,
+): Effect.Effect<void> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message:
+        'Use `Story.Command.expectExact` or `Story.Command.expectHas` instead of hand-rolled command-name assertions. Story command matchers account for Foldkit command identity and unresolved command coverage. (FK Story)',
+    }),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'prefer-story-command-matchers',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Prefer Story.Command.expectExact / expectHas over hand-rolled Foldkit command assertions in tests',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return yield* Visitor.filter(
+      isTestFile,
+      Visitor.on('CallExpression', node =>
+        toMatchObjectOffense(node) || toBeNameOffense(node)
+          ? report(ctx, node)
+          : Effect.void,
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/require-completed-mirrors-command.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/require-completed-mirrors-command.ts
@@ -1,0 +1,138 @@
+import { Match, pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+import * as Schema from 'effect/Schema'
+
+const CompletedTag = Schema.String.check(
+  Schema.isPattern(/^Completed[A-Z]/, {
+    identifier: 'CompletedTag',
+    title: 'Completed-prefixed Message Tag',
+    description:
+      'A Message tag of the form `Completed<Action>` where `<Action>` begins with an uppercase letter.',
+  }),
+)
+const isCompletedTag = Schema.is(CompletedTag)
+
+interface Mention {
+  readonly kind: 'command' | 'completed'
+  readonly action: string
+  readonly node: ESTree.CallExpression
+}
+
+const stringLiteralValue = (arg: ESTree.Argument): Option.Option<string> =>
+  arg.type === 'Literal' && P.isString(arg.value)
+    ? Option.some(arg.value)
+    : Option.none()
+
+const stringLiteralArg = (
+  call: ESTree.CallExpression,
+): Option.Option<string> => {
+  const arg = call.arguments[0]
+  return arg === undefined ? Option.none() : stringLiteralValue(arg)
+}
+
+const extractMention = (node: ESTree.Node): Option.Option<Mention> => {
+  if (node.type !== 'CallExpression') return Option.none()
+  const call = node
+
+  if (AST.isCallOf(call, 'Command', 'define')) {
+    return pipe(
+      stringLiteralArg(call),
+      Option.map(action => ({
+        kind: 'command' as const,
+        action,
+        node: call,
+      })),
+    )
+  }
+
+  if (call.callee.type === 'Identifier' && call.callee.name === 'm') {
+    return pipe(
+      stringLiteralArg(call),
+      Option.filter(isCompletedTag),
+      Option.map(tag => ({
+        kind: 'completed' as const,
+        action: tag.slice('Completed'.length),
+        node: call,
+      })),
+    )
+  }
+
+  return Option.none()
+}
+
+interface Partitioned {
+  readonly commandActions: HashSet.HashSet<string>
+  readonly completed: ReadonlyArray<{
+    readonly action: string
+    readonly node: ESTree.CallExpression
+  }>
+}
+
+const partitionMentions = (items: ReadonlyArray<Mention>): Partitioned => ({
+  commandActions: pipe(
+    items,
+    Arr.filterMap(i =>
+      i.kind === 'command' ? Result.succeed(i.action) : Result.failVoid,
+    ),
+    HashSet.fromIterable,
+  ),
+  completed: pipe(
+    items,
+    Arr.filterMap(i =>
+      i.kind === 'completed'
+        ? Result.succeed({ action: i.action, node: i.node })
+        : Result.failVoid,
+    ),
+  ),
+})
+
+const rule: CreateRule = Rule.define({
+  name: 'require-completed-mirrors-command',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      '`m("Completed<X>")` Messages must mirror a `Command.define("<X>", ...)` in the same file — verb-first, not noun-first (FK-1)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+
+    return yield* Visitor.accumulate<Mention>(
+      'CallExpression',
+      extractMention,
+      items => {
+        const { commandActions, completed } = partitionMentions(items)
+
+        // Only flag when the file defines at least one Command —
+        // otherwise we can't make a confident judgment.
+        return Match.value(HashSet.size(commandActions)).pipe(
+          Match.when(0, () => Effect.void),
+          Match.orElse(() =>
+            Effect.forEach(
+              completed,
+              ({ action, node }) =>
+                HashSet.has(commandActions, action)
+                  ? Effect.void
+                  : ctx.report(
+                      Diagnostic.make({
+                        node,
+                        message: `\`Completed${action}\` does not mirror any \`Command.define(...)\` in this file. \`Completed*\` Messages must repeat the Command name verb-first (e.g. Command \`FocusInput\` → Message \`CompletedFocusInput\`, not \`CompletedInputFocus\`). (FK-1)`,
+                      }),
+                    ),
+              { concurrency: 1, discard: true },
+            ),
+          ),
+        )
+      },
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/require-past-tense-message-names.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/require-past-tense-message-names.ts
@@ -1,0 +1,177 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Schema from 'effect/Schema'
+
+/**
+ * Allowed verb-first past-tense prefixes for Foldkit Message tags.
+ *
+ * Drawn from `conventions.md` — every Message is past-tense, verb-first.
+ */
+const ALLOWED_PREFIXES = [
+  'Aborted',
+  'Acknowledged',
+  'Added',
+  'Applied',
+  'Approved',
+  'Archived',
+  'Began',
+  'Blurred',
+  'Canceled',
+  'Cancelled',
+  'Changed',
+  'Checked',
+  'Chose',
+  'Cleared',
+  'Clicked',
+  'Closed',
+  'Collapsed',
+  'Committed',
+  'Completed',
+  'Confirmed',
+  'Connected',
+  'Copied',
+  'Created',
+  'Deleted',
+  'Disabled',
+  'Disconnected',
+  'Dismissed',
+  'Dragged',
+  'Dropped',
+  'Duplicated',
+  'Edited',
+  'Enabled',
+  'Ended',
+  'Entered',
+  'Expanded',
+  'Failed',
+  'Fetched',
+  'Filtered',
+  'Flipped',
+  'Focused',
+  'Got',
+  'Hid',
+  'Highlighted',
+  'Hovered',
+  'Imported',
+  'Ingested',
+  'Initialized',
+  'Loaded',
+  'Mounted',
+  'Moved',
+  'Navigated',
+  'Opened',
+  'Paused',
+  'Persisted',
+  'Pinned',
+  'Played',
+  'Pressed',
+  'Probed',
+  'Ran',
+  'Received',
+  'Refreshed',
+  'Regenerated',
+  'Rejected',
+  'Removed',
+  'Renamed',
+  'Rendered',
+  'Reordered',
+  'Reported',
+  'Requested',
+  'Reset',
+  'Resized',
+  'Restored',
+  'Resumed',
+  'Returned',
+  'Revealed',
+  'Saved',
+  'Scrolled',
+  'Searched',
+  'Selected',
+  'Sent',
+  'Set',
+  'Sorted',
+  'Started',
+  'Stopped',
+  'Submitted',
+  'Subscribed',
+  'Succeeded',
+  'Switched',
+  'Tick',
+  'Ticked',
+  'Toggled',
+  'Typed',
+  'Unchecked',
+  'Unmounted',
+  'Unpinned',
+  'Unsubscribed',
+  'Updated',
+  'Uploaded',
+  'Viewed',
+  'Zoomed',
+] as const
+
+/**
+ * A string that begins with an allowed verb-prefix followed by either
+ * a word boundary (uppercase letter) or end-of-string.
+ */
+const PastTenseMessageTag = Schema.String.check(
+  Schema.isPattern(new RegExp(`^(${ALLOWED_PREFIXES.join('|')})([A-Z]|$)`), {
+    identifier: 'PastTenseMessageTag',
+    title: 'Past-Tense Message Tag',
+    description:
+      'Foldkit Message tag whose first word is a past-tense verb prefix.',
+  }),
+)
+
+const isPastTenseMessageTag = Schema.is(PastTenseMessageTag)
+
+/** Boolean wrapper that does not narrow callers via the brand refinement. */
+const startsWithPastTensePrefix = (tag: string): boolean =>
+  isPastTenseMessageTag(tag)
+
+const mTagFromCall = (call: ESTree.CallExpression): Option.Option<string> => {
+  if (call.callee.type !== 'Identifier' || call.callee.name !== 'm') {
+    return Option.none()
+  }
+  const arg = call.arguments[0]
+  return arg !== undefined && arg.type === 'Literal' && P.isString(arg.value)
+    ? Option.some(arg.value)
+    : Option.none()
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'require-past-tense-message-names',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Enforce verb-first past-tense Foldkit Message names (e.g. ClickedSubmit, UpdatedEmail). (FK-1)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      pipe(
+        mTagFromCall(node),
+        Option.filter(tag => tag !== 'NoOp' && !startsWithPastTensePrefix(tag)),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: tag =>
+            ctx.report(
+              Diagnostic.make({
+                node,
+                message: `Message tag \`${tag}\` does not start with an allowed verb-first past-tense prefix. Use one of: ${ALLOWED_PREFIXES.join(
+                  ', ',
+                )}. (FK-1)`,
+              }),
+            ),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/require-rel-for-external-link.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/require-rel-for-external-link.ts
@@ -1,0 +1,74 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+
+const isTargetBlankCall = (node: ESTree.Node): boolean => {
+  if (node.type !== 'CallExpression') return false
+  if (node.callee.type !== 'Identifier' || node.callee.name !== 'Target')
+    return false
+  const arg0 = node.arguments[0]
+  return (
+    arg0 !== undefined &&
+    arg0.type === 'Literal' &&
+    P.isString(arg0.value) &&
+    arg0.value === '_blank'
+  )
+}
+
+const isRelCall = (node: ESTree.Node): boolean =>
+  node.type === 'CallExpression' &&
+  node.callee.type === 'Identifier' &&
+  node.callee.name === 'Rel'
+
+const findTargetBlank = (
+  arr: ESTree.ArrayExpression,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    arr.elements,
+    Arr.filter(P.isNotNull),
+    Arr.findFirst(el =>
+      isTargetBlankCall(el) ? Option.some(el) : Option.none(),
+    ),
+  )
+
+const hasRel = (arr: ESTree.ArrayExpression): boolean =>
+  pipe(
+    arr.elements,
+    Arr.some(el => el !== null && isRelCall(el)),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'require-rel-for-external-link',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Attribute arrays containing `Target("_blank")` must also contain `Rel("noopener noreferrer")` (FK-5)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('ArrayExpression', node =>
+      pipe(
+        findTargetBlank(node),
+        Option.filter(() => !hasRel(node)),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: targetNode =>
+            ctx.report(
+              Diagnostic.make({
+                node: targetNode,
+                message:
+                  "`Target('_blank')` opens an external context. Pair it with `Rel('noopener noreferrer')` in the same attribute array to prevent tabnabbing and referrer leakage. (FK-5)",
+              }),
+            ),
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/require-succeeded-failed-pair.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/require-succeeded-failed-pair.ts
@@ -1,0 +1,131 @@
+import { Match, pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashMap from 'effect/HashMap'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+import * as Schema from 'effect/Schema'
+import * as Tuple from 'effect/Tuple'
+
+const SucceededTag = Schema.String.check(
+  Schema.isPattern(/^Succeeded[A-Z]/, {
+    identifier: 'SucceededTag',
+    title: 'Succeeded-prefixed Message Tag',
+    description:
+      'A Message tag of the form `Succeeded<Action>` where `<Action>` begins with an uppercase letter.',
+  }),
+)
+const isSucceededTag = Schema.is(SucceededTag)
+
+const FailedTag = Schema.String.check(
+  Schema.isPattern(/^Failed[A-Z]/, {
+    identifier: 'FailedTag',
+    title: 'Failed-prefixed Message Tag',
+    description:
+      'A Message tag of the form `Failed<Action>` where `<Action>` begins with an uppercase letter.',
+  }),
+)
+const isFailedTag = Schema.is(FailedTag)
+
+const classifyTag = (
+  tag: string,
+): Option.Option<{
+  readonly kind: 'succeeded' | 'failed'
+  readonly action: string
+}> =>
+  Match.value(tag).pipe(
+    Match.when(isSucceededTag, t =>
+      Option.some({
+        kind: 'succeeded' as const,
+        action: t.slice('Succeeded'.length),
+      }),
+    ),
+    Match.when(isFailedTag, t =>
+      Option.some({
+        kind: 'failed' as const,
+        action: t.slice('Failed'.length),
+      }),
+    ),
+    Match.orElse(() => Option.none()),
+  )
+
+interface MessageMention {
+  readonly kind: 'succeeded' | 'failed'
+  readonly action: string
+  readonly node: ESTree.CallExpression
+}
+
+const stringLiteralValue = (arg: ESTree.Argument): Option.Option<string> =>
+  arg.type === 'Literal' && P.isString(arg.value)
+    ? Option.some(arg.value)
+    : Option.none()
+
+const extractMention = (node: ESTree.Node): Option.Option<MessageMention> => {
+  if (node.type !== 'CallExpression') return Option.none()
+  if (node.callee.type !== 'Identifier' || node.callee.name !== 'm') {
+    return Option.none()
+  }
+  const arg = node.arguments[0]
+  if (arg === undefined) return Option.none()
+  return pipe(
+    stringLiteralValue(arg),
+    Option.flatMap(classifyTag),
+    Option.map(({ kind, action }) => ({ kind, action, node })),
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'require-succeeded-failed-pair',
+  meta: Rule.meta({
+    type: 'suggestion',
+    description:
+      'Every `m("Succeeded<Action>")` requires a matching `m("Failed<Action>")` in the same file (FK-1)',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+
+    return yield* Visitor.accumulate<MessageMention>(
+      'CallExpression',
+      extractMention,
+      items => {
+        const succeededByAction = pipe(
+          items,
+          Arr.filterMap(i =>
+            i.kind === 'succeeded'
+              ? Result.succeed(Tuple.make(i.action, i.node))
+              : Result.failVoid,
+          ),
+          HashMap.fromIterable,
+        )
+        const failedActions = pipe(
+          items,
+          Arr.filterMap(i =>
+            i.kind === 'failed' ? Result.succeed(i.action) : Result.failVoid,
+          ),
+          HashSet.fromIterable,
+        )
+
+        return Effect.forEach(
+          HashMap.toEntries(succeededByAction),
+          ([action, node]) =>
+            HashSet.has(failedActions, action)
+              ? Effect.void
+              : ctx.report(
+                  Diagnostic.make({
+                    node,
+                    message: `\`Succeeded${action}\` has no paired \`Failed${action}\` in this file. Every fallible Command needs both Success and Failure Messages. (FK-1)`,
+                  }),
+                ),
+          { concurrency: 1, discard: true },
+        )
+      },
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/route-oneof-shadowing-order.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/route-oneof-shadowing-order.ts
@@ -1,0 +1,462 @@
+import { Match, pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashMap from 'effect/HashMap'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Ref from 'effect/Ref'
+import * as Result from 'effect/Result'
+import * as Tuple from 'effect/Tuple'
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type LiteralLike = {
+  readonly type: string
+  readonly value: unknown
+}
+
+type MemberExpressionLike = {
+  readonly type: string
+  readonly computed: unknown
+  readonly object: unknown
+  readonly property: unknown
+}
+
+type CallExpressionLike = {
+  readonly type: string
+  readonly callee: unknown
+  readonly arguments: ReadonlyArray<unknown>
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isLiteralLike = (value: unknown): value is LiteralLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Literal' &&
+  'value' in value
+
+const isMemberExpressionLike = (
+  value: unknown,
+): value is MemberExpressionLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'MemberExpression' &&
+  'computed' in value &&
+  'object' in value &&
+  'property' in value
+
+const isCallExpressionLike = (value: unknown): value is CallExpressionLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'CallExpression' &&
+  'callee' in value &&
+  'arguments' in value &&
+  Array.isArray(value.arguments)
+
+const memberPath = (
+  value: unknown,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  if (isIdentifierLike(value)) return Option.some([value.name])
+  if (!isMemberExpressionLike(value) || value.computed === true) {
+    return Option.none()
+  }
+  const property = value.property
+  if (!isIdentifierLike(property)) return Option.none()
+  return pipe(
+    memberPath(value.object),
+    Option.map(path => [...path, property.name]),
+  )
+}
+
+const pathEquals = (
+  path: ReadonlyArray<string>,
+  expected: ReadonlyArray<string>,
+): boolean =>
+  path.length === expected.length &&
+  pipe(
+    Arr.zip(path, expected),
+    Arr.every(([left, right]) => left === right),
+  )
+
+const callPath = (
+  call: CallExpressionLike,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => memberPath(call.callee)
+
+const isCallPath = (
+  call: CallExpressionLike,
+  expected: ReadonlyArray<string>,
+): boolean =>
+  pipe(
+    callPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path => pathEquals(path, expected),
+    }),
+  )
+
+type RouteSegment =
+  | { readonly _tag: 'literal'; readonly value: string }
+  | { readonly _tag: 'string' }
+  | { readonly _tag: 'int' }
+
+interface RouteShape {
+  readonly routerName: string
+  readonly segments: ReadonlyArray<RouteSegment>
+  readonly isQueryGuarded: boolean
+}
+
+interface OneOfRouter {
+  readonly name: string
+  readonly node: ESTree.Node
+}
+
+interface AnalysisInput {
+  readonly routers: HashMap.HashMap<string, ESTree.Node>
+  readonly oneOfCalls: ReadonlyArray<ReadonlyArray<OneOfRouter>>
+}
+
+const stringLiteralArg = (call: CallExpressionLike): Option.Option<string> => {
+  const args = call.arguments
+  const arg = args[0]
+  return isLiteralLike(arg) && P.isString(arg.value)
+    ? Option.some(arg.value)
+    : Option.none()
+}
+
+const parseSegment = (value: unknown): Option.Option<RouteSegment> => {
+  if (!isCallExpressionLike(value)) return Option.none()
+  return pipe(
+    callPath(value),
+    Option.flatMap(path => {
+      if (pathEquals(path, ['literal'])) {
+        return pipe(
+          stringLiteralArg(value),
+          Option.map(literal => ({
+            _tag: 'literal' as const,
+            value: literal,
+          })),
+        )
+      }
+      if (pathEquals(path, ['string'])) {
+        return Option.some<RouteSegment>({ _tag: 'string' })
+      }
+      if (pathEquals(path, ['int'])) {
+        return Option.some<RouteSegment>({ _tag: 'int' })
+      }
+      return Option.none()
+    }),
+  )
+}
+
+const parseInitialStep = (
+  value: unknown,
+): Option.Option<ReadonlyArray<RouteSegment>> => {
+  if (isIdentifierLike(value) && value.name === 'root') {
+    return Option.some([])
+  }
+  if (isMemberExpressionLike(value)) {
+    return pipe(
+      memberPath(value),
+      Option.filter(path => pathEquals(path, ['Route', 'root'])),
+      Option.map(() => []),
+    )
+  }
+  return pipe(
+    parseSegment(value),
+    Option.map(segment => [segment]),
+  )
+}
+
+type ParseStepResult =
+  | { readonly _tag: 'segment'; readonly segment: RouteSegment }
+  | { readonly _tag: 'query' }
+  | { readonly _tag: 'ignore' }
+
+const parsePipeStep = (value: unknown): Option.Option<ParseStepResult> => {
+  if (!isCallExpressionLike(value)) return Option.none()
+  if (isCallPath(value, ['Route', 'mapTo'])) {
+    return Option.some({ _tag: 'ignore' })
+  }
+  if (isCallPath(value, ['Route', 'query'])) {
+    return Option.some({ _tag: 'query' })
+  }
+  if (isCallPath(value, ['slash'])) {
+    const args = value.arguments
+    const arg = args[0]
+    return pipe(
+      parseSegment(arg),
+      Option.map(segment => ({ _tag: 'segment' as const, segment })),
+    )
+  }
+  return pipe(
+    parseSegment(value),
+    Option.map(segment => ({ _tag: 'segment' as const, segment })),
+  )
+}
+
+const appendStep = (shape: RouteShape, step: ParseStepResult): RouteShape =>
+  Match.value(step).pipe(
+    Match.tag('segment', ({ segment }) => ({
+      ...shape,
+      segments: [...shape.segments, segment],
+    })),
+    Match.tag('query', () => ({ ...shape, isQueryGuarded: true })),
+    Match.tag('ignore', () => shape),
+    Match.exhaustive,
+  )
+
+const routeShapeFromPipeCall = (
+  routerName: string,
+  pipeCall: CallExpressionLike,
+): Option.Option<RouteShape> => {
+  if (!isCallPath(pipeCall, ['pipe'])) return Option.none()
+  const args = pipeCall.arguments
+  const first = args[0]
+  return pipe(
+    parseInitialStep(first),
+    Option.flatMap(segments => {
+      const initial: RouteShape = {
+        routerName,
+        segments,
+        isQueryGuarded: false,
+      }
+      return pipe(
+        Arr.drop(args, 1),
+        Arr.reduce(Option.some(initial), (acc, arg) =>
+          pipe(
+            acc,
+            Option.flatMap(shape =>
+              pipe(
+                parsePipeStep(arg),
+                Option.map(step => appendStep(shape, step)),
+              ),
+            ),
+          ),
+        ),
+      )
+    }),
+  )
+}
+
+const routeShape = (
+  routerName: string,
+  init: Option.Option<ESTree.Node>,
+): Option.Option<RouteShape> =>
+  pipe(
+    init,
+    Option.filter(isCallExpressionLike),
+    Option.flatMap(pipeCall => routeShapeFromPipeCall(routerName, pipeCall)),
+  )
+
+const routeDeclaration = (
+  node: ESTree.VariableDeclarator,
+): Option.Option<readonly [string, ESTree.Node]> => {
+  const id = node.id
+  if (!isIdentifierLike(id)) return Option.none()
+  return pipe(
+    Option.fromNullishOr(node.init),
+    Option.flatMap(init =>
+      pipe(
+        routeShape(id.name, Option.some(init)),
+        Option.map(() => Tuple.make(id.name, init)),
+      ),
+    ),
+  )
+}
+
+const oneOfRouters = (
+  call: ESTree.CallExpression,
+): Option.Option<ReadonlyArray<OneOfRouter>> =>
+  isCallPath(call, ['Route', 'oneOf'])
+    ? Option.some(
+        pipe(
+          call.arguments,
+          Arr.filterMap(arg =>
+            isIdentifierLike(arg)
+              ? Result.succeed({ name: arg.name, node: arg })
+              : Result.failVoid,
+          ),
+        ),
+      )
+    : Option.none()
+
+const literalIntPattern = /^-?\d+$/
+
+const segmentCovers = (left: RouteSegment, right: RouteSegment): boolean =>
+  Match.value(left).pipe(
+    Match.tag('literal', literal =>
+      Match.value(right).pipe(
+        Match.tag('literal', candidate => literal.value === candidate.value),
+        Match.orElse(() => false),
+      ),
+    ),
+    Match.tag('string', () => true),
+    Match.tag('int', () =>
+      Match.value(right).pipe(
+        Match.tag('int', () => true),
+        Match.tag('literal', literal => literalIntPattern.test(literal.value)),
+        Match.orElse(() => false),
+      ),
+    ),
+    Match.exhaustive,
+  )
+
+const coversPrefix = (
+  left: ReadonlyArray<RouteSegment>,
+  right: ReadonlyArray<RouteSegment>,
+): boolean => {
+  if (Arr.isReadonlyArrayEmpty(left)) return Arr.isReadonlyArrayEmpty(right)
+  if (left.length > right.length) return false
+  return pipe(
+    Arr.zip(left, Arr.take(right, left.length)),
+    Arr.every(([leftSegment, rightSegment]) =>
+      segmentCovers(leftSegment, rightSegment),
+    ),
+  )
+}
+
+const shadowDiagnostic = (opts: {
+  readonly shadowingRouter: RouteShape
+  readonly shadowedRouter: RouteShape
+  readonly node: ESTree.Node
+}) =>
+  Diagnostic.make({
+    node: opts.node,
+    message:
+      opts.shadowingRouter.segments.length ===
+      opts.shadowedRouter.segments.length
+        ? `Router \`${opts.shadowedRouter.routerName}\` is unreachable in \`Route.oneOf(...)\`: earlier router \`${opts.shadowingRouter.routerName}\` matches the same path shape. Put the more specific router first or remove the duplicate. (FK routing)`
+        : `Router \`${opts.shadowedRouter.routerName}\` is unreachable in \`Route.oneOf(...)\`: earlier router \`${opts.shadowingRouter.routerName}\` matches its path prefix. Put longer or more specific routes before wildcard prefixes. (FK routing)`,
+  })
+
+const firstShadowingRouter = (
+  previous: ReadonlyArray<RouteShape>,
+  current: RouteShape,
+): Option.Option<RouteShape> =>
+  pipe(
+    previous,
+    Arr.findFirst(
+      candidate =>
+        !candidate.isQueryGuarded &&
+        coversPrefix(candidate.segments, current.segments),
+    ),
+  )
+
+const analyzeOneOf = (
+  ctx: RuleContext['Service'],
+  routers: HashMap.HashMap<string, ESTree.Node>,
+  entries: ReadonlyArray<OneOfRouter>,
+): Effect.Effect<void, never, RuleContext> => {
+  const resolved = pipe(
+    entries,
+    Arr.filterMap(entry =>
+      pipe(
+        HashMap.get(routers, entry.name),
+        Option.flatMap(init => routeShape(entry.name, Option.some(init))),
+        Option.map(shape => ({ ...entry, shape })),
+        Result.fromOption(() => undefined),
+      ),
+    ),
+  )
+  return Effect.forEach(
+    Arr.range(0, resolved.length - 1),
+    index => {
+      const current = resolved[index]
+      if (current === undefined) return Effect.void
+      return pipe(
+        firstShadowingRouter(
+          pipe(
+            resolved,
+            Arr.take(index),
+            Arr.map(entry => entry.shape),
+          ),
+          current.shape,
+        ),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: shadowingRouter =>
+            ctx.report(
+              shadowDiagnostic({
+                shadowingRouter,
+                shadowedRouter: current.shape,
+                node: current.node,
+              }),
+            ),
+        }),
+      )
+    },
+    { concurrency: 1, discard: true },
+  )
+}
+
+const analyze = (
+  ctx: RuleContext['Service'],
+  input: AnalysisInput,
+): Effect.Effect<void, never, RuleContext> =>
+  Effect.forEach(
+    input.oneOfCalls,
+    entries => analyzeOneOf(ctx, input.routers, entries),
+    { concurrency: 1, discard: true },
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'route-oneof-shadowing-order',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Keep Foldkit Route.oneOf routers ordered from most-specific to least-specific so earlier parsers do not shadow later ones',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const routersRef = yield* Ref.make<HashMap.HashMap<string, ESTree.Node>>(
+      HashMap.empty(),
+    )
+    const oneOfCallsRef = yield* Ref.make<
+      ReadonlyArray<ReadonlyArray<OneOfRouter>>
+    >([])
+
+    return Visitor.merge(
+      Visitor.on('VariableDeclarator', node =>
+        pipe(
+          routeDeclaration(node),
+          Option.match({
+            onNone: () => Effect.void,
+            onSome: ([name, init]) =>
+              Ref.update(routersRef, HashMap.set(name, init)),
+          }),
+        ),
+      ),
+      Visitor.on('CallExpression', node =>
+        pipe(
+          oneOfRouters(node),
+          Option.match({
+            onNone: () => Effect.void,
+            onSome: entries =>
+              Ref.update(oneOfCallsRef, calls => [...calls, entries]),
+          }),
+        ),
+      ),
+      Visitor.on('Program:exit', () =>
+        Effect.gen(function* () {
+          const routers = yield* Ref.get(routersRef)
+          const oneOfCalls = yield* Ref.get(oneOfCallsRef)
+          yield* analyze(ctx, { routers, oneOfCalls })
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/route-union-parser-registration.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/route-union-parser-registration.ts
@@ -1,0 +1,430 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashMap from 'effect/HashMap'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Ref from 'effect/Ref'
+import * as Result from 'effect/Result'
+import * as Tuple from 'effect/Tuple'
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type MemberExpressionLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly object?: unknown
+  readonly property?: unknown
+}
+
+type CallExpressionLike = {
+  readonly type: string
+  readonly callee?: unknown
+  readonly arguments?: ReadonlyArray<unknown>
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpressionLike = (
+  value: unknown,
+): value is MemberExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isCallExpressionLike = (value: unknown): value is CallExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'CallExpression'
+
+const isCallExpression = (value: unknown): value is ESTree.CallExpression =>
+  isCallExpressionLike(value)
+
+const memberPath = (
+  value: unknown,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  if (isIdentifierLike(value)) return Option.some([value.name])
+  if (!isMemberExpressionLike(value) || value.computed === true) {
+    return Option.none()
+  }
+  const property = value.property
+  if (!isIdentifierLike(property)) return Option.none()
+  return pipe(
+    memberPath(value.object),
+    Option.map(path => [...path, property.name]),
+  )
+}
+
+const pathEquals = (
+  path: ReadonlyArray<string>,
+  expected: ReadonlyArray<string>,
+): boolean =>
+  path.length === expected.length &&
+  pipe(
+    Arr.zip(path, expected),
+    Arr.every(([left, right]) => left === right),
+  )
+
+const callPath = (
+  call: CallExpressionLike,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => memberPath(call.callee)
+
+const firstIdentifierArg = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.IdentifierName> => {
+  const arg = call.arguments[0]
+  return arg !== undefined && isIdentifierLike(arg)
+    ? Option.some(arg)
+    : Option.none()
+}
+
+const isRouteDeclarationInit = (value: unknown): boolean =>
+  isCallExpressionLike(value) &&
+  pipe(
+    callPath(value),
+    Option.match({
+      onNone: () => false,
+      onSome: path => pathEquals(path, ['r']),
+    }),
+  )
+
+const routeDeclaration = (
+  node: ESTree.VariableDeclarator,
+): Option.Option<{ readonly name: string; readonly node: ESTree.Node }> =>
+  node.id.type === 'Identifier' && isRouteDeclarationInit(node.init)
+    ? Option.some({ name: node.id.name, node: node.id })
+    : Option.none()
+
+const isRouteMapToCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    callPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path => pathEquals(path, ['Route', 'mapTo']),
+    }),
+  )
+
+const routeMapToTarget = (
+  call: ESTree.CallExpression,
+): Option.Option<{ readonly routeName: string; readonly node: ESTree.Node }> =>
+  isRouteMapToCall(call)
+    ? pipe(
+        firstIdentifierArg(call),
+        Option.map(arg => ({ routeName: arg.name, node: arg })),
+      )
+    : Option.none()
+
+const mapToTargetsIn = (
+  root: unknown,
+): ReadonlyArray<{
+  readonly routeName: string
+  readonly node: ESTree.Node
+}> => {
+  if (!P.isObject(root)) return []
+  const self = isCallExpression(root)
+    ? pipe(
+        routeMapToTarget(root),
+        Option.match({
+          onNone: () => [],
+          onSome: target => [target],
+        }),
+      )
+    : []
+  return [
+    ...self,
+    ...pipe(
+      Object.entries(root),
+      Arr.flatMap(([key, child]) =>
+        key === 'parent'
+          ? []
+          : Array.isArray(child)
+            ? pipe(child, Arr.flatMap(mapToTargetsIn))
+            : mapToTargetsIn(child),
+      ),
+    ),
+  ]
+}
+
+interface RouterMapping {
+  readonly routeName: string
+  readonly routerName: string
+  readonly routeNode: ESTree.Node
+  readonly routerNode: ESTree.Node
+}
+
+const routerMappings = (
+  node: ESTree.VariableDeclarator,
+): ReadonlyArray<RouterMapping> => {
+  if (node.id.type !== 'Identifier') return []
+  const routerId = node.id
+  return pipe(
+    mapToTargetsIn(node.init),
+    Arr.map(target => ({
+      routeName: target.routeName,
+      routerName: routerId.name,
+      routeNode: target.node,
+      routerNode: routerId,
+    })),
+  )
+}
+
+interface UnionMember {
+  readonly name: string
+  readonly node: ESTree.Node
+}
+
+const identifierElements = (
+  array: ESTree.ArrayExpression,
+): ReadonlyArray<UnionMember> =>
+  pipe(
+    array.elements,
+    Arr.filterMap(element =>
+      element !== null && isIdentifierLike(element)
+        ? Result.succeed({ name: element.name, node: element })
+        : Result.failVoid,
+    ),
+  )
+
+const unionMembers = (
+  call: ESTree.CallExpression,
+): Option.Option<ReadonlyArray<UnionMember>> =>
+  pipe(
+    callPath(call),
+    Option.filter(path => pathEquals(path, ['S', 'Union'])),
+    Option.flatMap(() => {
+      const arg = call.arguments[0]
+      return arg !== undefined && arg.type === 'ArrayExpression'
+        ? Option.some(identifierElements(arg))
+        : Option.none()
+    }),
+  )
+
+const oneOfRouters = (
+  call: ESTree.CallExpression,
+): Option.Option<ReadonlyArray<string>> =>
+  pipe(
+    callPath(call),
+    Option.filter(path => pathEquals(path, ['Route', 'oneOf'])),
+    Option.map(() =>
+      pipe(
+        call.arguments,
+        Arr.filterMap(arg =>
+          isIdentifierLike(arg) ? Result.succeed(arg.name) : Result.failVoid,
+        ),
+      ),
+    ),
+  )
+
+const fallbackRoute = (call: ESTree.CallExpression): Option.Option<string> =>
+  pipe(
+    callPath(call),
+    Option.filter(path => pathEquals(path, ['Route', 'parseUrlWithFallback'])),
+    Option.flatMap(() => {
+      const arg = call.arguments[1]
+      return isIdentifierLike(arg) ? Option.some(arg.name) : Option.none()
+    }),
+  )
+
+const selectRouteUnion = (
+  unions: ReadonlyArray<ReadonlyArray<UnionMember>>,
+  routes: HashSet.HashSet<string>,
+): Option.Option<ReadonlyArray<UnionMember>> =>
+  pipe(
+    unions,
+    Arr.filter(
+      members =>
+        Arr.isReadonlyArrayNonEmpty(members) &&
+        pipe(
+          members,
+          Arr.every(member => HashSet.has(routes, member.name)),
+        ),
+    ),
+    Arr.reduce(Option.none<ReadonlyArray<UnionMember>>(), (best, members) =>
+      pipe(
+        best,
+        Option.match({
+          onNone: () => Option.some(members),
+          onSome: current =>
+            members.length > current.length ? Option.some(members) : best,
+        }),
+      ),
+    ),
+  )
+
+const analyze = (
+  ctx: RuleContext['Service'],
+  routeDecls: ReadonlyArray<{
+    readonly name: string
+    readonly node: ESTree.Node
+  }>,
+  unions: ReadonlyArray<ReadonlyArray<UnionMember>>,
+  mappings: ReadonlyArray<RouterMapping>,
+  registeredRouters: HashSet.HashSet<string>,
+  fallbacks: HashSet.HashSet<string>,
+): Effect.Effect<void, never, RuleContext> => {
+  if (
+    Arr.isReadonlyArrayEmpty(routeDecls) ||
+    HashSet.size(registeredRouters) === 0
+  ) {
+    return Effect.void
+  }
+  const routeNames = pipe(
+    routeDecls,
+    Arr.map(route => route.name),
+    HashSet.fromIterable,
+  )
+  const routeUnion = selectRouteUnion(unions, routeNames)
+  if (Option.isNone(routeUnion)) return Effect.void
+  const mappedRoutes = pipe(
+    mappings,
+    Arr.map(mapping => mapping.routeName),
+    HashSet.fromIterable,
+  )
+  const routerNames = pipe(
+    mappings,
+    Arr.map(mapping => Tuple.make(mapping.routerName, mapping)),
+    HashMap.fromIterable,
+  )
+
+  const missingRouters = Effect.forEach(
+    routeUnion.value,
+    member =>
+      HashSet.has(fallbacks, member.name) ||
+      HashSet.has(mappedRoutes, member.name)
+        ? Effect.void
+        : ctx.report(
+            Diagnostic.make({
+              node: member.node,
+              message: `Route union member \`${member.name}\` has no \`Route.mapTo(${member.name})\` parser. Add a router and include it in \`Route.oneOf(...)\`, or make it the parse fallback. (FK routing)`,
+            }),
+          ),
+    { concurrency: 1, discard: true },
+  )
+
+  const absentFromOneOf = Effect.forEach(
+    HashMap.toValues(routerNames),
+    mapping =>
+      HashSet.has(registeredRouters, mapping.routerName)
+        ? Effect.void
+        : ctx.report(
+            Diagnostic.make({
+              node: mapping.routerNode,
+              message: `Router \`${mapping.routerName}\` maps \`${mapping.routeName}\` but is not passed to \`Route.oneOf(...)\`. Registered route parsers must stay in sync with the AppRoute union. (FK routing)`,
+            }),
+          ),
+    { concurrency: 1, discard: true },
+  )
+
+  return Effect.andThen(missingRouters, absentFromOneOf)
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'route-union-parser-registration',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Keep Foldkit route union members, Route.mapTo routers, and Route.oneOf registrations in sync',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const routesRef = yield* Ref.make<
+      ReadonlyArray<{ readonly name: string; readonly node: ESTree.Node }>
+    >([])
+    const unionsRef = yield* Ref.make<
+      ReadonlyArray<ReadonlyArray<UnionMember>>
+    >([])
+    const mappingsRef = yield* Ref.make<ReadonlyArray<RouterMapping>>([])
+    const registeredRoutersRef = yield* Ref.make<HashSet.HashSet<string>>(
+      HashSet.empty(),
+    )
+    const fallbacksRef = yield* Ref.make<HashSet.HashSet<string>>(
+      HashSet.empty(),
+    )
+
+    return Visitor.merge(
+      Visitor.on('VariableDeclarator', node =>
+        Effect.all(
+          [
+            pipe(
+              routeDeclaration(node),
+              Option.match({
+                onNone: () => Effect.void,
+                onSome: route =>
+                  Ref.update(routesRef, routes => [...routes, route]),
+              }),
+            ),
+            Ref.update(mappingsRef, items => [
+              ...items,
+              ...routerMappings(node),
+            ]),
+          ],
+          { concurrency: 1, discard: true },
+        ),
+      ),
+      Visitor.on('CallExpression', node =>
+        Effect.all(
+          [
+            pipe(
+              unionMembers(node),
+              Option.match({
+                onNone: () => Effect.void,
+                onSome: members =>
+                  Ref.update(unionsRef, items => [...items, members]),
+              }),
+            ),
+            pipe(
+              oneOfRouters(node),
+              Option.match({
+                onNone: () => Effect.void,
+                onSome: routers =>
+                  Ref.update(registeredRoutersRef, set =>
+                    pipe(
+                      routers,
+                      Arr.reduce(set, (acc, router) =>
+                        HashSet.add(acc, router),
+                      ),
+                    ),
+                  ),
+              }),
+            ),
+            pipe(
+              fallbackRoute(node),
+              Option.match({
+                onNone: () => Effect.void,
+                onSome: name => Ref.update(fallbacksRef, HashSet.add(name)),
+              }),
+            ),
+          ],
+          { concurrency: 1, discard: true },
+        ),
+      ),
+      Visitor.on('Program:exit', () =>
+        Effect.gen(function* () {
+          const routes = yield* Ref.get(routesRef)
+          const unions = yield* Ref.get(unionsRef)
+          const mappings = yield* Ref.get(mappingsRef)
+          const registeredRouters = yield* Ref.get(registeredRoutersRef)
+          const fallbacks = yield* Ref.get(fallbacksRef)
+          yield* analyze(
+            ctx,
+            routes,
+            unions,
+            mappings,
+            registeredRouters,
+            fallbacks,
+          )
+        }),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/scene-tests-run-from-root.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/scene-tests-run-from-root.ts
@@ -1,0 +1,528 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { AST, Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Ref from 'effect/Ref'
+import * as Result from 'effect/Result'
+import * as Str from 'effect/String'
+
+interface ImportBinding {
+  readonly local: string
+  readonly source: string
+}
+
+interface ObjectBinding {
+  readonly local: string
+  readonly object: ESTree.ObjectExpression
+}
+
+type Provenance =
+  | {
+      readonly kind: 'page'
+      readonly source: string
+    }
+  | {
+      readonly kind: 'widget'
+      readonly source: string
+      readonly widget: string
+    }
+
+const normalizedPath = (filename: string): string =>
+  Str.replaceAll('\\', '/')(filename)
+
+const isTestFile = (filename: string): boolean => {
+  const normalized = normalizedPath(filename)
+  return (
+    Str.includes('/apps/ui/test/')(normalized) && /\.tsx?$/.test(normalized)
+  )
+}
+
+const parentOf = (node: {
+  readonly parent?: unknown
+}): Option.Option<{ readonly type: string; readonly parent?: unknown }> =>
+  pipe(
+    Option.fromNullishOr(node.parent),
+    Option.filter(
+      (
+        parent,
+      ): parent is { readonly type: string; readonly parent?: unknown } =>
+        P.isObject(parent) && 'type' in parent && P.isString(parent.type),
+    ),
+  )
+
+const isIdentifier = (
+  value: unknown,
+): value is ESTree.IdentifierName | ESTree.IdentifierReference =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpression = (value: unknown): value is ESTree.MemberExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isFunctionLike = (
+  value: unknown,
+): value is ESTree.ArrowFunctionExpression | ESTree.Function =>
+  P.isObject(value) &&
+  'type' in value &&
+  (value.type === 'ArrowFunctionExpression' ||
+    value.type === 'FunctionExpression') &&
+  'params' in value &&
+  Array.isArray(value.params) &&
+  'body' in value
+
+const isObjectExpression = (value: unknown): value is ESTree.ObjectExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'ObjectExpression'
+
+const isObjectProperty = (value: unknown): value is ESTree.ObjectProperty =>
+  P.isObject(value) && 'type' in value && value.type === 'Property'
+
+const isVariableDeclaration = (
+  value: unknown,
+): value is ESTree.VariableDeclaration =>
+  P.isObject(value) && 'type' in value && value.type === 'VariableDeclaration'
+
+const unwrapExpression = (value: unknown): unknown => {
+  if (!P.isObject(value) || !('type' in value)) return value
+  if (
+    (value.type === 'ChainExpression' ||
+      value.type === 'ParenthesizedExpression' ||
+      value.type === 'TSNonNullExpression' ||
+      value.type === 'TSAsExpression' ||
+      value.type === 'TSSatisfiesExpression' ||
+      value.type === 'TSTypeAssertion' ||
+      value.type === 'TSInstantiationExpression') &&
+    'expression' in value
+  ) {
+    return unwrapExpression(value.expression)
+  }
+  return value
+}
+
+const staticKeyName = (
+  property: ESTree.ObjectProperty,
+): Option.Option<string> => {
+  if (property.computed) return Option.none()
+  if (isIdentifier(property.key)) return Option.some(property.key.name)
+  return property.key.type === 'Literal' && P.isString(property.key.value)
+    ? Option.some(property.key.value)
+    : Option.none()
+}
+
+const objectValue = (
+  object: ESTree.ObjectExpression,
+  key: string,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    object.properties,
+    Arr.findFirst(
+      (property): property is ESTree.ObjectProperty =>
+        isObjectProperty(property) &&
+        pipe(
+          staticKeyName(property),
+          Option.match({
+            onNone: () => false,
+            onSome: name => name === key,
+          }),
+        ),
+    ),
+    Option.map(property => property.value),
+  )
+
+const localName = (
+  specifier: ESTree.ImportDeclaration['specifiers'][number],
+): Option.Option<string> => {
+  if (
+    specifier.type === 'ImportSpecifier' ||
+    specifier.type === 'ImportDefaultSpecifier' ||
+    specifier.type === 'ImportNamespaceSpecifier'
+  ) {
+    return Option.some(specifier.local.name)
+  }
+  return Option.none()
+}
+
+const importBindings = (
+  node: ESTree.ImportDeclaration,
+): ReadonlyArray<ImportBinding> =>
+  pipe(
+    node.specifiers,
+    Arr.filterMap(specifier =>
+      pipe(
+        localName(specifier),
+        Option.map(local => ({ local, source: node.source.value })),
+        Result.fromOption(() => undefined),
+      ),
+    ),
+  )
+
+const lookupImportSource = (
+  imports: ReadonlyArray<ImportBinding>,
+  local: string,
+): Option.Option<string> =>
+  pipe(
+    imports,
+    Arr.findFirst(binding => binding.local === local),
+    Option.map(binding => binding.source),
+  )
+
+const stripExtension = (segment: string): string =>
+  segment.replace(/\.[cm]?tsx?$/, '')
+
+const widgetNameFromSource = (source: string): Option.Option<string> => {
+  const segments = Str.split('/')(normalizedPath(source))
+  const widgetIndex = Arr.findFirstIndex(
+    segments,
+    segment => segment === 'widget',
+  )
+  return pipe(
+    widgetIndex,
+    Option.flatMap(index => Arr.get(segments, index + 1)),
+    Option.map(stripExtension),
+  )
+}
+
+const provenanceFromSource = (source: string): Option.Option<Provenance> => {
+  const normalized = normalizedPath(source)
+  if (Str.includes('/page/')(normalized)) {
+    return Option.some({ kind: 'page', source })
+  }
+  return Str.includes('/widget/')(normalized)
+    ? pipe(
+        widgetNameFromSource(source),
+        Option.map(widget => ({
+          kind: 'widget' as const,
+          source,
+          widget,
+        })),
+      )
+    : Option.none()
+}
+
+const rootIdentifier = (value: unknown): Option.Option<string> => {
+  const unwrapped = unwrapExpression(value)
+  if (isIdentifier(unwrapped)) return Option.some(unwrapped.name)
+  if (isMemberExpression(unwrapped)) return rootIdentifier(unwrapped.object)
+  return Option.none()
+}
+
+const importedProvenance = (
+  imports: ReadonlyArray<ImportBinding>,
+  local: string,
+): ReadonlyArray<Provenance> =>
+  pipe(
+    lookupImportSource(imports, local),
+    Option.flatMap(provenanceFromSource),
+    Option.match({
+      onNone: () => [],
+      onSome: provenance => [provenance],
+    }),
+  )
+
+const paramNames = (value: unknown): ReadonlyArray<string> => {
+  if (!isFunctionLike(value)) return []
+  return pipe(
+    value.params,
+    Arr.filterMap(param =>
+      isIdentifier(param) ? Result.succeed(param.name) : Result.failVoid,
+    ),
+  )
+}
+
+const declaredName = (value: unknown): Option.Option<string> =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'VariableDeclarator' &&
+  'id' in value &&
+  isIdentifier(value.id)
+    ? Option.some(value.id.name)
+    : Option.none()
+
+const importSourcesIn = (
+  root: unknown,
+  imports: ReadonlyArray<ImportBinding>,
+  shadowed: HashSet.HashSet<string> = HashSet.empty(),
+): ReadonlyArray<string> => {
+  const unwrapped = unwrapExpression(root)
+  if (isIdentifier(unwrapped)) {
+    return HashSet.has(shadowed, unwrapped.name)
+      ? []
+      : pipe(
+          lookupImportSource(imports, unwrapped.name),
+          Option.match({
+            onNone: () => [],
+            onSome: source => [source],
+          }),
+        )
+  }
+  if (isMemberExpression(unwrapped)) {
+    const rootSources = pipe(
+      rootIdentifier(unwrapped.object),
+      Option.filter(name => !HashSet.has(shadowed, name)),
+      Option.flatMap(name => lookupImportSource(imports, name)),
+      Option.match({
+        onNone: () => [],
+        onSome: source => [source],
+      }),
+    )
+    const computedSources = unwrapped.computed
+      ? importSourcesIn(unwrapped.property, imports, shadowed)
+      : []
+    return [...rootSources, ...computedSources]
+  }
+  if (isObjectProperty(unwrapped)) {
+    const keySources = unwrapped.computed
+      ? importSourcesIn(unwrapped.key, imports, shadowed)
+      : []
+    return [
+      ...keySources,
+      ...importSourcesIn(unwrapped.value, imports, shadowed),
+    ]
+  }
+  if (!P.isObject(unwrapped)) return []
+  const nextShadowed = isFunctionLike(unwrapped)
+    ? pipe(
+        paramNames(unwrapped),
+        Arr.reduce(shadowed, (set, name) => HashSet.add(set, name)),
+      )
+    : pipe(
+        declaredName(unwrapped),
+        Option.match({
+          onNone: () => shadowed,
+          onSome: name => HashSet.add(shadowed, name),
+        }),
+      )
+  return pipe(
+    Object.entries(unwrapped),
+    Arr.flatMap(([key, child]) =>
+      key === 'parent'
+        ? []
+        : Array.isArray(child)
+          ? pipe(
+              child,
+              Arr.flatMap(item => importSourcesIn(item, imports, nextShadowed)),
+            )
+          : importSourcesIn(child, imports, nextShadowed),
+    ),
+  )
+}
+
+const expressionProvenance = (
+  expression: ESTree.Node,
+  imports: ReadonlyArray<ImportBinding>,
+): ReadonlyArray<Provenance> => {
+  const unwrapped = unwrapExpression(expression)
+  if (isIdentifier(unwrapped))
+    return importedProvenance(imports, unwrapped.name)
+  if (isMemberExpression(unwrapped)) {
+    return pipe(
+      rootIdentifier(unwrapped.object),
+      Option.match({
+        onNone: () => [],
+        onSome: name => importedProvenance(imports, name),
+      }),
+    )
+  }
+  if (isFunctionLike(unwrapped)) {
+    return pipe(
+      importSourcesIn(unwrapped.body, imports),
+      Arr.filterMap(source =>
+        pipe(
+          provenanceFromSource(source),
+          Result.fromOption(() => undefined),
+        ),
+      ),
+    )
+  }
+  return []
+}
+
+const isSceneSceneCall = (call: ESTree.CallExpression): boolean =>
+  call.callee.type === 'MemberExpression' &&
+  pipe(
+    AST.memberPath(call.callee),
+    Option.match({
+      onNone: () => false,
+      onSome: path =>
+        path.length === 2 && path[0] === 'Scene' && path[1] === 'scene',
+    }),
+  )
+
+const constObjectBinding = (
+  node: ESTree.VariableDeclarator,
+): Option.Option<ObjectBinding> => {
+  const id = node.id
+  const init = node.init
+  if (!isIdentifier(id) || !isObjectExpression(init)) return Option.none()
+  return pipe(
+    parentOf(node),
+    Option.filter(
+      parent => isVariableDeclaration(parent) && parent.kind === 'const',
+    ),
+    Option.map(() => ({ local: id.name, object: init })),
+  )
+}
+
+const resolveConfigObject = (
+  arg: ESTree.Node,
+  objects: ReadonlyArray<ObjectBinding>,
+): Option.Option<ESTree.ObjectExpression> => {
+  const unwrapped = unwrapExpression(arg)
+  if (isObjectExpression(unwrapped)) return Option.some(unwrapped)
+  return isIdentifier(unwrapped)
+    ? pipe(
+        objects,
+        Arr.findFirst(binding => binding.local === unwrapped.name),
+        Option.map(binding => binding.object),
+      )
+    : Option.none()
+}
+
+const sameWidget = (
+  left: ReadonlyArray<Provenance>,
+  right: ReadonlyArray<Provenance>,
+): Option.Option<string> => {
+  const leftWidgets = pipe(
+    left,
+    Arr.filterMap(provenance =>
+      provenance.kind === 'widget'
+        ? Result.succeed(provenance.widget)
+        : Result.failVoid,
+    ),
+  )
+  const rightWidgets = pipe(
+    right,
+    Arr.filterMap(provenance =>
+      provenance.kind === 'widget'
+        ? Result.succeed(provenance.widget)
+        : Result.failVoid,
+    ),
+  )
+  return pipe(
+    leftWidgets,
+    Arr.findFirst(widget => Arr.contains(rightWidgets, widget)),
+  )
+}
+
+const violationReason = (
+  updateProvenance: ReadonlyArray<Provenance>,
+  viewProvenance: ReadonlyArray<Provenance>,
+): Option.Option<string> => {
+  const all = [...updateProvenance, ...viewProvenance]
+  const page = pipe(
+    all,
+    Arr.findFirst(provenance => provenance.kind === 'page'),
+  )
+  if (Option.isSome(page)) {
+    return Option.some(
+      `Scene.scene config traces to page module \`${page.value.source}\``,
+    )
+  }
+  return pipe(
+    sameWidget(updateProvenance, viewProvenance),
+    Option.map(
+      widget =>
+        `Scene.scene config isolates widget \`${widget}\` for both update and view`,
+    ),
+  )
+}
+
+const analyzeSceneCall = (
+  ctx: RuleContext['Service'],
+  call: ESTree.CallExpression,
+  imports: ReadonlyArray<ImportBinding>,
+  objects: ReadonlyArray<ObjectBinding>,
+): Effect.Effect<void> => {
+  const arg = call.arguments[0]
+  if (arg === undefined || arg.type === 'SpreadElement') return Effect.void
+  return pipe(
+    resolveConfigObject(arg, objects),
+    Option.flatMap(config =>
+      Option.all({
+        update: objectValue(config, 'update'),
+        view: objectValue(config, 'view'),
+      }),
+    ),
+    Option.flatMap(({ update, view }) =>
+      violationReason(
+        expressionProvenance(update, imports),
+        expressionProvenance(view, imports),
+      ),
+    ),
+    Option.match({
+      onNone: () => Effect.void,
+      onSome: reason =>
+        ctx.report(
+          Diagnostic.make({
+            node: call,
+            message: `${reason}. Scene tests must run from the root update and root view; child-isolation belongs in Story tests or pure render-helper tests with stub updates. (FK Scene)`,
+          }),
+        ),
+    }),
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'scene-tests-run-from-root',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Require Foldkit Scene.scene tests to use root update and root view instead of page/widget-isolated configs',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const importsRef = yield* Ref.make<ReadonlyArray<ImportBinding>>([])
+    const objectsRef = yield* Ref.make<ReadonlyArray<ObjectBinding>>([])
+    const sceneCallsRef = yield* Ref.make<ReadonlyArray<ESTree.CallExpression>>(
+      [],
+    )
+
+    return yield* Visitor.filter(
+      isTestFile,
+      Visitor.merge(
+        Visitor.on('ImportDeclaration', node =>
+          Ref.update(importsRef, imports => [
+            ...imports,
+            ...importBindings(node),
+          ]),
+        ),
+        Visitor.on('VariableDeclarator', node =>
+          pipe(
+            constObjectBinding(node),
+            Option.match({
+              onNone: () => Effect.void,
+              onSome: binding =>
+                Ref.update(objectsRef, objects => [...objects, binding]),
+            }),
+          ),
+        ),
+        Visitor.on('CallExpression', node =>
+          isSceneSceneCall(node)
+            ? Ref.update(sceneCallsRef, calls => [...calls, node])
+            : Effect.void,
+        ),
+        Visitor.on('Program:exit', () =>
+          Effect.gen(function* () {
+            const imports = yield* Ref.get(importsRef)
+            const objects = yield* Ref.get(objectsRef)
+            const sceneCalls = yield* Ref.get(sceneCallsRef)
+            yield* Effect.forEach(
+              sceneCalls,
+              call => analyzeSceneCall(ctx, call, imports, objects),
+              { concurrency: 1, discard: true },
+            )
+          }),
+        ),
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/selection-submodel-factory-at-module-scope.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/selection-submodel-factory-at-module-scope.ts
@@ -1,0 +1,260 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+
+const SELECTION_COMPONENTS = HashSet.make(
+  'Combobox',
+  'Listbox',
+  'Menu',
+  'RadioGroup',
+  'Tabs',
+)
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type MemberExpressionLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly object?: unknown
+  readonly property?: unknown
+}
+
+type ExpressionWrapperLike = {
+  readonly type: string
+  readonly expression?: unknown
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpressionLike = (
+  value: unknown,
+): value is MemberExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isEstreeNode = (value: unknown): value is ESTree.Node =>
+  P.isObject(value) && 'type' in value && P.isString(value.type)
+
+const isCallExpressionNode = (value: unknown): value is ESTree.CallExpression =>
+  isEstreeNode(value) && value.type === 'CallExpression'
+
+const isExpressionWrapperLike = (
+  value: unknown,
+): value is ExpressionWrapperLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  P.isString(value.type) &&
+  'expression' in value &&
+  (value.type === 'ParenthesizedExpression' ||
+    value.type === 'TSAsExpression' ||
+    value.type === 'TSSatisfiesExpression' ||
+    value.type === 'TSTypeAssertion' ||
+    value.type === 'TSNonNullExpression' ||
+    value.type === 'TSInstantiationExpression' ||
+    value.type === 'ChainExpression')
+
+const unwrapExpression = (value: unknown): unknown =>
+  isExpressionWrapperLike(value) ? unwrapExpression(value.expression) : value
+
+const memberPath = (
+  value: unknown,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  const unwrapped = unwrapExpression(value)
+  if (isIdentifierLike(unwrapped)) return Option.some([unwrapped.name])
+  if (!isMemberExpressionLike(unwrapped) || unwrapped.computed === true) {
+    return Option.none()
+  }
+  const property = unwrapped.property
+  if (!isIdentifierLike(property)) return Option.none()
+  return pipe(
+    memberPath(unwrapped.object),
+    Option.map(path => [...path, property.name]),
+  )
+}
+
+const segmentEquals = (
+  path: ReadonlyArray<string>,
+  index: number,
+  expected: string,
+): boolean =>
+  pipe(
+    Arr.get(path, index),
+    Option.match({
+      onNone: () => false,
+      onSome: segment => segment === expected,
+    }),
+  )
+
+const hasSelectionComponent = (path: ReadonlyArray<string>): boolean =>
+  pipe(
+    Arr.get(path, 1),
+    Option.match({
+      onNone: () => false,
+      onSome: component => HashSet.has(SELECTION_COMPONENTS, component),
+    }),
+  )
+
+const isSelectionFactoryPath = (
+  path: Arr.NonEmptyReadonlyArray<string>,
+): boolean =>
+  ((path.length === 3 && segmentEquals(path, 2, 'create')) ||
+    (path.length === 4 &&
+      segmentEquals(path, 2, 'Multi') &&
+      segmentEquals(path, 3, 'create'))) &&
+  segmentEquals(path, 0, 'Ui') &&
+  hasSelectionComponent(path)
+
+const selectionFactoryPath = (
+  call: ESTree.CallExpression,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> =>
+  pipe(memberPath(call.callee), Option.filter(isSelectionFactoryPath))
+
+const isSelectionFactoryCall = (call: ESTree.CallExpression): boolean =>
+  Option.isSome(selectionFactoryPath(call))
+
+const selectionFactoryName = (call: ESTree.CallExpression): string =>
+  pipe(
+    selectionFactoryPath(call),
+    Option.match({
+      onNone: () => 'Ui.<Component>.create',
+      onSome: path => Arr.join(path, '.'),
+    }),
+  )
+
+const exportedVariableDeclaration = (
+  statement: ESTree.Program['body'][number],
+): Option.Option<ESTree.VariableDeclaration> => {
+  if (statement.type === 'VariableDeclaration') return Option.some(statement)
+  if (statement.type !== 'ExportNamedDeclaration') return Option.none()
+  return pipe(
+    Option.fromNullishOr(statement.declaration),
+    Option.filter(declaration => declaration.type === 'VariableDeclaration'),
+  )
+}
+
+const topLevelDeclarators = (
+  program: ESTree.Program,
+): ReadonlyArray<ESTree.VariableDeclarator> =>
+  pipe(
+    program.body,
+    Arr.filterMap(statement =>
+      pipe(
+        exportedVariableDeclaration(statement),
+        Option.map(declaration => declaration.declarations),
+        Result.fromOption(() => undefined),
+      ),
+    ),
+    Arr.flatten,
+  )
+
+const directInitializerFactory = (
+  declarator: ESTree.VariableDeclarator,
+): Option.Option<ESTree.CallExpression> =>
+  pipe(
+    Option.fromNullishOr(declarator.init),
+    Option.map(unwrapExpression),
+    Option.filter(isCallExpressionNode),
+    Option.filter(isSelectionFactoryCall),
+  )
+
+const allowedFactoryCalls = (
+  program: ESTree.Program,
+): ReadonlyArray<ESTree.CallExpression> =>
+  pipe(
+    topLevelDeclarators(program),
+    Arr.filterMap(declarator =>
+      pipe(
+        directInitializerFactory(declarator),
+        Result.fromOption(() => undefined),
+      ),
+    ),
+  )
+
+const walkChildren = <A>(
+  value: object,
+  visit: (child: unknown) => ReadonlyArray<A>,
+): ReadonlyArray<A> =>
+  pipe(
+    Object.entries(value),
+    Arr.flatMap(([key, child]) =>
+      key === 'parent'
+        ? []
+        : Array.isArray(child)
+          ? pipe(child, Arr.flatMap(visit))
+          : visit(child),
+    ),
+  )
+
+const selectionFactoryCallsIn = (
+  root: unknown,
+): ReadonlyArray<ESTree.CallExpression> => {
+  const self =
+    isCallExpressionNode(root) && isSelectionFactoryCall(root) ? [root] : []
+  return P.isObject(root)
+    ? [...self, ...walkChildren(root, selectionFactoryCallsIn)]
+    : self
+}
+
+const isAllowedFactoryCall = (
+  call: ESTree.CallExpression,
+  allowed: ReadonlyArray<ESTree.CallExpression>,
+): boolean =>
+  pipe(
+    allowed,
+    Arr.some(item => item === call),
+  )
+
+const reportFactory = (
+  ctx: RuleContext['Service'],
+  call: ESTree.CallExpression,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node: call,
+      message: `\`${selectionFactoryName(call)}(...)\` factories must be declared once as a module-scope variable initializer. Inline or function-scoped selection submodel factories can drift from update/view types and create unstable view identities. (FK UI)`,
+    }),
+  )
+
+const analyze = (
+  ctx: RuleContext['Service'],
+  program: ESTree.Program,
+): Effect.Effect<void, never, RuleContext> => {
+  const allowed = allowedFactoryCalls(program)
+  return Effect.forEach(
+    selectionFactoryCallsIn(program),
+    call =>
+      isAllowedFactoryCall(call, allowed)
+        ? Effect.void
+        : reportFactory(ctx, call),
+    { concurrency: 1, discard: true },
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'selection-submodel-factory-at-module-scope',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Require Ui selection submodel factories to be declared once at module scope',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('Program:exit', node => analyze(ctx, node))
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/subscription-file-canonical-shape.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/subscription-file-canonical-shape.ts
@@ -1,0 +1,461 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as HashSet from 'effect/HashSet'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+import * as Str from 'effect/String'
+
+type SubscriptionMethod = 'make' | 'lift' | 'aggregate'
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type MemberExpressionLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly object?: unknown
+  readonly property?: unknown
+}
+
+type CallExpressionLike = {
+  readonly type: string
+  readonly callee?: unknown
+  readonly arguments?: ReadonlyArray<unknown>
+}
+
+type ExpressionWrapperLike = {
+  readonly type: string
+  readonly expression?: unknown
+}
+
+type ObjectExpressionLike = {
+  readonly type: string
+  readonly properties?: ReadonlyArray<unknown>
+}
+
+type SpreadElementLike = {
+  readonly type: string
+  readonly argument?: unknown
+}
+
+interface ModuleConst {
+  readonly name: string
+  readonly id: ESTree.Node
+  readonly init: Option.Option<ESTree.Node>
+  readonly exported: boolean
+}
+
+interface SpreadCandidate {
+  readonly node: ESTree.Node
+  readonly argument: unknown
+}
+
+const normalizedPath = (filename: string): string =>
+  Str.replaceAll('\\', '/')(filename)
+
+const basename = (filename: string): string =>
+  pipe(
+    Str.split('/')(normalizedPath(filename)),
+    Arr.last,
+    Option.getOrElse(() => filename),
+  )
+
+const isSubscriptionFile = (filename: string): boolean =>
+  basename(filename) === 'subscription.ts'
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpressionLike = (
+  value: unknown,
+): value is MemberExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isCallExpressionLike = (value: unknown): value is CallExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'CallExpression'
+
+const isEstreeNode = (value: unknown): value is ESTree.Node =>
+  P.isObject(value) && 'type' in value && P.isString(value.type)
+
+const isObjectExpressionLike = (
+  value: unknown,
+): value is ObjectExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'ObjectExpression'
+
+const isSpreadElementLike = (value: unknown): value is SpreadElementLike =>
+  P.isObject(value) && 'type' in value && value.type === 'SpreadElement'
+
+const isExpressionWrapperLike = (
+  value: unknown,
+): value is ExpressionWrapperLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  P.isString(value.type) &&
+  'expression' in value &&
+  (value.type === 'ParenthesizedExpression' ||
+    value.type === 'TSAsExpression' ||
+    value.type === 'TSSatisfiesExpression' ||
+    value.type === 'TSTypeAssertion' ||
+    value.type === 'TSNonNullExpression' ||
+    value.type === 'TSInstantiationExpression' ||
+    value.type === 'ChainExpression')
+
+const memberPath = (
+  value: unknown,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  if (isIdentifierLike(value)) return Option.some([value.name])
+  if (!isMemberExpressionLike(value) || value.computed === true) {
+    return Option.none()
+  }
+  const property = value.property
+  if (!isIdentifierLike(property)) return Option.none()
+  return pipe(
+    memberPath(value.object),
+    Option.map(path => [...path, property.name]),
+  )
+}
+
+const pathEquals = (
+  path: ReadonlyArray<string>,
+  expected: ReadonlyArray<string>,
+): boolean =>
+  path.length === expected.length &&
+  pipe(
+    Arr.zip(path, expected),
+    Arr.every(([left, right]) => left === right),
+  )
+
+const subscriptionMemberMethod = (
+  value: unknown,
+): Option.Option<SubscriptionMethod> =>
+  pipe(
+    memberPath(value),
+    Option.flatMap(path => {
+      if (pathEquals(path, ['Subscription', 'make'])) {
+        return Option.some('make')
+      }
+      if (pathEquals(path, ['Subscription', 'lift'])) {
+        return Option.some('lift')
+      }
+      if (pathEquals(path, ['Subscription', 'aggregate'])) {
+        return Option.some('aggregate')
+      }
+      return Option.none()
+    }),
+  )
+
+const rootedSubscriptionMethod = (
+  value: unknown,
+): Option.Option<SubscriptionMethod> => {
+  if (isExpressionWrapperLike(value)) {
+    return rootedSubscriptionMethod(value.expression)
+  }
+  if (isCallExpressionLike(value)) {
+    return rootedSubscriptionMethod(value.callee)
+  }
+  return subscriptionMemberMethod(value)
+}
+
+const exportedVariableDeclaration = (
+  statement: ESTree.Program['body'][number],
+): Option.Option<{
+  readonly declaration: ESTree.VariableDeclaration
+  readonly exported: boolean
+}> => {
+  if (statement.type === 'VariableDeclaration') {
+    return Option.some({ declaration: statement, exported: false })
+  }
+  if (
+    statement.type === 'ExportNamedDeclaration' &&
+    statement.declaration?.type === 'VariableDeclaration'
+  ) {
+    return Option.some({
+      declaration: statement.declaration,
+      exported: true,
+    })
+  }
+  return Option.none()
+}
+
+const moduleConsts = (program: ESTree.Program): ReadonlyArray<ModuleConst> =>
+  pipe(
+    program.body,
+    Arr.filterMap(statement =>
+      pipe(
+        exportedVariableDeclaration(statement),
+        Option.filter(({ declaration }) => declaration.kind === 'const'),
+        Option.map(({ declaration, exported }) =>
+          pipe(
+            declaration.declarations,
+            Arr.filterMap(declarator =>
+              declarator.id.type === 'Identifier'
+                ? Result.succeed({
+                    name: declarator.id.name,
+                    id: declarator.id,
+                    init: Option.fromNullishOr(declarator.init),
+                    exported,
+                  })
+                : Result.failVoid,
+            ),
+          ),
+        ),
+        Result.fromOption(() => undefined),
+      ),
+    ),
+    Arr.flatten,
+  )
+
+const walkChildren = <A>(
+  value: object,
+  visit: (child: unknown) => ReadonlyArray<A>,
+): ReadonlyArray<A> =>
+  pipe(
+    Object.entries(value),
+    Arr.flatMap(([key, child]) =>
+      key === 'parent'
+        ? []
+        : Array.isArray(child)
+          ? pipe(child, Arr.flatMap(visit))
+          : visit(child),
+    ),
+  )
+
+const subscriptionCallsIn = (root: unknown): ReadonlyArray<ESTree.Node> => {
+  const self =
+    isEstreeNode(root) &&
+    isCallExpressionLike(root) &&
+    Option.isSome(rootedSubscriptionMethod(root))
+      ? [root]
+      : []
+  return P.isObject(root)
+    ? [...self, ...walkChildren(root, subscriptionCallsIn)]
+    : self
+}
+
+const objectSpreadCandidates = (
+  object: ObjectExpressionLike,
+): ReadonlyArray<SpreadCandidate> =>
+  pipe(
+    object.properties ?? [],
+    Arr.filterMap(property => {
+      if (!isEstreeNode(property) || !isSpreadElementLike(property)) {
+        return Result.failVoid
+      }
+      return pipe(
+        Option.fromNullishOr(property.argument),
+        Option.map(argument => ({ node: property, argument })),
+        Result.fromOption(() => undefined),
+      )
+    }),
+  )
+
+const spreadCandidatesIn = (root: unknown): ReadonlyArray<SpreadCandidate> => {
+  const self = isObjectExpressionLike(root) ? objectSpreadCandidates(root) : []
+  return P.isObject(root)
+    ? [...self, ...walkChildren(root, spreadCandidatesIn)]
+    : self
+}
+
+const isSubscriptionsMember = (value: unknown): boolean =>
+  pipe(
+    memberPath(value),
+    Option.match({
+      onNone: () => false,
+      onSome: path => Arr.lastNonEmpty(path) === 'subscriptions',
+    }),
+  )
+
+const subscriptionBindingNames = (
+  consts: ReadonlyArray<ModuleConst>,
+): HashSet.HashSet<string> =>
+  pipe(
+    consts,
+    Arr.filterMap(item =>
+      pipe(
+        item.init,
+        Option.flatMap(rootedSubscriptionMethod),
+        Option.map(() => item.name),
+        Result.fromOption(() => undefined),
+      ),
+    ),
+    HashSet.fromIterable,
+  )
+
+const isSubscriptionSpread = (
+  candidate: SpreadCandidate,
+  bindings: HashSet.HashSet<string>,
+): boolean => {
+  const argument = candidate.argument
+  return (
+    (isIdentifierLike(argument) && HashSet.has(bindings, argument.name)) ||
+    isSubscriptionsMember(argument)
+  )
+}
+
+const reportMissingSubscriptions = (
+  ctx: RuleContext['Service'],
+  node: ESTree.Node,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message:
+        'Files named `subscription.ts` that use Foldkit subscriptions must export one canonical `subscriptions` const built with `Subscription.make(...)` or `Subscription.aggregate(...)`. (FK subscriptions)',
+    }),
+  )
+
+const reportInvalidSubscriptionsInitializer = (
+  ctx: RuleContext['Service'],
+  node: ESTree.Node,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message:
+        'The canonical `subscriptions` export must be initialized from `Subscription.make(...)` or `Subscription.aggregate(...)`. Use local helpers for lifted child records, then aggregate them into `subscriptions`. (FK subscriptions)',
+    }),
+  )
+
+const reportExtraExportedSubscription = (
+  ctx: RuleContext['Service'],
+  item: ModuleConst,
+  method: SubscriptionMethod,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node: item.id,
+      message: `Only the canonical \`subscriptions\` const may export subscription records. Keep \`Subscription.${method}(...)\` helpers local and aggregate them into \`subscriptions\`. (FK subscriptions)`,
+    }),
+  )
+
+const reportSubscriptionSpread = (
+  ctx: RuleContext['Service'],
+  node: ESTree.Node,
+): Effect.Effect<void, never, RuleContext> =>
+  ctx.report(
+    Diagnostic.make({
+      node,
+      message:
+        'Do not spread subscription records or `.subscriptions` members into object literals. Use `Subscription.aggregate(...)` so duplicate subscription keys fail loudly. (FK subscriptions)',
+    }),
+  )
+
+const analyze = (
+  ctx: RuleContext['Service'],
+  program: ESTree.Program,
+): Effect.Effect<void, never, RuleContext> => {
+  const consts = moduleConsts(program)
+  const subscriptionCalls = subscriptionCallsIn(program)
+  const spreadCandidates = spreadCandidatesIn(program)
+  const bindings = subscriptionBindingNames(consts)
+  const offendingSpreads = pipe(
+    spreadCandidates,
+    Arr.filter(candidate => isSubscriptionSpread(candidate, bindings)),
+  )
+  const hasSubscriptionUsage =
+    !Arr.isReadonlyArrayEmpty(subscriptionCalls) ||
+    !Arr.isReadonlyArrayEmpty(offendingSpreads)
+  const canonical = pipe(
+    consts,
+    Arr.findFirst(item => item.exported && item.name === 'subscriptions'),
+  )
+
+  const missingExport =
+    hasSubscriptionUsage && Option.isNone(canonical)
+      ? pipe(
+          Arr.head(subscriptionCalls),
+          Option.orElse(() =>
+            pipe(
+              offendingSpreads,
+              Arr.head,
+              Option.map(candidate => candidate.node),
+            ),
+          ),
+          Option.match({
+            onNone: () => Effect.void,
+            onSome: node => reportMissingSubscriptions(ctx, node),
+          }),
+        )
+      : Effect.void
+
+  const invalidCanonical = pipe(
+    canonical,
+    Option.flatMap(item =>
+      pipe(
+        item.init,
+        Option.flatMap(rootedSubscriptionMethod),
+        Option.filter(method => method === 'make' || method === 'aggregate'),
+        Option.match({
+          onSome: () => Option.none<ESTree.Node>(),
+          onNone: () =>
+            Option.some(
+              pipe(
+                item.init,
+                Option.getOrElse(() => item.id),
+              ),
+            ),
+        }),
+      ),
+    ),
+    Option.match({
+      onNone: () => Effect.void,
+      onSome: node => reportInvalidSubscriptionsInitializer(ctx, node),
+    }),
+  )
+
+  const extraExports = Effect.forEach(
+    consts,
+    item => {
+      if (!item.exported || item.name === 'subscriptions') return Effect.void
+      return pipe(
+        item.init,
+        Option.flatMap(rootedSubscriptionMethod),
+        Option.match({
+          onNone: () => Effect.void,
+          onSome: method => reportExtraExportedSubscription(ctx, item, method),
+        }),
+      )
+    },
+    { concurrency: 1, discard: true },
+  )
+
+  const spreadReports = Effect.forEach(
+    offendingSpreads,
+    candidate => reportSubscriptionSpread(ctx, candidate.node),
+    { concurrency: 1, discard: true },
+  )
+
+  return Effect.all(
+    [missingExport, invalidCanonical, extraExports, spreadReports],
+    { concurrency: 1, discard: true },
+  )
+}
+
+const rule: CreateRule = Rule.define({
+  name: 'subscription-file-canonical-shape',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Require subscription.ts files to expose one canonical subscriptions export and compose records with Subscription.aggregate',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return yield* Visitor.filter(
+      isSubscriptionFile,
+      Visitor.on('Program:exit', node => analyze(ctx, node)),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/ui-toview-must-spread-attribute-bundles.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/ui-toview-must-spread-attribute-bundles.ts
@@ -1,0 +1,399 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type MemberExpressionLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly object?: unknown
+  readonly property?: unknown
+}
+
+type CallExpressionLike = {
+  readonly type: string
+  readonly callee?: unknown
+  readonly arguments?: ReadonlyArray<unknown>
+}
+
+type SpreadElementLike = {
+  readonly type: string
+  readonly argument?: unknown
+}
+
+type FunctionLike = ESTree.ArrowFunctionExpression | ESTree.Function
+
+type ObjectExpressionLike = {
+  readonly type: string
+  readonly properties?: ReadonlyArray<unknown>
+}
+
+type ObjectPropertyLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly key?: unknown
+  readonly value?: unknown
+}
+
+interface ToViewCandidate {
+  readonly component: string
+  readonly fn: FunctionLike
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpressionLike = (
+  value: unknown,
+): value is MemberExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isCallExpressionLike = (value: unknown): value is CallExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'CallExpression'
+
+const isSpreadElementLike = (value: unknown): value is SpreadElementLike =>
+  P.isObject(value) && 'type' in value && value.type === 'SpreadElement'
+
+const isFunctionLike = (value: unknown): value is FunctionLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  (value.type === 'ArrowFunctionExpression' ||
+    value.type === 'FunctionExpression') &&
+  'params' in value &&
+  Array.isArray(value.params) &&
+  'body' in value
+
+const isObjectExpressionLike = (
+  value: unknown,
+): value is ObjectExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'ObjectExpression'
+
+const isObjectPropertyLike = (value: unknown): value is ObjectPropertyLike =>
+  P.isObject(value) && 'type' in value && value.type === 'Property'
+
+const memberPath = (
+  value: unknown,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  if (isIdentifierLike(value)) return Option.some([value.name])
+  if (!isMemberExpressionLike(value) || value.computed === true) {
+    return Option.none()
+  }
+  const property = value.property
+  if (!isIdentifierLike(property)) return Option.none()
+  return pipe(
+    memberPath(value.object),
+    Option.map(path => [...path, property.name]),
+  )
+}
+
+const pathEquals = (
+  path: ReadonlyArray<string>,
+  expected: ReadonlyArray<string>,
+): boolean =>
+  path.length === expected.length &&
+  pipe(
+    Arr.zip(path, expected),
+    Arr.every(([left, right]) => left === right),
+  )
+
+const uiViewComponentFromPath = (
+  path: ReadonlyArray<string>,
+): Option.Option<string> =>
+  path.length === 3
+    ? pipe(
+        Option.all({
+          root: Arr.get(path, 0),
+          component: Arr.get(path, 1),
+          method: Arr.get(path, 2),
+        }),
+        Option.filter(({ root, method }) => root === 'Ui' && method === 'view'),
+        Option.map(({ component }) => component),
+      )
+    : Option.none()
+
+const callPath = (
+  call: CallExpressionLike,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => memberPath(call.callee)
+
+const uiViewCallComponent = (
+  call: ESTree.CallExpression,
+): Option.Option<string> =>
+  pipe(callPath(call), Option.flatMap(uiViewComponentFromPath))
+
+const uiViewMemberComponent = (value: unknown): Option.Option<string> =>
+  pipe(memberPath(value), Option.flatMap(uiViewComponentFromPath))
+
+const propertyKeyName = (
+  property: ObjectPropertyLike,
+): Option.Option<string> => {
+  if (property.computed === true) return Option.none()
+  const key = property.key
+  if (isIdentifierLike(key)) return Option.some(key.name)
+  return P.isObject(key) &&
+    'type' in key &&
+    key.type === 'Literal' &&
+    'value' in key &&
+    P.isString(key.value)
+    ? Option.some(key.value)
+    : Option.none()
+}
+
+const objectProperty = (
+  object: ObjectExpressionLike,
+  key: string,
+): Option.Option<ObjectPropertyLike> =>
+  pipe(
+    object.properties ?? [],
+    Arr.findFirst(
+      (property): property is ObjectPropertyLike =>
+        isObjectPropertyLike(property) &&
+        pipe(
+          propertyKeyName(property),
+          Option.match({
+            onNone: () => false,
+            onSome: name => name === key,
+          }),
+        ),
+    ),
+  )
+
+const objectValue = (
+  object: ObjectExpressionLike,
+  key: string,
+): Option.Option<unknown> =>
+  pipe(
+    objectProperty(object, key),
+    Option.flatMap(property => Option.fromNullishOr(property.value)),
+  )
+
+const firstObjectArgument = (
+  call: ESTree.CallExpression,
+): Option.Option<ObjectExpressionLike> =>
+  pipe(Arr.head(call.arguments), Option.filter(isObjectExpressionLike))
+
+const functionParamName = (fn: FunctionLike): Option.Option<string> =>
+  pipe(
+    Arr.head(fn.params),
+    Option.filter(isIdentifierLike),
+    Option.map(p => p.name),
+  )
+
+const toViewCandidatesInObject = (
+  object: ObjectExpressionLike,
+  component: string,
+): ReadonlyArray<ToViewCandidate> =>
+  pipe(
+    object.properties ?? [],
+    Arr.filterMap(property => {
+      if (!isObjectPropertyLike(property)) return Result.failVoid
+      return pipe(
+        propertyKeyName(property),
+        Option.filter(key => key === 'toView'),
+        Option.flatMap(() =>
+          pipe(
+            Option.fromNullishOr(property.value),
+            Option.filter(isFunctionLike),
+          ),
+        ),
+        Option.map(fn => ({ component, fn })),
+        Result.fromOption(() => undefined),
+      )
+    }),
+  )
+
+const directUiViewCandidates = (
+  call: ESTree.CallExpression,
+): ReadonlyArray<ToViewCandidate> =>
+  pipe(
+    uiViewCallComponent(call),
+    Option.flatMap(component =>
+      pipe(
+        firstObjectArgument(call),
+        Option.map(object => ({ component, object })),
+      ),
+    ),
+    Option.match({
+      onNone: () => [],
+      onSome: ({ component, object }) =>
+        toViewCandidatesInObject(object, component),
+    }),
+  )
+
+const submodelViewInputsCandidates = (
+  call: ESTree.CallExpression,
+): ReadonlyArray<ToViewCandidate> =>
+  pipe(
+    callPath(call),
+    Option.filter(
+      path =>
+        pathEquals(path, ['h', 'submodel']) || pathEquals(path, ['submodel']),
+    ),
+    Option.flatMap(() => firstObjectArgument(call)),
+    Option.flatMap(config =>
+      pipe(
+        objectValue(config, 'view'),
+        Option.flatMap(uiViewMemberComponent),
+        Option.flatMap(component =>
+          pipe(
+            objectValue(config, 'viewInputs'),
+            Option.filter(isObjectExpressionLike),
+            Option.map(viewInputs => ({ component, viewInputs })),
+          ),
+        ),
+      ),
+    ),
+    Option.match({
+      onNone: () => [],
+      onSome: ({ component, viewInputs }) =>
+        toViewCandidatesInObject(viewInputs, component),
+    }),
+  )
+
+const isParamRootedBundle = (value: unknown, paramName: string): boolean =>
+  pipe(
+    memberPath(value),
+    Option.match({
+      onNone: () => false,
+      onSome: path => path.length > 1 && Arr.headNonEmpty(path) === paramName,
+    }),
+  )
+
+const directCallArgumentUsesParamBundle = (
+  value: unknown,
+  paramName: string,
+): boolean =>
+  isCallExpressionLike(value) &&
+  pipe(
+    value.arguments ?? [],
+    Arr.some(arg => isParamRootedBundle(arg, paramName)),
+  )
+
+const walkObjectChildren = (
+  value: object,
+  visit: (child: unknown) => boolean,
+): boolean =>
+  pipe(
+    Object.entries(value),
+    Arr.some(([key, child]) =>
+      key === 'parent'
+        ? false
+        : Array.isArray(child)
+          ? pipe(child, Arr.some(visit))
+          : visit(child),
+    ),
+  )
+
+const bodyUsesAttributeBundle = (
+  value: unknown,
+  paramName: string,
+): boolean => {
+  const walk = (node: unknown): boolean => {
+    if (isSpreadElementLike(node)) {
+      return isParamRootedBundle(node.argument, paramName)
+    }
+    if (isFunctionLike(node)) return false
+    if (directCallArgumentUsesParamBundle(node, paramName)) return true
+    return P.isObject(node) ? walkObjectChildren(node, walk) : false
+  }
+  return walk(value)
+}
+
+const bodyContainsHDialog = (value: unknown): boolean => {
+  const walk = (node: unknown): boolean => {
+    if (isFunctionLike(node)) return false
+    if (
+      isCallExpressionLike(node) &&
+      pipe(
+        callPath(node),
+        Option.match({
+          onNone: () => false,
+          onSome: path => pathEquals(path, ['h', 'dialog']),
+        }),
+      )
+    ) {
+      return true
+    }
+    return P.isObject(node) ? walkObjectChildren(node, walk) : false
+  }
+  return walk(value)
+}
+
+const analyzeToView = (
+  ctx: RuleContext['Service'],
+  candidate: ToViewCandidate,
+): Effect.Effect<void, never, RuleContext> => {
+  const paramName = functionParamName(candidate.fn)
+  const attributeCheck = pipe(
+    paramName,
+    Option.filter(name => bodyUsesAttributeBundle(candidate.fn.body, name)),
+    Option.match({
+      onSome: () => Effect.void,
+      onNone: () =>
+        ctx.report(
+          Diagnostic.make({
+            node: candidate.fn,
+            message: `Ui.${candidate.component}.view toView callbacks must spread or pass through the Foldkit-provided attribute bundles. Otherwise ARIA, handlers, and submodel wiring can be dropped. (FK UI)`,
+          }),
+        ),
+    }),
+  )
+  const dialogCheck =
+    candidate.component === 'Dialog' && !bodyContainsHDialog(candidate.fn.body)
+      ? ctx.report(
+          Diagnostic.make({
+            node: candidate.fn,
+            message:
+              'Ui.Dialog.view toView callbacks must render with `h.dialog(...)` so native dialog semantics and Foldkit dialog attributes stay attached. (FK UI)',
+          }),
+        )
+      : Effect.void
+  return Effect.all([attributeCheck, dialogCheck], {
+    concurrency: 1,
+    discard: true,
+  })
+}
+
+const candidatesFromCall = (
+  call: ESTree.CallExpression,
+): ReadonlyArray<ToViewCandidate> => [
+  ...directUiViewCandidates(call),
+  ...submodelViewInputsCandidates(call),
+]
+
+const rule: CreateRule = Rule.define({
+  name: 'ui-toview-must-spread-attribute-bundles',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Custom Ui.* toView callbacks must pass through Foldkit-provided attribute bundles; Dialog toViews must render h.dialog',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      Effect.forEach(
+        candidatesFromCall(node),
+        candidate => analyzeToView(ctx, candidate),
+        {
+          concurrency: 1,
+          discard: true,
+        },
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/src/rules/wrap-child-output-in-got-message.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/wrap-child-output-in-got-message.ts
@@ -1,0 +1,337 @@
+import { pipe } from 'effect'
+import type { CreateRule } from 'effect-oxlint'
+import type { ESTree } from 'effect-oxlint'
+import { Diagnostic, Rule, RuleContext, Visitor } from 'effect-oxlint'
+import * as Arr from 'effect/Array'
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import * as P from 'effect/Predicate'
+import * as Result from 'effect/Result'
+
+const gotMessageNamePattern = /^Got\w*Message$/
+const delegatePageNames = [
+  'delegatePage',
+  'delegatePageWithOutMessage',
+] as const
+const wrapperExpressionTypes = [
+  'ChainExpression',
+  'ParenthesizedExpression',
+  'TSAsExpression',
+  'TSInstantiationExpression',
+  'TSNonNullExpression',
+  'TSSatisfiesExpression',
+  'TypeCastExpression',
+] as const
+
+type IdentifierLike = {
+  readonly type: string
+  readonly name: string
+}
+
+type MemberExpressionLike = {
+  readonly type: string
+  readonly computed?: unknown
+  readonly object?: unknown
+  readonly property?: unknown
+}
+
+type ExpressionWrapper = {
+  readonly type: string
+  readonly expression: unknown
+}
+
+const isIdentifierLike = (value: unknown): value is IdentifierLike =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'Identifier' &&
+  'name' in value &&
+  P.isString(value.name)
+
+const isMemberExpressionLike = (
+  value: unknown,
+): value is MemberExpressionLike =>
+  P.isObject(value) && 'type' in value && value.type === 'MemberExpression'
+
+const isExpressionWrapper = (value: unknown): value is ExpressionWrapper =>
+  P.isObject(value) &&
+  'type' in value &&
+  P.isString(value.type) &&
+  'expression' in value
+
+const isCallExpression = (value: unknown): value is ESTree.CallExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'CallExpression'
+
+const isArrowFunction = (
+  value: unknown,
+): value is ESTree.ArrowFunctionExpression =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'ArrowFunctionExpression'
+
+const isObjectExpression = (value: unknown): value is ESTree.ObjectExpression =>
+  P.isObject(value) && 'type' in value && value.type === 'ObjectExpression'
+
+const isObjectProperty = (value: unknown): value is ESTree.ObjectProperty =>
+  P.isObject(value) && 'type' in value && value.type === 'Property'
+
+const isBlockStatement = (value: unknown): value is ESTree.BlockStatement =>
+  P.isObject(value) &&
+  'type' in value &&
+  value.type === 'BlockStatement' &&
+  'body' in value &&
+  Array.isArray(value.body)
+
+const unwrapExpression = (value: unknown): unknown =>
+  isExpressionWrapper(value) && Arr.contains(wrapperExpressionTypes, value.type)
+    ? unwrapExpression(value.expression)
+    : value
+
+const memberPath = (
+  value: unknown,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => {
+  const expression = unwrapExpression(value)
+  if (isIdentifierLike(expression)) return Option.some([expression.name])
+  if (!isMemberExpressionLike(expression) || expression.computed === true) {
+    return Option.none()
+  }
+  const property = unwrapExpression(expression.property)
+  if (!isIdentifierLike(property)) return Option.none()
+  return pipe(
+    memberPath(expression.object),
+    Option.map(path => [...path, property.name]),
+  )
+}
+
+const pathEquals = (
+  path: ReadonlyArray<string>,
+  expected: ReadonlyArray<string>,
+): boolean =>
+  path.length === expected.length &&
+  pipe(
+    Arr.zip(path, expected),
+    Arr.every(([left, right]) => left === right),
+  )
+
+const callPath = (
+  call: ESTree.CallExpression,
+): Option.Option<Arr.NonEmptyReadonlyArray<string>> => memberPath(call.callee)
+
+const isCommandMapCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    callPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path =>
+        pathEquals(path, ['Command', 'mapMessages']) ||
+        pathEquals(path, ['Command', 'mapMessage']),
+    }),
+  )
+
+const isDelegatePageCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    callPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path =>
+        path.length === 1 && Arr.contains(delegatePageNames, path[0]),
+    }),
+  )
+
+const isSubscriptionLiftCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    callPath(call),
+    Option.match({
+      onNone: () => false,
+      onSome: path => pathEquals(path, ['Subscription', 'lift']),
+    }),
+  )
+
+const argumentAt = (
+  call: ESTree.CallExpression,
+  index: number,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    Arr.get(call.arguments, index),
+    Option.filter(arg => arg.type !== 'SpreadElement'),
+  )
+
+const arrowArgumentAt = (
+  call: ESTree.CallExpression,
+  index: number,
+): Option.Option<ESTree.ArrowFunctionExpression> =>
+  pipe(argumentAt(call, index), Option.filter(isArrowFunction))
+
+const propertyKeyName = (
+  property: ESTree.ObjectProperty,
+): Option.Option<string> => {
+  if (property.computed) return Option.none()
+  const key = unwrapExpression(property.key)
+  if (isIdentifierLike(key)) return Option.some(key.name)
+  return P.isObject(key) &&
+    'type' in key &&
+    key.type === 'Literal' &&
+    'value' in key &&
+    P.isString(key.value)
+    ? Option.some(key.value)
+    : Option.none()
+}
+
+const objectPropertyValue = (
+  object: ESTree.ObjectExpression,
+  key: string,
+): Option.Option<ESTree.Node> =>
+  pipe(
+    object.properties,
+    Arr.findFirst(
+      (property): property is ESTree.ObjectProperty =>
+        isObjectProperty(property) &&
+        pipe(
+          propertyKeyName(property),
+          Option.match({
+            onNone: () => false,
+            onSome: name => name === key,
+          }),
+        ),
+    ),
+    Option.map(property => property.value),
+  )
+
+const subscriptionLiftConfig = (
+  call: ESTree.CallExpression,
+): Option.Option<ESTree.ObjectExpression> => {
+  const applied = unwrapExpression(call.callee)
+  return isCallExpression(applied) && isSubscriptionLiftCall(applied)
+    ? pipe(argumentAt(call, 0), Option.filter(isObjectExpression))
+    : Option.none()
+}
+
+interface MapperArrow {
+  readonly arrow: ESTree.ArrowFunctionExpression
+  readonly source: 'command' | 'subscription' | 'delegate'
+}
+
+const commandMapper = (
+  call: ESTree.CallExpression,
+): Option.Option<MapperArrow> =>
+  isCommandMapCall(call)
+    ? pipe(
+        arrowArgumentAt(call, 1),
+        Option.map(arrow => ({ arrow, source: 'command' as const })),
+      )
+    : Option.none()
+
+const delegateMapper = (
+  call: ESTree.CallExpression,
+): Option.Option<MapperArrow> =>
+  isDelegatePageCall(call)
+    ? pipe(
+        arrowArgumentAt(call, 3),
+        Option.map(arrow => ({ arrow, source: 'delegate' as const })),
+      )
+    : Option.none()
+
+const subscriptionMapper = (
+  call: ESTree.CallExpression,
+): Option.Option<MapperArrow> =>
+  pipe(
+    subscriptionLiftConfig(call),
+    Option.flatMap(config => objectPropertyValue(config, 'toParentMessage')),
+    Option.filter(isArrowFunction),
+    Option.map(arrow => ({ arrow, source: 'subscription' as const })),
+  )
+
+const mappersForCall = (
+  call: ESTree.CallExpression,
+): ReadonlyArray<MapperArrow> =>
+  pipe(
+    [commandMapper(call), delegateMapper(call), subscriptionMapper(call)],
+    Arr.filterMap(Result.fromOption(() => undefined)),
+  )
+
+const soleReturnedCall = (
+  body: ESTree.BlockStatement,
+): Option.Option<ESTree.CallExpression> =>
+  body.body.length === 1 && body.body[0]?.type === 'ReturnStatement'
+    ? pipe(
+        Option.fromNullishOr(body.body[0].argument),
+        Option.map(unwrapExpression),
+        Option.filter(isCallExpression),
+      )
+    : Option.none()
+
+const arrowBodyCall = (
+  arrow: ESTree.ArrowFunctionExpression,
+): Option.Option<ESTree.CallExpression> => {
+  const body = unwrapExpression(arrow.body)
+  if (isCallExpression(body)) return Option.some(body)
+  return isBlockStatement(body) ? soleReturnedCall(body) : Option.none()
+}
+
+const calleePathLabel = (call: ESTree.CallExpression): string =>
+  pipe(
+    memberPath(call.callee),
+    Option.map(path => pipe(path, Arr.join('.'))),
+    Option.getOrElse(() => '<dynamic call>'),
+  )
+
+const calleeConstructorName = (
+  call: ESTree.CallExpression,
+): Option.Option<string> =>
+  pipe(memberPath(call.callee), Option.map(Arr.lastNonEmpty))
+
+const isGotMessageCall = (call: ESTree.CallExpression): boolean =>
+  pipe(
+    calleeConstructorName(call),
+    Option.match({
+      onNone: () => false,
+      onSome: name => gotMessageNamePattern.test(name),
+    }),
+  )
+
+const sourceLabel = (source: MapperArrow['source']): string =>
+  source === 'command'
+    ? 'Command mapper'
+    : source === 'subscription'
+      ? 'Subscription lift `toParentMessage`'
+      : '`delegatePage` wrapper'
+
+const analyzeMapper = (
+  ctx: RuleContext['Service'],
+  mapper: MapperArrow,
+): Effect.Effect<void, never, RuleContext> =>
+  pipe(
+    arrowBodyCall(mapper.arrow),
+    Option.match({
+      onNone: () => Effect.void,
+      onSome: call =>
+        isGotMessageCall(call)
+          ? Effect.void
+          : ctx.report(
+              Diagnostic.make({
+                node: call,
+                message: `${sourceLabel(mapper.source)} must wrap child output with a \`Got*Message\` constructor. \`${calleePathLabel(call)}(...)\` does not preserve Foldkit's one-wrap-per-level submodel convention. (FK submodel)`,
+              }),
+            ),
+    }),
+  )
+
+const rule: CreateRule = Rule.define({
+  name: 'wrap-child-output-in-got-message',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Require child Command, Subscription, and delegatePage output mappers to wrap through Got*Message constructors',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    return Visitor.on('CallExpression', node =>
+      Effect.forEach(
+        mappersForCall(node),
+        mapper => analyzeMapper(ctx, mapper),
+        { concurrency: 1, discard: true },
+      ),
+    )
+  },
+})
+
+export default rule

--- a/packages/oxlint-plugin-foldkit/test/rules/command-define-pascal-const.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/command-define-pascal-const.test.ts
@@ -1,0 +1,192 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/command-define-pascal-const.ts'
+
+interface MutableNode {
+  type: string
+  parent?: MutableNode
+  init?: MutableNode
+  callee?: unknown
+  arguments?: ReadonlyArray<unknown>
+  id?: unknown
+}
+
+/**
+ * Build a `Command.define(name, body)` call wired into a `VariableDeclarator`
+ * named `declaratorName` (which becomes its parent and `init`).
+ *
+ * Pass `declaratorName: undefined` to omit the wrapper entirely (inline call,
+ * e.g. inside a `pipe()` or expression statement).
+ */
+const buildCall = (opts: {
+  readonly arg0?: unknown
+  readonly declaratorName?: string
+}): MutableNode => {
+  const call: MutableNode = {
+    type: 'CallExpression',
+    callee: Testing.memberExpr('Command', 'define'),
+    arguments: opts.arg0 === undefined ? [] : [opts.arg0],
+  }
+  if (opts.declaratorName !== undefined) {
+    const declarator: MutableNode = {
+      type: 'VariableDeclarator',
+      id: Testing.id(opts.declaratorName),
+      init: call,
+    }
+    call.parent = declarator
+  }
+  return call
+}
+
+/**
+ * Build Foldkit's canonical curried form
+ * `const <declaratorName> = Command.define(name, payload, ctor)(handler)`.
+ *
+ * Returns the inner `Command.define(...)` call (the node the rule matches via
+ * `AST.isCallOf`). Its parent is the outer application call, whose parent is the
+ * `VariableDeclarator` — mirroring the real AST shape.
+ */
+const buildCurriedCall = (opts: {
+  readonly arg0?: unknown
+  readonly declaratorName?: string
+}): MutableNode => {
+  const inner: MutableNode = {
+    type: 'CallExpression',
+    callee: Testing.memberExpr('Command', 'define'),
+    arguments: opts.arg0 === undefined ? [] : [opts.arg0],
+  }
+  const outer: MutableNode = {
+    type: 'CallExpression',
+    callee: inner,
+    arguments: [],
+  }
+  inner.parent = outer
+  if (opts.declaratorName !== undefined) {
+    const declarator: MutableNode = {
+      type: 'VariableDeclarator',
+      id: Testing.id(opts.declaratorName),
+      init: outer,
+    }
+    outer.parent = declarator
+  }
+  return inner
+}
+
+describe('command-define-pascal-const', () => {
+  // ── happy path ───────────────────────────────────────────
+  it('does not flag `const FetchWeather = Command.define("FetchWeather", ...)`', () => {
+    const node = buildCall({
+      arg0: Testing.strLiteral('FetchWeather'),
+      declaratorName: 'FetchWeather',
+    })
+    expect(Testing.runRule(rule, 'CallExpression', node)).toHaveLength(0)
+  })
+
+  it('does not flag curried `const NavigateInternal = Command.define("NavigateInternal", payload, ctor)(handler)`', () => {
+    const node = buildCurriedCall({
+      arg0: Testing.strLiteral('NavigateInternal'),
+      declaratorName: 'NavigateInternal',
+    })
+    expect(Testing.runRule(rule, 'CallExpression', node)).toHaveLength(0)
+  })
+
+  it('flags curried const-name mismatch `const Foo = Command.define("Bar", ...)(handler)`', () => {
+    const node = buildCurriedCall({
+      arg0: Testing.strLiteral('Bar'),
+      declaratorName: 'Foo',
+    })
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'mirror the Command identity',
+    )
+  })
+
+  it('flags inline curried `Command.define("Foo", ...)(handler)` (no enclosing declarator)', () => {
+    const node = buildCurriedCall({ arg0: Testing.strLiteral('Foo') })
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'must be assigned to a PascalCase',
+    )
+  })
+
+  // ── name shape ───────────────────────────────────────────
+  it('flags non-PascalCase Command name `Command.define("fetchWeather", ...)`', () => {
+    const node = buildCall({
+      arg0: Testing.strLiteral('fetchWeather'),
+      declaratorName: 'fetchWeather',
+    })
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('PascalCase')
+  })
+
+  it('flags snake_case Command name', () => {
+    const node = buildCall({
+      arg0: Testing.strLiteral('fetch_weather'),
+      declaratorName: 'fetch_weather',
+    })
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('PascalCase')
+  })
+
+  // ── const wrapper requirements ───────────────────────────
+  it('flags inline `Command.define("Foo", ...)` (no enclosing declarator)', () => {
+    const node = buildCall({ arg0: Testing.strLiteral('Foo') })
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'must be assigned to a PascalCase',
+    )
+  })
+
+  it('flags const-name mismatch `const Foo = Command.define("Bar", ...)`', () => {
+    const node = buildCall({
+      arg0: Testing.strLiteral('Bar'),
+      declaratorName: 'Foo',
+    })
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'mirror the Command identity',
+    )
+    expect(result[0]?.diagnostic.message).toContain('got `Foo`')
+  })
+
+  // ── argument shape ───────────────────────────────────────
+  it('flags `Command.define()` with no arguments', () => {
+    const node = buildCall({})
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('literal string name')
+  })
+
+  it('flags `Command.define(someVar, ...)` (non-literal first arg)', () => {
+    const node = buildCall({ arg0: Testing.id('someVar') })
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('literal string name')
+  })
+
+  // ── non-target calls ─────────────────────────────────────
+  it('does not flag unrelated calls like `Foo.bar(...)`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('Foo', 'bar', [Testing.strLiteral('x')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `Command.something(...)` (different method)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('Command', 'something', [Testing.strLiteral('x')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/command-failed-result-requires-catch.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/command-failed-result-requires-catch.test.ts
@@ -1,0 +1,200 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/command-failed-result-requires-catch.ts'
+
+const commandDefine = (...args: ReadonlyArray<unknown>) =>
+  Testing.callOfMember('Command', 'define', args)
+
+const msg = (name: string) => Testing.memberExpr('Msg', name)
+
+const failedDefine = () =>
+  commandDefine(
+    Testing.strLiteral('FetchUser'),
+    msg('SucceededFetchUser'),
+    msg('FailedFetchUser'),
+  )
+
+const failedDefineWithArgs = () =>
+  commandDefine(
+    Testing.strLiteral('CreateUser'),
+    Testing.objectExpr([{ key: 'id', value: Testing.id('String') }]),
+    msg('SucceededCreateUser'),
+    msg('FailedCreateUser'),
+  )
+
+const completedDefine = () =>
+  commandDefine(Testing.strLiteral('FocusInput'), msg('CompletedFocusInput'))
+
+const applyDefine = (
+  defineCall: ReturnType<typeof commandDefine>,
+  effect: unknown,
+) => {
+  const applied = {
+    type: 'CallExpression',
+    callee: defineCall,
+    arguments: [effect],
+  }
+  Object.defineProperty(defineCall, 'parent', { value: applied })
+  return applied
+}
+
+const effectGen = () => Testing.callOfMember('Effect', 'gen')
+
+const effectWithCatch = (method: string) =>
+  Testing.callExpr('pipe', [
+    effectGen(),
+    Testing.callOfMember('Effect', method, [Testing.arrowFn()]),
+  ])
+
+const programExit = ['Program:exit', Testing.program()] as const
+
+describe('command-failed-result-requires-catch', () => {
+  it('flags Failed*-declaring Commands whose applied Effect has no catch', () => {
+    const defineCall = failedDefine()
+    const applied = applyDefine(defineCall, effectGen())
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('FailedFetchUser')
+    expect(result[0]?.diagnostic.message).toContain('Effect.catch')
+  })
+
+  it('ignores parent links when searching the applied Effect subtree', () => {
+    const defineCall = failedDefine()
+    const effect = effectGen()
+    const applied = applyDefine(defineCall, effect)
+    Object.defineProperty(effect, 'parent', { value: applied })
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('FailedFetchUser')
+  })
+
+  it.each([
+    'catch',
+    'catchAll',
+    'catchCause',
+    'catchIf',
+    'catchTag',
+    'catchTags',
+    'match',
+    'matchCause',
+  ])('accepts Effect.%s in the applied Effect subtree', method => {
+    const defineCall = failedDefine()
+    const applied = applyDefine(defineCall, effectWithCatch(method))
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips the optional args object before looking for Failed* results', () => {
+    const defineCall = failedDefineWithArgs()
+    const applied = applyDefine(defineCall, effectGen())
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('FailedCreateUser')
+  })
+
+  it('does not flag Commands with only Completed* results', () => {
+    const defineCall = completedDefine()
+    const applied = applyDefine(defineCall, effectGen())
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags Failed*-declaring `Command.define` calls that are not immediately applied', () => {
+    const result = Testing.runRule(rule, 'CallExpression', failedDefine())
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('not immediately applied')
+  })
+
+  it('does not flag split Completed*-only `Command.define` calls', () => {
+    const result = Testing.runRule(rule, 'CallExpression', completedDefine())
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not double-report an immediately applied Failed* Command when both calls are visited', () => {
+    const defineCall = failedDefine()
+    const applied = applyDefine(defineCall, effectWithCatch('catchCause'))
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', defineCall],
+      ['CallExpression', applied],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  // ── helper-extracted catch (one level of local indirection) ──
+  const arrowCalling = (fnName: string) =>
+    Testing.arrowFn(Testing.callExpr(fnName, [Testing.id('args')]), [
+      Testing.id('args'),
+    ])
+
+  it('does not flag when the catch is extracted into a local helper', () => {
+    const defineCall = failedDefine()
+    const applied = applyDefine(defineCall, arrowCalling('tasksInto'))
+    const helper = Testing.varDecl(
+      'const',
+      'tasksInto',
+      Testing.arrowFn(effectWithCatch('catch')),
+    )
+    const prog = Testing.program([helper, Testing.exprStmt(applied)])
+    Object.defineProperty(applied, 'parent', { value: prog })
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag an inline catch in the applied Effect', () => {
+    const defineCall = failedDefine()
+    const applied = applyDefine(defineCall, effectWithCatch('catchAll'))
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags when neither the applied Effect nor the called helper catches', () => {
+    const defineCall = failedDefine()
+    const applied = applyDefine(defineCall, arrowCalling('tasksInto'))
+    const helper = Testing.varDecl(
+      'const',
+      'tasksInto',
+      Testing.arrowFn(effectGen()),
+    )
+    const prog = Testing.program([helper, Testing.exprStmt(applied)])
+    Object.defineProperty(applied, 'parent', { value: prog })
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('FailedFetchUser')
+  })
+
+  it('flags when the called helper cannot be resolved locally', () => {
+    const defineCall = failedDefine()
+    const applied = applyDefine(defineCall, arrowCalling('unknownHelper'))
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('FailedFetchUser')
+  })
+
+  it('resolves a helper declared as a top-level function', () => {
+    const defineCall = failedDefine()
+    const applied = applyDefine(defineCall, arrowCalling('tasksInto'))
+    const helper = {
+      type: 'FunctionDeclaration',
+      id: Testing.id('tasksInto'),
+      params: [],
+      body: Testing.blockStmt([
+        Testing.returnStmt(effectWithCatch('catchTag')),
+      ]),
+    }
+    const prog = Testing.program([helper, Testing.exprStmt(applied)])
+    Object.defineProperty(applied, 'parent', { value: prog })
+    const result = Testing.runRule(rule, 'CallExpression', applied)
+    expect(result).toHaveLength(0)
+  })
+
+  it('ignores unrelated calls', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('Task', 'define', [msg('FailedFetchUser')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/foldkit-primitives-declared-in-role-files.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/foldkit-primitives-declared-in-role-files.test.ts
@@ -1,0 +1,155 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/foldkit-primitives-declared-in-role-files.ts'
+
+const filename = (path: string) => ({ filename: path })
+
+const commandDefine = () => Testing.callOfMember('Command', 'define', [])
+
+const subscriptionCall = (method: string) =>
+  Testing.callOfMember('Subscription', method, [])
+
+const importFoldkitMessage = () => Testing.importDecl('foldkit/message')
+
+const importFoldkitSchema = (...names: ReadonlyArray<string>) =>
+  Testing.importDeclWithSpecifiers(
+    'foldkit/schema',
+    names.map(name => Testing.importSpecifier(name)),
+  )
+
+describe('foldkit-primitives-declared-in-role-files', () => {
+  it('flags imports from `foldkit/message` outside message role files', () => {
+    const result = Testing.runRule(
+      rule,
+      'ImportDeclaration',
+      importFoldkitMessage(),
+      filename('/repo/apps/ui/src/page/tasks/update.ts'),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('message.ts')
+  })
+
+  it('allows imports from `foldkit/message` in `message.ts`', () => {
+    const result = Testing.runRule(
+      rule,
+      'ImportDeclaration',
+      importFoldkitMessage(),
+      filename('/repo/apps/ui/src/page/tasks/message.ts'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows imports from `foldkit/message` in a `message/` role folder', () => {
+    const result = Testing.runRule(
+      rule,
+      'ImportDeclaration',
+      importFoldkitMessage(),
+      filename('/repo/apps/ui/src/page/tasks/message/index.ts'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags the `m` specifier from `foldkit/schema` outside message role files', () => {
+    const result = Testing.runRule(
+      rule,
+      'ImportDeclaration',
+      importFoldkitSchema('ts', 'm'),
+      filename('/repo/apps/ui/src/page/tasks/view.ts'),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Message constructors')
+  })
+
+  it('does not flag other `foldkit/schema` specifiers outside message role files', () => {
+    const result = Testing.runRule(
+      rule,
+      'ImportDeclaration',
+      importFoldkitSchema('ts'),
+      filename('/repo/apps/ui/src/page/tasks/view.ts'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags `Command.define(...)` outside command role files', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      commandDefine(),
+      filename('/repo/apps/ui/src/page/tasks/update.ts'),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('command.ts')
+  })
+
+  it('allows `Command.define(...)` in `command.ts`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      commandDefine(),
+      filename('/repo/apps/ui/src/page/tasks/command.ts'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows `Command.define(...)` in a `command/` role folder', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      commandDefine(),
+      filename('/repo/apps/ui/src/page/tasks/command/fetch.ts'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it.each(['make', 'lift', 'aggregate', 'persistent'])(
+    'flags `Subscription.%s(...)` outside subscription role files',
+    method => {
+      const result = Testing.runRule(
+        rule,
+        'CallExpression',
+        subscriptionCall(method),
+        filename('/repo/apps/ui/src/page/tasks/update.ts'),
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0]?.diagnostic.message).toContain(`Subscription.${method}`)
+    },
+  )
+
+  it('allows Subscription primitives in `subscription.ts`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      subscriptionCall('aggregate'),
+      filename('/repo/apps/ui/src/page/tasks/subscription.ts'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows Subscription primitives in a `subscription/` role folder', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      subscriptionCall('make'),
+      filename('/repo/apps/ui/src/page/tasks/subscription/keyboard.ts'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag unrelated Command or Subscription calls', () => {
+    const commandResult = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('Command', 'mapMessages', []),
+      filename('/repo/apps/ui/src/page/tasks/update.ts'),
+    )
+    const subscriptionResult = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('Subscription', 'unknown', []),
+      filename('/repo/apps/ui/src/page/tasks/update.ts'),
+    )
+    expect(commandResult).toHaveLength(0)
+    expect(subscriptionResult).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/got-wrapper-carries-only-routing.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/got-wrapper-carries-only-routing.test.ts
@@ -1,0 +1,168 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/got-wrapper-carries-only-routing.ts'
+
+const prop = (key: string, value: unknown = Testing.id('Value')) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: false,
+  method: false,
+  shorthand: false,
+  key: Testing.id(key),
+  value,
+})
+
+const stringKeyProp = (key: string, value: unknown = Testing.id('Value')) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: false,
+  method: false,
+  shorthand: false,
+  key: Testing.strLiteral(key),
+  value,
+})
+
+const computedProp = (key: string, value: unknown = Testing.id('Value')) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: true,
+  method: false,
+  shorthand: false,
+  key: Testing.id(key),
+  value,
+})
+
+const spread = (name: string) => ({
+  type: 'SpreadElement',
+  argument: Testing.id(name),
+})
+
+const objectExpr = (properties: ReadonlyArray<unknown>) => ({
+  type: 'ObjectExpression',
+  properties: Array.from(properties),
+})
+
+const m = (tag: string, fields?: unknown) =>
+  Testing.callExpr(
+    'm',
+    fields === undefined
+      ? [Testing.strLiteral(tag)]
+      : [Testing.strLiteral(tag), fields],
+  )
+
+describe('got-wrapper-carries-only-routing', () => {
+  it('allows canonical Got wrappers with only `message`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m('GotChatMessage', objectExpr([prop('message')])),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows `id` and `*Id` routing fields', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m(
+        'GotPiRuntimeModelComboboxMessage',
+        objectExpr([prop('message'), prop('id'), prop('sessionId')]),
+      ),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags Got wrapper tags that do not end with Message', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m('GotChatUpdates', objectExpr([prop('message')])),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Got*Message')
+    expect(result[0]?.diagnostic.suggest).toHaveLength(1)
+  })
+
+  it('flags missing fields argument', () => {
+    const result = Testing.runRule(rule, 'CallExpression', m('GotChatMessage'))
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('must declare fields')
+  })
+
+  it('flags object fields missing `message`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m('GotChatMessage', objectExpr([prop('id')])),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('must include a `message`')
+  })
+
+  it('flags extra non-routing fields', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m('GotChatMessage', objectExpr([prop('message'), prop('thought')])),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('extra field `thought`')
+  })
+
+  it('flags string-literal extra field keys', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m(
+        'GotChatMessage',
+        objectExpr([prop('message'), stringKeyProp('payload')]),
+      ),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('extra field `payload`')
+  })
+
+  it('skips non-object fields arguments', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m('GotChatMessage', Testing.id('Fields')),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips spread and computed fields when checking extras', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m(
+        'GotChatMessage',
+        objectExpr([
+          prop('message'),
+          spread('extras'),
+          computedProp('dynamic'),
+        ]),
+      ),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not classify `Goto*` tags as Got wrappers', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m('GotoSettings', objectExpr([prop('thought')])),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('can report name and field diagnostics on the same wrapper', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      m('GotChatUpdates', objectExpr([prop('thought')])),
+    )
+    expect(result).toHaveLength(3)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/keyed-required-for-mapped-rows.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/keyed-required-for-mapped-rows.test.ts
@@ -1,0 +1,269 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/keyed-required-for-mapped-rows.ts'
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+const arr = (elements: ReadonlyArray<unknown>) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const ident = (name: string) => ({ type: 'Identifier', name })
+
+const memberAccess = (object: string, property: string) => ({
+  type: 'MemberExpression',
+  computed: false,
+  object: ident(object),
+  property: ident(property),
+})
+
+const arrowFn = (paramName: string, body: unknown) => ({
+  type: 'ArrowFunctionExpression',
+  expression: true,
+  async: false,
+  params: [ident(paramName)],
+  body,
+  id: null,
+  generator: false,
+})
+
+const arrowFnDestructured = (body: unknown) => ({
+  type: 'ArrowFunctionExpression',
+  expression: true,
+  async: false,
+  params: [{ type: 'ObjectPattern', properties: [] }],
+  body,
+  id: null,
+  generator: false,
+})
+
+// items.map(fn)
+const methodMap = (receiver: unknown, fn: unknown) => ({
+  type: 'CallExpression',
+  callee: {
+    type: 'MemberExpression',
+    computed: false,
+    object: receiver,
+    property: ident('map'),
+  },
+  arguments: [fn],
+})
+
+// Array.map(items, fn)
+const arrayMap = (items: unknown, fn: unknown) => ({
+  type: 'CallExpression',
+  callee: {
+    type: 'MemberExpression',
+    computed: false,
+    object: ident('Array'),
+    property: ident('map'),
+  },
+  arguments: [items, fn],
+})
+
+// li([attrs], [children])
+const rowCall = (tag: string, attrs: unknown, children: unknown) => ({
+  type: 'CallExpression',
+  callee: ident(tag),
+  arguments: [attrs, children],
+})
+
+// keyed('li')(id, attrs, children)
+const keyedRowCall = (
+  tag: string,
+  id: unknown,
+  attrs: unknown,
+  children: unknown,
+) => ({
+  type: 'CallExpression',
+  callee: {
+    type: 'CallExpression',
+    callee: ident('keyed'),
+    arguments: [{ type: 'Literal', value: tag }],
+  },
+  arguments: [id, attrs, children],
+})
+
+// OnClick(ClickedDelete({ id: item.id }))
+const onClickReferencingId = (paramName: string) =>
+  Testing.callExpr('OnClick', [
+    Testing.callExpr('ClickedDelete', [
+      {
+        type: 'ObjectExpression',
+        properties: [
+          {
+            type: 'Property',
+            kind: 'init',
+            computed: false,
+            method: false,
+            shorthand: false,
+            key: ident('id'),
+            value: memberAccess(paramName, 'id'),
+          },
+        ],
+      },
+    ]),
+  ])
+
+describe('keyed-required-for-mapped-rows', () => {
+  it('flags `items.map((item) => li([], [item.id]))` (id-bearing row)', () => {
+    const node = methodMap(
+      ident('items'),
+      arrowFn(
+        'item',
+        rowCall('li', arr([]), arr([memberAccess('item', 'id')])),
+      ),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('keyed')
+  })
+
+  it('flags `items.map((item) => li([OnClick(...{ id: item.id })], []))`', () => {
+    const node = methodMap(
+      ident('items'),
+      arrowFn(
+        'item',
+        rowCall('li', arr([onClickReferencingId('item')]), arr([])),
+      ),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags `Array.map(items, (item) => div([], [item.id]))`', () => {
+    const node = arrayMap(
+      ident('items'),
+      arrowFn(
+        'item',
+        rowCall('div', arr([]), arr([memberAccess('item', 'id')])),
+      ),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it.each(['tr', 'article', 'section'])('flags `%s` row elements', tag => {
+    const node = methodMap(
+      ident('items'),
+      arrowFn('item', rowCall(tag, arr([]), arr([memberAccess('item', 'id')]))),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags destructured params (assumed identity-bearing)', () => {
+    const node = methodMap(
+      ident('items'),
+      arrowFnDestructured(rowCall('li', arr([]), arr([]))),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag `items.map((item) => keyed("li")(item.id, [], []))`', () => {
+    const node = methodMap(
+      ident('items'),
+      arrowFn(
+        'item',
+        keyedRowCall('li', memberAccess('item', 'id'), arr([]), arr([])),
+      ),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag stateless static lists (no `<param>.id` reference)', () => {
+    const node = methodMap(
+      ident('tags'),
+      arrowFn('tag', rowCall('li', arr([]), arr([ident('tag')]))),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag non-row elements (e.g. `span`, `p`)', () => {
+    const node = methodMap(
+      ident('items'),
+      arrowFn(
+        'item',
+        rowCall('span', arr([]), arr([memberAccess('item', 'id')])),
+      ),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag arrow body that returns something that is not a row call', () => {
+    const node = methodMap(
+      ident('items'),
+      arrowFn('item', Testing.callExpr('renderHabitRow', [ident('item')])),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles block-bodied arrow with explicit return', () => {
+    const blockArrow = {
+      type: 'ArrowFunctionExpression',
+      expression: false,
+      async: false,
+      params: [ident('item')],
+      body: {
+        type: 'BlockStatement',
+        body: [
+          {
+            type: 'ReturnStatement',
+            argument: rowCall('li', arr([]), arr([memberAccess('item', 'id')])),
+          },
+        ],
+      },
+      id: null,
+      generator: false,
+    }
+    const node = methodMap(ident('items'), blockArrow)
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag non-`.map` method calls', () => {
+    const node = methodMap(
+      ident('items'),
+      arrowFn(
+        'item',
+        rowCall('li', arr([]), arr([memberAccess('item', 'id')])),
+      ),
+    )
+    // Override the method name
+    const nonMapNode = {
+      ...node,
+      callee: { ...node.callee, property: ident('forEach') },
+    }
+    const result = Testing.runRule(rule, 'CallExpression', nonMapNode)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `Array.map(items, function(item) {...})` (non-arrow)', () => {
+    const fnExpr = {
+      type: 'FunctionExpression',
+      async: false,
+      generator: false,
+      id: null,
+      params: [ident('item')],
+      body: {
+        type: 'BlockStatement',
+        body: [
+          {
+            type: 'ReturnStatement',
+            argument: rowCall('li', arr([]), arr([memberAccess('item', 'id')])),
+          },
+        ],
+      },
+    }
+    const node = arrayMap(ident('items'), fnExpr)
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/label-requires-for.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/label-requires-for.test.ts
@@ -1,0 +1,72 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/label-requires-for.ts'
+
+const arr = (elements: ReadonlyArray<unknown>) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const labelCall = (attrs: unknown, children: unknown) =>
+  Testing.callExpr('label', [attrs, children])
+
+const For = (value: string) =>
+  Testing.callExpr('For', [Testing.strLiteral(value)])
+
+const Class = (value: string) =>
+  Testing.callExpr('Class', [Testing.strLiteral(value)])
+
+describe('label-requires-for', () => {
+  it('flags `label([], [...])`', () => {
+    const node = labelCall(arr([]), arr([Testing.strLiteral('Email')]))
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('For(id)')
+  })
+
+  it('flags `label([Class("...")], [...])` (no For)', () => {
+    const node = labelCall(
+      arr([Class('block')]),
+      arr([Testing.strLiteral('Email')]),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag `label([For("id"), ...], [...])`', () => {
+    const node = labelCall(
+      arr([For('email-input'), Class('block')]),
+      arr([Testing.strLiteral('Email')]),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `label([Class("..."), For("id")], [...])` (any order)', () => {
+    const node = labelCall(
+      arr([Class('block'), For('email-input')]),
+      arr([Testing.strLiteral('Email')]),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag non-label calls', () => {
+    const node = Testing.callExpr('span', [arr([]), arr([])])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `label(spread)` without an ArrayExpression first arg', () => {
+    const node = Testing.callExpr('label', [Testing.id('sharedAttrs'), arr([])])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag a label with no arguments', () => {
+    const node = Testing.callExpr('label', [])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/lazy-view-stable-references.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/lazy-view-stable-references.test.ts
@@ -1,0 +1,225 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/lazy-view-stable-references.ts'
+
+const callFromCallee = (
+  callee: unknown,
+  args: ReadonlyArray<unknown> = [],
+) => ({
+  type: 'CallExpression',
+  callee,
+  arguments: Array.from(args),
+})
+
+const memberFromObject = (object: unknown, property: string) => ({
+  type: 'MemberExpression',
+  object,
+  property: Testing.id(property),
+  computed: false,
+})
+
+const parenthesized = (expression: unknown) => ({
+  type: 'ParenthesizedExpression',
+  expression,
+})
+
+const createLazy = () => Testing.callExpr('createLazy')
+const createKeyedLazy = () => Testing.callExpr('createKeyedLazy')
+
+const constDecl = (name: string, init: unknown) =>
+  Testing.varDecl('const', name, init)
+
+const letDecl = (name: string, init: unknown) =>
+  Testing.varDecl('let', name, init)
+
+const exportConst = (name: string, init: unknown) =>
+  Testing.exportNamedDecl(constDecl(name, init))
+
+const arrow = (body: unknown, params: ReadonlyArray<string> = []) =>
+  Testing.arrowFn(body, params.map(Testing.id))
+
+const blockReturn = (expression: unknown) =>
+  Testing.blockStmt([Testing.returnStmt(expression)])
+
+const viewFunction = (
+  body: unknown,
+  params: ReadonlyArray<string> = ['model'],
+) => exportConst('view', arrow(blockReturn(body), params))
+
+const programExit = (body: ReadonlyArray<unknown>) =>
+  Testing.runRule(rule, 'Program:exit', Testing.program(body))
+
+describe('lazy-view-stable-references', () => {
+  it('allows module-scope createLazy slots called with module-scope view functions', () => {
+    const result = programExit([
+      constDecl('lazyHeader', createLazy()),
+      constDecl('viewHeader', arrow(Testing.id('model'), ['model'])),
+      viewFunction(
+        Testing.callExpr('lazyHeader', [
+          Testing.id('viewHeader'),
+          Testing.id('model'),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows module-scope createKeyedLazy slots called with module-scope view functions', () => {
+    const result = programExit([
+      constDecl('lazyRow', parenthesized(createKeyedLazy())),
+      constDecl('viewRow', arrow(Testing.id('row'), ['row'])),
+      viewFunction(
+        Testing.callExpr('lazyRow', [
+          memberFromObject(Testing.id('model'), 'id'),
+          Testing.id('viewRow'),
+          Testing.id('model'),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags createLazy calls that are not direct module-scope const initializers', () => {
+    const result = programExit([
+      viewFunction(
+        Testing.callExpr('render', [createLazy(), Testing.id('model')]),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'direct module-scope `const` initializers',
+    )
+  })
+
+  it('flags createKeyedLazy calls that are not direct module-scope const initializers', () => {
+    const result = programExit([
+      exportConst(
+        'makeView',
+        arrow(
+          Testing.blockStmt([
+            constDecl('lazyRow', createKeyedLazy()),
+            Testing.returnStmt(Testing.id('lazyRow')),
+          ]),
+        ),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('createKeyedLazy')
+  })
+
+  it('flags module-scope lazy calls hidden inside another initializer', () => {
+    const result = programExit([
+      constDecl('lazyHeader', callFromCallee('makeSlot', [createLazy()])),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('createLazy')
+  })
+
+  it('flags module-scope non-const lazy slot declarations', () => {
+    const result = programExit([letDecl('lazyHeader', createLazy())])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'direct module-scope `const`',
+    )
+  })
+
+  it('flags inline createLazy view functions at slot call sites', () => {
+    const result = programExit([
+      constDecl('lazyHeader', createLazy()),
+      viewFunction(
+        Testing.callExpr('lazyHeader', [
+          arrow(Testing.id('model'), ['model']),
+          Testing.id('model'),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('not an inline function')
+  })
+
+  it('flags inline createKeyedLazy view functions at argument index 1', () => {
+    const result = programExit([
+      constDecl('lazyRow', createKeyedLazy()),
+      viewFunction(
+        Testing.callExpr('lazyRow', [
+          Testing.id('rowId'),
+          arrow(Testing.id('row'), ['row']),
+          Testing.id('model'),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('not an inline function')
+  })
+
+  it('flags function-scoped createLazy view identifiers', () => {
+    const result = programExit([
+      constDecl('lazyHeader', createLazy()),
+      viewFunction(
+        Testing.callExpr('lazyHeader', [
+          Testing.id('viewHeader'),
+          Testing.id('model'),
+        ]),
+        ['model', 'viewHeader'],
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'function-scoped view reference `viewHeader`',
+    )
+  })
+
+  it('flags local const view identifiers passed to lazy slots', () => {
+    const result = programExit([
+      constDecl('lazyHeader', createLazy()),
+      exportConst(
+        'view',
+        arrow(
+          Testing.blockStmt([
+            constDecl('viewHeader', arrow(Testing.id('model'), ['model'])),
+            Testing.returnStmt(
+              Testing.callExpr('lazyHeader', [
+                Testing.id('viewHeader'),
+                Testing.id('model'),
+              ]),
+            ),
+          ]),
+          ['model'],
+        ),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'function-scoped view reference `viewHeader`',
+    )
+  })
+
+  it('does not inspect imported or otherwise untracked lazy slot calls', () => {
+    const result = programExit([
+      viewFunction(
+        Testing.callExpr('importedLazyHeader', [
+          Testing.id('viewHeader'),
+          Testing.id('model'),
+        ]),
+        ['model', 'viewHeader'],
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not treat non-view arguments as lazy view functions', () => {
+    const result = programExit([
+      constDecl('lazyRow', createKeyedLazy()),
+      constDecl('viewRow', arrow(Testing.id('row'), ['row'])),
+      viewFunction(
+        Testing.callExpr('lazyRow', [
+          Testing.id('functionScopedKey'),
+          Testing.id('viewRow'),
+        ]),
+        ['model', 'functionScopedKey'],
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/managed-resource-for-stateful-handles.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/managed-resource-for-stateful-handles.test.ts
@@ -1,0 +1,126 @@
+import type { ESTree } from 'effect-oxlint'
+import * as Testing from 'effect-oxlint/testing'
+import * as P from 'effect/Predicate'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/managed-resource-for-stateful-handles.ts'
+
+const srcFile = '/repo/apps/ui/src/page/chat/command.ts'
+
+const isNamedGlobal =
+  (globals: ReadonlyArray<string>) => (candidate: unknown) =>
+    P.isObject(candidate) &&
+    'type' in candidate &&
+    candidate.type === 'Identifier' &&
+    'name' in candidate &&
+    P.isString(candidate.name) &&
+    globals.includes(candidate.name)
+
+const runNewExpression = (
+  node: ESTree.NewExpression,
+  globals: ReadonlyArray<string>,
+  filename = srcFile,
+) => {
+  const { context, diagnostics } = Testing.createMockContext({ filename })
+  Object.defineProperty(context.sourceCode, 'isGlobalReference', {
+    value: isNamedGlobal(globals),
+  })
+  const visitors = rule.create(context)
+  visitors.NewExpression?.(node)
+  return diagnostics
+}
+
+const runCallExpression = (
+  node: ESTree.CallExpression,
+  globals: ReadonlyArray<string>,
+  filename = srcFile,
+) => {
+  const { context, diagnostics } = Testing.createMockContext({ filename })
+  Object.defineProperty(context.sourceCode, 'isGlobalReference', {
+    value: isNamedGlobal(globals),
+  })
+  const visitors = rule.create(context)
+  visitors.CallExpression?.(node)
+  return diagnostics
+}
+
+const mediaDevicesCall = (method: 'getUserMedia' | 'getDisplayMedia') => {
+  const node = Testing.callExpr('placeholder')
+  Object.defineProperty(node, 'callee', {
+    value: Testing.chainedMemberExpr('navigator', 'mediaDevices', method),
+  })
+  return node
+}
+
+describe('managed-resource-for-stateful-handles', () => {
+  it.each([
+    'WebSocket',
+    'MediaRecorder',
+    'Worker',
+    'SharedWorker',
+    'RTCPeerConnection',
+  ])(
+    'flags global `new %s(...)` outside resource/subscription/client files',
+    name => {
+      const result = runNewExpression(Testing.newExpr(name), [name])
+      expect(result).toHaveLength(1)
+      expect(result[0]?.diagnostic.message).toContain('ManagedResource')
+    },
+  )
+
+  it('does not flag a local class named WebSocket', () => {
+    const result = runNewExpression(Testing.newExpr('WebSocket'), [])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag unrelated constructors', () => {
+    const result = runNewExpression(Testing.newExpr('AbortController'), [
+      'AbortController',
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it.each([
+    '/repo/apps/ui/src/page/chat/managedResource.ts',
+    '/repo/apps/ui/src/page/chat/managed-resource.ts',
+    '/repo/apps/ui/src/page/chat/managed-resources-live.ts',
+    '/repo/apps/ui/src/page/chat/subscription.ts',
+    '/repo/apps/ui/src/page/chat/subscription-keyboard.ts',
+    '/repo/apps/ui/src/client/pi-runtime.ts',
+  ])('does not flag exempt file `%s`', filename => {
+    const result = runNewExpression(
+      Testing.newExpr('WebSocket'),
+      ['WebSocket'],
+      filename,
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it.each(['getUserMedia', 'getDisplayMedia'] as const)(
+    'flags global `navigator.mediaDevices.%s(...)`',
+    method => {
+      const result = runCallExpression(mediaDevicesCall(method), ['navigator'])
+      expect(result).toHaveLength(1)
+      expect(result[0]?.diagnostic.message).toContain(method)
+      expect(result[0]?.diagnostic.message).toContain('ManagedResource')
+    },
+  )
+
+  it('does not flag local `navigator.mediaDevices.getUserMedia(...)`', () => {
+    const result = runCallExpression(mediaDevicesCall('getUserMedia'), [])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag unrelated `navigator.mediaDevices.enumerateDevices(...)`', () => {
+    const node = Testing.callExpr('placeholder')
+    Object.defineProperty(node, 'callee', {
+      value: Testing.chainedMemberExpr(
+        'navigator',
+        'mediaDevices',
+        'enumerateDevices',
+      ),
+    })
+    const result = runCallExpression(node, ['navigator'])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/mount-factory-must-use-element.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/mount-factory-must-use-element.test.ts
@@ -1,0 +1,144 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/mount-factory-must-use-element.ts'
+
+const mountDefine = (method: 'define' | 'defineStream', factory: unknown) => ({
+  type: 'CallExpression',
+  callee: Testing.callOfMember('Mount', method, [
+    Testing.strLiteral('MountThing'),
+    Testing.id('CompletedMountThing'),
+  ]),
+  arguments: [factory],
+})
+
+const elementEffect = (elementName = 'element') =>
+  Testing.callExpr('useElement', [Testing.id(elementName)])
+
+const elementFactory = (paramName: string, body: unknown) =>
+  Testing.arrowFn(body, [Testing.id(paramName)])
+
+const argsFactory = (inner: unknown) =>
+  Testing.arrowFn(inner, [Testing.id('args')])
+
+const blockReturning = (value: unknown) =>
+  Testing.arrowFn(Testing.blockStmt([Testing.returnStmt(value)]), [
+    Testing.id('args'),
+  ])
+
+describe('mount-factory-must-use-element', () => {
+  it('allows `Mount.define(...)(element => Effect using element)`', () => {
+    const node = mountDefine(
+      'define',
+      elementFactory('element', elementEffect()),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows `Mount.defineStream(...)(element => Stream using element)`', () => {
+    const node = mountDefine(
+      'defineStream',
+      elementFactory('node', elementEffect('node')),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags argless Mount factories that never reference the element', () => {
+    const node = mountDefine(
+      'define',
+      elementFactory('element', Testing.callExpr('analyticsPing')),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('never used')
+  })
+
+  it('flags underscore-prefixed element parameters even when referenced', () => {
+    const node = mountDefine(
+      'define',
+      elementFactory('_element', elementEffect('_element')),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('explicitly ignored')
+  })
+
+  it('flags factories with no element parameter', () => {
+    const node = mountDefine('define', Testing.arrowFn(Testing.id('done')))
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('accept and use')
+  })
+
+  it('descends through args-form factories', () => {
+    const node = mountDefine(
+      'define',
+      argsFactory(elementFactory('element', Testing.callExpr('doWork'))),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('never used')
+  })
+
+  it('allows args-form factories whose inner element factory uses the element', () => {
+    const node = mountDefine(
+      'define',
+      argsFactory(elementFactory('element', elementEffect())),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('descends through block-bodied args factories that return an element factory', () => {
+    const node = mountDefine(
+      'define',
+      blockReturning(elementFactory('element', Testing.callExpr('doWork'))),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not count references to a shadowed nested parameter', () => {
+    const shadowingCallback = Testing.callExpr('Effect.sync', [
+      Testing.arrowFn(Testing.id('element'), [Testing.id('element')]),
+    ])
+    const node = mountDefine(
+      'define',
+      elementFactory('element', shadowingCallback),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('skips identifier-referenced factories', () => {
+    const node = mountDefine('define', Testing.id('makeMount'))
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag the inner `Mount.define(...)` call before application', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('Mount', 'define', [
+        Testing.strLiteral('MountThing'),
+        Testing.id('CompletedMountThing'),
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('ignores unrelated curried calls', () => {
+    const node = {
+      type: 'CallExpression',
+      callee: Testing.callOfMember('Command', 'define', [
+        Testing.strLiteral('DoThing'),
+      ]),
+      arguments: [elementFactory('element', Testing.callExpr('doWork'))],
+    }
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-array-index-view-keys.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-array-index-view-keys.test.ts
@@ -1,0 +1,170 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-array-index-view-keys.ts'
+
+const arr = (elements: ReadonlyArray<unknown> = []) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const parent = (child: object, value: object) => {
+  Object.defineProperty(child, 'parent', { value })
+}
+
+const arrow = (params: ReadonlyArray<string>, body: unknown) => ({
+  type: 'ArrowFunctionExpression',
+  expression: true,
+  async: false,
+  params: params.map(Testing.id),
+  body,
+  id: null,
+  generator: false,
+})
+
+const methodMap = (fn: object) => {
+  const call = Testing.callExpr('', [])
+  Object.assign(call, {
+    callee: Testing.memberExpr('items', 'map'),
+    arguments: [fn],
+  })
+  parent(fn, call)
+  return call
+}
+
+const arrMapDataFirst = (fn: object) => {
+  const call = Testing.callOfMember('Arr', 'map', [Testing.id('items'), fn])
+  parent(fn, call)
+  return call
+}
+
+const arrMapDataLast = (fn: object) => {
+  const call = Testing.callOfMember('Arr', 'map', [fn])
+  parent(fn, call)
+  return call
+}
+
+const arrMakeBy = (fn: object) => {
+  const call = Testing.callOfMember('Arr', 'makeBy', [
+    Testing.numLiteral(3),
+    fn,
+  ])
+  parent(fn, call)
+  return call
+}
+
+const hKeyed = (key: unknown) => ({
+  type: 'CallExpression',
+  callee: Testing.callOfMember('h', 'keyed', [Testing.strLiteral('div')]),
+  arguments: [key, arr(), arr()],
+})
+
+const hKey = (key: unknown) => Testing.callOfMember('h', 'Key', [key])
+
+const hSubmodel = (slotId: unknown) =>
+  Testing.callOfMember('h', 'submodel', [
+    Testing.objectExpr([{ key: 'slotId', value: slotId }]),
+  ])
+
+const keyedLazyCall = (name: string, key: unknown) =>
+  Testing.callExpr(name, [key, Testing.id('view')])
+
+const runInMap = (fn: object, sink: object) =>
+  Testing.runRuleMulti(rule, [
+    ['ArrowFunctionExpression', fn],
+    ['CallExpression', sink],
+    ['ArrowFunctionExpression:exit', fn],
+  ])
+
+describe('no-array-index-view-keys', () => {
+  it('flags array index keys in `h.keyed(...)` inside `.map` callbacks', () => {
+    const sink = hKeyed(Testing.id('i'))
+    const fn = arrow(['item', 'i'], sink)
+    methodMap(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('array index')
+  })
+
+  it('flags array index keys in data-first `Arr.map(xs, fn)`', () => {
+    const sink = hKeyed(Testing.id('index'))
+    const fn = arrow(['item', 'index'], sink)
+    arrMapDataFirst(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('`index`')
+  })
+
+  it('flags array index keys in data-last `Arr.map(fn)`', () => {
+    const sink = hKey(Testing.id('i'))
+    const fn = arrow(['item', 'i'], sink)
+    arrMapDataLast(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags `h.Key(index)` attributes', () => {
+    const sink = hKey(Testing.id('i'))
+    const fn = arrow(['item', 'i'], sink)
+    methodMap(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags `slotId` in `h.submodel({ ... })` configs', () => {
+    const sink = hSubmodel(Testing.id('i'))
+    const fn = arrow(['item', 'i'], sink)
+    methodMap(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags createKeyedLazy-derived slot calls', () => {
+    const declarator = Testing.varDeclarator(
+      'RowSlot',
+      Testing.callExpr('createKeyedLazy'),
+    )
+    const sink = keyedLazyCall('RowSlot', Testing.id('i'))
+    const fn = arrow(['item', 'i'], sink)
+    methodMap(fn)
+    const result = Testing.runRuleMulti(rule, [
+      ['VariableDeclarator', declarator],
+      ['ArrowFunctionExpression', fn],
+      ['CallExpression', sink],
+      ['ArrowFunctionExpression:exit', fn],
+    ])
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag keys derived from stable item fields', () => {
+    const sink = hKeyed(Testing.memberExpr('item', 'id'))
+    const fn = arrow(['item', 'i'], sink)
+    methodMap(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag first-parameter identifiers', () => {
+    const sink = hKey(Testing.id('item'))
+    const fn = arrow(['item', 'i'], sink)
+    methodMap(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag callbacks without a second parameter', () => {
+    const sink = hKey(Testing.id('i'))
+    const fn = arrow(['item'], sink)
+    methodMap(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not treat `Arr.makeBy` indexes as map row identity', () => {
+    const sink = hKey(Testing.id('i'))
+    const fn = arrow(['item', 'i'], sink)
+    arrMakeBy(fn)
+    const result = runInMap(fn, sink)
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-array-shorthand-type.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-array-shorthand-type.test.ts
@@ -1,0 +1,24 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-array-shorthand-type.ts'
+
+describe('no-array-shorthand-type', () => {
+  it('flags TSArrayType (`T[]`)', () => {
+    const result = Testing.runRule(rule, 'TSArrayType', {
+      type: 'TSArrayType',
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Array<T>')
+    expect(result[0]?.diagnostic.message).toContain('ReadonlyArray<T>')
+  })
+
+  it('does not flag TSTypeReference (`Array<T>`)', () => {
+    const result = Testing.runRule(
+      rule,
+      'TSTypeReference',
+      Testing.tsTypeRef('Array'),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-changed-message-prefix.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-changed-message-prefix.test.ts
@@ -1,0 +1,80 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-changed-message-prefix.ts'
+
+describe('no-changed-message-prefix', () => {
+  it('flags `m("ChangedEmail")`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.strLiteral('ChangedEmail')]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('UpdatedEmail')
+  })
+
+  it('flags exact `m("Changed")` (boundary case)', () => {
+    // `Changed` followed by end-of-string — still a `Changed*` tag.
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.strLiteral('Changed')]),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag `m("UpdatedEmail")`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.strLiteral('UpdatedEmail')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag route-change messages', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.strLiteral('ChangedRoute')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag URL-change messages', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.strLiteral('ChangedUrl')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `m("ChangelogOpened")` — `Change` prefix without word boundary', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.strLiteral('ChangelogOpened')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag non-`m` calls with the same shape', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('something', [Testing.strLiteral('ChangedEmail')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `m(...)` with non-string first argument', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.numLiteral(42)]),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-child-message-construction-in-root.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-child-message-construction-in-root.test.ts
@@ -1,0 +1,88 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-child-message-construction-in-root.ts'
+
+const childMessageCall = (namespace: string, constructor: string) => ({
+  type: 'CallExpression',
+  callee: Testing.chainedMemberExpr(namespace, 'Message', constructor),
+  arguments: [],
+})
+
+const callOf = (callee: unknown, args: ReadonlyArray<unknown> = []) => ({
+  type: 'CallExpression',
+  callee,
+  arguments: Array.from(args),
+})
+
+describe('no-child-message-construction-in-root', () => {
+  it('flags direct child Message constructor calls', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      childMessageCall('Chat', 'ClickedOpen'),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Chat.Message.ClickedOpen')
+  })
+
+  it('flags widget namespace Message constructor calls', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      childMessageCall('CommandPalette', 'OpenedCommandPalette'),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag the Message schema/type member itself', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      childMessageCall('Chat', 'Message'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag member paths whose namespace is not PascalCase', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      childMessageCall('chat', 'ClickedOpen'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag Message constructors used as values in guard arguments', () => {
+    const node = callOf(
+      Testing.callOfMember('S', 'is', [
+        Testing.chainedMemberExpr(
+          'CommandPalette',
+          'Message',
+          'OpenedCommandPalette',
+        ),
+      ]),
+      [Testing.id('message')],
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag shorter or longer member call paths', () => {
+    const shortPath = Testing.callOfMember('Message', 'ClickedOpen')
+    const longPath = callOf(
+      Testing.chainedMemberExpr('Root', 'Chat', 'Message', 'ClickedOpen'),
+    )
+    expect(Testing.runRule(rule, 'CallExpression', shortPath)).toHaveLength(0)
+    expect(Testing.runRule(rule, 'CallExpression', longPath)).toHaveLength(0)
+  })
+
+  it('does not flag non-Message member calls', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      callOf(Testing.chainedMemberExpr('Chat', 'Helpers', 'open')),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-disabling-dev-guardrails.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-disabling-dev-guardrails.test.ts
@@ -1,0 +1,95 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-disabling-dev-guardrails.ts'
+
+const prop = (key: string, value: unknown = Testing.boolLiteral(false)) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: false,
+  method: false,
+  shorthand: false,
+  key: Testing.id(key),
+  value,
+})
+
+const stringProp = (
+  key: string,
+  value: unknown = Testing.boolLiteral(false),
+) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: false,
+  method: false,
+  shorthand: false,
+  key: Testing.strLiteral(key),
+  value,
+})
+
+const computedProp = (
+  key: string,
+  value: unknown = Testing.boolLiteral(false),
+) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: true,
+  method: false,
+  shorthand: false,
+  key: Testing.id(key),
+  value,
+})
+
+const objectExpr = (properties: ReadonlyArray<unknown>) => ({
+  type: 'ObjectExpression',
+  properties: Array.from(properties),
+})
+
+const runObject = (properties: ReadonlyArray<unknown>) =>
+  Testing.runRule(rule, 'ObjectExpression', objectExpr(properties))
+
+describe('no-disabling-dev-guardrails', () => {
+  it('flags `slowView: false`', () => {
+    const result = runObject([prop('slowView')])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('slowView')
+  })
+
+  it('flags `freezeModel: false`', () => {
+    const result = runObject([prop('freezeModel')])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('freezeModel')
+  })
+
+  it('flags string-literal guardrail keys', () => {
+    const result = runObject([stringProp('slowView')])
+    expect(result).toHaveLength(1)
+  })
+
+  it('reports each disabled guardrail independently', () => {
+    const result = runObject([prop('slowView'), prop('freezeModel')])
+    expect(result).toHaveLength(2)
+  })
+
+  it('does not flag guardrails set to true', () => {
+    const result = runObject([
+      prop('slowView', Testing.boolLiteral(true)),
+      prop('freezeModel', Testing.boolLiteral(true)),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag dynamic false values', () => {
+    const result = runObject([prop('slowView', Testing.id('disabled'))])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag unrelated keys set to false', () => {
+    const result = runObject([prop('devTools'), stringProp('guardrails')])
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips computed guardrail-like keys', () => {
+    const result = runObject([computedProp('slowView')])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-duplicate-onmount-per-element.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-duplicate-onmount-per-element.test.ts
@@ -1,0 +1,111 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-duplicate-onmount-per-element.ts'
+
+const array = (elements: ReadonlyArray<unknown>) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const onMount = (name: string) =>
+  Testing.callExpr('OnMount', [Testing.id(name)])
+
+const memberOnMount = (namespace: string, name: string) => ({
+  type: 'CallExpression',
+  callee: Testing.memberExpr(namespace, 'OnMount'),
+  arguments: [Testing.id(name)],
+})
+
+const deepMemberOnMount = (name: string) => ({
+  type: 'CallExpression',
+  callee: Testing.chainedMemberExpr('Foldkit', 'Html', 'OnMount'),
+  arguments: [Testing.id(name)],
+})
+
+const conditionalMount = () => ({
+  type: 'ConditionalExpression',
+  test: Testing.id('condition'),
+  consequent: onMount('A'),
+  alternate: onMount('B'),
+})
+
+describe('no-duplicate-onmount-per-element', () => {
+  it('flags multiple bare OnMount calls in one attribute array', () => {
+    const result = Testing.runRule(
+      rule,
+      'ArrayExpression',
+      array([onMount('A'), onMount('B')]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Only one `OnMount`')
+  })
+
+  it('flags mixed bare and member-form OnMount calls', () => {
+    const result = Testing.runRule(
+      rule,
+      'ArrayExpression',
+      array([onMount('A'), memberOnMount('h', 'B')]),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags member paths ending in OnMount', () => {
+    const result = Testing.runRule(
+      rule,
+      'ArrayExpression',
+      array([memberOnMount('h', 'A'), deepMemberOnMount('B')]),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag a single OnMount call', () => {
+    const result = Testing.runRule(
+      rule,
+      'ArrayExpression',
+      array([Testing.callExpr('Class'), onMount('A')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag conditional top-level OnMount alternatives', () => {
+    const result = Testing.runRule(
+      rule,
+      'ArrayExpression',
+      array([conditionalMount()]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not count nested OnMount calls inside non-top-level expressions', () => {
+    const result = Testing.runRule(
+      rule,
+      'ArrayExpression',
+      array([Testing.callExpr('MaybeAttribute', [onMount('A')]), onMount('B')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag arrays with no OnMount calls', () => {
+    const result = Testing.runRule(
+      rule,
+      'ArrayExpression',
+      array([Testing.callExpr('Class'), Testing.callExpr('Id')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('ignores computed member calls', () => {
+    const computed = {
+      type: 'CallExpression',
+      callee: Testing.computedMemberExpr('h', 'OnMount'),
+      arguments: [Testing.id('A')],
+    }
+    const result = Testing.runRule(
+      rule,
+      'ArrayExpression',
+      array([computed, onMount('B')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-explicit-command-type-annotation.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-explicit-command-type-annotation.test.ts
@@ -1,0 +1,63 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-explicit-command-type-annotation.ts'
+
+/**
+ * Build a `TSTypeReference` to `name` with optional `typeArguments`.
+ *
+ * `tsTypeRef` from Testing always sets `typeArguments: null`; this rule
+ * specifically requires `typeArguments !== null`, so for the positive
+ * case we need to override.
+ */
+const tsTypeRefWithArgs = (name: string): unknown => ({
+  type: 'TSTypeReference',
+  typeName: Testing.id(name),
+  typeArguments: { type: 'TSTypeParameterInstantiation', params: [] },
+})
+
+describe('no-explicit-command-type-annotation', () => {
+  it('flags `Command<...>` (TSTypeReference with typeArguments)', () => {
+    const result = Testing.runRule(
+      rule,
+      'TSTypeReference',
+      tsTypeRefWithArgs('Command'),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Command<...>')
+  })
+
+  it('does not flag bare `Command` (no type arguments)', () => {
+    // Without `<...>` the annotation is just a re-export reference, not an
+    // explicit Effect-shape constraint.
+    const result = Testing.runRule(
+      rule,
+      'TSTypeReference',
+      Testing.tsTypeRef('Command'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `Foo<...>` (different identifier)', () => {
+    const result = Testing.runRule(
+      rule,
+      'TSTypeReference',
+      tsTypeRefWithArgs('Foo'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag a qualified type like `M.Command<...>`', () => {
+    // typeName is a TSQualifiedName, not an Identifier.
+    const result = Testing.runRule(rule, 'TSTypeReference', {
+      type: 'TSTypeReference',
+      typeName: {
+        type: 'TSQualifiedName',
+        left: Testing.id('M'),
+        right: Testing.id('Command'),
+      },
+      typeArguments: { type: 'TSTypeParameterInstantiation', params: [] },
+    })
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-hand-rolled-command-struct.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-hand-rolled-command-struct.test.ts
@@ -1,0 +1,143 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-hand-rolled-command-struct.ts'
+
+const spread = (argument: unknown) => ({
+  type: 'SpreadElement',
+  argument,
+})
+
+const computedProperty = (key: unknown, value: unknown) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: true,
+  method: false,
+  shorthand: false,
+  key,
+  value,
+})
+
+const objectWithProperties = (properties: ReadonlyArray<unknown>) => ({
+  type: 'ObjectExpression',
+  properties: Array.from(properties),
+})
+
+describe('no-hand-rolled-command-struct', () => {
+  it('flags `{ name, effect }` Command-shaped object literals', () => {
+    const result = Testing.runRule(
+      rule,
+      'ObjectExpression',
+      Testing.objectExpr([
+        { key: 'name', value: Testing.strLiteral('SaveDraft') },
+        { key: 'effect', value: Testing.id('effect') },
+      ]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Command.define')
+  })
+
+  it('flags `{ name, args, effect }` Command-shaped object literals', () => {
+    const result = Testing.runRule(
+      rule,
+      'ObjectExpression',
+      Testing.objectExpr([
+        { key: 'name', value: Testing.strLiteral('SaveDraft') },
+        { key: 'args', value: Testing.objectExpr([]) },
+        { key: 'effect', value: Testing.id('effect') },
+      ]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('name, args, effect')
+  })
+
+  it('flags string-literal keys with the same command struct shape', () => {
+    const result = Testing.runRule(
+      rule,
+      'ObjectExpression',
+      Testing.objectExprLiteralKeys([
+        { key: 'name', value: Testing.strLiteral('SaveDraft') },
+        { key: 'effect', value: Testing.id('effect') },
+      ]),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags object spread plus explicit `effect` rebuilds', () => {
+    const result = Testing.runRule(
+      rule,
+      'ObjectExpression',
+      objectWithProperties([
+        spread(Testing.id('command')),
+        {
+          type: 'Property',
+          kind: 'init',
+          computed: false,
+          method: false,
+          shorthand: false,
+          key: Testing.id('effect'),
+          value: Testing.id('nextEffect'),
+        },
+      ]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Command.mapEffect')
+  })
+
+  it('does not flag object literals with extra non-command keys', () => {
+    const result = Testing.runRule(
+      rule,
+      'ObjectExpression',
+      Testing.objectExpr([
+        { key: 'name', value: Testing.strLiteral('SaveDraft') },
+        { key: 'effect', value: Testing.id('effect') },
+        { key: 'metadata', value: Testing.objectExpr([]) },
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag config objects that only happen to have `effect`', () => {
+    const result = Testing.runRule(
+      rule,
+      'ObjectExpression',
+      Testing.objectExpr([
+        { key: 'effect', value: Testing.id('effect') },
+        { key: 'policy', value: Testing.strLiteral('retry') },
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag spreads without an explicit `effect` property', () => {
+    const result = Testing.runRule(
+      rule,
+      'ObjectExpression',
+      objectWithProperties([
+        spread(Testing.id('command')),
+        {
+          type: 'Property',
+          kind: 'init',
+          computed: false,
+          method: false,
+          shorthand: false,
+          key: Testing.id('args'),
+          value: Testing.objectExpr([]),
+        },
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not treat computed `effect` keys as explicit command rebuilds', () => {
+    const result = Testing.runRule(
+      rule,
+      'ObjectExpression',
+      objectWithProperties([
+        spread(Testing.id('command')),
+        computedProperty(Testing.id('effectKey'), Testing.id('nextEffect')),
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-hand-rolled-form-controls.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-hand-rolled-form-controls.test.ts
@@ -1,0 +1,98 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-hand-rolled-form-controls.ts'
+
+const arr = (elements: ReadonlyArray<unknown>) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const spread = (object: string, property: string) => ({
+  type: 'SpreadElement',
+  argument: {
+    type: 'MemberExpression',
+    object: Testing.id(object),
+    property: Testing.id(property),
+    computed: false,
+  },
+})
+
+describe('no-hand-rolled-form-controls', () => {
+  it('flags bare `input([...], [])`', () => {
+    const node = Testing.callExpr('input', [arr([]), arr([])])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Ui.Input.view')
+  })
+
+  it('flags bare `textarea([...], [])`', () => {
+    const node = Testing.callExpr('textarea', [arr([]), arr([])])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Ui.Textarea.view')
+  })
+
+  it('flags bare `button([...], [...])`', () => {
+    const node = Testing.callExpr('button', [
+      arr([]),
+      arr([Testing.strLiteral('Submit')]),
+    ])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Ui.Button')
+  })
+
+  it('does not flag `button([...attributes.button, ...], [...])` (Ui.Button toView callback)', () => {
+    const node = Testing.callExpr('button', [
+      arr([
+        spread('attributes', 'button'),
+        Testing.callExpr('Class', [Testing.strLiteral('custom')]),
+      ]),
+      arr([Testing.id('label')]),
+    ])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `input([...attributes.input], [])` (Ui.Input toView callback)', () => {
+    const node = Testing.callExpr('input', [
+      arr([spread('attributes', 'input')]),
+      arr([]),
+    ])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag unrelated calls', () => {
+    const node = Testing.callExpr('span', [arr([]), arr([])])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag calls whose callee is not `input`/`textarea`/`button`', () => {
+    const node = Testing.callExpr('viewSomething', [arr([])])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag spreads of other identifiers (e.g. `...inputAttrs`)', () => {
+    const node = Testing.callExpr('input', [
+      arr([
+        {
+          type: 'SpreadElement',
+          argument: Testing.id('inputAttrs'),
+        },
+      ]),
+      arr([]),
+    ])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags `input()` with no arguments at all', () => {
+    const node = Testing.callExpr('input', [])
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-hardcoded-route-strings.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-hardcoded-route-strings.test.ts
@@ -1,0 +1,114 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-hardcoded-route-strings.ts'
+
+const tplLit = (head: string): unknown => ({
+  type: 'TemplateLiteral',
+  quasis: [{ type: 'TemplateElement', value: { cooked: head, raw: head } }],
+  expressions: [],
+})
+
+describe('no-hardcoded-route-strings', () => {
+  // ── literal-string forms ────────────────────────────────
+  it.each(['Href', 'navigateInternal', 'loadExternalUrl'])(
+    'flags `%s("/path")`',
+    fn => {
+      const result = Testing.runRule(
+        rule,
+        'CallExpression',
+        Testing.callExpr(fn, [Testing.strLiteral('/path')]),
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0]?.diagnostic.message).toContain(fn)
+      expect(result[0]?.diagnostic.message).toContain('/path')
+    },
+  )
+
+  it('flags `Href("https://example.com")`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Href', [Testing.strLiteral('https://example.com')]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('https://example.com')
+  })
+
+  it('flags `Href("http://example.com")`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Href', [Testing.strLiteral('http://example.com')]),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  // ── template-literal forms ──────────────────────────────
+  it('flags `Href(`/users/${id}`)` (template-literal route)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Href', [tplLit('/users/')]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('template')
+  })
+
+  // ── allowed: bidirectional router calls ─────────────────
+  it('does not flag `Href(homeRouter())`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Href', [Testing.callExpr('homeRouter', [])]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `Href(someVar)` (non-literal arg)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Href', [Testing.id('someVar')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  // ── non-routing functions ───────────────────────────────
+  it('does not flag `console.log("/path")` (not a routing function)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('console', 'log', [Testing.strLiteral('/path')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `foo("/path")` (not a routing function)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('foo', [Testing.strLiteral('/path')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  // ── strings that don't look like routes ─────────────────
+  it('does not flag `Href("home")` (not starting with `/` or `http(s)://`)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Href', [Testing.strLiteral('home')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `Href(`api-${endpoint}`)` (template not starting with route prefix)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Href', [tplLit('api-')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-impure-calls-in-pure-layer.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-impure-calls-in-pure-layer.test.ts
@@ -1,0 +1,147 @@
+import type { ESTree } from 'effect-oxlint'
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-impure-calls-in-pure-layer.ts'
+
+const updateFile = '/repo/apps/ui/src/page/tasks/update.ts'
+const viewFile = '/repo/apps/ui/src/page/tasks/view/row.ts'
+const commandFile = '/repo/apps/ui/src/page/tasks/command.ts'
+
+const runCall = (
+  node: ESTree.CallExpression,
+  opts: {
+    readonly filename?: string
+    readonly isGlobalReference?: boolean
+  } = {},
+) => {
+  const mock = Testing.createMockContext({
+    filename: opts.filename ?? updateFile,
+  })
+  Object.defineProperty(mock.context.sourceCode, 'isGlobalReference', {
+    value: () => opts.isGlobalReference ?? true,
+  })
+  const visitors = rule.create(mock.context)
+  visitors.CallExpression?.(node)
+  return mock.diagnostics
+}
+
+const runNew = (
+  node: ESTree.NewExpression,
+  opts: {
+    readonly filename?: string
+  } = {},
+) => {
+  const mock = Testing.createMockContext({
+    filename: opts.filename ?? updateFile,
+  })
+  const visitors = rule.create(mock.context)
+  visitors.NewExpression?.(node)
+  return mock.diagnostics
+}
+
+const runIdentifier = (
+  node: ESTree.IdentifierName,
+  opts: {
+    readonly filename?: string
+    readonly isGlobalReference?: boolean
+  } = {},
+) => {
+  const mock = Testing.createMockContext({
+    filename: opts.filename ?? viewFile,
+  })
+  Object.defineProperty(mock.context.sourceCode, 'isGlobalReference', {
+    value: () => opts.isGlobalReference ?? true,
+  })
+  const visitors = rule.create(mock.context)
+  visitors.Identifier?.(node)
+  return mock.diagnostics
+}
+
+describe('no-impure-calls-in-pure-layer', () => {
+  it('flags `Date.now()` in update files', () => {
+    const result = runCall(Testing.callOfMember('Date', 'now'))
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Date.now')
+  })
+
+  it('flags `Math.random()` in view subdirectories', () => {
+    const result = runCall(Testing.callOfMember('Math', 'random'), {
+      filename: viewFile,
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Math.random')
+  })
+
+  it('flags `performance.now()` and `crypto.randomUUID()`', () => {
+    const performanceResult = runCall(
+      Testing.callOfMember('performance', 'now'),
+    )
+    const cryptoResult = runCall(Testing.callOfMember('crypto', 'randomUUID'))
+    expect(performanceResult).toHaveLength(1)
+    expect(cryptoResult).toHaveLength(1)
+  })
+
+  it('flags zero-argument `new Date()`', () => {
+    const result = runNew(Testing.newExpr('Date'))
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('new Date()')
+  })
+
+  it('does not flag `new Date(value)`', () => {
+    const result = runNew(Testing.newExpr('Date', [Testing.id('value')]))
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags global browser identifiers like `window`', () => {
+    const result = runIdentifier(Testing.id('window'))
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('window')
+  })
+
+  it('does not flag shadowed browser identifiers', () => {
+    const result = runIdentifier(Testing.id('document'), {
+      isGlobalReference: false,
+    })
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag static object property keys named like globals', () => {
+    const key = Testing.id('window')
+    const property = {
+      type: 'Property',
+      computed: false,
+      key,
+      value: Testing.strLiteral('ok'),
+    }
+    Object.defineProperty(key, 'parent', { value: property })
+    const result = runIdentifier(key)
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags any `.addEventListener(...)` call', () => {
+    const result = runCall(
+      Testing.callOfMember('element', 'addEventListener', [
+        Testing.strLiteral('click'),
+        Testing.arrowFn(),
+      ]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('addEventListener')
+  })
+
+  it('does not flag impure calls inside `Command.define` factories', () => {
+    const dateNow = Testing.callOfMember('Date', 'now')
+    const defineCall = Testing.callOfMember('Command', 'define', [dateNow])
+    Object.defineProperty(dateNow, 'parent', { value: defineCall })
+    const result = runCall(dateNow)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not run outside pure-layer files', () => {
+    const result = runCall(Testing.callOfMember('Date', 'now'), {
+      filename: commandFile,
+    })
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-raw-dom-event-attributes.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-raw-dom-event-attributes.test.ts
@@ -1,0 +1,166 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-raw-dom-event-attributes.ts'
+
+const templateLiteral = (value: string) => ({
+  type: 'TemplateLiteral',
+  expressions: [],
+  quasis: [
+    {
+      type: 'TemplateElement',
+      value: { cooked: value, raw: value },
+      tail: true,
+    },
+  ],
+})
+
+const dynamicTemplateLiteral = (head: string) => ({
+  type: 'TemplateLiteral',
+  expressions: [Testing.id('eventName')],
+  quasis: [
+    {
+      type: 'TemplateElement',
+      value: { cooked: head, raw: head },
+      tail: false,
+    },
+    {
+      type: 'TemplateElement',
+      value: { cooked: '', raw: '' },
+      tail: true,
+    },
+  ],
+})
+
+const memberCall = (
+  object: string,
+  property: string,
+  args: ReadonlyArray<unknown>,
+) => ({
+  type: 'CallExpression',
+  callee: Testing.memberExpr(object, property),
+  arguments: Array.from(args),
+})
+
+const typeArguments = (params: ReadonlyArray<unknown>) => ({
+  type: 'TSTypeParameterInstantiation',
+  params: Array.from(params),
+})
+
+const htmlCall = (typeArgs?: unknown) => ({
+  type: 'CallExpression',
+  callee: Testing.id('html'),
+  typeArguments: typeArgs,
+  arguments: [],
+})
+
+const neverType = { type: 'TSNeverKeyword' }
+const stringType = { type: 'TSStringKeyword' }
+
+const sourceFile = { filename: '/repo/apps/ui/src/view.ts' }
+const crashViewFile = { filename: '/repo/apps/ui/src/crash-view.ts' }
+
+describe('no-raw-dom-event-attributes', () => {
+  it('flags raw event Attribute calls outside crash-view.ts', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Attribute', [Testing.strLiteral('onclick')]),
+      sourceFile,
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('onclick')
+  })
+
+  it('flags raw event Prop calls outside crash-view.ts', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Prop', [Testing.strLiteral('onInput')]),
+      sourceFile,
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags member-form h.Attribute and h.Prop calls', () => {
+    const attribute = memberCall('h', 'Attribute', [
+      Testing.strLiteral('onmouseover'),
+    ])
+    const prop = memberCall('h', 'Prop', [Testing.strLiteral('ONCLICK')])
+    expect(
+      Testing.runRule(rule, 'CallExpression', attribute, sourceFile),
+    ).toHaveLength(1)
+    expect(
+      Testing.runRule(rule, 'CallExpression', prop, sourceFile),
+    ).toHaveLength(1)
+  })
+
+  it('flags static template-literal event names', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Attribute', [templateLiteral('onkeyup')]),
+      sourceFile,
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag non-event attributes or dynamic event-name templates', () => {
+    const classAttr = Testing.callExpr('Attribute', [
+      Testing.strLiteral('class'),
+    ])
+    const dynamic = Testing.callExpr('Attribute', [
+      dynamicTemplateLiteral('on'),
+    ])
+    expect(
+      Testing.runRule(rule, 'CallExpression', classAttr, sourceFile),
+    ).toHaveLength(0)
+    expect(
+      Testing.runRule(rule, 'CallExpression', dynamic, sourceFile),
+    ).toHaveLength(0)
+  })
+
+  it('allows raw event attributes in crash-view.ts', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Attribute', [Testing.strLiteral('onclick')]),
+      crashViewFile,
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('requires crash-view.ts html calls to use a never Message type', () => {
+    expect(
+      Testing.runRule(rule, 'CallExpression', htmlCall(), crashViewFile),
+    ).toHaveLength(1)
+    expect(
+      Testing.runRule(
+        rule,
+        'CallExpression',
+        htmlCall(typeArguments([stringType])),
+        crashViewFile,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('allows crash-view.ts html<never>() calls', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      htmlCall(typeArguments([neverType])),
+      crashViewFile,
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags crash-view.ts html calls with extra type parameters', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      htmlCall(typeArguments([neverType, stringType])),
+      crashViewFile,
+    )
+    expect(result).toHaveLength(1)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/no-spread-in-evo.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-spread-in-evo.test.ts
@@ -1,0 +1,163 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/no-spread-in-evo.ts'
+
+/** Build `evo(model, updates)` where `updates` is the supplied object expression. */
+const evoCall = (updates: unknown) =>
+  Testing.callExpr('evo', [Testing.id('model'), updates])
+
+/**
+ * `{ field: () => <body> }` — the wrapping update for one field.
+ * Tests pass an arrow body to validate spread detection in expression-bodied
+ * and block-bodied updaters.
+ */
+const updaterField = (field: string, arrowBody: unknown) =>
+  Testing.objectExpr([
+    {
+      key: field,
+      value: Testing.arrowFn(arrowBody),
+    },
+  ])
+
+describe('no-spread-in-evo', () => {
+  it('flags `evo(m, { f: () => ({ ...m.f, x: 1 }) })` (expression-body spread)', () => {
+    const innerObj = Testing.objectExprWithSpread(
+      Testing.memberExpr('model', 'f'),
+    )
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      evoCall(updaterField('f', innerObj)),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('field `f`')
+    expect(result[0]?.diagnostic.message).toContain('nested `evo`')
+  })
+
+  it('flags spread inside a block-body updater', () => {
+    const innerObj = Testing.objectExprWithSpread(
+      Testing.memberExpr('model', 'f'),
+    )
+    const blockBody = Testing.blockStmt([Testing.returnStmt(innerObj)])
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      evoCall(updaterField('f', blockBody)),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('field `f`')
+  })
+
+  it('flags spreads in multiple fields independently', () => {
+    const spreadObj = Testing.objectExprWithSpread(
+      Testing.memberExpr('model', 'a'),
+    )
+    const updates = Testing.objectExpr([
+      { key: 'a', value: Testing.arrowFn(spreadObj) },
+      { key: 'b', value: Testing.arrowFn(spreadObj) },
+    ])
+    const result = Testing.runRule(rule, 'CallExpression', evoCall(updates))
+    expect(result).toHaveLength(2)
+  })
+
+  it('does not flag a clean `evo(m, { f: () => evo(m.f, { x: 1 }) })`', () => {
+    const nestedEvo = Testing.callExpr('evo', [
+      Testing.memberExpr('model', 'f'),
+      Testing.objectExpr([{ key: 'x', value: Testing.numLiteral(1) }]),
+    ])
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      evoCall(updaterField('f', nestedEvo)),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `evo(m, { f: () => ({ x: 1 }) })` (object literal without spread)', () => {
+    const cleanObj = Testing.objectExpr([
+      { key: 'x', value: Testing.numLiteral(1) },
+    ])
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      evoCall(updaterField('f', cleanObj)),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag spread combined with a computed key (dynamic record update)', () => {
+    // `expanded: (x) => ({ ...x, [slug]: !v })` — a computed-key update that a
+    // static nested `evo` cannot express, so the spread is legitimate.
+    const spreadPlusComputed = {
+      type: 'ObjectExpression',
+      properties: [
+        {
+          type: 'SpreadElement',
+          argument: Testing.id('x'),
+        },
+        {
+          type: 'Property',
+          key: Testing.id('slug'),
+          value: Testing.unaryExpr('!', Testing.id('v')),
+          computed: true,
+        },
+      ],
+    }
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      evoCall(updaterField('expanded', spreadPlusComputed)),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('still flags spread combined with only static keys', () => {
+    const spreadPlusStatic = {
+      type: 'ObjectExpression',
+      properties: [
+        {
+          type: 'SpreadElement',
+          argument: Testing.memberExpr('model', 'f'),
+        },
+        {
+          type: 'Property',
+          key: Testing.id('y'),
+          value: Testing.numLiteral(1),
+          computed: false,
+        },
+      ],
+    }
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      evoCall(updaterField('f', spreadPlusStatic)),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('field `f`')
+  })
+
+  it('does not flag a non-`evo` call with the same shape', () => {
+    const innerObj = Testing.objectExprWithSpread(
+      Testing.memberExpr('model', 'f'),
+    )
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('foo', [
+        Testing.id('model'),
+        updaterField('f', innerObj),
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `evo(m, x)` (second arg not an object literal)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('evo', [Testing.id('model'), Testing.id('x')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/prefer-dom-helpers-for-element-ops.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/prefer-dom-helpers-for-element-ops.test.ts
@@ -1,0 +1,205 @@
+import type { ESTree } from 'effect-oxlint'
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/prefer-dom-helpers-for-element-ops.ts'
+
+const commandFile = '/repo/apps/ui/src/page/chat/command.ts'
+const viewFile = '/repo/apps/ui/src/page/chat/view.ts'
+
+const parent = (child: object, value: object) => {
+  Object.defineProperty(child, 'parent', { value })
+}
+
+const runCall = (
+  node: ESTree.CallExpression,
+  isGlobalReference = true,
+  filename = commandFile,
+) => {
+  const { context, diagnostics } = Testing.createMockContext({ filename })
+  Object.defineProperty(context.sourceCode, 'isGlobalReference', {
+    value: () => isGlobalReference,
+  })
+  const visitors = rule.create(context)
+  visitors.CallExpression?.(node)
+  return diagnostics
+}
+
+const runDeclarator = (
+  node: ESTree.VariableDeclarator,
+  references: ReadonlyArray<{
+    readonly identifier: ESTree.IdentifierName
+    readonly init: boolean
+  }> = [],
+  isGlobalReference = true,
+  filename = commandFile,
+) => {
+  const { context, diagnostics } = Testing.createMockContext({ filename })
+  Object.defineProperty(context.sourceCode, 'isGlobalReference', {
+    value: () => isGlobalReference,
+  })
+  Object.defineProperty(context.sourceCode, 'getDeclaredVariables', {
+    value: () => [
+      {
+        name: 'el',
+        references,
+      },
+    ],
+  })
+  const visitors = rule.create(context)
+  visitors.VariableDeclarator?.(node)
+  return diagnostics
+}
+
+const documentQuery = (
+  method: 'getElementById' | 'querySelector' = 'getElementById',
+) => Testing.callOfMember('document', method, [Testing.strLiteral('target')])
+
+const methodCallOn = (receiver: unknown, method: string, optional = false) => {
+  const node = Testing.callExpr('placeholder')
+  Object.defineProperty(node, 'callee', {
+    value: {
+      type: 'MemberExpression',
+      object: receiver,
+      property: Testing.id(method),
+      computed: false,
+      optional,
+    },
+  })
+  Object.defineProperty(node, 'optional', { value: false })
+  return node
+}
+
+const constQueryDeclarator = () => {
+  const declarator = Testing.varDeclarator('el', documentQuery())
+  parent(declarator, {
+    type: 'VariableDeclaration',
+    kind: 'const',
+    declarations: [declarator],
+  })
+  return declarator
+}
+
+const receiverReference = (method: string) => {
+  const identifier = Testing.id('el')
+  const member = {
+    type: 'MemberExpression',
+    object: identifier,
+    property: Testing.id(method),
+    computed: false,
+    optional: false,
+  }
+  const call = { type: 'CallExpression', callee: member, arguments: [] }
+  parent(identifier, member)
+  parent(member, call)
+  return identifier
+}
+
+const ifGuardReference = () => {
+  const identifier = Testing.id('el')
+  const statement = Testing.ifStmt(identifier)
+  parent(identifier, statement)
+  return identifier
+}
+
+const argumentReference = () => {
+  const identifier = Testing.id('el')
+  const call = Testing.callExpr('doSomething', [identifier])
+  parent(identifier, call)
+  return identifier
+}
+
+const reference = (identifier: ESTree.IdentifierName) => ({
+  identifier,
+  init: false,
+})
+
+describe('prefer-dom-helpers-for-element-ops', () => {
+  it.each(['focus', 'scrollIntoView', 'click', 'showModal', 'close'])(
+    'flags direct document query `%s()` calls in command files',
+    method => {
+      const result = runCall(methodCallOn(documentQuery(), method, true))
+      expect(result).toHaveLength(1)
+      expect(result[0]?.diagnostic.message).toContain('Dom')
+      expect(result[0]?.diagnostic.message).toContain(method)
+    },
+  )
+
+  it('flags direct querySelector chains', () => {
+    const result = runCall(
+      methodCallOn(documentQuery('querySelector'), 'showModal'),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag unrelated direct DOM calls', () => {
+    const result = runCall(methodCallOn(documentQuery(), 'setSelectionRange'))
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag local document-shaped values', () => {
+    const result = runCall(methodCallOn(documentQuery(), 'focus'), false)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not run outside command/subscription files', () => {
+    const result = runCall(
+      methodCallOn(documentQuery(), 'focus'),
+      true,
+      viewFile,
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags query variables whose only reads are target method receivers plus existence guards', () => {
+    const result = runDeclarator(constQueryDeclarator(), [
+      reference(ifGuardReference()),
+      reference(receiverReference('focus')),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('document.getElementById')
+  })
+
+  it('flags query variables used as optional target method receivers', () => {
+    const result = runDeclarator(constQueryDeclarator(), [
+      reference(receiverReference('scrollIntoView')),
+    ])
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag query variables also passed to unrelated code', () => {
+    const result = runDeclarator(constQueryDeclarator(), [
+      reference(receiverReference('focus')),
+      reference(argumentReference()),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag focus plus setSelectionRange pairs', () => {
+    const result = runDeclarator(constQueryDeclarator(), [
+      reference(receiverReference('focus')),
+      reference(receiverReference('setSelectionRange')),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag query variables with no target method receiver reads', () => {
+    const result = runDeclarator(constQueryDeclarator(), [
+      reference(ifGuardReference()),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag non-const query variables', () => {
+    const declarator = Testing.varDeclarator('el', documentQuery())
+    parent(declarator, {
+      type: 'VariableDeclaration',
+      kind: 'let',
+      declarations: [declarator],
+    })
+    const result = runDeclarator(declarator, [
+      reference(receiverReference('focus')),
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/prefer-empty-over-empty-element.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/prefer-empty-over-empty-element.test.ts
@@ -1,0 +1,101 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/prefer-empty-over-empty-element.ts'
+
+const arr = (elements: ReadonlyArray<unknown> = []) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const emptyArr = arr([])
+
+describe('prefer-empty-over-empty-element', () => {
+  // ── bare-identifier hyperscript helpers ─────────────────
+  it.each(['span', 'div', 'p', 'section', 'article'])(
+    'flags `%s([], [])`',
+    elementName => {
+      const result = Testing.runRule(
+        rule,
+        'CallExpression',
+        Testing.callExpr(elementName, [emptyArr, emptyArr]),
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0]?.diagnostic.message).toContain(elementName)
+      expect(result[0]?.diagnostic.message).toContain('`empty`')
+    },
+  )
+
+  // ── member-style hyperscript helpers (`h.span([], [])`) ──
+  it('flags `h.span([], [])` and recommends `h.empty`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('h', 'span', [emptyArr, emptyArr]),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('h.empty')
+  })
+
+  // ── allowed: non-empty children or attributes ───────────
+  it('does not flag `span([], [text("hi")])`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('span', [
+        emptyArr,
+        arr([Testing.callExpr('text', [Testing.strLiteral('hi')])]),
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `span([Class("a")], [])`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('span', [
+        arr([Testing.callExpr('Class', [Testing.strLiteral('a')])]),
+        emptyArr,
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `span([])` (one arg, missing children)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('span', [emptyArr]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  // ── non-target elements ─────────────────────────────────
+  it('does not flag `button([], [])` (not in the empty-able list)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('button', [emptyArr, emptyArr]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `Foo([], [])` (PascalCase identifier, not a hyperscript helper)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('Foo', [emptyArr, emptyArr]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `obj.button([], [])` (member callee but not a known element)', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callOfMember('h', 'button', [emptyArr, emptyArr]),
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/prefer-evo-over-model-spread.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/prefer-evo-over-model-spread.test.ts
@@ -1,0 +1,117 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/prefer-evo-over-model-spread.ts'
+
+const UPDATE_FILE = '/repo/apps/ui/src/page/tasks/update.ts'
+const VIEW_FILE = '/repo/apps/ui/src/page/tasks/view.ts'
+
+const modelSpreadObject = () =>
+  Testing.objectExprWithSpread(Testing.id('model'))
+
+const arraySpread = () => ({
+  type: 'ArrayExpression',
+  elements: [
+    {
+      type: 'SpreadElement',
+      argument: Testing.memberExpr('model', 'items'),
+    },
+  ],
+})
+
+const arrowWithParams = (params: ReadonlyArray<string>, body: unknown) =>
+  Testing.arrowFn(
+    body,
+    params.map(param => Testing.id(param)),
+  )
+
+const runInArrow = (
+  fn: object,
+  object: object,
+  filename: string = UPDATE_FILE,
+) =>
+  Testing.runRuleMulti(
+    rule,
+    [
+      ['ArrowFunctionExpression', fn],
+      ['ObjectExpression', object],
+      ['ArrowFunctionExpression:exit', fn],
+    ],
+    { filename },
+  )
+
+const functionDeclaration = (params: ReadonlyArray<string>, body: unknown) => ({
+  type: 'FunctionDeclaration',
+  params: params.map(Testing.id),
+  body,
+})
+
+describe('prefer-evo-over-model-spread', () => {
+  it('flags object-spreading a `model` parameter in update.ts', () => {
+    const object = modelSpreadObject()
+    const fn = arrowWithParams(['model', 'message'], object)
+    const result = runInArrow(fn, object)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('evo(model')
+  })
+
+  it('flags object-spreading a `model` parameter under update directories', () => {
+    const object = modelSpreadObject()
+    const fn = arrowWithParams(['model'], object)
+    const result = runInArrow(
+      fn,
+      object,
+      '/repo/apps/ui/src/page/tasks/update/child.ts',
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags function declarations with a `model` parameter', () => {
+    const object = modelSpreadObject()
+    const fn = functionDeclaration(['model'], Testing.blockStmt())
+    const result = Testing.runRuleMulti(
+      rule,
+      [
+        ['FunctionDeclaration', fn],
+        ['ObjectExpression', object],
+        ['FunctionDeclaration:exit', fn],
+      ],
+      { filename: UPDATE_FILE },
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag object spreads of non-model values', () => {
+    const object = Testing.objectExprWithSpread(Testing.id('edit'))
+    const fn = arrowWithParams(['model'], object)
+    const result = runInArrow(fn, object)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag when no in-scope function parameter is named `model`', () => {
+    const object = modelSpreadObject()
+    const fn = arrowWithParams(['state'], object)
+    const result = runInArrow(fn, object)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag array spreads from model fields', () => {
+    const fn = arrowWithParams(['model'], arraySpread())
+    const result = Testing.runRuleMulti(
+      rule,
+      [
+        ['ArrowFunctionExpression', fn],
+        ['ArrowFunctionExpression:exit', fn],
+      ],
+      { filename: UPDATE_FILE },
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not run outside update files', () => {
+    const object = modelSpreadObject()
+    const fn = arrowWithParams(['model'], object)
+    const result = runInArrow(fn, object, VIEW_FILE)
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/prefer-option-match-over-map-getorelse.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/prefer-option-match-over-map-getorelse.test.ts
@@ -1,0 +1,114 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/prefer-option-match-over-map-getorelse.ts'
+
+const optionMap = (...args: ReadonlyArray<unknown>) =>
+  Testing.callOfMember('Option', 'map', args)
+
+const optionGetOrElse = (...args: ReadonlyArray<unknown>) =>
+  Testing.callOfMember('Option', 'getOrElse', args)
+
+const optionMatch = (...args: ReadonlyArray<unknown>) =>
+  Testing.callOfMember('Option', 'match', args)
+
+describe('prefer-option-match-over-map-getorelse', () => {
+  // ── method-form pipe: Option.map(...).pipe(Option.getOrElse(...)) ──
+  it('flags `Option.map(...).pipe(Option.getOrElse(...))`', () => {
+    const node = {
+      type: 'CallExpression',
+      callee: {
+        type: 'MemberExpression',
+        object: optionMap(Testing.arrowFn()),
+        property: Testing.id('pipe'),
+        computed: false,
+        optional: false,
+      },
+      arguments: [optionGetOrElse(Testing.arrowFn())],
+    }
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Option.match')
+  })
+
+  // ── freestanding pipe form: pipe(value, Option.map, Option.getOrElse) ──
+  it('flags `pipe(value, Option.map(...), Option.getOrElse(...))`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('pipe', [
+        Testing.id('value'),
+        optionMap(Testing.arrowFn()),
+        optionGetOrElse(Testing.arrowFn()),
+      ]),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags pipe with `Option.map` ⟶ `Option.getOrElse` even when other steps surround them', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('pipe', [
+        Testing.id('value'),
+        optionMap(Testing.arrowFn()),
+        optionGetOrElse(Testing.arrowFn()),
+        Testing.callExpr('trimEnd'),
+      ]),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  // ── correct usage ────────────────────────────────────────
+  it('does not flag direct `Option.match(...)`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      optionMatch(Testing.id('opt'), Testing.objectExpr([])),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag a pipe with only `Option.map` and no `Option.getOrElse`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('pipe', [
+        Testing.id('value'),
+        optionMap(Testing.arrowFn()),
+        Testing.callOfMember('Option', 'flatMap', [Testing.arrowFn()]),
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag a pipe with only `Option.getOrElse` and no `Option.map`', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('pipe', [
+        Testing.id('value'),
+        optionGetOrElse(Testing.arrowFn()),
+      ]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `Option.map(...).pipe(...)` without `Option.getOrElse`', () => {
+    const node = {
+      type: 'CallExpression',
+      callee: {
+        type: 'MemberExpression',
+        object: optionMap(Testing.arrowFn()),
+        property: Testing.id('pipe'),
+        computed: false,
+        optional: false,
+      },
+      arguments: [
+        Testing.callOfMember('Option', 'flatMap', [Testing.arrowFn()]),
+      ],
+    }
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/prefer-story-command-matchers.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/prefer-story-command-matchers.test.ts
@@ -1,0 +1,152 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/prefer-story-command-matchers.ts'
+
+const testFile = '/repo/apps/ui/test/page/tasks/tasks.story.test.ts'
+const sourceFile = '/repo/apps/ui/src/page/tasks/update.ts'
+
+const runCall = (node: unknown, filename = testFile) =>
+  Testing.runRule(rule, 'CallExpression', node, { filename })
+
+const elementAccess = (name = 'commands') =>
+  Testing.computedMemberExpr(name, 'index')
+
+const expectMatcher = (
+  matcher: string,
+  expectArg: unknown,
+  matcherArg: unknown,
+) => {
+  const expectCall = Testing.callExpr('expect', [expectArg])
+  const node = Testing.callExpr('placeholder', [matcherArg])
+  Object.defineProperty(node, 'callee', {
+    value: {
+      type: 'MemberExpression',
+      object: expectCall,
+      property: Testing.id(matcher),
+      computed: false,
+      optional: false,
+    },
+  })
+  return node
+}
+
+const toMatchObject = (expectArg: unknown, objectArg: unknown) =>
+  expectMatcher('toMatchObject', expectArg, objectArg)
+
+const toBe = (expectArg: unknown, value: string) =>
+  expectMatcher('toBe', expectArg, Testing.strLiteral(value))
+
+const commandShape = (name: string, withArgs = false) =>
+  Testing.objectExpr([
+    { key: 'name', value: Testing.strLiteral(name) },
+    ...(withArgs ? [{ key: 'args', value: Testing.objectExpr([]) }] : []),
+  ])
+
+const propertyAccess = (
+  object: unknown,
+  property: string,
+  optional = false,
+) => ({
+  type: 'MemberExpression',
+  object,
+  property: Testing.id(property),
+  computed: false,
+  optional,
+})
+
+describe('prefer-story-command-matchers', () => {
+  it('flags `expect(commands[0]).toMatchObject({ name: ... })`', () => {
+    const result = runCall(
+      toMatchObject(elementAccess('commands'), commandShape('FetchTasks')),
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Story.Command.expect')
+  })
+
+  it('flags name+args command shape matchers', () => {
+    const result = runCall(
+      toMatchObject(
+        elementAccess('pageCommands'),
+        commandShape('CreateTask', true),
+      ),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags singular command collection identifiers', () => {
+    const result = runCall(
+      toMatchObject(elementAccess('command'), commandShape('FetchTask')),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags `expect(commands[0]?.name).toBe(...)`', () => {
+    const result = runCall(
+      toBe(
+        propertyAccess(elementAccess('commands'), 'name', true),
+        'FetchTasks',
+      ),
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag command matcher objects without PascalCase names', () => {
+    const result = runCall(
+      toMatchObject(elementAccess('commands'), commandShape('fetchTasks')),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag objects with non-command keys', () => {
+    const result = runCall(
+      toMatchObject(
+        elementAccess('commands'),
+        Testing.objectExpr([
+          { key: 'name', value: Testing.strLiteral('FetchTasks') },
+          { key: 'status', value: Testing.strLiteral('pending') },
+        ]),
+      ),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag command matcher objects without a name key', () => {
+    const result = runCall(
+      toMatchObject(
+        elementAccess('commands'),
+        Testing.objectExpr([{ key: 'args', value: Testing.objectExpr([]) }]),
+      ),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag toMatchObject when the expected value is not a command element access', () => {
+    const result = runCall(
+      toMatchObject(elementAccess('results'), commandShape('FetchTasks')),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag toBe when the asserted value is not `.name`', () => {
+    const result = runCall(
+      toBe(propertyAccess(elementAccess('commands'), 'label'), 'FetchTasks'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag toBe with non-PascalCase expected strings', () => {
+    const result = runCall(
+      toBe(propertyAccess(elementAccess('commands'), 'name'), 'fetchTasks'),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not run outside apps/ui/test files', () => {
+    const result = runCall(
+      toMatchObject(elementAccess('commands'), commandShape('FetchTasks')),
+      sourceFile,
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/require-completed-mirrors-command.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/require-completed-mirrors-command.test.ts
@@ -1,0 +1,86 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/require-completed-mirrors-command.ts'
+
+const m = (tag: string) => Testing.callExpr('m', [Testing.strLiteral(tag)])
+
+const cmd = (name: string) =>
+  Testing.callOfMember('Command', 'define', [
+    Testing.strLiteral(name),
+    Testing.arrowFn(), // body — not inspected by this rule
+  ])
+
+const programExit = ['Program:exit', { type: 'Program' }] as const
+
+describe('require-completed-mirrors-command', () => {
+  it('flags `m("CompletedX")` when no `Command.define("X", ...)` exists', () => {
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', cmd('FocusInput')],
+      ['CallExpression', m('CompletedInputFocus')], // noun-first, not mirror
+      programExit,
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('CompletedInputFocus')
+    expect(result[0]?.diagnostic.message).toContain('verb-first')
+  })
+
+  it('does not flag `m("CompletedX")` that mirrors `Command.define("X", ...)`', () => {
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', cmd('FocusInput')],
+      ['CallExpression', m('CompletedFocusInput')],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags only the `Completed*` Messages that have no Command mirror', () => {
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', cmd('FocusInput')],
+      ['CallExpression', cmd('FetchWeather')],
+      ['CallExpression', m('CompletedFocusInput')], // mirrors
+      ['CallExpression', m('CompletedSomethingElse')], // doesn't mirror
+      programExit,
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('CompletedSomethingElse')
+  })
+
+  it('does NOT flag when the file defines no Commands at all', () => {
+    // Files without any `Command.define` cannot give a confident judgment —
+    // the `Completed*` may be defined elsewhere and re-used here.
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', m('CompletedAnythingHere')],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag non-`Completed*` Messages', () => {
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', cmd('FocusInput')],
+      ['CallExpression', m('SucceededFocusInput')],
+      ['CallExpression', m('FailedFocusInput')],
+      ['CallExpression', m('ClickedSubmit')],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not crash when `Command.define` has a non-string first argument', () => {
+    // `Command.define(someVar, ...)` — we cannot extract the action name,
+    // so the file is treated as if no Command was defined at all.
+    const result = Testing.runRuleMulti(rule, [
+      [
+        'CallExpression',
+        Testing.callOfMember('Command', 'define', [
+          Testing.id('someVar'),
+          Testing.arrowFn(),
+        ]),
+      ],
+      ['CallExpression', m('CompletedAnything')],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/require-past-tense-message-names.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/require-past-tense-message-names.test.ts
@@ -1,0 +1,141 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/require-past-tense-message-names.ts'
+
+describe('require-past-tense-message-names', () => {
+  const flag = (tag: string) =>
+    Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.strLiteral(tag)]),
+    )
+
+  // ── allowed past-tense prefixes ──────────────────────────
+  it.each([
+    'ClickedSubmit',
+    'UpdatedEmail',
+    'PressedEscape',
+    'SubmittedForm',
+    'ToggledSidebar',
+    'SucceededFetchUser',
+    'FailedFetchUser',
+    'CompletedFocusInput',
+    'GotWeather',
+    'OpenedDialog',
+    'ScrolledFeed',
+  ])('allows `m("%s")`', tag => {
+    expect(flag(tag)).toHaveLength(0)
+  })
+
+  // ── single-word past-tense (end-of-string is allowed) ────
+  it('allows the bare prefix `m("Loaded")`', () => {
+    expect(flag('Loaded')).toHaveLength(0)
+  })
+
+  // ── extended past-tense verbs (verb-first, real call sites) ──
+  it.each([
+    'CreatedTask',
+    'DeletedThought',
+    'ReceivedChatDelta',
+    'CancelledReviewEdit',
+    'CommittedTermEdit',
+    'ConfirmedDeleteJotStack',
+    'AppliedMentionSelection',
+    'ChoseReviewDecision',
+    'ClearedChat',
+    'CopiedPiRuntimeText',
+    'DuplicatedSourceBrief',
+    'IngestedLibraryUrl',
+    'MovedCommandPaletteActive',
+    'RanSourceBrief',
+    'RegeneratedSourceBrief',
+    'ReportedSaveDecisionFailure',
+    'RequestedDeleteSourceBrief',
+    'ResetSourceBriefComposer',
+    'SavedReviewDecision',
+    'SetWritingStyleSourcesSelected',
+    'StartedTermEdit',
+    'StoppedChat',
+    'ChangedRoute',
+  ])('allows `m("%s")`', tag => {
+    expect(flag(tag)).toHaveLength(0)
+  })
+
+  // ── regression: real past-tense UI verbs must not false-positive ──
+  it.each([
+    'FlippedCard',
+    'RenderedDiagrams',
+    'ZoomedIn',
+    'PinnedNote',
+    'UnpinnedNote',
+    'ArchivedThread',
+    'RestoredDraft',
+    'FilteredResults',
+    'SortedColumn',
+    'SearchedLibrary',
+    'HighlightedRange',
+    'RevealedAnswer',
+  ])('allows `m("%s")`', tag => {
+    expect(flag(tag)).toHaveLength(0)
+  })
+
+  it('still flags present-tense `m("StartPractice")`', () => {
+    const result = flag('StartPractice')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('StartPractice')
+  })
+
+  // ── genuine noun-first tags still flag after the allowlist grew ──
+  it.each(['MentionCommitted', 'JotspotMutated', 'PiRuntimeTextCopied'])(
+    'flags noun-first `m("%s")`',
+    tag => {
+      expect(flag(tag)).toHaveLength(1)
+    },
+  )
+
+  it('leaves `m("NoOp")` to the dedicated no-noop-message rule', () => {
+    expect(flag('NoOp')).toHaveLength(0)
+  })
+
+  // ── disallowed prefixes ──────────────────────────────────
+  it.each([
+    ['ChangeEmail', 'present tense `Change*`'],
+    ['ChangingEmail', 'continuous `Changing*`'],
+    ['EmailFocused', 'noun-first `*Focused`'],
+    ['MouseEnter', 'unknown verb'],
+    ['LoadUser', 'imperative `Load*` (use `Loaded*`)'],
+  ])('flags `m("%s")` (%s)', tag => {
+    const result = flag(tag)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(tag)
+  })
+
+  // ── non-targets ──────────────────────────────────────────
+  it('does not flag non-`m` calls with a past-tense prefix string', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('foo', [Testing.strLiteral('LoadUser')]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `m(...)` with a non-string first argument', () => {
+    const result = Testing.runRule(
+      rule,
+      'CallExpression',
+      Testing.callExpr('m', [Testing.numLiteral(0)]),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  // ── boundary: prefix must be followed by uppercase ───────
+  it('does not flag prefix-as-substring without word boundary `m("Loadedness")`', () => {
+    // Note: `Loaded` is in the prefix list. The regex `^Loaded([A-Z]|$)` requires
+    // uppercase or end-of-string after the prefix; `Loadedness` has lowercase after,
+    // so it fails the past-tense check and IS flagged.
+    const result = flag('Loadedness')
+    expect(result).toHaveLength(1)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/require-rel-for-external-link.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/require-rel-for-external-link.test.ts
@@ -1,0 +1,68 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/require-rel-for-external-link.ts'
+
+const arr = (elements: ReadonlyArray<unknown>) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const target = (value: string) =>
+  Testing.callExpr('Target', [Testing.strLiteral(value)])
+
+const rel = (value: string) =>
+  Testing.callExpr('Rel', [Testing.strLiteral(value)])
+
+describe('require-rel-for-external-link', () => {
+  it('flags `[Target("_blank")]` with no `Rel(...)`', () => {
+    const node = arr([target('_blank')])
+    const result = Testing.runRule(rule, 'ArrayExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('noopener noreferrer')
+  })
+
+  it('flags `[Class("link"), Target("_blank")]` (no `Rel`)', () => {
+    const node = arr([
+      Testing.callExpr('Class', [Testing.strLiteral('link')]),
+      target('_blank'),
+    ])
+    const result = Testing.runRule(rule, 'ArrayExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('does not flag `[Target("_blank"), Rel("noopener noreferrer")]`', () => {
+    const node = arr([target('_blank'), rel('noopener noreferrer')])
+    const result = Testing.runRule(rule, 'ArrayExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `[Rel("..."), Target("_blank")]` (any order)', () => {
+    const node = arr([rel('noopener'), target('_blank')])
+    const result = Testing.runRule(rule, 'ArrayExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `[Target("_self")]` (not external)', () => {
+    const node = arr([target('_self')])
+    const result = Testing.runRule(rule, 'ArrayExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag a plain attribute array `[Class("link")]` (no Target)', () => {
+    const node = arr([Testing.callExpr('Class', [Testing.strLiteral('link')])])
+    const result = Testing.runRule(rule, 'ArrayExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag `[Target(someVar)]` (non-literal target)', () => {
+    const node = arr([Testing.callExpr('Target', [Testing.id('someVar')])])
+    const result = Testing.runRule(rule, 'ArrayExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag an empty array', () => {
+    const result = Testing.runRule(rule, 'ArrayExpression', arr([]))
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/require-succeeded-failed-pair.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/require-succeeded-failed-pair.test.ts
@@ -1,0 +1,79 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/require-succeeded-failed-pair.ts'
+
+const m = (tag: string) => Testing.callExpr('m', [Testing.strLiteral(tag)])
+
+const programExit = ['Program:exit', { type: 'Program' }] as const
+
+describe('require-succeeded-failed-pair', () => {
+  it('flags a `Succeeded*` Message with no matching `Failed*`', () => {
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', m('SucceededFetchUser')],
+      programExit,
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('SucceededFetchUser')
+    expect(result[0]?.diagnostic.message).toContain('FailedFetchUser')
+  })
+
+  it('does not flag when both `Succeeded*` and `Failed*` are present', () => {
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', m('SucceededFetchUser')],
+      ['CallExpression', m('FailedFetchUser')],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags only the `Succeeded*` that lacks its `Failed*` partner', () => {
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', m('SucceededFetchUser')],
+      ['CallExpression', m('FailedFetchUser')], // paired
+      ['CallExpression', m('SucceededSaveDraft')], // unpaired
+      programExit,
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('SucceededSaveDraft')
+  })
+
+  it('flags multiple unpaired `Succeeded*` Messages', () => {
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', m('SucceededFetchUser')],
+      ['CallExpression', m('SucceededSaveDraft')],
+      programExit,
+    ])
+    expect(result).toHaveLength(2)
+  })
+
+  it('does not flag a `Failed*` Message without a matching `Succeeded*`', () => {
+    // The rule is asymmetric — it only walks `Succeeded*` ⟶ `Failed*`,
+    // since a Failure on its own (e.g. validation failure) is meaningful.
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', m('FailedSomethingOrOther')],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag non-`m` calls', () => {
+    const result = Testing.runRuleMulti(rule, [
+      [
+        'CallExpression',
+        Testing.callExpr('foo', [Testing.strLiteral('SucceededWhatever')]),
+      ],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag prefix-without-word-boundary tags', () => {
+    // `Succeededness` does not match `^Succeeded[A-Z]` — not classified as a pair candidate.
+    const result = Testing.runRuleMulti(rule, [
+      ['CallExpression', m('Succeededness')],
+      programExit,
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/route-oneof-shadowing-order.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/route-oneof-shadowing-order.test.ts
@@ -1,0 +1,217 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/route-oneof-shadowing-order.ts'
+
+const programExit = ['Program:exit', Testing.program()] as const
+
+const routeMapTo = (routeName: string) =>
+  Testing.callOfMember('Route', 'mapTo', [Testing.id(routeName)])
+
+const literal = (segment: string) =>
+  Testing.callExpr('literal', [Testing.strLiteral(segment)])
+
+const stringParam = (name: string) =>
+  Testing.callExpr('string', [Testing.strLiteral(name)])
+
+const intParam = (name: string) =>
+  Testing.callExpr('int', [Testing.strLiteral(name)])
+
+const slash = (segment: unknown) => Testing.callExpr('slash', [segment])
+
+const query = () =>
+  Testing.callOfMember('Route', 'query', [Testing.objectExpr([])])
+
+const pipeRouter = (parts: ReadonlyArray<unknown>) =>
+  Testing.callExpr('pipe', parts)
+
+const routerDecl = (routerName: string, parts: ReadonlyArray<unknown>) =>
+  Testing.varDeclarator(routerName, pipeRouter(parts))
+
+const oneOf = (...routerNames: ReadonlyArray<string>) =>
+  Testing.callOfMember(
+    'Route',
+    'oneOf',
+    routerNames.map(routerName => Testing.id(routerName)),
+  )
+
+const run = (events: ReadonlyArray<readonly [string, unknown]>) =>
+  Testing.runRuleMulti(rule, [...events, programExit])
+
+describe('route-oneof-shadowing-order', () => {
+  it('does not flag specific routers before wildcard or prefix routers', () => {
+    const result = run([
+      [
+        'VariableDeclarator',
+        routerDecl('newTaskRouter', [
+          literal('tasks'),
+          slash(literal('new')),
+          routeMapTo('NewTaskRoute'),
+        ]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('taskRouter', [
+          literal('tasks'),
+          slash(stringParam('id')),
+          routeMapTo('TaskRoute'),
+        ]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('tasksRouter', [literal('tasks'), routeMapTo('TasksRoute')]),
+      ],
+      ['CallExpression', oneOf('newTaskRouter', 'taskRouter', 'tasksRouter')],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags a wildcard router before a later literal with the same prefix', () => {
+    const result = run([
+      [
+        'VariableDeclarator',
+        routerDecl('taskRouter', [
+          literal('tasks'),
+          slash(stringParam('id')),
+          routeMapTo('TaskRoute'),
+        ]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('taskArchiveRouter', [
+          literal('tasks'),
+          slash(literal('archive')),
+          routeMapTo('TaskArchiveRoute'),
+        ]),
+      ],
+      ['CallExpression', oneOf('taskRouter', 'taskArchiveRouter')],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('taskArchiveRouter')
+    expect(result[0]?.diagnostic.message).toContain('taskRouter')
+    expect(result[0]?.diagnostic.message).toContain('same path shape')
+  })
+
+  it('flags a shorter prefix router before a longer route', () => {
+    const result = run([
+      [
+        'VariableDeclarator',
+        routerDecl('tasksRouter', [literal('tasks'), routeMapTo('TasksRoute')]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('taskRouter', [
+          literal('tasks'),
+          slash(stringParam('id')),
+          routeMapTo('TaskRoute'),
+        ]),
+      ],
+      ['CallExpression', oneOf('tasksRouter', 'taskRouter')],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('path prefix')
+  })
+
+  it('does not let query-guarded earlier routers shadow later path routers', () => {
+    const result = run([
+      [
+        'VariableDeclarator',
+        routerDecl('peopleRouter', [
+          literal('people'),
+          query(),
+          routeMapTo('PeopleRoute'),
+        ]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('personRouter', [
+          literal('people'),
+          slash(stringParam('personId')),
+          routeMapTo('PersonRoute'),
+        ]),
+      ],
+      ['CallExpression', oneOf('peopleRouter', 'personRouter')],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('treats int parameters as covering numeric literals only', () => {
+    const result = run([
+      [
+        'VariableDeclarator',
+        routerDecl('itemNumberRouter', [
+          literal('items'),
+          slash(intParam('id')),
+          routeMapTo('ItemNumberRoute'),
+        ]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('itemArchiveRouter', [
+          literal('items'),
+          slash(literal('archive')),
+          routeMapTo('ItemArchiveRoute'),
+        ]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('itemFortyTwoRouter', [
+          literal('items'),
+          slash(literal('42')),
+          routeMapTo('ItemFortyTwoRoute'),
+        ]),
+      ],
+      [
+        'CallExpression',
+        oneOf('itemNumberRouter', 'itemArchiveRouter', 'itemFortyTwoRouter'),
+      ],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('itemFortyTwoRouter')
+  })
+
+  it('does not let the root router shadow non-root routes', () => {
+    const result = run([
+      [
+        'VariableDeclarator',
+        routerDecl('homeRouter', [Testing.id('root'), routeMapTo('HomeRoute')]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('tasksRouter', [literal('tasks'), routeMapTo('TasksRoute')]),
+      ],
+      ['CallExpression', oneOf('homeRouter', 'tasksRouter')],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips opaque routers whose pipe chain cannot be resolved', () => {
+    const result = run([
+      [
+        'VariableDeclarator',
+        Testing.varDeclarator(
+          'opaqueRouter',
+          Testing.callExpr('makeRouter', []),
+        ),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('taskRouter', [
+          literal('tasks'),
+          slash(stringParam('id')),
+          routeMapTo('TaskRoute'),
+        ]),
+      ],
+      [
+        'VariableDeclarator',
+        routerDecl('taskArchiveRouter', [
+          literal('tasks'),
+          slash(literal('archive')),
+          routeMapTo('TaskArchiveRoute'),
+        ]),
+      ],
+      ['CallExpression', oneOf('opaqueRouter', 'taskArchiveRouter')],
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/route-union-parser-registration.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/route-union-parser-registration.test.ts
@@ -1,0 +1,111 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/route-union-parser-registration.ts'
+
+const arr = (elements: ReadonlyArray<unknown>) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const routeDecl = (name: string) =>
+  Testing.varDeclarator(name, Testing.callExpr('r', [Testing.strLiteral(name)]))
+
+const routerDecl = (routerName: string, routeName: string) =>
+  Testing.varDeclarator(
+    routerName,
+    Testing.callOfMember('Route', 'mapTo', [Testing.id(routeName)]),
+  )
+
+const appRouteUnion = (routeNames: ReadonlyArray<string>) =>
+  Testing.callOfMember('S', 'Union', [arr(routeNames.map(Testing.id))])
+
+const oneOf = (routerNames: ReadonlyArray<string>) =>
+  Testing.callOfMember('Route', 'oneOf', routerNames.map(Testing.id))
+
+const fallback = (routeName: string) =>
+  Testing.callOfMember('Route', 'parseUrlWithFallback', [
+    Testing.id('routeParser'),
+    Testing.id(routeName),
+  ])
+
+const programExit = ['Program:exit', Testing.program()] as const
+
+const runRouteRule = (events: ReadonlyArray<readonly [string, unknown]>) =>
+  Testing.runRuleMulti(rule, [...events, programExit])
+
+describe('route-union-parser-registration', () => {
+  it('does not flag a complete route union / router / oneOf registration set', () => {
+    const result = runRouteRule([
+      ['VariableDeclarator', routeDecl('HomeRoute')],
+      ['VariableDeclarator', routeDecl('UserRoute')],
+      ['VariableDeclarator', routeDecl('NotFoundRoute')],
+      [
+        'CallExpression',
+        appRouteUnion(['HomeRoute', 'UserRoute', 'NotFoundRoute']),
+      ],
+      ['VariableDeclarator', routerDecl('homeRouter', 'HomeRoute')],
+      ['VariableDeclarator', routerDecl('userRouter', 'UserRoute')],
+      ['CallExpression', oneOf(['homeRouter', 'userRouter'])],
+      ['CallExpression', fallback('NotFoundRoute')],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags union route members with no Route.mapTo parser, excluding the fallback route', () => {
+    const result = runRouteRule([
+      ['VariableDeclarator', routeDecl('HomeRoute')],
+      ['VariableDeclarator', routeDecl('UserRoute')],
+      ['VariableDeclarator', routeDecl('NotFoundRoute')],
+      [
+        'CallExpression',
+        appRouteUnion(['HomeRoute', 'UserRoute', 'NotFoundRoute']),
+      ],
+      ['VariableDeclarator', routerDecl('homeRouter', 'HomeRoute')],
+      ['CallExpression', oneOf(['homeRouter'])],
+      ['CallExpression', fallback('NotFoundRoute')],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('UserRoute')
+    expect(result[0]?.diagnostic.message).toContain('Route.mapTo')
+  })
+
+  it('flags routers that map a route but are absent from Route.oneOf', () => {
+    const result = runRouteRule([
+      ['VariableDeclarator', routeDecl('HomeRoute')],
+      ['VariableDeclarator', routeDecl('UserRoute')],
+      ['VariableDeclarator', routeDecl('NotFoundRoute')],
+      [
+        'CallExpression',
+        appRouteUnion(['HomeRoute', 'UserRoute', 'NotFoundRoute']),
+      ],
+      ['VariableDeclarator', routerDecl('homeRouter', 'HomeRoute')],
+      ['VariableDeclarator', routerDecl('userRouter', 'UserRoute')],
+      ['CallExpression', oneOf(['homeRouter'])],
+      ['CallExpression', fallback('NotFoundRoute')],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('userRouter')
+    expect(result[0]?.diagnostic.message).toContain('Route.oneOf')
+  })
+
+  it('handles a missing parseUrlWithFallback call without crashing', () => {
+    const result = runRouteRule([
+      ['VariableDeclarator', routeDecl('HomeRoute')],
+      ['VariableDeclarator', routeDecl('NotFoundRoute')],
+      ['CallExpression', appRouteUnion(['HomeRoute', 'NotFoundRoute'])],
+      ['VariableDeclarator', routerDecl('homeRouter', 'HomeRoute')],
+      ['CallExpression', oneOf(['homeRouter'])],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('NotFoundRoute')
+  })
+
+  it('does not run unless the file has route declarations and Route.oneOf', () => {
+    const result = runRouteRule([
+      ['CallExpression', appRouteUnion(['HomeRoute'])],
+      ['VariableDeclarator', routerDecl('homeRouter', 'HomeRoute')],
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/scene-tests-run-from-root.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/scene-tests-run-from-root.test.ts
@@ -1,0 +1,260 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/scene-tests-run-from-root.ts'
+
+const testFile = '/repo/apps/ui/test/main.scene.test.ts'
+const sourceFile = '/repo/apps/ui/src/page/chat/view.ts'
+
+const parent = (child: object, value: object) => {
+  Object.defineProperty(child, 'parent', { value })
+}
+
+const namespaceImport = (local: string, source: string) =>
+  Testing.importDeclWithSpecifiers(source, [
+    Testing.importNamespaceSpecifier(local),
+  ])
+
+const namedImport = (imported: string, local: string, source: string) =>
+  Testing.importDeclWithSpecifiers(source, [
+    Testing.importSpecifier(imported, local),
+  ])
+
+const config = (update: unknown, view: unknown) =>
+  Testing.objectExpr([
+    { key: 'update', value: update },
+    { key: 'view', value: view },
+  ])
+
+const scene = (sceneConfig: unknown) =>
+  Testing.callOfMember('Scene', 'scene', [sceneConfig])
+
+const constConfig = (name: string, value: unknown) => {
+  const declarator = Testing.varDeclarator(name, value)
+  parent(declarator, {
+    type: 'VariableDeclaration',
+    kind: 'const',
+    declarations: [declarator],
+  })
+  return declarator
+}
+
+const viewFunctionCalling = (namespace: string) =>
+  Testing.arrowFn(
+    Testing.callOfMember(namespace, 'view', [Testing.id('model')]),
+    [Testing.id('model')],
+  )
+
+const stubUpdate = Testing.arrowFn(Testing.id('model'), [
+  Testing.id('model'),
+  Testing.id('_message'),
+])
+
+const run = (
+  events: ReadonlyArray<readonly [visitor: string, node: unknown]>,
+  filename = testFile,
+) =>
+  Testing.runRuleMulti(rule, [...events, ['Program:exit', Testing.program()]], {
+    filename,
+  })
+
+describe('scene-tests-run-from-root', () => {
+  it('flags literal Scene configs using page namespace update/view', () => {
+    const result = run([
+      [
+        'ImportDeclaration',
+        namespaceImport('Chat', '../../src/page/chat/index.ts'),
+      ],
+      [
+        'CallExpression',
+        scene(
+          config(
+            Testing.memberExpr('Chat', 'update'),
+            Testing.memberExpr('Chat', 'view'),
+          ),
+        ),
+      ],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('page module')
+  })
+
+  it('flags same-file const Scene configs whose view function references a page import', () => {
+    const sceneConfig = config(
+      Testing.id('update'),
+      viewFunctionCalling('Chat'),
+    )
+    const result = run([
+      [
+        'ImportDeclaration',
+        namespaceImport('Chat', '../../src/page/chat/index.ts'),
+      ],
+      [
+        'ImportDeclaration',
+        namedImport('update', 'update', '../src/update/index.ts'),
+      ],
+      ['VariableDeclarator', constConfig('config', sceneConfig)],
+      ['CallExpression', scene(Testing.id('config'))],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      '../../src/page/chat/index.ts',
+    )
+  })
+
+  it('flags page named imports used directly as update/view', () => {
+    const result = run([
+      [
+        'ImportDeclaration',
+        namedImport('update', 'chatUpdate', '../../src/page/chat/index.ts'),
+      ],
+      [
+        'ImportDeclaration',
+        namedImport('view', 'chatView', '../../src/page/chat/index.ts'),
+      ],
+      [
+        'CallExpression',
+        scene(config(Testing.id('chatUpdate'), Testing.id('chatView'))),
+      ],
+    ])
+    expect(result).toHaveLength(1)
+  })
+
+  it('flags widget-isolated configs only when update and view trace to the same widget', () => {
+    const result = run([
+      [
+        'ImportDeclaration',
+        namespaceImport('PromptPane', '../../src/widget/prompt-pane/index.ts'),
+      ],
+      [
+        'CallExpression',
+        scene(
+          config(
+            Testing.memberExpr('PromptPane', 'update'),
+            Testing.memberExpr('PromptPane', 'view'),
+          ),
+        ),
+      ],
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('widget `prompt-pane`')
+  })
+
+  it('allows root update/view Scene configs', () => {
+    const result = run([
+      [
+        'ImportDeclaration',
+        namedImport('update', 'update', '../src/update/index.ts'),
+      ],
+      [
+        'ImportDeclaration',
+        namedImport('view', 'view', '../src/view/index.ts'),
+      ],
+      [
+        'CallExpression',
+        scene(config(Testing.id('update'), Testing.id('view'))),
+      ],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows pure render-helper configs with a stub update and widget view', () => {
+    const result = run([
+      [
+        'ImportDeclaration',
+        namedImport('markdown', 'markdown', '../../src/widget/markdown.ts'),
+      ],
+      [
+        'CallExpression',
+        scene(
+          config(
+            stubUpdate,
+            Testing.arrowFn(
+              Testing.callExpr('markdown', [Testing.id('model')]),
+              [Testing.id('model')],
+            ),
+          ),
+        ),
+      ],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows widget provenance when update and view are different widgets', () => {
+    const result = run([
+      [
+        'ImportDeclaration',
+        namespaceImport('PromptPane', '../../src/widget/prompt-pane/index.ts'),
+      ],
+      [
+        'ImportDeclaration',
+        namespaceImport(
+          'CommandPalette',
+          '../../src/widget/command-palette/index.ts',
+        ),
+      ],
+      [
+        'CallExpression',
+        scene(
+          config(
+            Testing.memberExpr('PromptPane', 'update'),
+            Testing.memberExpr('CommandPalette', 'view'),
+          ),
+        ),
+      ],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag unused page fixture imports when Scene uses root update/view', () => {
+    const result = run([
+      [
+        'ImportDeclaration',
+        namespaceImport('CiPrompts', '../src/page/ci-prompts/index.ts'),
+      ],
+      [
+        'ImportDeclaration',
+        namedImport('update', 'update', '../src/update/index.ts'),
+      ],
+      [
+        'ImportDeclaration',
+        namedImport('view', 'view', '../src/view/index.ts'),
+      ],
+      [
+        'CallExpression',
+        scene(config(Testing.id('update'), Testing.id('view'))),
+      ],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('ignores non-object first args and missing same-file const configs', () => {
+    const result = run([
+      ['CallExpression', scene(Testing.callExpr('makeSceneConfig'))],
+      ['CallExpression', scene(Testing.id('externalConfig'))],
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not run outside apps/ui/test files', () => {
+    const result = run(
+      [
+        [
+          'ImportDeclaration',
+          namespaceImport('Chat', '../../src/page/chat/index.ts'),
+        ],
+        [
+          'CallExpression',
+          scene(
+            config(
+              Testing.memberExpr('Chat', 'update'),
+              Testing.memberExpr('Chat', 'view'),
+            ),
+          ),
+        ],
+      ],
+      sourceFile,
+    )
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/selection-submodel-factory-at-module-scope.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/selection-submodel-factory-at-module-scope.test.ts
@@ -1,0 +1,139 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/selection-submodel-factory-at-module-scope.ts'
+
+const callFromCallee = (
+  callee: unknown,
+  args: ReadonlyArray<unknown> = [],
+) => ({
+  type: 'CallExpression',
+  callee,
+  arguments: Array.from(args),
+})
+
+const memberFromObject = (object: unknown, property: string) => ({
+  type: 'MemberExpression',
+  object,
+  property: Testing.id(property),
+  computed: false,
+})
+
+const parenthesized = (expression: unknown) => ({
+  type: 'ParenthesizedExpression',
+  expression,
+})
+
+const tsAs = (expression: unknown) => ({
+  type: 'TSAsExpression',
+  expression,
+  typeAnnotation: { type: 'TSTypeReference' },
+})
+
+const satisfies = (expression: unknown) => ({
+  type: 'TSSatisfiesExpression',
+  expression,
+  typeAnnotation: { type: 'TSTypeReference' },
+})
+
+const uiCreate = (...segments: readonly [string, ...ReadonlyArray<string>]) =>
+  callFromCallee(Testing.chainedMemberExpr('Ui', ...segments, 'create'))
+
+const otherCreate = () =>
+  callFromCallee(Testing.chainedMemberExpr('Other', 'Listbox', 'create'))
+
+const constDecl = (name: string, init: unknown) =>
+  Testing.varDecl('const', name, init)
+
+const exportConst = (name: string, init: unknown) =>
+  Testing.exportNamedDecl(constDecl(name, init))
+
+const programExit = (body: ReadonlyArray<unknown>) =>
+  Testing.runRule(rule, 'Program:exit', Testing.program(body))
+
+describe('selection-submodel-factory-at-module-scope', () => {
+  it('allows Ui.<Component>.create as a direct module-scope const initializer', () => {
+    const result = programExit([constDecl('PlanListbox', uiCreate('Listbox'))])
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows Ui.<Component>.Multi.create as an exported module-scope const initializer', () => {
+    const result = programExit([
+      exportConst('FeatureSpecListbox', uiCreate('Listbox', 'Multi')),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows parenthesized, as, and satisfies wrappers around a direct initializer', () => {
+    const result = programExit([
+      exportConst(
+        'CityCombobox',
+        satisfies(tsAs(parenthesized(uiCreate('Combobox')))),
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags inline Ui selection factories inside function bodies', () => {
+    const result = programExit([
+      exportConst(
+        'view',
+        Testing.arrowFn(
+          Testing.blockStmt([
+            Testing.returnStmt(
+              callFromCallee(memberFromObject(uiCreate('Combobox'), 'view')),
+            ),
+          ]),
+        ),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'factories must be declared once as a module-scope variable initializer',
+    )
+  })
+
+  it('flags function-scoped direct variable initializers', () => {
+    const result = programExit([
+      exportConst(
+        'makeView',
+        Testing.arrowFn(
+          Testing.blockStmt([constDecl('InnerListbox', uiCreate('Listbox'))]),
+        ),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Ui.Listbox.create')
+  })
+
+  it('flags module-scope initializers that use the factory call as a nested expression', () => {
+    const result = programExit([
+      constDecl(
+        'PlanListboxView',
+        memberFromObject(uiCreate('Listbox'), 'view'),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Ui.Listbox.create')
+  })
+
+  it('flags factory calls nested inside exported module-scope initializers', () => {
+    const result = programExit([
+      exportConst(
+        'PlanListboxView',
+        callFromCallee('makeFactory', [uiCreate('Listbox')]),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Ui.Listbox.create')
+  })
+
+  it('does not flag unrelated Ui calls, non-selection Ui create calls, or non-Ui create calls', () => {
+    const result = programExit([
+      constDecl('buttonView', Testing.callOfMember('Ui', 'Button', [])),
+      constDecl('ButtonFactory', uiCreate('Button')),
+      constDecl('OtherListbox', otherCreate()),
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/subscription-file-canonical-shape.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/subscription-file-canonical-shape.test.ts
@@ -1,0 +1,226 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/subscription-file-canonical-shape.ts'
+
+const filename = (path = '/repo/apps/ui/src/page/tasks/subscription.ts') => ({
+  filename: path,
+})
+
+const arr = (elements: ReadonlyArray<unknown>) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const callFromCallee = (
+  callee: unknown,
+  args: ReadonlyArray<unknown> = [],
+) => ({
+  type: 'CallExpression',
+  callee,
+  arguments: Array.from(args),
+})
+
+const subscriptionMember = (
+  method: 'make' | 'lift' | 'aggregate',
+  args: ReadonlyArray<unknown> = [],
+) => Testing.callOfMember('Subscription', method, args)
+
+const subscriptionCall = (
+  method: 'make' | 'lift' | 'aggregate',
+  args: ReadonlyArray<unknown> = [],
+) => callFromCallee(subscriptionMember(method), args)
+
+const constDecl = (name: string, init: unknown) =>
+  Testing.varDecl('const', name, init)
+
+const exportConst = (name: string, init: unknown) =>
+  Testing.exportNamedDecl(constDecl(name, init))
+
+const programExit = (body: ReadonlyArray<unknown>, path?: string) =>
+  Testing.runRule(rule, 'Program:exit', Testing.program(body), filename(path))
+
+describe('subscription-file-canonical-shape', () => {
+  it('allows canonical subscriptions made with Subscription.make', () => {
+    const result = programExit([
+      exportConst(
+        'subscriptions',
+        subscriptionCall('make', [Testing.arrowFn()]),
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows canonical subscriptions made with Subscription.aggregate plus local lifted helpers and extra non-subscription exports', () => {
+    const result = programExit([
+      constDecl(
+        'virtualListSubscriptions',
+        subscriptionCall('lift', [
+          Testing.objectExpr([
+            {
+              key: 'libraryContainer',
+              value: Testing.chainedMemberExpr(
+                'Ui',
+                'VirtualList',
+                'subscriptions',
+                'containerEvents',
+              ),
+            },
+          ]),
+        ]),
+      ),
+      exportConst('RouteParams', Testing.callOfMember('S', 'Struct', [])),
+      exportConst(
+        'subscriptions',
+        subscriptionCall('aggregate', [Testing.id('virtualListSubscriptions')]),
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('ignores files not named subscription.ts', () => {
+    const result = programExit(
+      [constDecl('localSubscriptions', subscriptionCall('make'))],
+      '/repo/apps/ui/src/page/tasks/view.ts',
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags subscription usage without an exported subscriptions const', () => {
+    const result = programExit([
+      constDecl('localSubscriptions', subscriptionCall('make')),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'export one canonical `subscriptions` const',
+    )
+  })
+
+  it('flags a subscriptions export rooted at Subscription.lift', () => {
+    const result = programExit([
+      exportConst(
+        'subscriptions',
+        subscriptionCall('lift', [
+          Testing.memberExpr('Child', 'subscriptions'),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'initialized from `Subscription.make',
+    )
+  })
+
+  it('flags a subscriptions export not rooted at Subscription.make or Subscription.aggregate', () => {
+    const result = programExit([
+      exportConst('subscriptions', Testing.objectExpr([])),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'canonical `subscriptions` export',
+    )
+  })
+
+  it('walks curried callees when checking the subscriptions initializer', () => {
+    const result = programExit([
+      exportConst(
+        'subscriptions',
+        callFromCallee(subscriptionCall('aggregate'), [
+          Testing.id('localSubscriptions'),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags other exported consts rooted at Subscription.make, Subscription.lift, or Subscription.aggregate', () => {
+    const result = programExit([
+      exportConst('extraMake', subscriptionCall('make')),
+      exportConst(
+        'extraLift',
+        subscriptionCall('lift', [
+          Testing.memberExpr('Child', 'subscriptions'),
+        ]),
+      ),
+      exportConst('extraAggregate', subscriptionCall('aggregate')),
+      exportConst('subscriptions', subscriptionCall('make')),
+    ])
+    expect(result).toHaveLength(3)
+    expect(result.map(item => item.diagnostic.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Subscription.make'),
+        expect.stringContaining('Subscription.lift'),
+        expect.stringContaining('Subscription.aggregate'),
+      ]),
+    )
+  })
+
+  it('flags object-expression spreads of subscription-typed bindings', () => {
+    const result = programExit([
+      constDecl('localSubscriptions', subscriptionCall('make')),
+      exportConst(
+        'subscriptions',
+        subscriptionCall('aggregate', [
+          Testing.objectExprWithSpread(Testing.id('localSubscriptions')),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'Do not spread subscription records',
+    )
+  })
+
+  it('flags object-expression spreads of .subscriptions members', () => {
+    const result = programExit([
+      exportConst(
+        'subscriptions',
+        subscriptionCall('aggregate', [
+          Testing.objectExprWithSpread(
+            Testing.memberExpr('Child', 'subscriptions'),
+          ),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'Do not spread subscription records',
+    )
+  })
+
+  it('does not flag non-object spreads', () => {
+    const result = programExit([
+      constDecl('localSubscriptions', subscriptionCall('make')),
+      exportConst(
+        'subscriptions',
+        subscriptionCall('aggregate', [
+          {
+            type: 'SpreadElement',
+            argument: Testing.id('localSubscriptions'),
+          },
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not flag object spreads unrelated to subscriptions', () => {
+    const result = programExit([
+      exportConst(
+        'subscriptions',
+        subscriptionCall('aggregate', [
+          Testing.objectExprWithSpread(Testing.id('viewInputs')),
+        ]),
+      ),
+    ])
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows helper schema arrays without treating them as subscription records', () => {
+    const result = programExit([
+      exportConst('HelperUnion', Testing.callOfMember('S', 'Union', [arr([])])),
+      exportConst('subscriptions', subscriptionCall('make')),
+    ])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/ui-toview-must-spread-attribute-bundles.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/ui-toview-must-spread-attribute-bundles.test.ts
@@ -1,0 +1,195 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/ui-toview-must-spread-attribute-bundles.ts'
+
+const arr = (elements: ReadonlyArray<unknown>) => ({
+  type: 'ArrayExpression',
+  elements: Array.from(elements),
+})
+
+const prop = (key: string, value: unknown) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: false,
+  method: false,
+  shorthand: false,
+  key: Testing.id(key),
+  value,
+})
+
+const objectExpr = (properties: ReadonlyArray<unknown>) => ({
+  type: 'ObjectExpression',
+  properties: Array.from(properties),
+})
+
+const spread = (argument: unknown) => ({
+  type: 'SpreadElement',
+  argument,
+})
+
+const member = (...path: readonly [string, string, ...ReadonlyArray<string>]) =>
+  Testing.chainedMemberExpr(...path)
+
+const call = (callee: unknown, args: ReadonlyArray<unknown> = []) => ({
+  type: 'CallExpression',
+  callee,
+  arguments: Array.from(args),
+})
+
+const hCall = (name: string, args: ReadonlyArray<unknown> = []) =>
+  call(member('h', name), args)
+
+const arrow = (paramName: string, body: unknown) => ({
+  type: 'ArrowFunctionExpression',
+  expression: true,
+  async: false,
+  params: [Testing.id(paramName)],
+  body,
+  id: null,
+  generator: false,
+})
+
+const uiViewCall = (component: string, config: unknown) =>
+  call(member('Ui', component, 'view'), [config])
+
+const toViewConfig = (component: string, fn: unknown) =>
+  uiViewCall(component, objectExpr([prop('toView', fn)]))
+
+const submodelCall = (component: string, viewInputs: unknown) =>
+  hCall('submodel', [
+    objectExpr([
+      prop('slotId', Testing.strLiteral('slot')),
+      prop('model', Testing.id('model')),
+      prop('view', member('Ui', component, 'view')),
+      prop('viewInputs', viewInputs),
+      prop('toParentMessage', arrow('message', Testing.id('message'))),
+    ]),
+  ])
+
+describe('ui-toview-must-spread-attribute-bundles', () => {
+  it('allows direct Ui.*.view toViews that spread attribute bundles', () => {
+    const node = toViewConfig(
+      'Input',
+      arrow(
+        'attributes',
+        hCall('input', [
+          arr([spread(member('attributes', 'input')), hCall('Class')]),
+        ]),
+      ),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows submodel viewInputs toViews that pass a bundle as a direct call argument', () => {
+    const node = submodelCall(
+      'Checkbox',
+      objectExpr([
+        prop(
+          'toView',
+          arrow(
+            'attributes',
+            hCall('span', [
+              member('attributes', 'label'),
+              arr([Testing.strLiteral('Unblocked only')]),
+            ]),
+          ),
+        ),
+      ]),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags direct Ui.*.view toViews that drop all attribute bundles', () => {
+    const node = toViewConfig(
+      'Button',
+      arrow('attributes', hCall('button', [arr([hCall('Class')])])),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('attribute bundles')
+  })
+
+  it('flags submodel viewInputs toViews that drop all attribute bundles', () => {
+    const node = submodelCall(
+      'Input',
+      objectExpr([
+        prop(
+          'toView',
+          arrow('attributes', hCall('input', [arr([hCall('Class')])])),
+        ),
+      ]),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+  })
+
+  it('requires Ui.Dialog toViews to render h.dialog', () => {
+    const node = toViewConfig(
+      'Dialog',
+      arrow(
+        'info',
+        hCall('div', [arr([spread(member('info', 'dialog'))]), arr([])]),
+      ),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('h.dialog')
+  })
+
+  it('allows Ui.Dialog toViews that render h.dialog and pass dialog attributes', () => {
+    const node = submodelCall(
+      'Dialog',
+      objectExpr([
+        prop(
+          'toView',
+          arrow(
+            'info',
+            hCall('dialog', [arr([spread(member('info', 'dialog'))]), arr([])]),
+          ),
+        ),
+      ]),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('can report both missing attributes and missing h.dialog for Dialog', () => {
+    const node = toViewConfig(
+      'Dialog',
+      arrow('info', hCall('div', [arr([hCall('Class')]), arr([])])),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(2)
+  })
+
+  it('skips non-inline toView values', () => {
+    const node = uiViewCall(
+      'Input',
+      objectExpr([prop('toView', Testing.id('inputToView'))]),
+    )
+    const result = Testing.runRule(rule, 'CallExpression', node)
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips toView properties outside Ui.*.view calls and Ui-backed submodels', () => {
+    const unrelated = call(Testing.id('render'), [
+      objectExpr([prop('toView', arrow('attributes', hCall('div')))]),
+    ])
+    const customSubmodel = hCall('submodel', [
+      objectExpr([
+        prop('view', Testing.id('customView')),
+        prop(
+          'viewInputs',
+          objectExpr([prop('toView', arrow('attributes', hCall('div')))]),
+        ),
+      ]),
+    ])
+    expect(Testing.runRule(rule, 'CallExpression', unrelated)).toHaveLength(0)
+    expect(
+      Testing.runRule(rule, 'CallExpression', customSubmodel),
+    ).toHaveLength(0)
+  })
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/wrap-child-output-in-got-message.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/wrap-child-output-in-got-message.test.ts
@@ -1,0 +1,155 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import rule from '../../src/rules/wrap-child-output-in-got-message.ts'
+
+const prop = (key: string, value: unknown) => ({
+  type: 'Property',
+  kind: 'init',
+  computed: false,
+  method: false,
+  shorthand: false,
+  key: Testing.id(key),
+  value,
+})
+
+const objectExpr = (properties: ReadonlyArray<unknown>) => ({
+  type: 'ObjectExpression',
+  properties: Array.from(properties),
+})
+
+const arrow = (body: unknown) => Testing.arrowFn(body, [Testing.id('message')])
+
+const blockArrow = (call: unknown) =>
+  arrow(Testing.blockStmt([Testing.returnStmt(call)]))
+
+const gotCall = (name = 'GotChatMessage') =>
+  Testing.callOfMember('Msg', name, [Testing.objectExpr([{ key: 'message' }])])
+
+const nonGotCall = (name = 'ReceivedChatEvent') =>
+  Testing.callOfMember('Msg', name, [Testing.objectExpr([{ key: 'message' }])])
+
+const commandMapMessages = (mapper: unknown) =>
+  Testing.callOfMember('Command', 'mapMessages', [
+    Testing.id('commands'),
+    mapper,
+  ])
+
+const commandMapMessage = (mapper: unknown) =>
+  Testing.callOfMember('Command', 'mapMessage', [Testing.id('command'), mapper])
+
+const subscriptionLift = (mapper: unknown) => ({
+  type: 'CallExpression',
+  callee: Testing.callOfMember('Subscription', 'lift', [
+    Testing.id('subscriptions'),
+  ]),
+  arguments: [
+    objectExpr([
+      prop('toChildModel', arrow(Testing.memberExpr('model', 'chat'))),
+      prop('toParentMessage', mapper),
+    ]),
+  ],
+})
+
+const subscriptionLiftWithTypeArgs = (mapper: unknown) => ({
+  type: 'CallExpression',
+  callee: {
+    type: 'TSInstantiationExpression',
+    expression: Testing.callOfMember('Subscription', 'lift', [
+      Testing.id('subscriptions'),
+    ]),
+  },
+  arguments: [objectExpr([prop('toParentMessage', mapper)])],
+})
+
+const delegatePage = (mapper: unknown) =>
+  Testing.callExpr('delegatePage', [
+    Testing.id('model'),
+    Testing.id('result'),
+    arrow(Testing.id('nextModel')),
+    mapper,
+  ])
+
+const delegatePageWithOutMessage = (mapper: unknown) =>
+  Testing.callExpr('delegatePageWithOutMessage', [
+    Testing.id('model'),
+    Testing.id('result'),
+    arrow(Testing.id('nextModel')),
+    mapper,
+    Testing.id('handleOutMessage'),
+  ])
+
+const hSubmodel = (mapper: unknown) =>
+  Testing.callOfMember('h', 'submodel', [
+    objectExpr([prop('toParentMessage', mapper)]),
+  ])
+
+const runCall = (call: unknown) => Testing.runRule(rule, 'CallExpression', call)
+
+describe('wrap-child-output-in-got-message', () => {
+  it('allows Command.mapMessages mappers returning Got*Message calls', () => {
+    const result = runCall(commandMapMessages(arrow(gotCall())))
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags Command.mapMessage mappers returning non-Got constructors', () => {
+    const result = runCall(commandMapMessage(arrow(nonGotCall())))
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Got*Message')
+    expect(result[0]?.diagnostic.message).toContain('ReceivedChatEvent')
+  })
+
+  it('analyzes block-bodied arrows with a sole return call', () => {
+    const allowed = runCall(commandMapMessages(blockArrow(gotCall())))
+    const flagged = runCall(commandMapMessages(blockArrow(nonGotCall())))
+    expect(allowed).toHaveLength(0)
+    expect(flagged).toHaveLength(1)
+  })
+
+  it('skips non-inline Command mappers', () => {
+    const result = runCall(commandMapMessages(Testing.id('wrap')))
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags toParentMessage inside curried Subscription.lift configs', () => {
+    const result = runCall(subscriptionLift(arrow(nonGotCall())))
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('Subscription lift')
+  })
+
+  it('handles type-instantiated Subscription.lift applications', () => {
+    const result = runCall(subscriptionLiftWithTypeArgs(arrow(nonGotCall())))
+    expect(result).toHaveLength(1)
+  })
+
+  it('allows Subscription.lift toParentMessage Got wrappers', () => {
+    const result = runCall(subscriptionLift(arrow(gotCall())))
+    expect(result).toHaveLength(0)
+  })
+
+  it('flags delegatePage wrapper argument at index 3', () => {
+    const result = runCall(delegatePage(arrow(nonGotCall())))
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('delegatePage')
+  })
+
+  it('flags delegatePageWithOutMessage wrapper argument at index 3', () => {
+    const result = runCall(delegatePageWithOutMessage(arrow(nonGotCall())))
+    expect(result).toHaveLength(1)
+  })
+
+  it('allows delegatePage wrappers returning Got*Message calls', () => {
+    const result = runCall(delegatePage(arrow(gotCall())))
+    expect(result).toHaveLength(0)
+  })
+
+  it('does not enforce h.submodel toParentMessage', () => {
+    const result = runCall(hSubmodel(arrow(nonGotCall())))
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips arrow mappers whose body is not a call', () => {
+    const result = runCall(commandMapMessages(arrow(Testing.id('message'))))
+    expect(result).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## What

Ports **38 convention rules** from [`@mpsuesser/oxlint-plugin-foldkit`](https://github.com/mpsuesser/oxlint-plugin-foldkit) (MIT, © Marc Suesser) into `@foldkit/oxlint-plugin`, taking it from **8 → 46 rules**. This continues the direction started in #596 (`no-module-level-mutable-state`, credited to Marc) — bringing more of his opinionated rule family into the framework's own plugin.

The eight existing rules are untouched, each new rule lives in `src/rules/` (one file + co-located tests), and **nothing is enabled in the scaffold preset** — so this is purely additive and opt-in. No behavioural change for existing apps.

New rules, by convention surface:

- **Routing** — `route-union-parser-registration`, `route-oneof-shadowing-order`, `no-hardcoded-route-strings`
- **View keying & a11y** — `no-array-index-view-keys`, `keyed-required-for-mapped-rows`, `label-requires-for`, `require-rel-for-external-link`, `no-hand-rolled-form-controls`, `no-raw-dom-event-attributes`
- **`evo`/Model updates** — `prefer-evo-over-model-spread`, `no-spread-in-evo`, `prefer-option-match-over-map-getorelse`
- **Command shape** — `command-define-pascal-const`, `command-failed-result-requires-catch`, `no-hand-rolled-command-struct`, `no-explicit-command-type-annotation`, `require-succeeded-failed-pair`, `require-completed-mirrors-command`
- **Purity boundaries** — `no-impure-calls-in-pure-layer`, `no-disabling-dev-guardrails`
- **Submodel wiring** — `wrap-child-output-in-got-message`, `got-wrapper-carries-only-routing`, `no-child-message-construction-in-root`, `selection-submodel-factory-at-module-scope`
- **Lifecycle handles** — `managed-resource-for-stateful-handles`, `mount-factory-must-use-element`, `no-duplicate-onmount-per-element`
- **DOM & UI helpers** — `prefer-dom-helpers-for-element-ops`, `prefer-empty-over-empty-element`, `ui-toview-must-spread-attribute-bundles`, `lazy-view-stable-references`
- **Message naming** — `require-past-tense-message-names`, `no-changed-message-prefix`, `foldkit-primitives-declared-in-role-files`
- **Test shape** — `subscription-file-canonical-shape`, `prefer-story-command-matchers`, `scene-tests-run-from-root`
- **Type shape** — `no-array-shorthand-type`

## Why — agent-driven development lives or dies on lint

We build Foldkit apps with coding agents, and in that setting **the linter is the guardrail that keeps generated code idiomatic**. An agent will happily hand-roll a Command struct, spread the Model instead of using `evo`, key a list by array index, or invent a present-tense Message name — each individually plausible, each a slow erosion of the conventions that make a Foldkit codebase legible. Every one of those is a *mechanical* mistake a rule can catch at the point of edit, before it ever reaches review.

The more of Foldkit's conventions are encoded as rules, the more of the framework an agent can use correctly without a human re-explaining the idioms each time. That's why it feels right for **framework development and lint development to move together**: when a convention is worth teaching, it's worth a rule. Marc's plugin is the closest thing to a complete encoding of those conventions today — this PR pulls that body of work into the framework's own plugin so it ships and evolves alongside Foldkit itself.

## Notes

- Rules are unchanged ports of Marc's implementations (built on the same `effect-oxlint` SDK the plugin already uses). A few carry small false-positive fixes we contributed back to Marc's plugin ([#2](https://github.com/mpsuesser/oxlint-plugin-foldkit/pull/2), [#3](https://github.com/mpsuesser/oxlint-plugin-foldkit/pull/3)).
- Layout: introduces `src/rules/` (one rule per file) since inlining 46 rules in `index.ts` no longer scales. The existing 8 are left inline to keep the diff reviewable; happy to migrate them into `src/rules/` in a follow-up if you'd prefer a uniform layout.
- Changeset included (`minor`). Green locally: `format:check`, `lint`, `check:dead-code`, `changeset status`, build, `tsc --noEmit`, and **444 tests** (39 files).
- Enabling any of these in the scaffold preset is deliberately left to you — this PR only makes them available.
