### PR TITLE
build: wire @effect/language-service into tsconfig.base.json (example for #613)

### DIFF
--- a/.changeset/wire-effect-language-service.md
+++ b/.changeset/wire-effect-language-service.md
@@ -1,0 +1,8 @@
+---
+---
+
+Wire `@effect/language-service` into `tsconfig.base.json` with a browser / TEA
+severity preset, so every package, example, and scaffolded app gets Effect-4
+semantic diagnostics (floating Effects, missing channels, Schema over JSON) in
+the editor. See `docs/effect-language-service.md` for the preset and the one-time
+`effect-language-service patch` step that also surfaces them under `tsc` / CI.

--- a/docs/effect-language-service.md
+++ b/docs/effect-language-service.md
@@ -1,0 +1,59 @@
+# Effect language service
+
+Foldkit is built on Effect, so the Effect-4 semantic diagnostics from
+[`@effect/language-service`](https://github.com/Effect-TS/language-service) apply
+directly to Foldkit application code: floating Effects (including a Command that
+is created but never returned), missing error or context channels, `Schema` over
+`JSON.parse`, and Layer composition checks. It is the semantic companion to the
+syntactic `@foldkit/oxlint-plugin`.
+
+The plugin is wired into `tsconfig.base.json`, so every workspace package and
+example inherits it, and every scaffolded app (via `create-foldkit-app`) gets it
+too.
+
+## Severity preset (browser / TEA)
+
+The base config ships a preset tuned for browser apps:
+
+- `processEnv` and `processEnvInEffect` are `off`. Browser apps read configuration
+  through `import.meta.env` (Vite), never `process.env`, so those rules do not
+  apply. A Node package under `packages/` can re-tighten them in its own tsconfig.
+- `preferSchemaOverJson` is a `warning`.
+- `ignoreEffectWarningsInTscExitCode` and `ignoreEffectSuggestionsInTscExitCode`
+  are `true`, so only Effect **errors** (for example a floating Effect) affect the
+  `tsc` exit code. Warnings and suggestions ride along as advisory signal.
+
+## Editor vs CI
+
+`@effect/language-service` is a TypeScript language-service plugin. That means:
+
+- **Editors (tsserver)** pick it up with no extra step. Open a Foldkit file and
+  the diagnostics appear inline.
+- **`tsc` / CI** only load language-service plugins after the TypeScript install
+  is patched:
+
+  ```sh
+  pnpm effect-language-service patch
+  ```
+
+  Run once after install (a `prepare` hook is a natural home). The patch is
+  idempotent and reversible with `effect-language-service unpatch`. Until then,
+  `pnpm -r typecheck` behaves exactly as before, so wiring the plugin changes no
+  existing CI behavior.
+
+## Try it
+
+Drop a floating Effect into any example and run a patched `tsc`:
+
+```ts
+import { Effect } from 'effect'
+
+export const oops = () => {
+  Effect.sync(() => 42) // never yielded or returned
+  return 1
+}
+```
+
+```
+error TS3: This Effect value is neither yielded nor used in an assignment.
+```

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
+    "@effect/language-service": "^0.86.4",
     "@foldkit/oxlint-plugin": "workspace:*",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/node": "^25.9.3",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,24 @@
 {
+  "$schema": "./node_modules/@effect/language-service/schema.json",
   "compilerOptions": {
+    // NOTE: @effect/language-service is a TypeScript plugin, so its diagnostics
+    // surface in tsserver (editors) automatically, but tsc/CI only sees them
+    // after `effect-language-service patch`. See docs/effect-language-service.md.
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "processEnv": "off",
+          "processEnvInEffect": "off",
+          "globalConsole": "off",
+          "globalConsoleInEffect": "off",
+          "preferSchemaOverJson": "warning"
+        },
+        "ignoreEffectWarningsInTscExitCode": true,
+        "ignoreEffectSuggestionsInTscExitCode": true
+      }
+    ],
+
     "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
Example wiring for #613. Opened as a draft starting point; happy for you to take it the rest of the way (changeset copy, knip allowance for the plugin devDep, whether the preset belongs in base vs a shared frontend tsconfig).

## What this does

- Adds `@effect/language-service` to `tsconfig.base.json → compilerOptions.plugins` with a browser/TEA `diagnosticSeverity` preset.
- Adds `@effect/language-service` as a root devDependency.
- Adds `docs/effect-language-service.md` (preset rationale + the tsserver-vs-CI patch note).
- Adds an empty changeset.

## Preset

Env rules (`processEnv`, `processEnvInEffect`) are `off` since browser apps read config via `import.meta.env`, not `process.env`. `preferSchemaOverJson` is a warning. `ignoreEffectWarningsInTscExitCode` + `ignoreEffectSuggestionsInTscExitCode` are `true`, so only Effect **errors** (e.g. a floating Command) affect the `tsc` exit code.

## Safety

The plugin surfaces in tsserver (editors) automatically. `tsc`/CI only load it after `effect-language-service patch`, which this PR does not add to the CI flow, so `pnpm -r typecheck` behaves exactly as before. Pure editor-DX gain until you decide to activate it in CI.

## Verification

Smoke-tested in a twin setup (a separate Foldkit app on the same `effect@4.0.0-beta.88` with `@effect/language-service@0.86.4` and this exact preset): `overview` resolves the full Foldkit Effect surface across all files, and a patched `tsc --noEmit` flags a floating Command as `error TS3: This Effect value is neither yielded nor used in an assignment`. A full monorepo verify (install + patch + `pnpm -r typecheck`) is left to CI.
