### PR TITLE
feat(ui): add initialFocus attribute group to Dialog RenderInfo

### DIFF
--- a/.changeset/dialog-initial-focus.md
+++ b/.changeset/dialog-initial-focus.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/ui': minor
+---
+
+Add an `initialFocus` attribute group to Dialog's `RenderInfo`. Spread it onto the element that should receive focus when the dialog opens. `focusSelector` targets an element whose id you do not own, or a descendant selector, and takes precedence when both are set.

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -134,6 +134,11 @@ export type InitConfig = Readonly<{
   id: string
   isOpen?: boolean
   isAnimated?: boolean
+  /** CSS selector for the element that receives focus when the dialog opens.
+   *  A selector-based override of the `initialFocus` RenderInfo marker, for the
+   *  cases a spread-on marker cannot express: an element whose id you do not
+   *  own, or a descendant selector. Takes precedence over `initialFocus`. With
+   *  neither set, focus falls to the first focusable element. */
   focusSelector?: string
 }>
 
@@ -153,6 +158,14 @@ export const init = (config: InitConfig): Model => ({
 
 const dialogSelector = (id: string): string => idSelector(id)
 
+/** Data attribute the dialog places on the `initialFocus` RenderInfo group and
+ *  focuses on open. */
+export const initialFocusMarkerAttribute = 'foldkit-dialog-initial-focus'
+
+/** Selector for {@link initialFocusMarkerAttribute}, focused against the open
+ *  dialog when no `focusSelector` is configured. */
+export const initialFocusMarkerSelector = `[data-${initialFocusMarkerAttribute}]`
+
 type UpdateReturn = readonly [
   Model,
   ReadonlyArray<Command.Command<Message>>,
@@ -167,19 +180,11 @@ const withUpdateReturn = M.withReturnType<UpdateReturn>()
  *  component supplies its own backdrop. */
 export const ShowDialog = Command.define(
   'ShowDialog',
-  { id: S.String, maybeFocusSelector: S.Option(S.String) },
+  { id: S.String, focusSelector: S.String },
   CompletedShowDialog,
-)(({ id, maybeFocusSelector }) =>
+)(({ id, focusSelector }) =>
   Dom.lockScroll.pipe(
-    Effect.andThen(() =>
-      Dom.showDialog(
-        dialogSelector(id),
-        Option.match(maybeFocusSelector, {
-          onNone: () => undefined,
-          onSome: focusSelector => ({ focusSelector }),
-        }),
-      ),
-    ),
+    Effect.andThen(() => Dom.showDialog(dialogSelector(id), { focusSelector })),
     Effect.ignore,
     Effect.as(CompletedShowDialog()),
   ),
@@ -262,7 +267,10 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         const maybeShow = Option.liftPredicate(
           ShowDialog({
             id: model.id,
-            maybeFocusSelector: model.maybeFocusSelector,
+            focusSelector: Option.getOrElse(
+              model.maybeFocusSelector,
+              () => initialFocusMarkerSelector,
+            ),
           }),
           () => wasClosed,
         )
@@ -407,6 +415,10 @@ export const descriptionId = (model: Model): string =>
  *  - `description`: attributes for the description element. Carries the
  *    framework-managed id the dialog's `aria-describedby` points at. Spread
  *    onto your description element (`h.p([...description], [...])`).
+ *  - `initialFocus`: attributes for the element that should receive focus when
+ *    the dialog opens. Spread onto that element (`h.input([...initialFocus])`).
+ *    A configured `focusSelector` (see `init`) takes precedence, and focus
+ *    falls back to the default when no element carries the group.
  *  - `closeButton`: attributes for an in-panel close control such as a Cancel
  *    or dismiss button. Carries the `OnClick` handler that closes the
  *    dialog (suppressed while a leave animation is in progress). Spread
@@ -420,6 +432,7 @@ export type RenderInfo = Readonly<{
   panel: ReadonlyArray<ChildAttribute>
   title: ReadonlyArray<ChildAttribute>
   description: ReadonlyArray<ChildAttribute>
+  initialFocus: ReadonlyArray<ChildAttribute>
   closeButton: ReadonlyArray<ChildAttribute>
   isVisible: boolean
 }>
@@ -503,6 +516,9 @@ export const view = defineView<Model, Message, ViewInputs>(
 
     const titleAttributes = [h.Id(titleId(model))]
     const descriptionAttributes = [h.Id(descriptionId(model))]
+    const initialFocusAttributes = [
+      h.DataAttribute(initialFocusMarkerAttribute, ''),
+    ]
 
     const closeButtonAttributes = isLeaving ? [] : [h.OnClick(RequestedClose())]
 
@@ -512,6 +528,7 @@ export const view = defineView<Model, Message, ViewInputs>(
       panel: childAttributes(panelAttributes),
       title: childAttributes(titleAttributes),
       description: childAttributes(descriptionAttributes),
+      initialFocus: childAttributes(initialFocusAttributes),
       closeButton: childAttributes(closeButtonAttributes),
       isVisible,
     })

--- a/packages/ui/src/dialog/story.test.ts
+++ b/packages/ui/src/dialog/story.test.ts
@@ -1,4 +1,5 @@
-import { Option } from 'effect'
+import { Effect, Option, Predicate } from 'effect'
+import * as Dom from 'foldkit/dom'
 import { type ChildAttribute, html } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
 import * as Story from 'foldkit/story'
@@ -25,16 +26,15 @@ import {
   Unmounted,
   descriptionId,
   init,
+  initialFocusMarkerAttribute,
+  initialFocusMarkerSelector,
   titleId,
   update,
   view,
 } from './index.js'
 
 const isOnUnmount = (childAttribute: ChildAttribute): boolean =>
-  typeof childAttribute.attribute === 'object' &&
-  childAttribute.attribute !== null &&
-  '_tag' in childAttribute.attribute &&
-  childAttribute.attribute._tag === 'OnUnmount'
+  Predicate.isTagged(childAttribute.attribute, 'OnUnmount')
 
 // Renders the dialog view through the Scene harness (which manages the runtime
 // frame) and reports whether the published `dialog` attribute group carries the
@@ -77,13 +77,21 @@ const hasIdAttribute = (
   id: string,
 ): boolean =>
   group.some(
-    childAttribute =>
-      typeof childAttribute.attribute === 'object' &&
-      childAttribute.attribute !== null &&
-      '_tag' in childAttribute.attribute &&
-      childAttribute.attribute._tag === 'Id' &&
-      'value' in childAttribute.attribute &&
-      childAttribute.attribute.value === id,
+    ({ attribute }) =>
+      Predicate.isTagged(attribute, 'Id') &&
+      Predicate.hasProperty(attribute, 'value') &&
+      attribute.value === id,
+  )
+
+const hasDataAttribute = (
+  group: ReadonlyArray<ChildAttribute>,
+  key: string,
+): boolean =>
+  group.some(
+    ({ attribute }) =>
+      Predicate.isTagged(attribute, 'DataAttribute') &&
+      Predicate.hasProperty(attribute, 'key') &&
+      attribute.key === key,
   )
 
 const animationToDialogMessage = (message: Animation.Message) =>
@@ -136,6 +144,33 @@ describe('Dialog', () => {
           Story.model(model => {
             expect(model.isOpen).toBe(true)
           }),
+        )
+      })
+
+      it('shows with the initialFocus marker selector when no focusSelector is configured', () => {
+        Story.story(
+          update,
+          Story.with(init({ id: 'test' })),
+          Story.message(RequestedOpen()),
+          Story.Command.resolve(
+            ShowDialog({
+              id: 'test',
+              focusSelector: initialFocusMarkerSelector,
+            }),
+            CompletedShowDialog(),
+          ),
+        )
+      })
+
+      it('shows with the configured focusSelector, which wins over the marker', () => {
+        Story.story(
+          update,
+          Story.with(init({ id: 'test', focusSelector: '#search-input' })),
+          Story.message(RequestedOpen()),
+          Story.Command.resolve(
+            ShowDialog({ id: 'test', focusSelector: '#search-input' }),
+            CompletedShowDialog(),
+          ),
         )
       })
 
@@ -392,6 +427,41 @@ describe('Dialog', () => {
         ),
       ).toBe(true)
     })
+  })
+
+  describe('RenderInfo initialFocus', () => {
+    it('publishes the marker the dialog focuses on open', () => {
+      const model = init({ id: 'my-dialog' })
+      expect(
+        hasDataAttribute(
+          renderGroup(model, render => render.initialFocus),
+          initialFocusMarkerAttribute,
+        ),
+      ).toBe(true)
+    })
+
+    it.effect(
+      'focuses the element carrying the marker when the dialog opens',
+      () =>
+        Effect.gen(function* () {
+          const dialog = document.createElement('dialog')
+          dialog.id = 'focus-dialog'
+          const before = document.createElement('input')
+          const marked = document.createElement('input')
+          marked.setAttribute(`data-${initialFocusMarkerAttribute}`, '')
+          dialog.append(before, marked)
+          document.body.appendChild(dialog)
+
+          yield* Dom.showDialog('#focus-dialog', {
+            focusSelector: initialFocusMarkerSelector,
+          })
+
+          expect(document.activeElement).toBe(marked)
+
+          yield* Dom.closeDialog('#focus-dialog')
+          document.body.innerHTML = ''
+        }),
+    )
   })
 
   describe('view OnUnmount gating', () => {

--- a/packages/website/src/page/ui/dialogPage.ts
+++ b/packages/website/src/page/ui/dialogPage.ts
@@ -131,7 +131,7 @@ const initConfigProps: ReadonlyArray<PropEntry> = [
     name: 'focusSelector',
     type: 'string',
     description:
-      'CSS selector for the element to focus when the dialog opens. Defaults to the first focusable element.',
+      'CSS selector for the element that receives focus when the dialog opens. A selector-based override of the `initialFocus` marker, for an element whose id you do not own or a descendant selector. Takes precedence over `initialFocus`; with neither set, focus falls to the first focusable element.',
   },
 ]
 
@@ -185,6 +185,12 @@ const renderInfoProps: ReadonlyArray<PropEntry> = [
     type: 'ReadonlyArray<ChildAttribute>',
     description:
       'Spread onto your description element (`h.p([...description], [...])`). Carries the framework-managed id the dialog’s `aria-describedby` points at, so the association wires up without hand-rolling the id.',
+  },
+  {
+    name: 'initialFocus',
+    type: 'ReadonlyArray<ChildAttribute>',
+    description:
+      'Spread onto the element that should receive focus when the dialog opens (`h.input([...initialFocus])`). A configured `focusSelector` takes precedence; to focus an element whose id you do not own, use `focusSelector`.',
   },
   {
     name: 'closeButton',


### PR DESCRIPTION
Fixes #656.

## What

`Dialog` moves initial focus on open. Before this the only lever was `focusSelector`, so focusing one of your own elements meant hand-rolling an id, spreading it onto the element, and restating it in the selector.

This adds an `initialFocus` attribute group to `Dialog`'s `RenderInfo`, a sibling of `title` / `description` / `closeButton`. Spread it onto the element that should receive focus on open; the dialog focuses it.

```ts
toView: ({ dialog, panel, title, initialFocus, closeButton }) =>
  h.dialog(
    [...dialog],
    [
      h.h2([...title], ['...']),
      h.input([...initialFocus]),
      // ...
    ],
  )
```

`focusSelector` remains for focusing an element whose id you do not own, or a descendant selector, and takes precedence when both are set.

## Design decisions

**The marker is a data attribute, not a reserved id.** The issue raised id-vs-data-attribute as an open question. The deciding reason is id-namespace hygiene. ids on the focus target are load-bearing for ARIA (`aria-labelledby`, `aria-describedby`, label `for`), and the element you want to focus usually already carries an id you chose. A reserved framework id would collide with that or force the consumer to surrender it, whereas a namespaced data attribute (`data-foldkit-dialog-initial-focus`) is purely additive. It also degrades sanely if the group is accidentally spread onto more than one element (valid HTML, `element.querySelector` takes the first in DOM order), but that is a graceful failure mode for an authoring mistake, not a supported capability: the marker means one element. No marked element falls back to the default focus.

**Precedence: `focusSelector` > `initialFocus` marker > default.** Resolved in `update` with `Option.getOrElse`, so `Dom.showDialog` is untouched.

## Changes

- `packages/ui/src/dialog/index.ts`: `initialFocus` on `RenderInfo`, the data-attribute marker in `view`, and marker-vs-`focusSelector` resolution in `update`. `ShowDialog` carries the resolved `focusSelector`. The marker attribute and selector are exported so the tests share the source of truth.
- `packages/ui/src/dialog/story.test.ts`: Story tests for the marker fallback and `focusSelector` precedence, a Scene test that the group publishes the marker, and a real-DOM `it.effect` test that opening focuses the marked element.
- `packages/website/src/page/ui/dialogPage.ts`: `initialFocus` row in the `RenderInfo` API table.
- Changeset: `minor` for `@foldkit/ui`.

## Verification

- `pnpm -F @foldkit/ui test`: 901 passing.
- Typechecked `@foldkit/ui`, `website`, `ui-showcase`, and `pixel-art-example`; lint and dead-code clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)