### PR TITLE
feat(route): add restString catch-all string param

### DIFF
--- a/.changeset/restring-catch-all-param.md
+++ b/.changeset/restring-catch-all-param.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `restString`, a terminal catch-all route param that captures the raw remaining URL path — slashes and dots included — as a single `string` and round-trips bidirectionally (`/vault/a/b/c.md` ⇄ `{ path: 'a/b/c.md' }`). Where `rest` yields a `NonEmptyArray` of segments, `restString` rejoins the tail into one path string, so file-tree and docs routes can carry a repository-relative path as clean `{ path: S.String }` route data. Exported from `foldkit/route`.

--- a/packages/foldkit/src/route/parser.test.ts
+++ b/packages/foldkit/src/route/parser.test.ts
@@ -14,6 +14,7 @@ import {
   parseUrlWithFallback,
   query,
   rest,
+  restString,
   root,
   schemaSegment,
   slash,
@@ -323,6 +324,124 @@ describe('rest', () => {
       expect(filesRouter({ path: parsed.path })).toBe('/files/documents/taxes')
     }),
   )
+})
+
+describe('restString', () => {
+  const Vault = r('Vault', { path: S.String })
+  const NotFound = r('NotFound', { path: S.String })
+
+  const vaultRouter = pipe(
+    literal('vault'),
+    slash(restString('path')),
+    mapTo(Vault),
+  )
+
+  it.effect('captures all remaining segments as one slash-joined string', () =>
+    Effect.gen(function* () {
+      const [value, remaining] = yield* restString('path').parse([
+        'a',
+        'b',
+        'c.md',
+      ])
+      expect(value).toStrictEqual({ path: 'a/b/c.md' })
+      expect(remaining).toStrictEqual([])
+    }),
+  )
+
+  it.effect('captures a single-segment tail', () =>
+    Effect.gen(function* () {
+      const [value] = yield* restString('path').parse(['notes.md'])
+      expect(value).toStrictEqual({ path: 'notes.md' })
+    }),
+  )
+
+  it.effect('fails on empty segments', () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(restString('path').parse([]))
+      expect(error._tag).toBe('ParseError')
+      expect(error.actual).toBe('end of path')
+    }),
+  )
+
+  it.effect('prints the raw path as a single segment', () =>
+    Effect.gen(function* () {
+      const state = yield* restString('path').print(
+        { path: 'documents/taxes/2024.pdf' },
+        { segments: ['vault'], queryParams: new URLSearchParams() },
+      )
+      expect(state.segments).toStrictEqual([
+        'vault',
+        'documents/taxes/2024.pdf',
+      ])
+    }),
+  )
+
+  it.effect('composes after literals', () =>
+    Effect.gen(function* () {
+      const parser = pipe(literal('vault'), slash(restString('path')))
+      const [value, remaining] = yield* parser.parse(['vault', 'a', 'b.md'])
+      expect(value).toStrictEqual({ path: 'a/b.md' })
+      expect(remaining).toStrictEqual([])
+    }),
+  )
+
+  it.effect('combines with query parameters', () =>
+    Effect.gen(function* () {
+      const parser = pipe(
+        literal('vault'),
+        slash(restString('path')),
+        query(S.Struct({ sort: S.String })),
+      )
+      const [value] = yield* parser.parse(['vault', 'a.md'], 'sort=name')
+      expect(value).toStrictEqual({ path: 'a.md', sort: 'name' })
+    }),
+  )
+
+  it('cannot be extended with slash', () => {
+    // @ts-expect-error slash cannot follow a terminal parser
+    const invalidParser = pipe(restString('path'), slash(literal('x')))
+    expect(invalidParser).toBeDefined()
+  })
+
+  it('builds a URL from restString route data', () => {
+    const url = vaultRouter({
+      path: '20-upgrade/teach/the-elm-architecture.md',
+    })
+    expect(url).toBe('/vault/20-upgrade/teach/the-elm-architecture.md')
+  })
+
+  it.effect('parse then build round-trips a path with slashes and dots', () =>
+    Effect.gen(function* () {
+      const [parsed] = yield* vaultRouter.parse(['vault', 'a', 'b', 'c.md'])
+      expect(vaultRouter({ path: parsed.path })).toBe('/vault/a/b/c.md')
+    }),
+  )
+
+  it('parses a full URL through the router', () => {
+    const parser = oneOf(vaultRouter)
+    const route = parseUrlWithFallback(
+      parser,
+      NotFound,
+    )(makeUrl('/vault/a/b/c.md'))
+    expect(route).toStrictEqual(Vault.make({ path: 'a/b/c.md' }))
+  })
+
+  it('normalizes a trailing slash away', () => {
+    const parser = oneOf(vaultRouter)
+    const route = parseUrlWithFallback(parser, NotFound)(makeUrl('/vault/a/b/'))
+    expect(route).toStrictEqual(Vault.make({ path: 'a/b' }))
+  })
+
+  it('round-trips a percent-encoded tail unchanged', () => {
+    const parser = oneOf(vaultRouter)
+    const encodedPath = 'a%20b/c.md'
+    const route = parseUrlWithFallback(
+      parser,
+      NotFound,
+    )(makeUrl(`/vault/${encodedPath}`))
+    expect(route).toStrictEqual(Vault.make({ path: encodedPath }))
+    expect(vaultRouter({ path: encodedPath })).toBe(`/vault/${encodedPath}`)
+  })
 })
 
 describe('slash', () => {

--- a/packages/foldkit/src/route/parser.ts
+++ b/packages/foldkit/src/route/parser.ts
@@ -392,6 +392,63 @@ export const rest = <K extends string>(
 }
 
 /**
+ * Creates a parser that captures all remaining URL segments as a single
+ * named string field, preserving the slashes between them.
+ *
+ * Where `rest` yields a `NonEmptyArray` of segments, `restString` rejoins
+ * the tail into one raw path string, so a value that itself contains both
+ * slashes and dots — like a repository-relative file path
+ * `documents/taxes/2024.pdf` — round-trips through the bidirectional router
+ * as clean `{ path: string }` route data. It is the greedy catch-all every
+ * file-tree or docs router eventually needs.
+ *
+ * Requires at least one remaining segment. A bare prefix like `/vault`
+ * does not match; give it its own route alongside the restString route.
+ *
+ * A restString route also matches every URL that a more specific route under
+ * the same prefix accepts, so in `oneOf` the specific route must come first.
+ *
+ * Nothing can follow `restString` in the path, so the result is a
+ * `TerminalParser`. It can still be extended with `query`.
+ *
+ * @example
+ * ```ts
+ * pipe(literal('vault'), slash(restString('path')))
+ * // parses /vault/a/b/c.md   into { path: 'a/b/c.md' }
+ * // builds { path: 'a/b/c.md' } into /vault/a/b/c.md
+ * ```
+ */
+export const restString = <K extends string>(
+  name: K,
+): TerminalParser<Record<K, string>> => {
+  const parser: Biparser<Record<K, string>> = {
+    parse: segments =>
+      Array.match(segments, {
+        onEmpty: () =>
+          Effect.fail(
+            new ParseError({
+              message: `Expected remaining path (${name})`,
+              expected: `remaining path (${name})`,
+              actual: 'end of path',
+              position: 0,
+            }),
+          ),
+        onNonEmpty: remainingSegments =>
+          Effect.succeed([
+            Record.singleton(name, Array.join(remainingSegments, '/')),
+            [],
+          ]),
+      }),
+    print: (value, state) =>
+      Effect.succeed({
+        ...state,
+        segments: [...state.segments, value[name]],
+      }),
+  }
+  return makeTerminalParser(parser)
+}
+
+/**
  * A parse-only parser with no print/build capabilities.
  *
  * Returned by `oneOf`, which combines multiple parsers whose print

--- a/packages/foldkit/src/route/public.ts
+++ b/packages/foldkit/src/route/public.ts
@@ -7,6 +7,7 @@ export {
   schemaSegment,
   root,
   rest,
+  restString,
   oneOf,
   mapTo,
   slash,


### PR DESCRIPTION
Implements #617.

## What

Adds `restString`, a terminal route-parser combinator that captures the raw
remaining URL path — **including slashes and dots** — as a single `string`,
and round-trips bidirectionally:

```ts
pipe(literal('vault'), slash(restString('path')), mapTo(VaultNoteRoute))
// parse: /vault/a/b/c.md      -> { path: 'a/b/c.md' }
// build: { path: 'a/b/c.md' } -> /vault/a/b/c.md
```

## Why

Feedback from a production Foldkit app (#617): a screen addresses a vault note
by its repository-relative path (`20-upgrade/teach/the-elm-architecture.md`),
which contains both `/` and `.`. Neither existing building block round-trips it:

- `string('path')` matches a single segment, stopping at the first `/`.
- `rest('path')` yields a `NonEmptyArray<string>` of segments — it has split on
  `/`, so reassembling a raw path is lossy and awkward to feed back into the
  bidirectional router.

`restString` is the greedy catch-all every file-tree / docs router eventually
needs (cf. Remix / Next `[...slug]`). It mirrors `rest` exactly but rejoins the
tail into one path string, so `{ path: S.String }` route data can be sourced
from a natural path-shaped URL instead of a `?path=` query workaround.

## How

Same terminal `Biparser` shape as `rest`: requires at least one remaining
segment, returns a `TerminalParser` (nothing can follow it in the path; still
extendable with `query`). Parse joins the tail with `/`; print pushes the raw
value as a single path piece.

## Tests

New `describe('restString')` block in `parser.test.ts` mirroring `rest`, with
round-trip coverage for the edge cases: multiple segments, dots in the tail,
single-segment tail, empty tail (fails, like `rest`), trailing-slash
normalization, percent-encoded tail (passes through unchanged), composition
after literals, combination with `query`, and the `slash`-after-terminal
`@ts-expect-error` guard. Full `foldkit` suite green (1470 pass); `foldkit`,
`@foldkit/ui`, `@foldkit/devtools` typecheck clean; prettier + oxlint clean.

Changeset: `minor` bump for `foldkit` (additive API).