### PR TITLE
feat(test): Story.fromSession — lower a captured session into a regression Story

### DIFF
--- a/.changeset/story-from-session.md
+++ b/.changeset/story-from-session.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `Story.fromSession`, which lowers a captured session artifact into a runnable regression `Story`. The artifact is init Model plus an ordered log of entries (each a dispatched Message, the Commands it triggered, and the resulting Model snapshot), decoded with `Schema` against the app's Model and Message Schemas. Each entry dispatches its Message as fresh input, or, when Commands from earlier entries are still pending, resolves the oldest pending Command with this entry's Message, mirroring how a Command's outcome surfaces as its own later Message entry in the log. Every entry asserts the replayed Model against its recorded snapshot, so the generated story fails the moment replay drifts from the capture. Splice the result into `Story.story(update, ...Story.fromSession(artifact, { Model, Message }))`.

--- a/packages/foldkit/src/test/session.test.ts
+++ b/packages/foldkit/src/test/session.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'vitest'
+
+import { Message, Model, update } from './apps/counter.js'
+import * as Story from './story.js'
+
+// A captured session is init Model + an ordered log of entries, each carrying
+// the dispatched Message, the Commands it triggered, and the resulting Model
+// snapshot. These fixtures are hand-authored in the wire shape the devtools
+// store serializes (`args` is `null` for argless Commands, matching
+// `SerializedCommand`'s `OptionFromNullOr`).
+
+const schemas = { Model, Message } as const
+
+describe('fromSession', () => {
+  test('lowers a pure-Message sequence into a runnable Story', () => {
+    const artifact = {
+      model: { count: 0, log: [] },
+      entries: [
+        {
+          message: { _tag: 'ClickedIncrement' },
+          commands: [],
+          model: { count: 1, log: [] },
+        },
+        {
+          message: { _tag: 'ClickedIncrement' },
+          commands: [],
+          model: { count: 2, log: [] },
+        },
+        {
+          message: { _tag: 'ClickedDecrement' },
+          commands: [],
+          model: { count: 1, log: [] },
+        },
+      ],
+    }
+
+    Story.story(update, ...Story.fromSession(artifact, schemas))
+  })
+
+  test('wires a Command outcome from its later result-Message entry', () => {
+    const artifact = {
+      model: { count: 0, log: [] },
+      entries: [
+        {
+          message: { _tag: 'ClickedFetch' },
+          commands: [{ name: 'FetchCount', args: null }],
+          model: { count: 0, log: [] },
+        },
+        {
+          message: { _tag: 'SucceededFetchCount', count: 42 },
+          commands: [],
+          model: { count: 42, log: [42] },
+        },
+      ],
+    }
+
+    Story.story(update, ...Story.fromSession(artifact, schemas))
+  })
+
+  test('matches a Command with args to its result Message', () => {
+    const artifact = {
+      model: { count: 0, log: [] },
+      entries: [
+        {
+          message: { _tag: 'ClickedFetchById', id: 7 },
+          commands: [{ name: 'FetchCountById', args: { id: 7 } }],
+          model: { count: 0, log: [] },
+        },
+        {
+          message: { _tag: 'SucceededFetchCount', count: 7 },
+          commands: [],
+          model: { count: 7, log: [7] },
+        },
+      ],
+    }
+
+    Story.story(update, ...Story.fromSession(artifact, schemas))
+  })
+
+  test('asserts each intermediate Model, catching a recorded-snapshot drift', () => {
+    const artifact = {
+      model: { count: 0, log: [] },
+      entries: [
+        {
+          message: { _tag: 'ClickedIncrement' },
+          commands: [],
+          model: { count: 99, log: [] },
+        },
+      ],
+    }
+
+    expect(() =>
+      Story.story(update, ...Story.fromSession(artifact, schemas)),
+    ).toThrow()
+  })
+
+  test('leaves the triggering Command unresolved when no result entry follows', () => {
+    const artifact = {
+      model: { count: 0, log: [] },
+      entries: [
+        {
+          message: { _tag: 'ClickedFetch' },
+          commands: [{ name: 'FetchCount', args: null }],
+          model: { count: 0, log: [] },
+        },
+      ],
+    }
+
+    expect(() =>
+      Story.story(update, ...Story.fromSession(artifact, schemas)),
+    ).toThrow('I found Commands without resolvers')
+  })
+
+  test('rejects a structurally malformed artifact with a Schema decode error', () => {
+    const artifact = {
+      model: { count: 0, log: [] },
+      entries: 'not-an-array',
+    }
+
+    expect(() => Story.fromSession(artifact, schemas)).toThrow()
+  })
+
+  test('rejects an entry whose Message does not match the app Message Schema', () => {
+    const artifact = {
+      model: { count: 0, log: [] },
+      entries: [
+        {
+          message: { _tag: 'NotARealMessage' },
+          commands: [],
+          model: { count: 0, log: [] },
+        },
+      ],
+    }
+
+    expect(() => Story.fromSession(artifact, schemas)).toThrow()
+  })
+})

