### PR TITLE
Scope lint and test scripts to src, ignore Claude worktrees

### DIFF
--- a/.changeset/readme-respects-package-manager.md
+++ b/.changeset/readme-respects-package-manager.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Generate the README's Getting Started commands from the selected package manager instead of always showing pnpm.

--- a/.changeset/scope-scaffold-lint-and-test-to-src.md
+++ b/.changeset/scope-scaffold-lint-and-test-to-src.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Scope the generated `lint` script and Vitest config to `src`, and ignore `.claude/worktrees/`. Tooling in a scaffolded project no longer reaches into vendored `repos/` subtrees.

--- a/packages/create-foldkit-app/src/commands/create.ts
+++ b/packages/create-foldkit-app/src/commands/create.ts
@@ -1,14 +1,16 @@
 import chalk from 'chalk'
-import { Console, Effect, FileSystem, Match, Option, Path } from 'effect'
+import { Console, Effect, FileSystem, Option, Path } from 'effect'
 import { Prompt } from 'effect/unstable/cli'
 import { spawnSync } from 'node:child_process'
 
 import { type Example, examples } from '../examples.js'
 import { createProject } from '../utils/files.js'
-import { installDependencies } from '../utils/packages.js'
+import {
+  type PackageManager,
+  devCommand,
+  installDependencies,
+} from '../utils/packages.js'
 import { validateProjectName } from '../validateName.js'
-
-type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
 type CreateInput = Readonly<{
   name: Option.Option<string>
@@ -124,21 +126,12 @@ const installProjectDependencies = (
     yield* Console.log('')
   })
 
