### PR TITLE
refactor: adopt Update.noOp for no-op update branches

### DIFF
--- a/.changeset/remove-update-noop.md
+++ b/.changeset/remove-update-noop.md
@@ -1,0 +1,10 @@
+---
+'foldkit': minor
+---
+
+Remove `Update.noOp`.
+
+It only wrapped `[model, []]`, the update return with an empty Command
+batch. The tuple is already the clearest form and stays edit-stable when a
+branch later gains a Command (you just fill the empty slot), so the wrapper
+did not earn its keep. Return `[model, []]` directly.

--- a/packages/foldkit/src/update/public.ts
+++ b/packages/foldkit/src/update/public.ts
@@ -1,4 +1,4 @@
-export { noOp, combine, refresh } from './index.js'
+export { combine, refresh } from './index.js'
 
 export type {
   Commands,

--- a/packages/foldkit/src/update/update.test.ts
+++ b/packages/foldkit/src/update/update.test.ts
@@ -12,7 +12,6 @@ import {
   type ReturnWithOutMessage,
   type Step,
   combine,
-  noOp,
   refresh,
 } from './update.js'
 
@@ -56,15 +55,6 @@ const incrementAndEmitLoadNotes: Step<TestModel, TestMessage> = model => [
   { count: model.count + 1 },
   [loadNotes],
 ]
-
-describe('noOp', () => {
-  it('returns the same model reference and no commands', () => {
-    const model: TestModel = { count: 3 }
-    const [nextModel, commands] = noOp(model)
-    expect(nextModel).toBe(model)
-    expect(commands).toEqual([])
-  })
-})
 
 describe('combine', () => {
   it('threads the model through the steps in order', () => {
@@ -284,14 +274,6 @@ describe('types', () => {
     ).toEqualTypeOf<Return<TestModel, TestMessage>>()
   })
 
-  it('noOp widens to a Return of any concrete Message', () => {
-    expectTypeOf(noOp(baseModel)).toEqualTypeOf<
-      readonly [TestModel, ReadonlyArray<never>]
-    >()
-    const asUpdateReturn: Return<TestModel, TestMessage> = noOp(baseModel)
-    expectTypeOf(asUpdateReturn).toEqualTypeOf<Return<TestModel, TestMessage>>()
-  })
-
   it('compiles the app-local withReturnType idiom over a two-variant message union', () => {
     // NOTE: This test is the factory-cut compile proof. Foldkit does not
     // export a Match factory for update returns; applications pin the alias
@@ -306,7 +288,7 @@ describe('types', () => {
         withUpdateReturn,
         M.tagsExhaustive({
           IncrementedCount: () => [{ count: model.count + 1 }, []],
-          CompletedLoad: () => noOp(model),
+          CompletedLoad: () => [model, []],
         }),
       )
 

--- a/packages/foldkit/src/update/update.ts
+++ b/packages/foldkit/src/update/update.ts
@@ -51,14 +51,6 @@ export type Step<Model, Message, R = never> = (
   model: Model,
 ) => Return<Model, Message, R>
 
-/** The no-op update step: returns the Model unchanged and asks for no
- *  Commands, so the whole update does nothing. Reach for it where a
- *  branch has nothing to contribute, for example the `onNone` arm of a
- *  lookup or the "nothing moved" case of a conditional step list. */
-export const noOp = <Model>(
-  model: Model,
-): readonly [Model, ReadonlyArray<never>] => [model, []]
-
 /** Composes a list of update steps into one. Each step runs against the
  *  Model the previous step produced, and every step's Commands are
  *  concatenated into a single batch, in step order.
@@ -70,8 +62,8 @@ export const noOp = <Model>(
  *
  *  Steps only ever accumulate Commands; a step cannot cancel or replace
  *  another step's Commands, and no Command runs during the fold. The
- *  runtime runs the batch after update returns. `combine([])` is
- *  {@link noOp}.
+ *  runtime runs the batch after update returns. `combine([])` returns
+ *  `[model, []]`.
  *
  *  ```ts
  *  SucceededUpdateNote: ({ note }) =>
@@ -98,7 +90,7 @@ export const combine: {
     model: Model,
     steps: ReadonlyArray<Step<Model, Message, R>>,
   ): Return<Model, Message, R> => {
-    const seed: Return<Model, Message, R> = noOp(model)
+    const seed: Return<Model, Message, R> = [model, []]
     return Array.reduce(steps, seed, ([currentModel, commands], step) => {
       const [nextModel, nextCommands] = step(currentModel)
       return [nextModel, [...commands, ...nextCommands]]
@@ -128,7 +120,7 @@ export type Refreshable<Model, Message, A, E, R = never> = Readonly<{
  *  cache: read the entry, ask `revalidate` whether it should transition,
  *  and only when it says yes write the transitioned state and emit the
  *  load Command. When `revalidate` returns `None` (a missing entry, or a
- *  state with nothing to revalidate) the step is {@link noOp}: same
+ *  state with nothing to revalidate) the step returns `[model, []]`: same
  *  Model, no Command. That one rule is what makes blanket revalidation
  *  safe, because only the caches that actually hold data reload.
  *
@@ -149,7 +141,7 @@ export const refresh =
       refreshable.read(model),
       Option.flatMap(refreshable.revalidate),
       Option.match({
-        onNone: () => noOp(model),
+        onNone: () => [model, []],
         onSome: next => [refreshable.write(model, next), [refreshable.load]],
       }),
     )


### PR DESCRIPTION
Replace [model, []] with Update.noOp(model) at genuine no-op update
returns across the example apps, @foldkit/ui (Tooltip, VirtualList),
@foldkit/devtools (overlay), the typing-game client, and the website
app. This names the intent of a do-nothing branch and matches how the
Update module already uses noOp internally.

Only sites returning the unchanged input model are converted. Returns
that carry a modified model with no commands (such as
[modelWithActiveTab, []]), init functions, teaching snippets, and test
fixtures are left as they were.

Make the websocket-chat and typing-game update-return types readonly so
they match Update.Return. noOp returns a readonly tuple, and the mutable
tuple literals from the other branches stay assignable to it.

The empty changeset marks this as behavior-preserving with no release.