### PR TITLE
fix(website): keep Nav demo tabs centered on mobile

### DIFF
--- a/packages/website/src/page/ui/nav.ts
+++ b/packages/website/src/page/ui/nav.ts
@@ -54,7 +54,7 @@ const navClassName =
   'flex gap-1 p-1.5 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-900'
 
 const linkClassName =
-  'flex-1 text-center px-4 py-2 text-sm font-normal rounded-lg cursor-pointer transition text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-500/10 dark:hover:bg-gray-400/10 data-[current]:bg-cream data-[current]:dark:bg-gray-800 data-[current]:hover:bg-cream data-[current]:dark:hover:bg-gray-800 data-[current]:text-gray-900 data-[current]:dark:text-white data-[current]:shadow-sm'
+  'flex-1 text-center px-2 sm:px-4 py-2 text-sm font-normal rounded-lg cursor-pointer transition text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-500/10 dark:hover:bg-gray-400/10 data-[current]:bg-cream data-[current]:dark:bg-gray-800 data-[current]:hover:bg-cream data-[current]:dark:hover:bg-gray-800 data-[current]:text-gray-900 data-[current]:dark:text-white data-[current]:shadow-sm'
 
 // VIEW
 


### PR DESCRIPTION
The Nav example tabs used px-4 on every viewport, so the four-tab bar
needed ~324px minimum. Inside the demo container's p-8 padding a phone
only offers ~262-292px, so the bar overflowed the right padding and the
demo looked shifted off center. Shrink the tab padding to px-2 on mobile
(px-4 from the sm breakpoint up) so all four tabs fit in one row and the
demo stays centered. Desktop is unchanged.