### PR TITLE
feat(foldkit): route-coverage ratchet test helper

### DIFF
--- a/.changeset/route-coverage-ratchet.md
+++ b/.changeset/route-coverage-ratchet.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `Coverage`, a zero-dependency `foldkit/test` helper that asserts every route has at least one behavioral Scene. `Coverage.everyRouteHasAScene({ routeSource, testDir, knownDebt })` reads the route registry straight from the `r(...)` declarations in `route.ts`, scans co-located test files for a `describe('route:<Tag>', ...)` marker, and hard-errors on any uncovered route except those in a `knownDebt` set that only shrinks. Covering a route forces its removal from the set (a stale entry is itself an error), so coverage can never silently regress. `Coverage.audit(...)` exposes the same computation as a pure report. Depends only on vitest plus `node:fs`/`node:path`.

--- a/packages/foldkit/package.json
+++ b/packages/foldkit/package.json
@@ -147,6 +147,7 @@
   "devDependencies": {
     "@effect/platform-browser": "4.0.0-beta.88",
     "@effect/vitest": "4.0.0-beta.88",
+    "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^4.1.9",
     "effect": "4.0.0-beta.88",
     "happy-dom": "^20.10.4",

--- a/packages/foldkit/src/test/coverage.test.ts
+++ b/packages/foldkit/src/test/coverage.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import * as Coverage from './coverage.js'
+
+// A minimal on-disk Foldkit app: a route registry plus co-located test files.
+type Fixture = Readonly<{
+  root: string
+  routeSource: string
+  writeRoute: (tags: ReadonlyArray<string>) => void
+  writeTest: (name: string, coveredTags: ReadonlyArray<string>) => void
+}>
+
+const fixtures: Array<string> = []
+
+const makeFixture = (): Fixture => {
+  const root = mkdtempSync(join(tmpdir(), 'fk-coverage-'))
+  fixtures.push(root)
+  const routeSource = join(root, 'route.ts')
+  return {
+    root,
+    routeSource,
+    writeRoute: tags => {
+      const body = tags
+        .map(tag => `export const ${tag}Route = r('${tag}')`)
+        .join('\n')
+      writeFileSync(routeSource, `import { r } from 'foldkit/route'\n${body}\n`)
+    },
+    writeTest: (name, coveredTags) => {
+      const body = coveredTags
+        .map(tag => `describe('route:${tag}', () => { test('x', () => {}) })`)
+        .join('\n')
+      writeFileSync(
+        join(root, name),
+        `import { describe, test } from 'vitest'\n${body}\n`,
+      )
+    },
+  }
+}
+
+afterEach(() => {
+  fixtures.length = 0
+})
+
+describe('Coverage.audit', () => {
+  test('reads the route registry from r(...) declarations, dropping ignored fallbacks', () => {
+    const fixture = makeFixture()
+    fixture.writeRoute(['Home', 'Weather', 'NotFound'])
+    fixture.writeTest('home.test.ts', [])
+
+    const report = Coverage.audit({
+      routeSource: fixture.routeSource,
+      testDir: fixture.root,
+    })
+
+    expect(report.registry).toEqual(['Home', 'Weather'])
+  })
+
+  test('the marker convention and ignore set are configurable', () => {
+    const fixture = makeFixture()
+    fixture.writeRoute(['Dashboard', 'Login', 'NotFound'])
+    // A bespoke marker: describe('screen:Dashboard', ...)
+    writeFileSync(
+      join(fixture.root, 'dashboard.test.ts'),
+      `describe('screen:Dashboard', () => {})\n`,
+    )
+
+    const report = Coverage.audit({
+      routeSource: fixture.routeSource,
+      testDir: fixture.root,
+      ignore: ['NotFound', 'Login'],
+      markerPattern: /describe\(\s*['"`]screen:(\w+)['"`]/g,
+    })
+
+    expect(report.registry).toEqual(['Dashboard'])
+    expect(report.covered).toEqual(['Dashboard'])
+    expect(report.uncovered).toEqual([])
+  })
+
+  test('a route with a describe(route:Tag) marker counts as covered', () => {
+    const fixture = makeFixture()
+    fixture.writeRoute(['Home', 'Weather'])
+    fixture.writeTest('home.test.ts', ['Home'])
+
+    const report = Coverage.audit({
+      routeSource: fixture.routeSource,
+      testDir: fixture.root,
+    })
+
+    expect(report.covered).toEqual(['Home'])
+    expect(report.uncovered).toEqual(['Weather'])
+    expect(report.errors).toEqual(['Weather'])
+  })
+})
+
+describe('Coverage.everyRouteHasAScene', () => {
+  const run =
+    (fixture: Fixture, knownDebt: ReadonlyArray<string> = []) =>
+    () =>
+      Coverage.everyRouteHasAScene({
+        routeSource: fixture.routeSource,
+        testDir: fixture.root,
+        knownDebt,
+      })
+
+  test('throws, naming the route, when a route has no Scene', () => {
+    const fixture = makeFixture()
+    fixture.writeRoute(['Home', 'Weather'])
+    fixture.writeTest('home.test.ts', ['Home'])
+
+    expect(run(fixture)).toThrow(/Weather/)
+  })
+
+  test('passes when every route is covered', () => {
+    const fixture = makeFixture()
+    fixture.writeRoute(['Home', 'Weather'])
+    fixture.writeTest('home.test.ts', ['Home'])
+    fixture.writeTest('weather.test.ts', ['Weather'])
+
+    expect(run(fixture)).not.toThrow()
+  })
+
+  test('a knownDebt route is allowed to lack a Scene and surfaces as tracked debt', () => {
+    const fixture = makeFixture()
+    fixture.writeRoute(['Home', 'Weather'])
+    fixture.writeTest('home.test.ts', ['Home'])
+
+    expect(run(fixture, ['Weather'])).not.toThrow()
+
+    const report = Coverage.audit({
+      routeSource: fixture.routeSource,
+      testDir: fixture.root,
+      knownDebt: ['Weather'],
+    })
+    expect(report.errors).toEqual([])
+    expect(report.debt).toEqual(['Weather'])
+  })
+
+  test('a stale knownDebt entry (route now covered) throws so the ratchet re-arms', () => {
+    const fixture = makeFixture()
+    fixture.writeRoute(['Home', 'Weather'])
+    fixture.writeTest('home.test.ts', ['Home'])
+    fixture.writeTest('weather.test.ts', ['Weather'])
+
+    expect(run(fixture, ['Weather'])).toThrow(/stale/)
+  })
+
+  test('a knownDebt entry naming no existing route is flagged as stale', () => {
+    const fixture = makeFixture()
+    fixture.writeRoute(['Home'])
+    fixture.writeTest('home.test.ts', ['Home'])
+
+    expect(run(fixture, ['Ghost'])).toThrow(/Ghost/)
+  })
+})

--- a/packages/foldkit/src/test/coverage.ts
+++ b/packages/foldkit/src/test/coverage.ts
@@ -1,0 +1,150 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** The default route-declaration scanner. Captures the tag `T` from every
+ *  `r('T')` / `r("T")` route builder call. Group 1 must be the tag. */
+const DEFAULT_ROUTE_PATTERN = /\br\(\s*['"`](\w+)['"`]/g
+
+/** The default coverage marker. A route `T` is covered when some test file
+ *  contains `describe('route:T', ...)`. Group 1 must be the tag. */
+const DEFAULT_MARKER_PATTERN = /describe\(\s*['"`]route:(\w+)['"`]/g
+
+const DEFAULT_TEST_FILE_SUFFIX = '.test.ts'
+
+export type Options = Readonly<{
+  /** Path (or `file:` URL) to the module that declares the route registry,
+   *  typically `route.ts`. Scanned as text; never imported. */
+  routeSource: string | URL
+  /** Directory whose test files are scanned for coverage markers. */
+  testDir: string | URL
+  /** Route tags allowed to lack a spec, tracked as debt. Only ever shrinks. */
+  knownDebt?: Iterable<string>
+  /** Route tags excluded from the registry (fallbacks). Default `['NotFound']`. */
+  ignore?: Iterable<string>
+  /** Overrides {@link DEFAULT_ROUTE_PATTERN}. Group 1 must capture the tag. */
+  routePattern?: RegExp
+  /** Overrides {@link DEFAULT_MARKER_PATTERN}. Group 1 must capture the tag. */
+  markerPattern?: RegExp
+  /** Test-file suffix scanned for markers. Default `'.test.ts'`. */
+  testFileSuffix?: string
+}>
+
+/** The outcome of a coverage audit. Both `errors` and `staleDebt` must be
+ *  empty for the ratchet to hold; `debt` is tracked, non-blocking. */
+export type Report = Readonly<{
+  /** Every route tag declared in `routeSource`, minus `ignore`. */
+  registry: ReadonlyArray<string>
+  /** Registry tags carrying a coverage marker. */
+  covered: ReadonlyArray<string>
+  /** Registry tags with no coverage marker. */
+  uncovered: ReadonlyArray<string>
+  /** Uncovered tags NOT in `knownDebt`: new or regressed routes. Must be empty. */
+  errors: ReadonlyArray<string>
+  /** `knownDebt` tags that are no longer uncovered: stale, remove them. Must be empty. */
+  staleDebt: ReadonlyArray<string>
+  /** Uncovered tags that ARE in `knownDebt`: tracked debt, non-blocking. */
+  debt: ReadonlyArray<string>
+}>
+
+/** All capture-group-1 matches of `pattern` over `source`, in order, unique,
+ *  dropping empty slots. */
+const captures = (source: string, pattern: RegExp): ReadonlyArray<string> => {
+  const seen = new Set<string>()
+  for (const [, tag] of source.matchAll(pattern)) {
+    if (tag !== undefined) {
+      seen.add(tag)
+    }
+  }
+  return [...seen]
+}
+
+const toPath = (source: string | URL): string =>
+  typeof source === 'string' ? source : fileURLToPath(source)
+
+/** Every route tag marked as covered by some test file under `testDir`. */
+const coveredTags = (
+  testDir: string,
+  suffix: string,
+  markerPattern: RegExp,
+): ReadonlySet<string> => {
+  const covered = new Set<string>()
+  for (const entry of readdirSync(testDir, { recursive: true })) {
+    const relative = String(entry)
+    if (!relative.endsWith(suffix)) {
+      continue
+    }
+    const text = readFileSync(join(testDir, relative), 'utf8')
+    for (const tag of captures(text, markerPattern)) {
+      covered.add(tag)
+    }
+  }
+  return covered
+}
+
+/** Scan the route registry and test markers on disk and compute the coverage
+ *  report. Reads files only; imports no application code. */
+export const audit = (options: Options): Report => {
+  const ignore = new Set(options.ignore ?? ['NotFound'])
+  const knownDebt = new Set(options.knownDebt ?? [])
+  const routePattern = options.routePattern ?? DEFAULT_ROUTE_PATTERN
+  const markerPattern = options.markerPattern ?? DEFAULT_MARKER_PATTERN
+  const suffix = options.testFileSuffix ?? DEFAULT_TEST_FILE_SUFFIX
+
+  const routeText = readFileSync(toPath(options.routeSource), 'utf8')
+  const registry = captures(routeText, routePattern).filter(
+    tag => !ignore.has(tag),
+  )
+
+  const marked = coveredTags(toPath(options.testDir), suffix, markerPattern)
+  const covered = registry.filter(tag => marked.has(tag))
+  const uncovered = registry.filter(tag => !marked.has(tag))
+  const errors = uncovered.filter(tag => !knownDebt.has(tag))
+  const debt = uncovered.filter(tag => knownDebt.has(tag))
+  const staleDebt = [...knownDebt].filter(tag => !uncovered.includes(tag))
+
+  return { registry, covered, uncovered, errors, staleDebt, debt }
+}
+
+/** Assert that every declared route has at least one behavioral Scene, allowing
+ *  only the shrinking `knownDebt` set. Throws when a new or regressed route is
+ *  uncovered, or when a `knownDebt` entry is stale (its route is now covered or
+ *  no longer exists). Tracked debt is surfaced as a `console.warn`, never a
+ *  failure. Returns the {@link Report} on success. Call it inside one test:
+ *
+ *  ```ts
+ *  import { test } from 'vitest'
+ *  import { Coverage } from 'foldkit/test'
+ *
+ *  test('every route has a behavioral Scene', () => {
+ *    Coverage.everyRouteHasAScene({
+ *      routeSource: new URL('./route.ts', import.meta.url),
+ *      testDir: import.meta.dirname,
+ *      knownDebt: ['Board', 'Triage'],
+ *    })
+ *  })
+ *  ``` */
+export const everyRouteHasAScene = (options: Options): Report => {
+  const report = audit(options)
+  const problems = [
+    ...report.errors.map(
+      tag =>
+        `  - ${tag}: no behavioral Scene. Add describe('route:${tag}', ...).`,
+    ),
+    ...report.staleDebt.map(
+      tag =>
+        `  - ${tag}: stale knownDebt entry. It is covered (or gone); remove it from knownDebt.`,
+    ),
+  ]
+  if (problems.length > 0) {
+    throw new Error(`Route-coverage ratchet failed:\n${problems.join('\n')}`)
+  }
+  if (report.debt.length > 0) {
+    console.warn(
+      `Route-coverage debt: ${report.debt.length} route(s) lack a behavioral Scene:\n` +
+        report.debt.map(tag => `  - ${tag}`).join('\n') +
+        `\nCover a route, then delete it from knownDebt.`,
+    )
+  }
+  return report
+}

--- a/packages/foldkit/src/test/public.ts
+++ b/packages/foldkit/src/test/public.ts
@@ -1,2 +1,3 @@
 export * as Story from './story.js'
 export * as Scene from './scene.js'
+export * as Coverage from './coverage.js'

--- a/packages/foldkit/tsconfig.base.json
+++ b/packages/foldkit/tsconfig.base.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "rootDir": "src",
+    "types": ["node"],
     "noEmit": true
   },
   "include": ["src"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1518,6 +1518,9 @@ importers:
       '@effect/vitest':
         specifier: 4.0.0-beta.88
         version: 4.0.0-beta.88(effect@4.0.0-beta.88)(vitest@4.1.9)
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)


### PR DESCRIPTION
Implements #616.

## What form

Shipped as a `foldkit/test` helper (`Coverage`), the issue's preferred option. It generalizes the ~120-line production ratchet into a reusable, parameterized helper. New exports: `Coverage.everyRouteHasAScene`, `Coverage.audit`, and the `Options` / `Report` types, re-exported from `foldkit/test`.

## How it works

`Coverage.everyRouteHasAScene({ routeSource, testDir, knownDebt })`:

1. reads the route registry straight from the `r('Tag')` declarations in `routeSource` (e.g. `route.ts`) — the single source of truth, scanned as text, never imported;
2. scans co-located `*.test.ts` files under `testDir` for a `describe('route:<Tag>', ...)` marker;
3. **throws** on any uncovered route except those in `knownDebt`, and **throws** on any *stale* `knownDebt` entry (a route that is now covered or no longer exists). Covering a route forces its removal from the set, which re-arms the error, so coverage can never silently regress. Tracked debt surfaces as a `console.warn`, never a failure.

Usage is three lines in a test file:

```ts
import { test } from 'vitest'
import { Coverage } from 'foldkit/test'

test('every route has a behavioral Scene', () => {
  Coverage.everyRouteHasAScene({
    routeSource: new URL('./route.ts', import.meta.url),
    testDir: import.meta.dirname,
    knownDebt: ['Board', 'Triage'],
  })
})
```

`Coverage.audit(options)` exposes the same scan as a pure `Report` (`registry`, `covered`, `uncovered`, `errors`, `staleDebt`, `debt`) for custom wiring. The conventions are parameterized: `routePattern`, `markerPattern`, `ignore` (default `['NotFound']`), and `testFileSuffix`.

## Dependencies

Zero runtime deps beyond vitest + `node:fs`/`node:path`/`node:url`. Like `Story`/`Scene`, it is runner-agnostic: it throws on violation and lets the runner report. `foldkit/test` is a test-time surface (only imported from `*.test.ts`, never bundled to the browser), so `@types/node` was added to the package's devDeps and `types: ["node"]` to its local tsconfig base — mirroring `create-foldkit-app`, which already uses that setting. Happy to gate node globals via lint, or split this into a separate node-only entry, if you'd prefer to keep the core tsconfig node-free.

## Tests

`coverage.test.ts` builds temp on-disk fixtures and proves: the registry reads from `r(...)` (dropping `NotFound`); the marker/ignore conventions are configurable; an uncovered route errors (naming the route); full coverage passes; a `knownDebt` route is allowed and surfaces as tracked debt; a stale `knownDebt` entry (route now covered, or naming no route) errors so the ratchet re-arms.

Green locally: `foldkit` typecheck clean, build clean, full suite 1464 passing (8 new), lint + prettier clean, knip clean. Added a `minor` changeset for `foldkit`.

## Naming note

Used `feat(foldkit):` rather than `feat(test):` per AGENTS.md (scopes are package dirs; internal module names are not valid scopes).