--- a/packages/foldkit/src/test/story.ts
+++ b/packages/foldkit/src/test/story.ts
@@ -1,6 +1,15 @@
-import { Array, Effect, Equal, Option, Predicate, pipe } from 'effect'
+import {
+  Array,
+  Effect,
+  Equal,
+  Option,
+  Predicate,
+  Schema as S,
+  pipe,
+} from 'effect'
 
 import type { CommandDefinition } from '../command/index.js'
+import { SerializedCommand } from '../devTools/protocol.js'
 import type {
   AnyCommand,
   BaseInternal,
@@ -388,4 +397,160 @@ export const story: {
 
   const internal = toInternal(result)
   assertAllCommandsResolved(internal.commands)
+}
+
+// SESSION
+
+/** One entry of a captured session: the dispatched Message body, the Commands
+ *  that Message triggered (reusing the devtools `SerializedCommand` shape), and
+ *  the resulting Model snapshot. `message` and `model` stay `Unknown` here so
+ *  the envelope decodes without the app's Schemas; {@link fromSession} decodes
+ *  each against the Model and Message Schemas the caller supplies. */
+export const SessionEntry = S.Struct({
+  message: S.Unknown,
+  commands: S.Array(SerializedCommand),
+  model: S.Unknown,
+})
+/** One entry of a captured session. */
+export type SessionEntry = typeof SessionEntry.Type
+
+/** A captured runtime session: the initial Model plus an ordered log of
+ *  entries. This is the minimal, self-describing artifact a session export
+ *  emits, decodable without the app's Model/Message Schemas (those decode the
+ *  `Unknown` bodies later, in {@link fromSession}). */
+export const SessionArtifact = S.Struct({
+  model: S.Unknown,
+  entries: S.Array(SessionEntry),
+})
+/** A captured runtime session artifact. */
+export type SessionArtifact = typeof SessionArtifact.Type
+
+/** The app Schemas {@link fromSession} needs to decode a session artifact back
+ *  into runnable values: the Model Schema for the init Model and every recorded
+ *  snapshot, and the Message Schema for each dispatched and result Message. */
+export type SessionSchemas<Model, Message> = Readonly<{
+  Model: S.Codec<Model, any>
+  Message: S.Codec<Message, any>
+}>
+
+/** Resolves a pending Command matched by a plain `{ name, args? }` record (the
+ *  shape a serialized session carries) rather than a Definition or Instance.
+ *  Mirrors `Story.Command.resolve`: it guards against an ambiguous match and
+ *  throws with the pending list when nothing matches. */
+const resolveByRecord =
+  (matcher: AnyCommand, resultMessage: unknown) =>
+  <Model, Message, OutMessage>(
+    simulation: StorySimulation<Model, Message, OutMessage>,
+  ): StorySimulation<Model, Message, OutMessage> => {
+    const internal = toInternal(simulation)
+    assertResolveUnambiguous(internal.commands, matcher)
+    /* eslint-disable @typescript-eslint/consistent-type-assertions */
+    const next = resolveByMatcher(
+      internal as BaseInternal<Model, Message, unknown>,
+      matcher,
+      resultMessage as Message,
+    )
+    /* eslint-enable @typescript-eslint/consistent-type-assertions */
+
+    if (Predicate.isUndefined(next)) {
+      throw new Error(
+        `I tried to resolve "${formatMatcher(matcher)}" from the session log but no matching pending Command was found.\n\n` +
+          `Pending Commands:\n${Array.match(internal.commands, {
+            onEmpty: () => '    (none)',
+            onNonEmpty: nonEmpty =>
+              pipe(
+                nonEmpty,
+                Array.map(command => `    ${formatCommand(command)}`),
+                Array.join('\n'),
+              ),
+          })}\n\n` +
+          'This usually means the recorded log is inconsistent: a result Message ' +
+          'appears without the Command that would have produced it.',
+      )
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return next as StorySimulation<Model, Message, OutMessage>
+  }
+
+/** Builds a Command matcher from a serialized Command: name + args when the
+ *  entry recorded args, name-only otherwise. */
+const matcherFromSerialized = (command: SerializedCommand): AnyCommand =>
+  Option.match(command.args, {
+    onNone: () => ({ name: command.name }),
+    onSome: args => ({ name: command.name, args }),
+  })
+
+/** Lowers a captured session artifact into the steps of a runnable regression
+ *  {@link story}. Decodes the artifact envelope, the init Model, and every
+ *  Message/Model snapshot against the supplied app Schemas (a malformed
+ *  artifact or a Message that does not match the app Schema surfaces as a
+ *  Schema decode error here, before the story runs).
+ *
+ *  Each entry either dispatches its Message as fresh input or, when Commands
+ *  from earlier entries are still pending, resolves the oldest pending Command
+ *  with this entry's Message. That mirrors how a Command's outcome surfaces as
+ *  its own later Message entry in the log, so replay is deterministic even
+ *  though the original effects were not: the log already carries the resolved
+ *  outcomes, exactly what `Story.Command.resolve` consumes. Every entry also
+ *  emits a Model assertion against its recorded snapshot, so the generated
+ *  story fails the moment replay drifts from the capture.
+ *
+ *  Splice the result into {@link story}:
+ *
+ *  ```ts
+ *  Story.story(update, ...Story.fromSession(artifact, { Model, Message }))
+ *  ```
+ */
+export const fromSession = <Model, Message>(
+  artifact: unknown,
+  schemas: SessionSchemas<Model, Message>,
+): ReadonlyArray<StoryStep<Model>> => {
+  const decoded = S.decodeUnknownSync(SessionArtifact)(artifact)
+  const decodeModel = S.decodeUnknownSync(schemas.Model)
+  const decodeMessage = S.decodeUnknownSync(schemas.Message)
+
+  const initModel = decodeModel(decoded.model)
+
+  const steps: Array<StoryStep<Model>> = [with_(initModel)]
+  let pending: ReadonlyArray<SerializedCommand> = []
+
+  for (const entry of decoded.entries) {
+    const entryMessage = decodeMessage(entry.message)
+    const entryModel = decodeModel(entry.model)
+    const messageLabel =
+      Predicate.hasProperty(entryMessage, '_tag') &&
+      typeof entryMessage._tag === 'string'
+        ? entryMessage._tag
+        : 'Message'
+
+    const nextPending = Option.match(Array.head(pending), {
+      onNone: () => {
+        steps.push(message(entryMessage))
+        return pending
+      },
+      onSome: command => {
+        steps.push(
+          resolveByRecord(matcherFromSerialized(command), entryMessage),
+        )
+        return Array.drop(pending, 1)
+      },
+    })
+
+    pending = Array.appendAll(nextPending, entry.commands)
+
+    steps.push(
+      model((currentModel: Model) => {
+        if (!Equal.equals(currentModel, entryModel)) {
+          throw new Error(
+            `Replayed Model diverged from the recorded snapshot after "${messageLabel}":\n\n` +
+              `    expected: ${JSON.stringify(entryModel)}\n` +
+              `    actual:   ${JSON.stringify(currentModel)}`,
+          )
+        }
+      }),
+    )
+  }
+
+  return steps
 }


### PR DESCRIPTION
Implements the lowering half of #622. No new MCP tool or WebSocket protocol message (the `foldkit_export_session` / `foldkit session export` surface that *emits* the artifact is explicitly out of scope for this PR).

## What

`Story.fromSession(artifact, { Model, Message })` lowers a captured session artifact into the steps of a runnable regression `Story`. Splice it straight into the existing runner:

```ts
Story.story(update, ...Story.fromSession(artifact, { Model, Message }))
```

An artifact is the minimal, self-describing shape the issue proposes: the initial Model plus an ordered log of entries, each carrying a dispatched Message, the Commands it triggered, and the resulting Model snapshot. It decodes with `Schema` (no raw `JSON.parse`), and reuses the devtools `SerializedCommand` shape for the triggered-Command list rather than inventing a parallel format. New exports from `foldkit/test`: `Story.fromSession`, plus `Story.SessionArtifact` / `Story.SessionEntry` Schemas and the `Story.SessionSchemas` type.

## Why it replays deterministically

Per the effect-result nuance in the issue: a Command's outcome already shows up in the log as its own later Message entry. So the lowering walks the entries in order and, for each one, either

- dispatches the Message as fresh input (`Story.message`), or
- when Commands from earlier entries are still pending, resolves the oldest pending Command with this entry's Message — exactly what `Story.Command.resolve` consumes.

The recorded outcomes come from the log, so replay is deterministic even though the original effects were not. Every entry also asserts the replayed Model against its recorded snapshot (via `Equal.equals`), so the generated story fails the moment replay drifts from the capture.

## Tests

Hand-authored artifacts in the devtools wire shape, driven through the counter test app:

- a pure-Message sequence (no Commands);
- a Command whose result Message appears in a later entry (asserts the resolve wiring + the post-resolve Model), including the args-matching variant;
- an intermediate-snapshot drift that the generated story catches;
- a triggering Command with no following result entry (surfaces as `Story`'s existing unresolved-Command error);
- a structurally malformed artifact and an entry whose Message does not match the app Message Schema (both clean `Schema` decode errors).

Full `foldkit` suite green (1463 passing) and `tsc --noEmit` clean; changeset is `minor` (additive test API).

## What remains for the end-to-end loop

This PR is the `foldkit/test` bridge only. To close the capture→fixture loop, a follow-up needs the export surface that emits the artifact from a live session (`foldkit_export_session` MCP tool and/or a `foldkit session export` CLI over the existing WS bridge), including the exporter's job of correlating each triggered Command to the result-Message entry it produced. The current lowering pairs pending Commands to result entries positionally (FIFO), which is exact for the common linear session; richer correlation metadata from the exporter could later disambiguate interleaved/concurrent effects.