### PR TITLE
refactor(foldkit)!: rename matchDataSplit to matchDataSplitEmpty

### DIFF
--- a/.changeset/rename-match-data-split-empty.md
+++ b/.changeset/rename-match-data-split-empty.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Rename `AsyncData.matchDataSplit` to `AsyncData.matchDataSplitEmpty`. This is a breaking rename. The new name says what the variant splits: the `onEmpty` channel that `matchData` collapses is broken back into `onIdle` and `onLoading`. Behavior and handler shape are unchanged; update call sites from `AsyncData.matchDataSplit(...)` to `AsyncData.matchDataSplitEmpty(...)`.

--- a/examples/api-cache/src/main.ts
+++ b/examples/api-cache/src/main.ts
@@ -484,7 +484,7 @@ const postsListView = (model: Model): Html => {
           'Open a post, go back, and open it again. The second visit renders instantly from the Model. Invalidate marks the list stale and refetches it while the current list stays on screen.',
         ],
       ),
-      AsyncData.matchDataSplit(model.posts, {
+      AsyncData.matchDataSplitEmpty(model.posts, {
         onIdle: () =>
           h.keyed('div')('Idle', [], [loadingPanel('Loading posts...')]),
         onLoading: () =>
@@ -596,7 +596,7 @@ const postDetailView = (model: Model, postId: string): Html => {
             ['Back to posts'],
           ),
       }),
-      AsyncData.matchDataSplit(postDetailData, {
+      AsyncData.matchDataSplitEmpty(postDetailData, {
         onIdle: () =>
           h.keyed('div')('Idle', [], [loadingPanel('Loading post...')]),
         onLoading: () =>
@@ -675,7 +675,7 @@ const statsTabView = (model: Model): Html => {
           'Stats refetch every 5 seconds while this tab is open. The old numbers stay on screen while the new ones load.',
         ],
       ),
-      AsyncData.matchDataSplit(model.stats, {
+      AsyncData.matchDataSplitEmpty(model.stats, {
         onIdle: () =>
           h.keyed('div')('Idle', [], [loadingPanel('Loading stats...')]),
         onLoading: () =>

--- a/packages/foldkit/src/asyncData/asyncData.test.ts
+++ b/packages/foldkit/src/asyncData/asyncData.test.ts
@@ -254,7 +254,7 @@ describe('types', () => {
     expectTypeOf(AsyncData.fromOptionOrIdle(maybeNotes)).toEqualTypeOf<State>()
   })
 
-  it('matchData and matchDataSplit return the union of handler return types', () => {
+  it('matchData and matchDataSplitEmpty return the union of handler return types', () => {
     const dataResult = AsyncData.matchData(success, {
       onEmpty: () => null,
       onFailure: error => error.length,
@@ -262,7 +262,7 @@ describe('types', () => {
     })
     expectTypeOf(dataResult).toEqualTypeOf<null | number | boolean>()
 
-    const splitResult = AsyncData.matchDataSplit(success, {
+    const splitResult = AsyncData.matchDataSplitEmpty(success, {
       onIdle: () => null,
       onLoading: () => undefined,
       onFailure: error => error.length,
@@ -374,9 +374,9 @@ describe('matchData', () => {
   })
 })
 
-describe('matchDataSplit', () => {
+describe('matchDataSplitEmpty', () => {
   const describeState = (state: State) =>
-    AsyncData.matchDataSplit(state, {
+    AsyncData.matchDataSplitEmpty(state, {
       onIdle: () => 'idle',
       onLoading: () => 'loading',
       onFailure: error => `failure:${error}`,
@@ -402,7 +402,7 @@ describe('matchDataSplit', () => {
     expect(
       pipe(
         stale,
-        AsyncData.matchDataSplit({
+        AsyncData.matchDataSplitEmpty({
           onIdle: () => 'idle',
           onLoading: () => 'loading',
           onFailure: error => `failure:${error}`,

--- a/packages/foldkit/src/asyncData/asyncData.ts
+++ b/packages/foldkit/src/asyncData/asyncData.ts
@@ -210,7 +210,7 @@ export const Schema = <A, AI, E, EI>(
  *  })
  *  ```
  */
-// NOTE: match, matchData, matchDataSplit, getData, and getError use
+// NOTE: match, matchData, matchDataSplitEmpty, getData, and getError use
 // refinement chains instead of Match because tagsExhaustive returns
 // Unify<B>, which does not reduce when the handlers return a caller's
 // naked generic in effect 4.0.0-beta.88. Combinators whose handlers
@@ -273,7 +273,7 @@ export const match: {
  *  `onData` spans the data-bearing states (`Success`, `Refreshing`,
  *  `Stale`), `onFailure` receives the `Failure` error, and `onEmpty` covers
  *  `Idle` and `Loading` together. A `Stale` renders through `onData` so its
- *  data stays on screen. Use `matchDataSplit` when `Idle` and `Loading`
+ *  data stays on screen. Use `matchDataSplitEmpty` when `Idle` and `Loading`
  *  render differently, and `match` when the stale error or the `Refreshing`
  *  signal matters. */
 export const matchData: {
@@ -311,11 +311,11 @@ export const matchData: {
   },
 )
 
-/** Like `matchData`, but the two cold states are split: `onIdle` handles
- *  `Idle` and `onLoading` handles `Loading`, for views that render nothing
- *  requested yet differently from a request in flight. `onData` and
- *  `onFailure` behave exactly as in `matchData`. */
-export const matchDataSplit: {
+/** Like `matchData`, but the collapsed `onEmpty` channel is split in two:
+ *  `onIdle` handles `Idle` and `onLoading` handles `Loading`, for views that
+ *  render nothing requested yet differently from a request in flight.
+ *  `onData` and `onFailure` behave exactly as in `matchData`. */
+export const matchDataSplitEmpty: {
   <A, E, B, C = B, D = B, F = B>(handlers: {
     readonly onIdle: Function.LazyArg<B>
     readonly onLoading: Function.LazyArg<C>

--- a/packages/foldkit/src/asyncData/public.ts
+++ b/packages/foldkit/src/asyncData/public.ts
@@ -10,7 +10,7 @@ export {
   Schema,
   match,
   matchData,
-  matchDataSplit,
+  matchDataSplitEmpty,
   map,
   mapError,
   mapBoth,

--- a/packages/website/src/page/asyncData.ts
+++ b/packages/website/src/page/asyncData.ts
@@ -425,7 +425,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ' through ',
         inlineCode('onData'),
         ' is the point of keeping its data. ',
-        inlineCode('matchDataSplit'),
+        inlineCode('matchDataSplitEmpty'),
         ' is the same collapse with the two cold states split into ',
         inlineCode('onIdle'),
         ' and ',

--- a/packages/website/src/page/bestPractices/keying.ts
+++ b/packages/website/src/page/bestPractices/keying.ts
@@ -130,7 +130,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         'Restructure the view instead, so the branch structure itself carries the identity: collapse the states that render the same scaffold into one branch, and express their differences as keyed conditional inserts inside it. With ',
         link(asyncDataRouter(), 'AsyncData'),
         ' that is ',
-        inlineCode('matchDataSplit'),
+        inlineCode('matchDataSplitEmpty'),
         ': four branches, four keys, and the ',
         inlineCode('Refreshing'),
         ' badge and ',

--- a/packages/website/src/snippet/keyingOneKeyPerBranch.ts
+++ b/packages/website/src/snippet/keyingOneKeyPerBranch.ts
@@ -6,7 +6,7 @@ const postsSection = (model: Model): Html => {
   const h = html<Message>()
   const keyedDiv = h.keyed('div')
 
-  return AsyncData.matchDataSplit(model.posts, {
+  return AsyncData.matchDataSplitEmpty(model.posts, {
     onIdle: () => keyedDiv('Idle', [], [promptView()]),
     onLoading: () => keyedDiv('Loading', [], [spinnerView()]),
     onFailure: error => keyedDiv('Failure', [], [errorView(error)]),


### PR DESCRIPTION
## What and why

`AsyncData.matchDataSplit` is the one name in the module that says a variant splits *something* without saying what. This renames it to `matchDataSplitEmpty`, which names the thing it splits: the `onEmpty` channel that `matchData` collapses is broken back into `onIdle` and `onLoading`. The delta from `matchData` is now legible at the call site instead of only in the doc.

The three match altitudes read as a clean progression:

- `match` — full six-way
- `matchData` — collapses the cold pair into one `onEmpty`, and the data trio into one `onData`
- `matchDataSplitEmpty` — same data collapse, but `onEmpty` splits into `onIdle` + `onLoading`

The structure is unchanged and correct: most views render `Idle` and `Loading` identically, so `matchData` keeping the short name is the right ergonomic default. Only the string changes.

## What changed

- **`packages/foldkit/src/asyncData/asyncData.ts`**: renamed the export; tightened its TSDoc to lead with what is split; updated the `matchData` cross-reference and the internal implementation `NOTE`.
- **`public.ts`**: updated the barrel export.
- **`asyncData.test.ts`**: renamed the `describe` block, the type-test call sites, and every state-routing call site.
- **`examples/api-cache/src/main.ts`**: updated the three call sites.
- **Website**: updated the prose references on the Async Data and keying best-practices pages and the keying snippet.
- **Changeset**: `minor`, flagging the breaking rename.

Behavior and handler shape are identical. This is purely a rename plus a doc sharpening.

## Migration

Replace `AsyncData.matchDataSplit(...)` with `AsyncData.matchDataSplitEmpty(...)`. The handler object (`onIdle`, `onLoading`, `onFailure`, `onData`) is unchanged.

## Verification

Local gates green: foldkit build, foldkit unit tests (1499 passing), foldkit + api-cache + website typecheck, lint, dead-code, format, and api-cache tests (19 passing). The pre-push suite passed; website e2e runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YN96BtwnuQTwmDcv482Q3v)_