-const runDevServerCommand = (packageManager: PackageManager) =>
-  Match.value(packageManager).pipe(
-    Match.when('pnpm', () => 'pnpm dev'),
-    Match.when('npm', () => 'npm run dev'),
-    Match.when('yarn', () => 'yarn dev'),
-    Match.when('bun', () => 'bun dev'),
-    Match.exhaustive,
-  )
-
 const displaySuccessMessage = (name: string, packageManager: PackageManager) =>
   Effect.gen(function* () {
     yield* Console.log(chalk.bold('All systems nominal.'))
     yield* Console.log('')
     yield* Console.log(`  > ${chalk.cyan('cd')} ${name}`)
-    yield* Console.log(`  > ${chalk.cyan(runDevServerCommand(packageManager))}`)
+    yield* Console.log(`  > ${chalk.cyan(devCommand(packageManager))}`)
     yield* Console.log('')
     yield* Console.log(chalk.bold('AI-Assisted Development'))
     yield* Console.log('')

--- a/packages/create-foldkit-app/src/utils/files.test.ts
+++ b/packages/create-foldkit-app/src/utils/files.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { expect } from 'vitest'
+
+import { describe, it } from '@effect/vitest'
+
+import { applyPackageManager } from './files.js'
+
+const templateReadme = readFileSync(
+  fileURLToPath(new URL('../../templates/base/README.md', import.meta.url)),
+  'utf8',
+)
+
+describe('applyPackageManager', () => {
+  it('substitutes the README command placeholders for the selected manager', () => {
+    const bun = applyPackageManager(templateReadme, 'bun')
+    expect(bun).toContain('bun install')
+    expect(bun).toContain('bun dev')
+    expect(bun).not.toContain('{{')
+
+    const npm = applyPackageManager(templateReadme, 'npm')
+    expect(npm).toContain('npm install')
+    expect(npm).toContain('npm run dev')
+    expect(npm).not.toContain('{{')
+
+    const pnpm = applyPackageManager(templateReadme, 'pnpm')
+    expect(pnpm).toContain('pnpm install')
+    expect(pnpm).toContain('pnpm dev')
+    expect(pnpm).not.toContain('{{')
+  })
+})

--- a/packages/create-foldkit-app/src/utils/files.ts
+++ b/packages/create-foldkit-app/src/utils/files.ts
@@ -19,7 +19,7 @@ import {
 } from 'effect/unstable/http'
 import { fileURLToPath } from 'node:url'
 
-type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
+import { type PackageManager, devCommand, installCommand } from './packages.js'
 
 const GITHUB_API_BASE_URL =
   'https://api.github.com/repos/foldkit/foldkit/contents/examples'
@@ -168,21 +168,43 @@ export const createProject = (
 ) =>
   Effect.gen(function* () {
     yield* createBaseFiles(projectPath)
-    yield* modifyBaseFiles(projectPath, name)
+    yield* modifyBaseFiles(projectPath, name, packageManager)
     yield* createPackageManagerFiles(projectPath, packageManager)
     yield* createExampleFiles(projectPath, example)
   })
 
-const modifyBaseFiles = (projectPath: string, name: string) =>
+export const applyPackageManager = (
+  readme: string,
+  packageManager: PackageManager,
+): string =>
+  pipe(
+    readme,
+    String.replace('{{installCommand}}', installCommand(packageManager)),
+    String.replace('{{devCommand}}', devCommand(packageManager)),
+  )
+
+const modifyBaseFiles = (
+  projectPath: string,
+  name: string,
+  packageManager: PackageManager,
+) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
 
     const packageJsonPath = path.join(projectPath, 'package.json')
+    const packageJson = yield* fs.readFileString(packageJsonPath)
+    yield* fs.writeFileString(
+      packageJsonPath,
+      String.replace('{{name}}', name)(packageJson),
+    )
 
-    const content = yield* fs.readFileString(packageJsonPath)
-    const updatedContent = String.replace('my-foldkit-app', name)(content)
-    yield* fs.writeFileString(packageJsonPath, updatedContent)
+    const readmePath = path.join(projectPath, 'README.md')
+    const readme = yield* fs.readFileString(readmePath)
+    yield* fs.writeFileString(
+      readmePath,
+      applyPackageManager(readme, packageManager),
+    )
   })
 
 const GitHubFileEntry = Schema.Struct({

--- a/packages/create-foldkit-app/src/utils/packages.test.ts
+++ b/packages/create-foldkit-app/src/utils/packages.test.ts
@@ -2,7 +2,12 @@ import { expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
-import { buildUnresolvedDeps, buildUnresolvedDevDeps } from './packages.js'
+import {
+  buildUnresolvedDeps,
+  buildUnresolvedDevDeps,
+  devCommand,
+  installCommand,
+} from './packages.js'
 
 describe('buildUnresolvedDeps', () => {
   it('keeps third-party versions, resolves Foldkit workspace deps to latest, and drops foreign workspace deps', () => {
@@ -46,5 +51,23 @@ describe('buildUnresolvedDevDeps', () => {
       typescript: { _tag: 'Keep', version: '^6.0.3' },
       vite: { _tag: 'Keep', version: '^8.0.16' },
     })
+  })
+})
+
+describe('installCommand', () => {
+  it('installs with the selected package manager', () => {
+    expect(installCommand('pnpm')).toBe('pnpm install')
+    expect(installCommand('npm')).toBe('npm install')
+    expect(installCommand('yarn')).toBe('yarn install')
+    expect(installCommand('bun')).toBe('bun install')
+  })
+})
+
+describe('devCommand', () => {
+  it('runs the dev script, prefixing run only where npm needs it', () => {
+    expect(devCommand('pnpm')).toBe('pnpm dev')
+    expect(devCommand('npm')).toBe('npm run dev')
+    expect(devCommand('yarn')).toBe('yarn dev')
+    expect(devCommand('bun')).toBe('bun dev')
   })
 })

--- a/packages/create-foldkit-app/src/utils/packages.ts
+++ b/packages/create-foldkit-app/src/utils/packages.ts
@@ -13,7 +13,20 @@ import {
 import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { spawn } from 'node:child_process'
 
-type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
+export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
+
+export const installCommand = (packageManager: PackageManager): string =>
+  `${packageManager} install`
+
+const DEV_COMMANDS: Record<PackageManager, string> = {
+  pnpm: 'pnpm dev',
+  npm: 'npm run dev',
+  yarn: 'yarn dev',
+  bun: 'bun dev',
+}
+
+export const devCommand = (packageManager: PackageManager): string =>
+  DEV_COMMANDS[packageManager]
 
 const GITHUB_RAW_BASE_URL =
   'https://raw.githubusercontent.com/foldkit/foldkit/main/examples'

--- a/packages/create-foldkit-app/templates/base/README.md
+++ b/packages/create-foldkit-app/templates/base/README.md
@@ -5,8 +5,8 @@ A Foldkit application built with Effect.
 ## Getting Started
 
 ```bash
-pnpm install
-pnpm dev
+{{installCommand}}
+{{devCommand}}
 ```
 
 ## Learn More

--- a/packages/create-foldkit-app/templates/base/gitignore
+++ b/packages/create-foldkit-app/templates/base/gitignore
@@ -23,3 +23,6 @@ Thumbs.db
 
 # TypeScript
 *.tsbuildinfo
+
+# Claude Code worktrees
+.claude/worktrees/

--- a/packages/create-foldkit-app/templates/base/package.json
+++ b/packages/create-foldkit-app/templates/base/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-foldkit-app",
+  "name": "{{name}}",
   "version": "0.1.0",
   "type": "module",
   "scripts": {
@@ -9,6 +9,6 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier -w .",
     "test": "vitest run",
-    "lint": "oxlint"
+    "lint": "oxlint src"
   }
 }

--- a/packages/create-foldkit-app/templates/base/vitest.config.ts
+++ b/packages/create-foldkit-app/templates/base/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    include: ['src/**/*.{test,spec}.ts'],
     environment: 'happy-dom',
     setupFiles: ['./src/vitest-setup.ts'],
     server: {

--- a/scripts/check-create-foldkit-app-smoke.ts
+++ b/scripts/check-create-foldkit-app-smoke.ts
@@ -157,8 +157,8 @@ const assertTemplateTooling = (): void => {
     join(TEMPLATE_DIR, 'package.json'),
   )
   assertSmoke(
-    packageJson.scripts?.lint === 'oxlint',
-    'template package.json must use oxlint for the lint script',
+    packageJson.scripts?.lint === 'oxlint src',
+    'template package.json lint script must be scoped to src (oxlint src)',
   )
   assertSmoke(
     existsSync(join(TEMPLATE_DIR, '.oxlintrc.json')),


### PR DESCRIPTION
## Summary

Fixes issues with scaffolded projects that vendor Foldkit or Effect source as read-only subtrees by scoping the `lint` and `test` scripts to the `src` directory, and adds `.claude/worktrees/` to the generated `.gitignore`.

## Changes

- **package.json**: Changed `lint` script from `oxlint` to `oxlint src` to scope linting to the source directory
- **vitest.config.ts**: Added `include: ['src/**/*.{test,spec}.ts']` to scope test collection to the source directory
- **.gitignore**: Added `.claude/worktrees/` to exclude Claude Code worktrees from version control

## Details

Previously, the scaffolded scripts walked the entire project, which caused failures when vendoring dependencies as read-only subtrees:

- `oxlint` would discover nested `.oxlintrc.json` files under the subtree, fail to load their plugins, and exit with code 1
- Vitest would attempt to collect hundreds of test files from the subtree and hang

Scoping both scripts to `src` fixes these issues and is more correct even without vendored subtrees, as it prevents tools from processing dependency code and focuses linting and testing on the application itself.

https://claude.ai/code/session_01B161jVpbfg13LM4i9y984n