### PR TITLE
docs(create-foldkit-app): reframe File Organization as a floor, not a cap

### DIFF
--- a/.changeset/agents-file-organization-invariant.md
+++ b/.changeset/agents-file-organization-invariant.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Rewrite the `File Organization` section of the generated `AGENTS.md` to lead with the runtime-boot invariant (the definitions stay importable from tests because only `entry.ts` calls `Runtime.run`) and to describe when to split a growing app across more files. It now covers the revealed-seam heuristic, the two forced splits, and exemplars from the example apps.

--- a/packages/create-foldkit-app/templates/base/AGENTS.md
+++ b/packages/create-foldkit-app/templates/base/AGENTS.md
@@ -66,7 +66,9 @@ For DOM operations (focus, scroll, modals, scroll lock), Foldkit ships a `Dom` m
 
 ### File Organization
 
-A Foldkit app lives in two files. `src/main.ts` holds the pure definitions (Model, Messages, init, update, view). `src/entry.ts` imports them and boots the runtime with `Runtime.makeApplication` and `Runtime.run`. `index.html` references `entry.ts`. The split keeps `main.ts` importable from tests without booting a runtime as a side effect. Never call `Runtime.run` from `main.ts`.
+The invariant: keep the runtime boot separate from the pure definitions. `src/entry.ts` calls `Runtime.makeApplication` and `Runtime.run`, and `index.html` references it. The definitions (Model, Messages, init, update, view, Commands) never call `Runtime.run`, so they stay importable from tests without booting a runtime as a side effect. Never call `Runtime.run` from `main.ts`.
+
+For a small app the definitions all fit in one `src/main.ts`. Split a unit into its own file when it has _both_ a distinct reason to change _and_ a name you'd give it unprompted: the pure domain core into `timer.ts` or `domain.ts`, the view into `view.ts` (or a `components/` directory), a Command's owned resource into its own module. Split on that revealed seam, not on line count alone. A file that has grown large is _evidence_ a seam has formed, so treat its size as a prompt to re-check for one. Two splits are forced: extract Messages to `message.ts` when Commands need the constructors (this breaks the cycle between `command.ts` and `main.ts`), and colocate Commands with the update that returns them. Exemplars: counter and stopwatch are a single `main.ts`; kanban splits `domain` / `command` / `message` / `model`; typing-game splits views by page.
 
 Use uppercase section headers (`// MODEL`, `// MESSAGE`, `// INIT`, `// UPDATE`, `// COMMAND`, `// VIEW`) for wayfinding.
 


### PR DESCRIPTION
## What and why

The `### File Organization` section in the `AGENTS.md` generated by `create-foldkit-app` opened with "A Foldkit app lives in two files." Read as a headline, that states a cap. The actual rule (keep the runtime boot out of the test-importable definitions) was buried as a supporting clause, and the section then contradicted itself in the Testing paragraph a few lines down, which allows `update` and `view` to live in their own files.

The effect: an agent (or a person) skims the headline and piles the whole app, especially a large `view`, into `main.ts` rather than splitting on revealed seams. That is under-structure, and it fights the framework's own examples, which split by concern.

## What changed

Rewrote the section to lead with the invariant and state that `main.ts` plus `entry.ts` is the floor, not a cap:

- Lead with the invariant: keep the runtime boot separate from the pure definitions. `entry.ts` calls `Runtime.run`; the definitions never do, so they stay test-importable.
- State plainly that two files is the floor, not a cap.
- Add guidance on when to split a unit onto its own file: a distinct reason to change plus a name you'd give it unprompted. Note that a file which has grown large is evidence a seam has formed.
- Keep the two forced splits (extract Messages to `message.ts`; colocate Commands with their update).
- Add exemplars: counter and stopwatch are a single `main.ts`; kanban splits `domain` / `command` / `message` / `model`; typing-game splits views by page.

The fix lives in the `create-foldkit-app` template so every new project inherits it.

## Verification

Confirmed each exemplar claim against the example apps: `examples/counter` and `examples/stopwatch` are a single `main.ts`; `examples/kanban` splits `domain` / `command` / `message` / `model`; `packages/typing-game/client/src/page/` splits views by page. The full pre-push suite (format, changeset status, lint, dead-code, build, all-package typecheck, test) passed. Patch changeset added for `create-foldkit-app`.

Fixes #677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUPaxcTgamfTgLhPCzLiy3)_