### PR TITLE
fix(website): give Nav demo a stable, equal-width tab bar

### DIFF
--- a/packages/website/src/page/ui/nav.ts
+++ b/packages/website/src/page/ui/nav.ts
@@ -90,7 +90,7 @@ export const basicDemo = (url: Url) => {
 
   return [
     h.div(
-      [h.Class('max-w-md mx-auto')],
+      [h.Class('w-full max-w-lg mx-auto')],
       [
         Nav.view<NavDemoSection>({
           items: demoSections,


### PR DESCRIPTION
## Problem

On the Nav docs page, the demo tab bar's width changed depending on which section was selected, and the selected-tab highlight resized as you switched tabs.

The demo wrapper was `max-w-md` with no explicit width, so inside the demo container's `flex … items-center` it shrank to fit its content. That left `flex-1` with no definite width to distribute, so each tab sized to its own label instead of sharing the row:

| Tab | width (before) |
|---|---|
| Home | 71px |
| Search | 77px |
| Library | 78px |
| Profile | 74px |

Switching sections moved the highlight between tabs of different widths, and the whole block also grew/shrank with the URL text underneath.

## Fix

Change the wrapper from `max-w-md mx-auto` to `w-full max-w-lg mx-auto`:

- `w-full` gives the row a definite width, so `flex-1` splits it into four equal tabs. The highlight is now a fixed size regardless of selection.
- `max-w-lg` (512px, up from 448px) uses more of the space the demo has. I compared md/lg/xl while designing this; lg reads as generous without looking stretched.

## Verification

Drove the real page with Playwright across 360 / 393 / 768 / 1280px and every section:

- The demo width is identical across all four selections at each viewport (no more jump).
- Tabs are exactly equal at 393 / 768 / 1280px (e.g. 106/106/106/106 at the cap). At 360px there is a ~7px variance because four readable tabs genuinely crowd that width, but the overall width no longer changes with selection.
- No horizontal overflow; the mobile `px-2 sm:px-4` padding from the previous fix still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154Qcxrexe2PdTmVa2wwKyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0154Qcxrexe2PdTmVa2wwKyQ)_