### PR TITLE
feat: refresh example app interfaces

### DIFF
--- a/examples/api-cache/src/main.ts
+++ b/examples/api-cache/src/main.ts
@@ -348,10 +348,10 @@ const formatFetchedAt = (fetchedAt: number): string =>
   new Date(fetchedAt).toLocaleTimeString()
 
 const tabButtonClassName =
-  'px-4 py-2 rounded-lg bg-white text-slate-600 font-semibold hover:bg-slate-50 transition cursor-pointer data-[selected]:bg-indigo-600 data-[selected]:text-white data-[selected]:hover:bg-indigo-600'
+  'px-4 py-2.5 rounded-xl bg-white text-slate-600 font-semibold shadow-sm hover:bg-slate-50 cursor-pointer data-[selected]:bg-indigo-600 data-[selected]:text-white data-[selected]:hover:bg-indigo-600'
 
 const toolbarButtonClassName =
-  'px-3 py-1.5 bg-white text-slate-700 text-sm font-semibold rounded-md shadow hover:bg-slate-50 transition cursor-pointer data-[disabled]:opacity-50 data-[disabled]:cursor-default data-[disabled]:hover:bg-white'
+  'px-3 py-1.5 bg-white text-slate-700 text-sm font-semibold rounded-md shadow hover:bg-slate-50 transition cursor-pointer data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed data-[disabled]:hover:bg-white'
 
 export const view = (model: Model): Document => {
   const h = html<Message>()
@@ -359,10 +359,14 @@ export const view = (model: Model): Document => {
   return {
     title: 'API Cache',
     body: h.div(
-      [h.Class('min-h-screen bg-slate-100 flex justify-center p-6')],
+      [
+        h.Class(
+          'min-h-screen bg-slate-100 flex justify-center px-4 py-10 sm:px-6',
+        ),
+      ],
       [
         h.div(
-          [h.Class('w-full max-w-2xl flex flex-col gap-6')],
+          [h.Class('w-full max-w-3xl flex flex-col gap-7')],
           [
             headerView(),
             h.submodel({
@@ -541,7 +545,7 @@ const postListItems = (
               [
                 ...attributes.button,
                 h.Class(
-                  'w-full text-left bg-white rounded-lg shadow px-4 py-3 hover:bg-slate-50 transition cursor-pointer flex items-center justify-between gap-4',
+                  'w-full text-left bg-white rounded-2xl border border-slate-200/80 shadow-sm px-5 py-4 hover:bg-slate-50 cursor-pointer flex items-center justify-between gap-4',
                 ),
               ],
               [
@@ -632,7 +636,11 @@ const postDetailCard = (detail: PostDetail, fetchedAt: number): Html => {
 
   return h.keyed('article')(
     'detail',
-    [h.Class('bg-white rounded-xl shadow p-6 flex flex-col gap-3')],
+    [
+      h.Class(
+        'bg-white rounded-2xl border border-slate-200/80 shadow p-6 flex flex-col gap-3',
+      ),
+    ],
     [
       h.h2([h.Class('text-2xl font-bold text-slate-900')], [detail.title]),
       h.p([h.Class('text-sm text-slate-500')], [`By ${detail.author}`]),
@@ -750,7 +758,11 @@ const statCard = (label: string, value: string): Html => {
   const h = html<Message>()
 
   return h.div(
-    [h.Class('bg-white rounded-xl shadow p-4 flex flex-col gap-1')],
+    [
+      h.Class(
+        'bg-white rounded-2xl border border-slate-200/80 shadow-sm p-5 flex flex-col gap-1',
+      ),
+    ],
     [
       h.div([h.Class('text-sm text-slate-500')], [label]),
       h.div([h.Class('text-2xl font-bold text-slate-900')], [value]),

--- a/examples/api-cache/src/main.ts
+++ b/examples/api-cache/src/main.ts
@@ -331,18 +331,22 @@ const formatFetchedAt = (fetchedAt: number): string =>
   new Date(fetchedAt).toLocaleTimeString()
 
 const tabButtonClassName =
-  'px-4 py-2 rounded-lg bg-white text-slate-600 font-semibold hover:bg-slate-50 transition cursor-pointer data-[selected]:bg-indigo-600 data-[selected]:text-white data-[selected]:hover:bg-indigo-600'
+  'px-4 py-2.5 rounded-xl bg-white text-slate-600 font-semibold shadow-sm hover:bg-slate-50 cursor-pointer data-[selected]:bg-indigo-600 data-[selected]:text-white data-[selected]:hover:bg-indigo-600'
 
 const toolbarButtonClassName =
-  'px-3 py-1.5 bg-white text-slate-700 text-sm font-semibold rounded-md shadow hover:bg-slate-50 transition cursor-pointer data-[disabled]:opacity-50 data-[disabled]:cursor-default data-[disabled]:hover:bg-white'
+  'px-3 py-1.5 bg-white text-slate-700 text-sm font-semibold rounded-md shadow hover:bg-slate-50 transition cursor-pointer data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed data-[disabled]:hover:bg-white'
 
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   title: 'API Cache',
   body: h.div(
-    [h.Class('min-h-screen bg-slate-100 flex justify-center p-6')],
+    [
+      h.Class(
+        'min-h-screen bg-slate-100 flex justify-center px-4 py-10 sm:px-6',
+      ),
+    ],
     [
       h.div(
-        [h.Class('w-full max-w-2xl flex flex-col gap-6')],
+        [h.Class('w-full max-w-3xl flex flex-col gap-7')],
         [
           headerView(h),
           h.submodel({
@@ -502,7 +506,7 @@ const postListItems = (
                 [
                   ...attributes.button,
                   h.Class(
-                    'w-full text-left bg-white rounded-lg shadow px-4 py-3 hover:bg-slate-50 transition cursor-pointer flex items-center justify-between gap-4',
+                    'w-full text-left bg-white rounded-2xl border border-slate-200/80 shadow-sm px-5 py-4 hover:bg-slate-50 cursor-pointer flex items-center justify-between gap-4',
                   ),
                 ],
                 [
@@ -596,7 +600,11 @@ const postDetailCard = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.article(
-    [h.Class('bg-white rounded-xl shadow p-6 flex flex-col gap-3')],
+    [
+      h.Class(
+        'bg-white rounded-2xl border border-slate-200/80 shadow p-6 flex flex-col gap-3',
+      ),
+    ],
     [
       h.h2([h.Class('text-2xl font-bold text-slate-900')], [detail.title]),
       h.p([h.Class('text-sm text-slate-500')], [`By ${detail.author}`]),
@@ -705,7 +713,11 @@ const statCard = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.div(
-    [h.Class('bg-white rounded-xl shadow p-4 flex flex-col gap-1')],
+    [
+      h.Class(
+        'bg-white rounded-2xl border border-slate-200/80 shadow-sm p-5 flex flex-col gap-1',
+      ),
+    ],
     [
       h.div([h.Class('text-sm text-slate-500')], [label]),
       h.div([h.Class('text-2xl font-bold text-slate-900')], [value]),

--- a/examples/api-cache/src/styles.css
+++ b/examples/api-cache/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #4f46e5;
+}

--- a/examples/auth/src/page/loggedIn/view.ts
+++ b/examples/auth/src/page/loggedIn/view.ts
@@ -12,18 +12,22 @@ import * as Dashboard from './page/dashboard'
 import * as Settings from './page/settings'
 
 const navLinkClassName = (isActive: boolean) =>
-  clsx('hover:bg-blue-600 font-medium px-3 py-1 rounded transition', {
-    'bg-blue-700 bg-opacity-50': isActive,
+  clsx('hover:bg-violet-500 font-medium px-3 py-1.5 rounded-lg', {
+    'bg-violet-800/60': isActive,
   })
 
 const navigationView = (session: Session, currentRouteTag: string): Html => {
   const h = html<Message>()
 
   return h.nav(
-    [h.Class('bg-blue-500 text-white p-4')],
+    [h.Class('bg-violet-700/95 text-white px-4 py-3 shadow-sm backdrop-blur')],
     [
       h.div(
-        [h.Class('max-w-4xl mx-auto flex justify-between items-center')],
+        [
+          h.Class(
+            'max-w-4xl mx-auto flex flex-wrap justify-between items-center gap-3',
+          ),
+        ],
         [
           h.ul(
             [h.Class('flex gap-6 list-none')],

--- a/examples/auth/src/page/loggedIn/view.ts
+++ b/examples/auth/src/page/loggedIn/view.ts
@@ -12,8 +12,8 @@ import * as Dashboard from './page/dashboard'
 import * as Settings from './page/settings'
 
 const navLinkClassName = (isActive: boolean) =>
-  clsx('hover:bg-blue-600 font-medium px-3 py-1 rounded transition', {
-    'bg-blue-700 bg-opacity-50': isActive,
+  clsx('hover:bg-violet-500 font-medium px-3 py-1.5 rounded-lg', {
+    'bg-violet-800/60': isActive,
   })
 
 const navigationView = (
@@ -22,10 +22,14 @@ const navigationView = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.nav(
-    [h.Class('bg-blue-500 text-white p-4')],
+    [h.Class('bg-violet-700/95 text-white px-4 py-3 shadow-sm backdrop-blur')],
     [
       h.div(
-        [h.Class('max-w-4xl mx-auto flex justify-between items-center')],
+        [
+          h.Class(
+            'max-w-4xl mx-auto flex flex-wrap justify-between items-center gap-3',
+          ),
+        ],
         [
           h.ul(
             [h.Class('flex gap-6 list-none')],

--- a/examples/auth/src/page/loggedOut/page/home.ts
+++ b/examples/auth/src/page/loggedOut/page/home.ts
@@ -10,10 +10,14 @@ export const view = (): Html => {
     [h.Class('max-w-4xl mx-auto px-4')],
     [
       h.div(
-        [h.Class('text-center py-16')],
+        [h.Class('text-center py-16 sm:py-20')],
         [
           h.h1(
-            [h.Class('text-5xl font-bold text-gray-800 mb-6')],
+            [
+              h.Class(
+                'text-4xl sm:text-6xl font-semibold tracking-tight text-gray-900 mb-6',
+              ),
+            ],
             ['Welcome to Auth Example'],
           ),
           h.p(
@@ -26,7 +30,7 @@ export const view = (): Html => {
             [
               h.Href(loginRouter()),
               h.Class(
-                'inline-block px-8 py-3 bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-600 transition',
+                'inline-block px-8 py-3 bg-violet-700 text-white font-medium rounded-xl shadow-lg hover:bg-violet-800',
               ),
             ],
             ['Sign In'],
@@ -58,7 +62,11 @@ const featureCard = (title: string, description: string): Html => {
   const h = html<Message>()
 
   return h.div(
-    [h.Class('bg-white rounded-lg shadow-md p-6')],
+    [
+      h.Class(
+        'bg-white rounded-2xl border border-gray-200/80 shadow-md p-6 text-left',
+      ),
+    ],
     [
       h.h2([h.Class('text-xl font-semibold text-gray-800 mb-3')], [title]),
       h.p([h.Class('text-gray-600')], [description]),

--- a/examples/auth/src/page/loggedOut/page/home.ts
+++ b/examples/auth/src/page/loggedOut/page/home.ts
@@ -8,10 +8,14 @@ export const view = (h: HtmlBuilder<Message>): Html =>
     [h.Class('max-w-4xl mx-auto px-4')],
     [
       h.div(
-        [h.Class('text-center py-16')],
+        [h.Class('text-center py-16 sm:py-20')],
         [
           h.h1(
-            [h.Class('text-5xl font-bold text-gray-800 mb-6')],
+            [
+              h.Class(
+                'text-4xl sm:text-6xl font-semibold tracking-tight text-gray-900 mb-6',
+              ),
+            ],
             ['Welcome to Auth Example'],
           ),
           h.p(
@@ -24,7 +28,7 @@ export const view = (h: HtmlBuilder<Message>): Html =>
             [
               h.Href(loginRouter()),
               h.Class(
-                'inline-block px-8 py-3 bg-blue-500 text-white font-medium rounded-lg hover:bg-blue-600 transition',
+                'inline-block px-8 py-3 bg-violet-700 text-white font-medium rounded-xl shadow-lg hover:bg-violet-800',
               ),
             ],
             ['Sign In'],
@@ -60,7 +64,11 @@ const featureCard = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.div(
-    [h.Class('bg-white rounded-lg shadow-md p-6')],
+    [
+      h.Class(
+        'bg-white rounded-2xl border border-gray-200/80 shadow-md p-6 text-left',
+      ),
+    ],
     [
       h.h2([h.Class('text-xl font-semibold text-gray-800 mb-3')], [title]),
       h.p([h.Class('text-gray-600')], [description]),

--- a/examples/auth/src/page/loggedOut/page/login.ts
+++ b/examples/auth/src/page/loggedOut/page/login.ts
@@ -274,10 +274,18 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
     [h.Class('max-w-md mx-auto px-4')],
     [
       h.div(
-        [h.Class('bg-white rounded-xl shadow-lg p-8')],
+        [
+          h.Class(
+            'bg-white rounded-3xl border border-gray-200/80 shadow-xl p-8',
+          ),
+        ],
         [
           h.h1(
-            [h.Class('text-3xl font-bold text-gray-800 text-center mb-8')],
+            [
+              h.Class(
+                'text-3xl font-semibold tracking-tight text-gray-900 text-center mb-8',
+              ),
+            ],
             ['Sign In'],
           ),
           h.div(
@@ -317,9 +325,9 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
                       ...attributes.button,
                       h.Class(
                         clsx(
-                          'w-full py-3 font-medium rounded-lg transition',
+                          'w-full py-3 font-medium rounded-xl shadow-sm',
                           canSubmit
-                            ? 'bg-blue-500 text-white hover:bg-blue-600 cursor-pointer'
+                            ? 'bg-violet-700 text-white hover:bg-violet-800 cursor-pointer'
                             : 'bg-gray-300 text-gray-500 cursor-not-allowed',
                         ),
                       ),

--- a/examples/auth/src/page/loggedOut/page/login.ts
+++ b/examples/auth/src/page/loggedOut/page/login.ts
@@ -272,10 +272,18 @@ export const view = Submodel.defineView<Model, Message>((model, h) => {
     [h.Class('max-w-md mx-auto px-4')],
     [
       h.div(
-        [h.Class('bg-white rounded-xl shadow-lg p-8')],
+        [
+          h.Class(
+            'bg-white rounded-3xl border border-gray-200/80 shadow-xl p-8',
+          ),
+        ],
         [
           h.h1(
-            [h.Class('text-3xl font-bold text-gray-800 text-center mb-8')],
+            [
+              h.Class(
+                'text-3xl font-semibold tracking-tight text-gray-900 text-center mb-8',
+              ),
+            ],
             ['Sign In'],
           ),
           h.div(
@@ -318,9 +326,9 @@ export const view = Submodel.defineView<Model, Message>((model, h) => {
                         ...attributes.button,
                         h.Class(
                           clsx(
-                            'w-full py-3 font-medium rounded-lg transition',
+                            'w-full py-3 font-medium rounded-xl shadow-sm',
                             canSubmit
-                              ? 'bg-blue-500 text-white hover:bg-blue-600 cursor-pointer'
+                              ? 'bg-violet-700 text-white hover:bg-violet-800 cursor-pointer'
                               : 'bg-gray-300 text-gray-500 cursor-not-allowed',
                           ),
                         ),

--- a/examples/auth/src/styles.css
+++ b/examples/auth/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #7c3aed;
+}

--- a/examples/auth/src/view.ts
+++ b/examples/auth/src/view.ts
@@ -16,7 +16,7 @@ export const view = (model: Model): Document => {
   return {
     title: title(model),
     body: h.div(
-      [h.Class('min-h-screen bg-gray-100')],
+      [h.Class('min-h-screen bg-gray-50')],
       [
         h.keyed('div')(
           model._tag,

--- a/examples/auth/src/view.ts
+++ b/examples/auth/src/view.ts
@@ -13,7 +13,7 @@ const title = (model: Model): string =>
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   title: title(model),
   body: h.div(
-    [h.Class('min-h-screen bg-gray-100')],
+    [h.Class('min-h-screen bg-gray-50')],
     [
       M.value(model).pipe(
         M.tagsExhaustive({

--- a/examples/canvas-art/src/main.ts
+++ b/examples/canvas-art/src/main.ts
@@ -265,7 +265,10 @@ export const view = (model: Model): Document => {
         ),
       ],
       [
-        h.h1([h.Class('text-4xl font-bold mb-2')], ['Canvas Art']),
+        h.h1(
+          [h.Class('text-4xl font-semibold tracking-tight mb-2')],
+          ['Canvas Art'],
+        ),
         h.p(
           [h.Class('text-zinc-400 mb-6')],
           ['Click the canvas to spawn a ball.'],
@@ -274,7 +277,8 @@ export const view = (model: Model): Document => {
           width: CANVAS_WIDTH,
           height: CANVAS_HEIGHT,
           shapes: sceneShapes(model),
-          className: 'rounded-lg shadow-2xl cursor-crosshair',
+          className:
+            'rounded-2xl border border-white/10 shadow-2xl cursor-crosshair',
           onPointerDown: ({ x, y }) => ClickedCanvas({ x, y }),
         }),
         controlsView(model),

--- a/examples/canvas-art/src/main.ts
+++ b/examples/canvas-art/src/main.ts
@@ -264,7 +264,10 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
       ),
     ],
     [
-      h.h1([h.Class('text-4xl font-bold mb-2')], ['Canvas Art']),
+      h.h1(
+        [h.Class('text-4xl font-semibold tracking-tight mb-2')],
+        ['Canvas Art'],
+      ),
       h.p(
         [h.Class('text-zinc-400 mb-6')],
         ['Click the canvas to spawn a ball.'],
@@ -274,7 +277,8 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
           width: CANVAS_WIDTH,
           height: CANVAS_HEIGHT,
           shapes: sceneShapes(model),
-          className: 'rounded-lg shadow-2xl cursor-crosshair',
+          className:
+            'rounded-2xl border border-white/10 shadow-2xl cursor-crosshair',
           onPointerDown: ({ x, y }) => ClickedCanvas({ x, y }),
         },
         h,

--- a/examples/canvas-art/src/styles.css
+++ b/examples/canvas-art/src/styles.css
@@ -1,1 +1,7 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #f59e0b;
+  --app-glow-strength: 20%;
+}

--- a/examples/charting/src/domain.ts
+++ b/examples/charting/src/domain.ts
@@ -107,9 +107,13 @@ export const RepositorySnapshot = S.Struct({
 })
 export type RepositorySnapshot = typeof RepositorySnapshot.Type
 
+export const StargazerHistory = S.Literals(['Available', 'Unavailable'])
+export type StargazerHistory = typeof StargazerHistory.Type
+
 export const Telemetry = S.Struct({
   fetchedAt: S.Number,
   repository: RepositorySnapshot,
+  stargazerHistory: StargazerHistory,
   packages: S.Array(PackageSnapshot),
   weeks: S.Array(WeeklyTelemetry),
   dependencyEdges: S.Array(DependencyEdge),

--- a/examples/charting/src/echarts.ts
+++ b/examples/charting/src/echarts.ts
@@ -12,7 +12,11 @@ import {
 import * as echarts from 'echarts/core'
 import { LabelLayout, UniversalTransition } from 'echarts/features'
 import { CanvasRenderer } from 'echarts/renderers'
-import type { EChartsOption } from 'echarts/types/dist/shared'
+import type {
+  EChartsOption,
+  LineSeriesOption,
+  YAXisOption,
+} from 'echarts/types/dist/shared'
 import { Array, Match as M, Option, String, pipe } from 'effect'
 
 import {
@@ -146,80 +150,89 @@ const adoptionOption = (args: ChartOptionArgs): EChartsOption =>
       const weekLabels = Array.map(weeks, ({ weekStart }) =>
         weekLabel(weekStart),
       )
+      const subtitle =
+        args.telemetry.stargazerHistory === 'Available'
+          ? `${snapshot.displayName} downloads and GitHub stars`
+          : `${snapshot.displayName} downloads`
+      const downloadsYAxis = {
+        type: 'value',
+        name: 'downloads',
+        min: 0,
+        splitLine: { lineStyle: { color: '#e4e4e7' } },
+      } satisfies YAXisOption
+      const stargazerYAxes =
+        args.telemetry.stargazerHistory === 'Available'
+          ? [
+              {
+                type: 'value',
+                name: 'stars',
+                min: 0,
+                splitLine: { show: false },
+              } satisfies YAXisOption,
+            ]
+          : []
+      const downloadsSeries = {
+        name: 'npm downloads',
+        type: 'line',
+        smooth: true,
+        symbol: 'circle',
+        symbolSize: DEFAULT_SYMBOL_SIZE,
+        lineStyle: { width: 3, color: '#0891b2' },
+        itemStyle: { color: '#0891b2' },
+        areaStyle: { color: 'rgba(8, 145, 178, 0.12)' },
+        data: Array.map(weeks, week => {
+          const id = datumId('Adoption', snapshot.id, week.weekStart)
+          return {
+            id,
+            name: weekLabel(week.weekStart),
+            symbolSize: isSelected(args.maybeSelectedDatumId, id)
+              ? SELECTED_SYMBOL_SIZE
+              : DEFAULT_SYMBOL_SIZE,
+            value: downloadForWeek(snapshot, week.weekStart),
+          }
+        }),
+      } satisfies LineSeriesOption
+      const stargazerSeries =
+        args.telemetry.stargazerHistory === 'Available'
+          ? [
+              {
+                name: 'GitHub stars',
+                type: 'line',
+                smooth: true,
+                yAxisIndex: 1,
+                symbol: 'diamond',
+                symbolSize: DEFAULT_SYMBOL_SIZE,
+                lineStyle: { width: 3, color: '#7c3aed' },
+                itemStyle: { color: '#7c3aed' },
+                data: Array.map(weeks, week => {
+                  const id = datumId('Adoption', 'Stars', week.weekStart)
+                  return {
+                    id,
+                    name: weekLabel(week.weekStart),
+                    symbolSize: isSelected(args.maybeSelectedDatumId, id)
+                      ? SELECTED_SYMBOL_SIZE
+                      : DEFAULT_SYMBOL_SIZE,
+                    value: week.cumulativeStars,
+                  }
+                }),
+              } satisfies LineSeriesOption,
+            ]
+          : []
 
       return {
-        ...baseOption(
-          'Adoption',
-          `${snapshot.displayName} downloads and GitHub stars`,
-        ),
+        ...baseOption('Adoption', subtitle),
         xAxis: {
           type: 'category',
           boundaryGap: false,
           data: weekLabels,
         },
-        yAxis: [
-          {
-            type: 'value',
-            name: 'downloads',
-            min: 0,
-            splitLine: { lineStyle: { color: '#e4e4e7' } },
-          },
-          {
-            type: 'value',
-            name: 'stars',
-            min: 0,
-            splitLine: { show: false },
-          },
-        ],
+        yAxis: [downloadsYAxis, ...stargazerYAxes],
         dataZoom: [
           {
             type: 'inside',
           },
         ],
-        series: [
-          {
-            name: 'npm downloads',
-            type: 'line',
-            smooth: true,
-            symbol: 'circle',
-            symbolSize: DEFAULT_SYMBOL_SIZE,
-            lineStyle: { width: 3, color: '#0891b2' },
-            itemStyle: { color: '#0891b2' },
-            areaStyle: { color: 'rgba(8, 145, 178, 0.12)' },
-            data: Array.map(weeks, week => {
-              const id = datumId('Adoption', snapshot.id, week.weekStart)
-              return {
-                id,
-                name: weekLabel(week.weekStart),
-                symbolSize: isSelected(args.maybeSelectedDatumId, id)
-                  ? SELECTED_SYMBOL_SIZE
-                  : DEFAULT_SYMBOL_SIZE,
-                value: downloadForWeek(snapshot, week.weekStart),
-              }
-            }),
-          },
-          {
-            name: 'GitHub stars',
-            type: 'line',
-            smooth: true,
-            yAxisIndex: 1,
-            symbol: 'diamond',
-            symbolSize: DEFAULT_SYMBOL_SIZE,
-            lineStyle: { width: 3, color: '#7c3aed' },
-            itemStyle: { color: '#7c3aed' },
-            data: Array.map(weeks, week => {
-              const id = datumId('Adoption', 'Stars', week.weekStart)
-              return {
-                id,
-                name: weekLabel(week.weekStart),
-                symbolSize: isSelected(args.maybeSelectedDatumId, id)
-                  ? SELECTED_SYMBOL_SIZE
-                  : DEFAULT_SYMBOL_SIZE,
-                value: week.cumulativeStars,
-              }
-            }),
-          },
-        ],
+        series: [downloadsSeries, ...stargazerSeries],
       }
     },
   })
@@ -362,24 +375,33 @@ const packageSnapshotToDownloadDatumLabel =
 
 const weekToDatumLabels =
   (telemetry: Telemetry) =>
-  (week: WeeklyTelemetry): ReadonlyArray<DatumLabel> => [
-    ...Array.map(
-      telemetry.packages,
-      packageSnapshotToDownloadDatumLabel(week.weekStart),
-    ),
-    {
-      id: datumId('Adoption', 'Stars', week.weekStart),
-      label: `${week.weekStart}: ${week.cumulativeStars} stars`,
-    },
-    {
-      id: datumId('Velocity', 'Commits', week.weekStart),
-      label: `${week.weekStart}: ${week.commits} commits`,
-    },
-    {
-      id: datumId('Velocity', 'Releases', week.weekStart),
-      label: `${week.weekStart}: ${week.releases} releases`,
-    },
-  ]
+  (week: WeeklyTelemetry): ReadonlyArray<DatumLabel> => {
+    const maybeStargazerLabel =
+      telemetry.stargazerHistory === 'Available'
+        ? [
+            {
+              id: datumId('Adoption', 'Stars', week.weekStart),
+              label: `${week.weekStart}: ${week.cumulativeStars} stars`,
+            },
+          ]
+        : []
+
+    return [
+      ...Array.map(
+        telemetry.packages,
+        packageSnapshotToDownloadDatumLabel(week.weekStart),
+      ),
+      ...maybeStargazerLabel,
+      {
+        id: datumId('Velocity', 'Commits', week.weekStart),
+        label: `${week.weekStart}: ${week.commits} commits`,
+      },
+      {
+        id: datumId('Velocity', 'Releases', week.weekStart),
+        label: `${week.weekStart}: ${week.releases} releases`,
+      },
+    ]
+  }
 
 export const makeChartOption = (args: ChartOptionArgs) =>
   M.value(args.chartMode).pipe(

--- a/examples/charting/src/githubApi.ts
+++ b/examples/charting/src/githubApi.ts
@@ -88,7 +88,10 @@ type GitHubApiShape = Readonly<{
   ) => Effect.Effect<ReadonlyArray<typeof GitHubReleaseResponse.Type>, Error>
   fetchStargazers: (
     stargazerCount: number,
-  ) => Effect.Effect<ReadonlyArray<typeof GitHubStargazerResponse.Type>, Error>
+  ) => Effect.Effect<
+    GitHubStatResult<ReadonlyArray<typeof GitHubStargazerResponse.Type>>,
+    never
+  >
   fetchCommitActivity: Effect.Effect<
     GitHubStatResult<ReadonlyArray<typeof GitHubCommitActivityResponse.Type>>,
     never
@@ -249,18 +252,49 @@ export const GitHubApiLive: Layer.Layer<
           MAX_STARGAZER_PAGES,
           Math.ceil(stargazerCount / STARGAZER_PAGE_SIZE),
         )
-        return Effect.forEach(
-          Array.range(1, Math.max(1, pageCount)),
-          page =>
-            fetch_(S.Array(GitHubStargazerResponse))(
-              makeUrl(`${GITHUB_REPOSITORY_API}/stargazers`, {
-                per_page: `${STARGAZER_PAGE_SIZE}`,
-                page: `${page}`,
+        const fetchPage = (page: number) =>
+          fetch_(S.Array(GitHubStargazerResponse))(
+            makeUrl(`${GITHUB_REPOSITORY_API}/stargazers`, {
+              per_page: `${STARGAZER_PAGE_SIZE}`,
+              page: `${page}`,
+            }),
+            { Accept: 'application/vnd.github.star+json' },
+          )
+
+        const fetchFrom = (
+          page: number,
+          accumulated: ReadonlyArray<typeof GitHubStargazerResponse.Type>,
+        ): Effect.Effect<
+          GitHubStatResult<ReadonlyArray<typeof GitHubStargazerResponse.Type>>,
+          never
+        > =>
+          fetchPage(page).pipe(
+            Effect.flatMap(stargazers => {
+              const nextAccumulated = Array.appendAll(accumulated, stargazers)
+
+              if (page < Math.max(1, pageCount)) {
+                return fetchFrom(Number.increment(page), nextAccumulated)
+              }
+
+              return Effect.succeed({
+                data: Option.some(nextAccumulated),
+                warnings: [],
+              })
+            }),
+            Effect.catch(() =>
+              Effect.succeed({
+                data: Array.match(accumulated, {
+                  onEmpty: () => Option.none(),
+                  onNonEmpty: values => Option.some(values),
+                }),
+                warnings: [
+                  'Some stargazer history is unavailable. The current star total is still shown.',
+                ],
               }),
-              { Accept: 'application/vnd.github.star+json' },
             ),
-          { concurrency: 'unbounded' },
-        ).pipe(Effect.map(Array.flatten))
+          )
+
+        return fetchFrom(1, [])
       },
       fetchCommitActivity: fetchStat_(S.Array(GitHubCommitActivityResponse))(
         '/stats/commit_activity',

--- a/examples/charting/src/main.fixtures.ts
+++ b/examples/charting/src/main.fixtures.ts
@@ -23,6 +23,7 @@ export const sampleTelemetry = Telemetry.make({
     pushedAt: '2026-06-21T19:20:00Z',
     defaultBranch: 'main',
   }),
+  stargazerHistory: 'Available',
   packages: [
     PackageSnapshot.make({
       id: 'Core',

--- a/examples/charting/src/main.fixtures.ts
+++ b/examples/charting/src/main.fixtures.ts
@@ -30,6 +30,7 @@ export const sampleTelemetry = Telemetry.make({
     pushedAt: '2026-06-21T19:20:00Z',
     defaultBranch: 'main',
   }),
+  stargazerHistory: 'Available',
   packages: [
     PackageSnapshot.make({
       id: 'Core',

--- a/examples/charting/src/styles.css
+++ b/examples/charting/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #0284c7;
+}

--- a/examples/charting/src/telemetry.test.ts
+++ b/examples/charting/src/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { Array, Effect, Layer, Match as M, String } from 'effect'
+import { Array, Effect, Layer, Match as M, Option, String } from 'effect'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 import { expect, test } from 'vitest'
 
@@ -11,7 +11,9 @@ import {
 import { NpmApiLive } from './npmApi'
 import { fetchRawTelemetry, transformTelemetry } from './telemetry'
 
-test('folds public API responses into a Telemetry value', async () => {
+const fetchTelemetryWithRestrictedStargazerPage = async (
+  restrictedPage: number,
+) => {
   const mockClient = HttpClient.make(request =>
     Effect.sync(() => {
       const body = M.value(request.url).pipe(
@@ -42,9 +44,15 @@ test('folds public API responses into a Telemetry value', async () => {
         M.orElse(() => mockGitHubRepository),
       )
 
+      const isRestrictedStargazerPage =
+        request.url.includes('/stargazers') &&
+        request.url.includes(`page=${restrictedPage}`)
+
       return HttpClientResponse.fromWeb(
         request,
-        new Response(JSON.stringify(body), { status: 200 }),
+        new Response(JSON.stringify(body), {
+          status: isRestrictedStargazerPage ? 401 : 200,
+        }),
       )
     }),
   )
@@ -52,13 +60,43 @@ test('folds public API responses into a Telemetry value', async () => {
   const telemetryLayer = Layer.mergeAll(GitHubApiLive, NpmApiLive).pipe(
     Layer.provide(Layer.succeed(HttpClient.HttpClient, mockClient)),
   )
-  const telemetry = await fetchRawTelemetry.pipe(
-    Effect.map(transformTelemetry),
+  const raw = await fetchRawTelemetry.pipe(
     Effect.provide(telemetryLayer),
     Effect.runPromise,
   )
 
+  return { raw, telemetry: transformTelemetry(raw) }
+}
+
+test('keeps the current star total without charting partial history', async () => {
+  const { raw, telemetry } = await fetchTelemetryWithRestrictedStargazerPage(4)
+
   expect(telemetry.repository.stars).toBe(342)
   expect(telemetry.repository.openIssues).toBe(1)
   expect(Array.length(telemetry.packages)).toBeGreaterThan(0)
+  expect(telemetry.stargazerHistory).toBe('Unavailable')
+  expect(Array.every(telemetry.weeks, week => week.cumulativeStars === 0)).toBe(
+    true,
+  )
+  expect(Option.isSome(raw.stargazers.data)).toBe(true)
+  if (Option.isSome(raw.stargazers.data)) {
+    expect(Array.length(raw.stargazers.data.value)).toBe(3)
+  }
+  expect(telemetry.warnings).toContain(
+    'Some stargazer history is unavailable. The current star total is still shown.',
+  )
+})
+
+test('keeps the current star total when stargazer history is unavailable', async () => {
+  const { raw, telemetry } = await fetchTelemetryWithRestrictedStargazerPage(1)
+
+  expect(telemetry.repository.stars).toBe(342)
+  expect(telemetry.stargazerHistory).toBe('Unavailable')
+  expect(Option.isNone(raw.stargazers.data)).toBe(true)
+  expect(Array.every(telemetry.weeks, week => week.cumulativeStars === 0)).toBe(
+    true,
+  )
+  expect(telemetry.warnings).toContain(
+    'Some stargazer history is unavailable. The current star total is still shown.',
+  )
 })

--- a/examples/charting/src/telemetry.ts
+++ b/examples/charting/src/telemetry.ts
@@ -18,7 +18,7 @@ import {
   WeeklyTelemetry,
   packageSpecs,
 } from './domain'
-import type { PackageId, PackageSpec } from './domain'
+import type { PackageId, PackageSpec, StargazerHistory } from './domain'
 import type {
   GitHubCommitActivityResponse,
   GitHubContributorResponse,
@@ -69,7 +69,9 @@ export type RawTelemetry = Readonly<{
   issues: ReadonlyArray<typeof GitHubIssueResponse.Type>
   pullRequests: ReadonlyArray<typeof GitHubPullRequestResponse.Type>
   releases: ReadonlyArray<typeof GitHubReleaseResponse.Type>
-  stargazers: ReadonlyArray<typeof GitHubStargazerResponse.Type>
+  stargazers: GitHubStatResult<
+    ReadonlyArray<typeof GitHubStargazerResponse.Type>
+  >
   commitActivity: GitHubStatResult<
     ReadonlyArray<typeof GitHubCommitActivityResponse.Type>
   >
@@ -373,6 +375,17 @@ export const transformTelemetry = (
   raw: RawTelemetry,
 ): typeof Telemetry.Type => {
   const weekStarts = weekStartsForLastYear(raw.fetchedAt)
+  const stargazerHistory: StargazerHistory = Array.match(
+    raw.stargazers.warnings,
+    {
+      onEmpty: () => 'Available',
+      onNonEmpty: () => 'Unavailable',
+    },
+  )
+  const maybeCompleteStargazers =
+    stargazerHistory === 'Available'
+      ? raw.stargazers.data
+      : Option.none<ReadonlyArray<typeof GitHubStargazerResponse.Type>>()
 
   const packageResults = Array.map(
     raw.packageData,
@@ -395,12 +408,21 @@ export const transformTelemetry = (
       Order.flip,
     ),
   )
-  const cumulativeStars = cumulativeStarsByWeek(
-    raw.repository.stargazers_count,
-    raw.stargazers,
-    weekStarts,
+  const cumulativeStars = pipe(
+    maybeCompleteStargazers,
+    Option.map(stargazers =>
+      cumulativeStarsByWeek(
+        raw.repository.stargazers_count,
+        stargazers,
+        weekStarts,
+      ),
+    ),
+    Option.getOrElse(() => []),
   )
-  const warnings = raw.commitActivity.warnings
+  const warnings = Array.appendAll(
+    raw.commitActivity.warnings,
+    raw.stargazers.warnings,
+  )
 
   return Telemetry.make({
     fetchedAt: raw.fetchedAt,
@@ -414,6 +436,7 @@ export const transformTelemetry = (
       pushedAt: raw.repository.pushed_at,
       defaultBranch: raw.repository.default_branch,
     }),
+    stargazerHistory,
     packages: packageSnapshots,
     weeks: makeWeeklyTelemetry(
       weekStarts,

--- a/examples/charting/src/view/sidebar.ts
+++ b/examples/charting/src/view/sidebar.ts
@@ -41,7 +41,7 @@ export const sidebarView = (
   const h = html<Message>()
 
   return h.aside(
-    [h.Class('flex flex-col gap-4')],
+    [h.Class('min-w-0 flex flex-col gap-4')],
     [
       Option.match(maybeBanner, {
         onNone: () => h.empty,
@@ -50,7 +50,7 @@ export const sidebarView = (
             'TelemetryBanner',
             [
               h.Class(
-                'rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950',
+                'min-w-0 break-words rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm leading-5 text-amber-950',
               ),
             ],
             [banner],
@@ -95,7 +95,7 @@ export const summaryGridView = (telemetry: Telemetry): Html => {
     Array.map(summaries, summary =>
       h.keyed('div')(
         summary.id,
-        [h.Class('rounded-md border border-zinc-200 bg-white p-3')],
+        [h.Class('rounded-xl border border-zinc-200 bg-white p-4 shadow-sm')],
         [
           h.div(
             [h.Class('text-xs font-medium text-zinc-500')],
@@ -126,7 +126,7 @@ export const controlPanelView = (model: Model): Html => {
   const h = html<Message>()
 
   return h.section(
-    [h.Class('rounded-md border border-zinc-200 bg-white p-3')],
+    [h.Class('rounded-xl border border-zinc-200 bg-white p-4 shadow-sm')],
     [
       h.h2([h.Class('text-sm font-semibold text-zinc-950')], ['View']),
       h.div(
@@ -202,7 +202,7 @@ export const packagePanelView = (model: Model, telemetry: Telemetry): Html => {
   const h = html<Message>()
 
   return h.section(
-    [h.Class('rounded-md border border-zinc-200 bg-white p-3')],
+    [h.Class('rounded-xl border border-zinc-200 bg-white p-4 shadow-sm')],
     [
       h.h2([h.Class('text-sm font-semibold text-zinc-950')], ['Package']),
       h.div(
@@ -268,7 +268,7 @@ export const contributorsView = (telemetry: Telemetry): Html => {
   const h = html<Message>()
 
   return h.section(
-    [h.Class('rounded-md border border-zinc-200 bg-white p-3')],
+    [h.Class('rounded-xl border border-zinc-200 bg-white p-4 shadow-sm')],
     [
       h.div(
         [h.Class('flex items-center justify-between gap-3')],

--- a/examples/charting/src/view/sidebar.ts
+++ b/examples/charting/src/view/sidebar.ts
@@ -35,7 +35,7 @@ export const sidebarView = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.aside(
-    [h.Class('flex flex-col gap-4')],
+    [h.Class('min-w-0 flex flex-col gap-4')],
     [
       Option.match(maybeBanner, {
         onNone: () => h.empty,
@@ -43,7 +43,7 @@ export const sidebarView = (
           h.div(
             [
               h.Class(
-                'rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950',
+                'min-w-0 break-words rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm leading-5 text-amber-950',
               ),
             ],
             [banner],
@@ -88,7 +88,7 @@ export const summaryGridView = (
     Array.map(summaries, summary =>
       h.keyed('div')(
         summary.id,
-        [h.Class('rounded-md border border-zinc-200 bg-white p-3')],
+        [h.Class('rounded-xl border border-zinc-200 bg-white p-4 shadow-sm')],
         [
           h.div(
             [h.Class('text-xs font-medium text-zinc-500')],
@@ -117,7 +117,7 @@ const radioOptionClassName = (isSelected: boolean): string =>
 
 export const controlPanelView = (model: Model, h: HtmlBuilder<Message>): Html =>
   h.section(
-    [h.Class('rounded-md border border-zinc-200 bg-white p-3')],
+    [h.Class('rounded-xl border border-zinc-200 bg-white p-4 shadow-sm')],
     [
       h.h2([h.Class('text-sm font-semibold text-zinc-950')], ['View']),
       h.div(
@@ -203,7 +203,7 @@ export const packagePanelView = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.section(
-    [h.Class('rounded-md border border-zinc-200 bg-white p-3')],
+    [h.Class('rounded-xl border border-zinc-200 bg-white p-4 shadow-sm')],
     [
       h.h2([h.Class('text-sm font-semibold text-zinc-950')], ['Package']),
       h.div(
@@ -274,7 +274,7 @@ export const contributorsView = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.section(
-    [h.Class('rounded-md border border-zinc-200 bg-white p-3')],
+    [h.Class('rounded-xl border border-zinc-200 bg-white p-4 shadow-sm')],
     [
       h.div(
         [h.Class('flex items-center justify-between gap-3')],

--- a/examples/charting/src/view/view.ts
+++ b/examples/charting/src/view/view.ts
@@ -16,7 +16,7 @@ export const view = (model: Model): Document => {
         h.main(
           [
             h.Class(
-              'mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-5 px-4 py-4 sm:px-6 lg:px-8',
+              'mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8',
             ),
           ],
           [headerView(model), telemetryStateView(model)],

--- a/examples/charting/src/view/view.ts
+++ b/examples/charting/src/view/view.ts
@@ -13,7 +13,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
       h.main(
         [
           h.Class(
-            'mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-5 px-4 py-4 sm:px-6 lg:px-8',
+            'mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8',
           ),
         ],
         [headerView(model, h), telemetryStateView(model, h)],

--- a/examples/counter/src/main.ts
+++ b/examples/counter/src/main.ts
@@ -55,37 +55,52 @@ export const view = (model: Model): Document => {
   return {
     title: `Counter: ${model.count}`,
     body: h.div(
-      [
-        h.Class(
-          'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
-        ),
-      ],
+      [h.Class('min-h-screen bg-gray-50 flex items-center justify-center p-6')],
       [
         h.div(
-          [h.Class('text-6xl font-bold text-gray-800')],
-          [model.count.toString()],
-        ),
-        h.div(
-          [h.Class('flex flex-wrap justify-center gap-4')],
           [
-            Button.view<Message>({
-              onClick: ClickedDecrement(),
-              toView: attributes =>
-                h.button([...attributes.button, h.Class(buttonStyle)], ['-']),
-            }),
-            Button.view<Message>({
-              onClick: ClickedReset(),
-              toView: attributes =>
-                h.button(
-                  [...attributes.button, h.Class(buttonStyle)],
-                  ['Reset'],
+            h.Class(
+              'w-full max-w-sm rounded-3xl border border-gray-200/80 bg-white p-8 shadow-xl flex flex-col items-center gap-8',
+            ),
+          ],
+          [
+            h.div(
+              [
+                h.Class(
+                  'text-7xl font-semibold tracking-tight tabular-nums text-gray-900',
                 ),
-            }),
-            Button.view<Message>({
-              onClick: ClickedIncrement(),
-              toView: attributes =>
-                h.button([...attributes.button, h.Class(buttonStyle)], ['+']),
-            }),
+              ],
+              [model.count.toString()],
+            ),
+            h.div(
+              [h.Class('grid w-full grid-cols-3 gap-3')],
+              [
+                Button.view<Message>({
+                  onClick: ClickedDecrement(),
+                  toView: attributes =>
+                    h.button(
+                      [...attributes.button, h.Class(buttonStyle)],
+                      ['-'],
+                    ),
+                }),
+                Button.view<Message>({
+                  onClick: ClickedReset(),
+                  toView: attributes =>
+                    h.button(
+                      [...attributes.button, h.Class(buttonStyle)],
+                      ['Reset'],
+                    ),
+                }),
+                Button.view<Message>({
+                  onClick: ClickedIncrement(),
+                  toView: attributes =>
+                    h.button(
+                      [...attributes.button, h.Class(buttonStyle)],
+                      ['+'],
+                    ),
+                }),
+              ],
+            ),
           ],
         ),
       ],
@@ -95,4 +110,5 @@ export const view = (model: Model): Document => {
 
 // STYLE
 
-const buttonStyle = 'bg-black text-white hover:bg-gray-700 px-4 py-2 transition'
+const buttonStyle =
+  'rounded-xl bg-gray-900 px-4 py-3 font-medium text-white shadow-sm hover:bg-gray-700 cursor-pointer'

--- a/examples/counter/src/main.ts
+++ b/examples/counter/src/main.ts
@@ -53,45 +53,60 @@ export const init: Runtime.ApplicationInit<Model, Message> = () => [
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   title: `Counter: ${model.count}`,
   body: h.div(
+    [h.Class('min-h-screen bg-gray-50 flex items-center justify-center p-6')],
     [
-      h.Class(
-        'min-h-screen bg-white flex flex-col items-center justify-center gap-6 p-6',
-      ),
-    ],
-    [
-      h.p(
-        [h.Class('text-6xl font-bold text-gray-800')],
-        [model.count.toString()],
-      ),
       h.div(
-        [h.Class('flex flex-wrap justify-center gap-4')],
         [
-          Button.view(
-            {
-              onClick: ClickedDecrement(),
-              toView: attributes =>
-                h.button([...attributes.button, h.Class(buttonStyle)], ['-']),
-            },
-            h,
+          h.Class(
+            'w-full max-w-sm rounded-3xl border border-gray-200/80 bg-white p-8 shadow-xl flex flex-col items-center gap-8',
           ),
-          Button.view(
-            {
-              onClick: ClickedReset(),
-              toView: attributes =>
-                h.button(
-                  [...attributes.button, h.Class(buttonStyle)],
-                  ['Reset'],
-                ),
-            },
-            h,
+        ],
+        [
+          h.div(
+            [
+              h.Class(
+                'text-7xl font-semibold tracking-tight tabular-nums text-gray-900',
+              ),
+            ],
+            [model.count.toString()],
           ),
-          Button.view(
-            {
-              onClick: ClickedIncrement(),
-              toView: attributes =>
-                h.button([...attributes.button, h.Class(buttonStyle)], ['+']),
-            },
-            h,
+          h.div(
+            [h.Class('grid w-full grid-cols-3 gap-3')],
+            [
+              Button.view(
+                {
+                  onClick: ClickedDecrement(),
+                  toView: attributes =>
+                    h.button(
+                      [...attributes.button, h.Class(buttonStyle)],
+                      ['-'],
+                    ),
+                },
+                h,
+              ),
+              Button.view(
+                {
+                  onClick: ClickedReset(),
+                  toView: attributes =>
+                    h.button(
+                      [...attributes.button, h.Class(buttonStyle)],
+                      ['Reset'],
+                    ),
+                },
+                h,
+              ),
+              Button.view(
+                {
+                  onClick: ClickedIncrement(),
+                  toView: attributes =>
+                    h.button(
+                      [...attributes.button, h.Class(buttonStyle)],
+                      ['+'],
+                    ),
+                },
+                h,
+              ),
+            ],
           ),
         ],
       ),
@@ -101,4 +116,5 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
 
 // STYLE
 
-const buttonStyle = 'bg-black text-white hover:bg-gray-700 px-4 py-2 transition'
+const buttonStyle =
+  'rounded-xl bg-gray-900 px-4 py-3 font-medium text-white shadow-sm hover:bg-gray-700 cursor-pointer'

--- a/examples/counter/src/styles.css
+++ b/examples/counter/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #ea580c;
+}

--- a/examples/counters/src/counter.ts
+++ b/examples/counters/src/counter.ts
@@ -44,7 +44,7 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
   return h.div(
     [
       h.Class(
-        'flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-3',
+        'flex items-center gap-3 rounded-xl border border-gray-200/80 bg-white px-4 py-3 shadow-sm',
       ),
     ],
     [
@@ -67,4 +67,4 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
 })
 
 const buttonStyle =
-  'h-9 w-9 rounded bg-gray-900 text-white text-lg leading-none hover:bg-gray-700 transition cursor-pointer'
+  'h-9 w-9 rounded-lg bg-gray-900 text-white text-lg leading-none hover:bg-gray-700 cursor-pointer shadow-sm'

--- a/examples/counters/src/counter.ts
+++ b/examples/counters/src/counter.ts
@@ -42,7 +42,7 @@ export const view = Submodel.defineView<Model, Message>((model, h) =>
   h.div(
     [
       h.Class(
-        'flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-3',
+        'flex items-center gap-3 rounded-xl border border-gray-200/80 bg-white px-4 py-3 shadow-sm',
       ),
     ],
     [
@@ -71,4 +71,4 @@ export const view = Submodel.defineView<Model, Message>((model, h) =>
 )
 
 const buttonStyle =
-  'h-9 w-9 rounded bg-gray-900 text-white text-lg leading-none hover:bg-gray-700 transition cursor-pointer'
+  'h-9 w-9 rounded-lg bg-gray-900 text-white text-lg leading-none hover:bg-gray-700 cursor-pointer shadow-sm'

--- a/examples/counters/src/main.ts
+++ b/examples/counters/src/main.ts
@@ -136,7 +136,7 @@ const rowView = (row: Row): Html => {
             [
               ...attributes.button,
               h.Class(
-                'rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:border-red-300 hover:text-red-600 transition cursor-pointer',
+                'rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-600 hover:border-red-300 hover:text-red-600 cursor-pointer',
               ),
             ],
             ['Remove'],
@@ -154,13 +154,16 @@ export const view = (model: Model): Document => {
     body: h.div(
       [
         h.Class(
-          'min-h-screen bg-white flex flex-col items-center py-12 px-6 gap-6',
+          'min-h-screen bg-gray-50 flex flex-col items-center py-16 px-6 gap-7',
         ),
       ],
       [
-        h.h1([h.Class('text-2xl font-semibold text-gray-900')], ['Counters']),
+        h.h1(
+          [h.Class('text-4xl font-semibold tracking-tight text-gray-900')],
+          ['Counters'],
+        ),
         h.p(
-          [h.Class('text-sm text-gray-500 max-w-md text-center')],
+          [h.Class('text-sm leading-6 text-gray-500 max-w-lg text-center')],
           [
             'Each row is a Counter Submodel. The parent has no awareness of Counter internals; it just embeds the Submodel via h.submodel and routes dispatched messages back to the right row via the GotCounterMessage wrapper.',
           ],

--- a/examples/counters/src/main.ts
+++ b/examples/counters/src/main.ts
@@ -128,7 +128,7 @@ const rowView = (row: Row, h: HtmlBuilder<Message>): Html =>
               [
                 ...attributes.button,
                 h.Class(
-                  'rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:border-red-300 hover:text-red-600 transition cursor-pointer',
+                  'rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-600 hover:border-red-300 hover:text-red-600 cursor-pointer',
                 ),
               ],
               ['Remove'],
@@ -144,13 +144,16 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   body: h.div(
     [
       h.Class(
-        'min-h-screen bg-white flex flex-col items-center py-12 px-6 gap-6',
+        'min-h-screen bg-gray-50 flex flex-col items-center py-16 px-6 gap-7',
       ),
     ],
     [
-      h.h1([h.Class('text-2xl font-semibold text-gray-900')], ['Counters']),
+      h.h1(
+        [h.Class('text-4xl font-semibold tracking-tight text-gray-900')],
+        ['Counters'],
+      ),
       h.p(
-        [h.Class('text-sm text-gray-500 max-w-md text-center')],
+        [h.Class('text-sm leading-6 text-gray-500 max-w-lg text-center')],
         [
           'Each row is a Counter Submodel. The parent has no awareness of Counter internals; it just embeds the Submodel via h.submodel and routes dispatched messages back to the right row via the GotCounterMessage wrapper.',
         ],

--- a/examples/counters/src/styles.css
+++ b/examples/counters/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #e11d48;
+}

--- a/examples/crash-view/src/main.ts
+++ b/examples/crash-view/src/main.ts
@@ -38,7 +38,7 @@ export const view = (_model: Model): Document => {
   return {
     title: 'Crash View Example',
     body: h.div(
-      [h.Class('min-h-screen bg-white flex items-center justify-center')],
+      [h.Class('min-h-screen bg-gray-50 flex items-center justify-center p-6')],
       [
         Button.view<Message>({
           onClick: ClickedCrash(),
@@ -47,7 +47,7 @@ export const view = (_model: Model): Document => {
               [
                 ...attributes.button,
                 h.Class(
-                  'bg-red-600 text-white text-lg font-semibold hover:bg-red-700 px-6 py-3 rounded transition cursor-pointer',
+                  'bg-red-600 text-white text-lg font-semibold hover:bg-red-700 px-8 py-4 rounded-2xl shadow-lg cursor-pointer',
                 ),
               ],
               ['Crash'],
@@ -68,17 +68,21 @@ export const crashView = ({
   return {
     title: 'Crash View Example | crashed',
     body: h.div(
-      [h.Class('min-h-screen flex items-center justify-center bg-red-50 p-8')],
+      [h.Class('min-h-screen flex items-center justify-center bg-red-50 p-6')],
       [
         h.div(
           [
             h.Class(
-              'max-w-md w-full bg-white rounded-lg border border-red-200 p-8 text-center',
+              'max-w-md w-full bg-white rounded-3xl border border-red-200 p-8 text-center shadow-xl',
             ),
           ],
           [
             h.h1(
-              [h.Class('text-red-600 text-2xl font-semibold mb-4')],
+              [
+                h.Class(
+                  'text-red-700 text-3xl font-semibold tracking-tight mb-4',
+                ),
+              ],
               ['Something went wrong'],
             ),
             h.p(
@@ -91,7 +95,7 @@ export const crashView = ({
                   [
                     ...attributes.button,
                     h.Class(
-                      'bg-red-600 text-white border-none px-6 py-2.5 rounded-md text-sm font-medium cursor-pointer hover:bg-red-700 transition',
+                      'bg-red-600 text-white border-none px-6 py-3 rounded-xl text-sm font-medium cursor-pointer hover:bg-red-700 shadow-sm',
                     ),
                     // oxlint-disable-next-line foldkit/no-raw-dom-event-attributes -- the crash view renders outside the dispatch loop, so there is no runtime to route a Message
                     h.Attribute('onclick', 'location.reload()'),

--- a/examples/crash-view/src/main.ts
+++ b/examples/crash-view/src/main.ts
@@ -35,7 +35,7 @@ export const init: Runtime.ApplicationInit<Model, Message> = () => [null, []]
 export const view = (_model: Model, h: HtmlBuilder<Message>): Document => ({
   title: 'Crash View Example',
   body: h.div(
-    [h.Class('min-h-screen bg-white flex items-center justify-center')],
+    [h.Class('min-h-screen bg-gray-50 flex items-center justify-center p-6')],
     [
       Button.view(
         {
@@ -45,7 +45,7 @@ export const view = (_model: Model, h: HtmlBuilder<Message>): Document => ({
               [
                 ...attributes.button,
                 h.Class(
-                  'bg-red-600 text-white text-lg font-semibold hover:bg-red-700 px-6 py-3 rounded transition cursor-pointer',
+                  'bg-red-600 text-white text-lg font-semibold hover:bg-red-700 px-8 py-4 rounded-2xl shadow-lg cursor-pointer',
                 ),
               ],
               ['Crash'],
@@ -65,17 +65,21 @@ export const crashView = (
 ): Document => ({
   title: 'Crash View Example | crashed',
   body: h.div(
-    [h.Class('min-h-screen flex items-center justify-center bg-red-50 p-8')],
+    [h.Class('min-h-screen flex items-center justify-center bg-red-50 p-6')],
     [
       h.div(
         [
           h.Class(
-            'max-w-md w-full bg-white rounded-lg border border-red-200 p-8 text-center',
+            'max-w-md w-full bg-white rounded-3xl border border-red-200 p-8 text-center shadow-xl',
           ),
         ],
         [
           h.h1(
-            [h.Class('text-red-600 text-2xl font-semibold mb-4')],
+            [
+              h.Class(
+                'text-red-700 text-3xl font-semibold tracking-tight mb-4',
+              ),
+            ],
             ['Something went wrong'],
           ),
           h.p([h.Class('text-gray-700 mb-6 leading-relaxed')], [error.message]),
@@ -86,7 +90,7 @@ export const crashView = (
                   [
                     ...attributes.button,
                     h.Class(
-                      'bg-red-600 text-white border-none px-6 py-2.5 rounded-md text-sm font-medium cursor-pointer hover:bg-red-700 transition',
+                      'bg-red-600 text-white border-none px-6 py-3 rounded-xl text-sm font-medium cursor-pointer hover:bg-red-700 shadow-sm',
                     ),
                     // oxlint-disable-next-line foldkit/no-raw-dom-event-attributes -- the crash view renders outside the dispatch loop, so there is no runtime to route a Message
                     h.Attribute('onclick', 'location.reload()'),

--- a/examples/crash-view/src/styles.css
+++ b/examples/crash-view/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #dc2626;
+}

--- a/examples/embedding/src/host.ts
+++ b/examples/embedding/src/host.ts
@@ -23,9 +23,9 @@ const getInputElement = (elementId: string): HTMLInputElement => {
 
 export const startHost = (): void => {
   getElement('root').outerHTML = `
-    <div class="mx-auto flex min-h-screen max-w-xl flex-col gap-6 p-8">
+    <div class="mx-auto flex min-h-screen max-w-2xl flex-col gap-7 p-6 sm:p-10">
       <header class="flex flex-col gap-1">
-        <h1 class="text-2xl font-bold text-gray-900">Host application</h1>
+        <h1 class="text-3xl font-semibold tracking-tight text-gray-900">Host application</h1>
         <p class="text-sm text-gray-600">
           This page is plain TypeScript with no Foldkit runtime of its own. It
           embeds the widget below with <code>Runtime.embed</code> and talks to it
@@ -34,12 +34,12 @@ export const startHost = (): void => {
         </p>
       </header>
 
-      <section class="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-6">
+      <section class="flex flex-col gap-4 rounded-3xl border border-gray-200/80 bg-white p-6 shadow-lg">
         <h2 class="text-sm font-semibold text-gray-900">Host controls</h2>
         <div class="flex flex-wrap items-center gap-4">
           <button
             id="mount-toggle"
-            class="cursor-pointer rounded-lg bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-700"
+            class="cursor-pointer rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-gray-700"
           ></button>
           <label class="flex items-center gap-2 text-sm text-gray-700">
             Step

--- a/examples/embedding/src/main.ts
+++ b/examples/embedding/src/main.ts
@@ -97,7 +97,7 @@ export const view = (model: Model): Html => {
   return h.div(
     [
       h.Class(
-        'flex flex-col items-center gap-4 rounded-xl border border-teal-200 bg-teal-50 p-6',
+        'flex flex-col items-center gap-4 rounded-3xl border border-teal-200 bg-teal-50/80 p-7 shadow-lg',
       ),
     ],
     [
@@ -110,7 +110,11 @@ export const view = (model: Model): Html => {
         ['Foldkit widget'],
       ),
       h.div(
-        [h.Class('text-5xl font-bold tabular-nums text-gray-900')],
+        [
+          h.Class(
+            'text-6xl font-semibold tracking-tight tabular-nums text-gray-900',
+          ),
+        ],
         [String(model.count)],
       ),
       h.div(
@@ -124,7 +128,7 @@ export const view = (model: Model): Html => {
             [
               ...attributes.button,
               h.Class(
-                'cursor-pointer rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-500',
+                'cursor-pointer rounded-xl bg-teal-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-600',
               ),
             ],
             [`Advance by ${model.step}`],

--- a/examples/embedding/src/main.ts
+++ b/examples/embedding/src/main.ts
@@ -93,7 +93,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html =>
   h.div(
     [
       h.Class(
-        'flex flex-col items-center gap-4 rounded-xl border border-teal-200 bg-teal-50 p-6',
+        'flex flex-col items-center gap-4 rounded-3xl border border-teal-200 bg-teal-50/80 p-7 shadow-lg',
       ),
     ],
     [
@@ -106,7 +106,11 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html =>
         ['Foldkit widget'],
       ),
       h.div(
-        [h.Class('text-5xl font-bold tabular-nums text-gray-900')],
+        [
+          h.Class(
+            'text-6xl font-semibold tracking-tight tabular-nums text-gray-900',
+          ),
+        ],
         [String(model.count)],
       ),
       h.div(
@@ -121,7 +125,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html =>
               [
                 ...attributes.button,
                 h.Class(
-                  'cursor-pointer rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-500',
+                  'cursor-pointer rounded-xl bg-teal-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-teal-600',
                 ),
               ],
               [`Advance by ${model.step}`],

--- a/examples/embedding/src/styles.css
+++ b/examples/embedding/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #0f766e;
+}

--- a/examples/form/src/main.ts
+++ b/examples/form/src/main.ts
@@ -425,13 +425,21 @@ export const view = (model: Model): Document => {
   const canSubmit = isFormValid(model) && model.submission._tag !== 'Submitting'
 
   const body = h.div(
-    [h.Class('min-h-screen bg-gray-100 py-8')],
+    [h.Class('min-h-screen bg-gray-50 px-4 py-12')],
     [
       h.div(
-        [h.Class('max-w-md mx-auto bg-white rounded-xl shadow-lg p-6')],
+        [
+          h.Class(
+            'max-w-md mx-auto bg-white rounded-3xl border border-gray-200/80 shadow-xl p-7 sm:p-8',
+          ),
+        ],
         [
           h.h1(
-            [h.Class('text-3xl font-bold text-gray-800 text-center mb-8')],
+            [
+              h.Class(
+                'text-3xl font-semibold tracking-tight text-gray-900 text-center mb-8',
+              ),
+            ],
             ['Join Our Waitlist'],
           ),
 
@@ -464,7 +472,7 @@ export const view = (model: Model): Document => {
                       ...attributes.button,
                       h.Class(
                         clsx(
-                          'w-full py-2 px-4 rounded-md transition',
+                          'w-full py-3 px-4 rounded-xl font-medium shadow-sm',
                           canSubmit
                             ? 'bg-blue-500 text-white hover:bg-blue-600'
                             : 'bg-gray-300 text-gray-500 cursor-not-allowed',

--- a/examples/form/src/main.ts
+++ b/examples/form/src/main.ts
@@ -406,13 +406,21 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
   const canSubmit = isFormValid(model) && model.submission._tag !== 'Submitting'
 
   const body = h.div(
-    [h.Class('min-h-screen bg-gray-100 py-8')],
+    [h.Class('min-h-screen bg-gray-50 px-4 py-12')],
     [
       h.div(
-        [h.Class('max-w-md mx-auto bg-white rounded-xl shadow-lg p-6')],
+        [
+          h.Class(
+            'max-w-md mx-auto bg-white rounded-3xl border border-gray-200/80 shadow-xl p-7 sm:p-8',
+          ),
+        ],
         [
           h.h1(
-            [h.Class('text-3xl font-bold text-gray-800 text-center mb-8')],
+            [
+              h.Class(
+                'text-3xl font-semibold tracking-tight text-gray-900 text-center mb-8',
+              ),
+            ],
             ['Join Our Waitlist'],
           ),
 
@@ -453,7 +461,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
                         ...attributes.button,
                         h.Class(
                           clsx(
-                            'w-full py-2 px-4 rounded-md transition',
+                            'w-full py-3 px-4 rounded-xl font-medium shadow-sm',
                             canSubmit
                               ? 'bg-blue-500 text-white hover:bg-blue-600'
                               : 'bg-gray-300 text-gray-500 cursor-not-allowed',

--- a/examples/form/src/styles.css
+++ b/examples/form/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #7c3aed;
+}

--- a/examples/generative-art/src/styles.css
+++ b/examples/generative-art/src/styles.css
@@ -1,1 +1,7 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #d946ef;
+  --app-glow-strength: 22%;
+}

--- a/examples/job-application/src/styles.css
+++ b/examples/job-application/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #2563eb;
+}

--- a/examples/job-application/src/view/index.ts
+++ b/examples/job-application/src/view/index.ts
@@ -186,10 +186,10 @@ const pageHeader = (): Html => {
   const h = html<Message>()
 
   return h.div(
-    [h.Class('mb-6')],
+    [h.Class('mb-6 pr-28 xl:pr-0')],
     [
       h.h1(
-        [h.Class('text-2xl font-bold text-gray-900')],
+        [h.Class('text-3xl font-semibold tracking-tight text-gray-900')],
         ['Apply to Work on Foldkit'],
       ),
       h.p(
@@ -302,7 +302,7 @@ const desktopPreviewSidebar = (model: Model): Html => {
           h.div(
             [
               h.Class(
-                'rounded-xl border border-gray-200 bg-white p-6 shadow-sm',
+                'rounded-2xl border border-gray-200 bg-white p-6 shadow-sm',
               ),
             ],
             [preview(model)],
@@ -349,7 +349,7 @@ const mobilePreviewOverlay = (model: Model): Html => {
     'mobile-overlay',
     [
       h.Class(
-        'fixed inset-x-4 top-16 bottom-4 overflow-y-auto rounded-xl border border-gray-200 bg-white p-6 shadow-2xl xl:hidden',
+        'fixed inset-x-4 top-16 bottom-4 overflow-y-auto rounded-2xl border border-gray-200 bg-white p-6 shadow-2xl xl:hidden',
       ),
     ],
     [preview(model)],
@@ -365,7 +365,7 @@ export const view = (model: Model): Document => {
     [h.Class('min-h-screen bg-gray-50')],
     [
       h.div(
-        [h.Class('mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8')],
+        [h.Class('mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8')],
         [
           pageHeader(),
           h.div(

--- a/examples/job-application/src/view/index.ts
+++ b/examples/job-application/src/view/index.ts
@@ -177,10 +177,10 @@ const navigationButtons = (model: Model, h: HtmlBuilder<Message>): Html =>
 
 const pageHeader = (h: HtmlBuilder<Message>): Html =>
   h.div(
-    [h.Class('mb-6')],
+    [h.Class('mb-6 pr-28 xl:pr-0')],
     [
       h.h1(
-        [h.Class('text-2xl font-bold text-gray-900')],
+        [h.Class('text-3xl font-semibold tracking-tight text-gray-900')],
         ['Apply to Work on Foldkit'],
       ),
       h.p(
@@ -286,7 +286,7 @@ const desktopPreviewSidebar = (model: Model, h: HtmlBuilder<Message>): Html =>
           h.div(
             [
               h.Class(
-                'rounded-xl border border-gray-200 bg-white p-6 shadow-sm',
+                'rounded-2xl border border-gray-200 bg-white p-6 shadow-sm',
               ),
             ],
             [preview(model)],
@@ -328,7 +328,7 @@ const mobilePreviewOverlay = (model: Model, h: HtmlBuilder<Message>): Html =>
   h.div(
     [
       h.Class(
-        'fixed inset-x-4 top-16 bottom-4 overflow-y-auto rounded-xl border border-gray-200 bg-white p-6 shadow-2xl xl:hidden',
+        'fixed inset-x-4 top-16 bottom-4 overflow-y-auto rounded-2xl border border-gray-200 bg-white p-6 shadow-2xl xl:hidden',
       ),
     ],
     [preview(model)],
@@ -341,7 +341,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
     [h.Class('min-h-screen bg-gray-50')],
     [
       h.div(
-        [h.Class('mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8')],
+        [h.Class('mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8')],
         [
           pageHeader(h),
           h.div(

--- a/examples/kanban/src/styles.css
+++ b/examples/kanban/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #4f46e5;
+}

--- a/examples/kanban/src/view/card.ts
+++ b/examples/kanban/src/view/card.ts
@@ -46,7 +46,7 @@ export const cardView = (
     card.id,
     [
       h.Class(
-        clsx('rounded-lg p-3 border-2 outline-none', {
+        clsx('rounded-xl p-3.5 border-2 outline-none', {
           'bg-gray-100 border-dashed border-gray-300 opacity-50':
             isPointerDragged,
           'bg-white shadow-sm border-blue-400': isKeyboardDragged,
@@ -71,7 +71,7 @@ export const ghostCardView = (card: Card.Card): Html => {
   return h.div(
     [
       h.Class(
-        'rounded-lg bg-white shadow-lg p-3 border border-gray-200 scale-105 rotate-2',
+        'rounded-xl bg-white shadow-lg p-3.5 border border-gray-200 scale-105 rotate-2',
       ),
     ],
     cardContent(card),

--- a/examples/kanban/src/view/card.ts
+++ b/examples/kanban/src/view/card.ts
@@ -45,7 +45,7 @@ export const cardView = (
     card.id,
     [
       h.Class(
-        clsx('rounded-lg p-3 border-2 outline-none', {
+        clsx('rounded-xl p-3.5 border-2 outline-none', {
           'bg-gray-100 border-dashed border-gray-300 opacity-50':
             isPointerDragged,
           'bg-white shadow-sm border-blue-400': isKeyboardDragged,
@@ -72,7 +72,7 @@ export const ghostCardView = (card: Card.Card, h: HtmlBuilder<Message>): Html =>
   h.div(
     [
       h.Class(
-        'rounded-lg bg-white shadow-lg p-3 border border-gray-200 scale-105 rotate-2',
+        'rounded-xl bg-white shadow-lg p-3.5 border border-gray-200 scale-105 rotate-2',
       ),
     ],
     cardContent(card, h),

--- a/examples/kanban/src/view/column.ts
+++ b/examples/kanban/src/view/column.ts
@@ -234,7 +234,7 @@ export const columnView = (
       h.Role('region'),
       h.AriaLabel(column.name),
       h.Class(
-        clsx('bg-gray-50 rounded-lg p-3 flex flex-col min-h-0 border-2', {
+        clsx('bg-gray-100/80 rounded-2xl p-3 flex flex-col min-h-0 border-2', {
           'border-dashed border-blue-300': isDropTarget,
           'border-transparent': !isDropTarget,
         }),

--- a/examples/kanban/src/view/column.ts
+++ b/examples/kanban/src/view/column.ts
@@ -243,7 +243,7 @@ export const columnView = (
       h.Role('region'),
       h.AriaLabel(column.name),
       h.Class(
-        clsx('bg-gray-50 rounded-lg p-3 flex flex-col min-h-0 border-2', {
+        clsx('bg-gray-100/80 rounded-2xl p-3 flex flex-col min-h-0 border-2', {
           'border-dashed border-blue-300': isDropTarget,
           'border-transparent': !isDropTarget,
         }),

--- a/examples/kanban/src/view/index.ts
+++ b/examples/kanban/src/view/index.ts
@@ -46,13 +46,17 @@ export const view = (model: Model): Document => {
   return {
     title: 'Kanban Board',
     body: h.div(
-      [h.Class('flex flex-col min-h-screen bg-gray-100')],
+      [h.Class('flex flex-col min-h-screen bg-gray-50')],
       [
         h.div(
-          [h.Class('px-6 py-4 bg-white border-b border-gray-200')],
+          [
+            h.Class(
+              'sticky top-0 z-10 px-6 py-4 bg-white/90 border-b border-gray-200 backdrop-blur shadow-sm',
+            ),
+          ],
           [
             h.h1(
-              [h.Class('text-lg font-semibold text-gray-900')],
+              [h.Class('text-xl font-semibold tracking-tight text-gray-900')],
               ['Kanban Board'],
             ),
           ],
@@ -60,7 +64,7 @@ export const view = (model: Model): Document => {
         h.div(
           [
             h.Class(
-              'flex-1 p-6 grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-6 items-start',
+              'flex-1 p-4 sm:p-6 grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-5 items-start',
             ),
           ],
           Array.map(model.columns, column =>

--- a/examples/kanban/src/view/index.ts
+++ b/examples/kanban/src/view/index.ts
@@ -40,13 +40,17 @@ const ghostElement = (model: Model, h: HtmlBuilder<Message>) =>
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   title: 'Kanban Board',
   body: h.div(
-    [h.Class('flex flex-col min-h-screen bg-gray-100')],
+    [h.Class('flex flex-col min-h-screen bg-gray-50')],
     [
       h.div(
-        [h.Class('px-6 py-4 bg-white border-b border-gray-200')],
+        [
+          h.Class(
+            'sticky top-0 z-10 px-6 py-4 bg-white/90 border-b border-gray-200 backdrop-blur shadow-sm',
+          ),
+        ],
         [
           h.h1(
-            [h.Class('text-lg font-semibold text-gray-900')],
+            [h.Class('text-xl font-semibold tracking-tight text-gray-900')],
             ['Kanban Board'],
           ),
         ],
@@ -54,7 +58,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
       h.div(
         [
           h.Class(
-            'flex-1 p-6 grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-6 items-start',
+            'flex-1 p-4 sm:p-6 grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-5 items-start',
           ),
         ],
         Array.map(model.columns, column =>

--- a/examples/managed-resource-layer/src/main.ts
+++ b/examples/managed-resource-layer/src/main.ts
@@ -287,13 +287,17 @@ export const view = (model: Model): Document => {
   return {
     title: 'Managed Resource Layer',
     body: h.div(
-      [h.Class('min-h-screen bg-gray-100 flex items-center justify-center')],
+      [h.Class('min-h-screen bg-gray-50 flex items-center justify-center p-6')],
       [
         h.div(
-          [h.Class('bg-white p-8 rounded-lg shadow flex flex-col gap-5 w-96')],
+          [
+            h.Class(
+              'bg-white p-8 rounded-3xl border border-gray-200/80 shadow-xl flex flex-col gap-5 w-full max-w-96',
+            ),
+          ],
           [
             h.h1(
-              [h.Class('text-xl font-bold text-gray-900')],
+              [h.Class('text-2xl font-semibold tracking-tight text-gray-900')],
               ['Layer-backed Managed Resource'],
             ),
             engineStatusView(model.engine),

--- a/examples/managed-resource-layer/src/main.ts
+++ b/examples/managed-resource-layer/src/main.ts
@@ -292,13 +292,17 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
   return {
     title: 'Managed Resource Layer',
     body: h.div(
-      [h.Class('min-h-screen bg-gray-100 flex items-center justify-center')],
+      [h.Class('min-h-screen bg-gray-50 flex items-center justify-center p-6')],
       [
         h.div(
-          [h.Class('bg-white p-8 rounded-lg shadow flex flex-col gap-5 w-96')],
+          [
+            h.Class(
+              'bg-white p-8 rounded-3xl border border-gray-200/80 shadow-xl flex flex-col gap-5 w-full max-w-96',
+            ),
+          ],
           [
             h.h1(
-              [h.Class('text-xl font-bold text-gray-900')],
+              [h.Class('text-2xl font-semibold tracking-tight text-gray-900')],
               ['Layer-backed Managed Resource'],
             ),
             engineStatusView(model.engine, h),

--- a/examples/managed-resource-layer/src/styles.css
+++ b/examples/managed-resource-layer/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #059669;
+}

--- a/examples/map/src/main.ts
+++ b/examples/map/src/main.ts
@@ -514,7 +514,7 @@ const sidebarView = (model: Model): Html => {
   return h.aside(
     [
       h.Class(
-        'w-80 shrink-0 border-r border-slate-200 bg-white flex flex-col h-full',
+        'w-72 lg:w-80 shrink-0 border-r border-slate-200 bg-white/95 backdrop-blur flex flex-col h-full shadow-lg z-10',
       ),
     ],
     [
@@ -545,7 +545,7 @@ const sidebarView = (model: Model): Html => {
                 ...attributes.input,
                 h.AriaLabel('Filter locations'),
                 h.Class(
-                  'w-full px-3 py-2 text-sm rounded-md border border-slate-300 outline-none focus:border-slate-500 focus:ring-2 focus:ring-slate-200',
+                  'w-full px-3 py-2.5 text-sm rounded-xl border border-slate-300 bg-slate-50 outline-none focus:bg-white focus:border-emerald-600 focus:ring-2 focus:ring-emerald-100',
                 ),
               ]),
           }),
@@ -679,7 +679,7 @@ const mapErrorBannerView = (maybeReason: Option.Option<string>): Html => {
         [
           h.AriaLabel('Map failed to load'),
           h.Class(
-            'absolute top-3 left-1/2 -translate-x-1/2 max-w-md bg-rose-50 border border-rose-200 text-rose-900 rounded-md shadow-sm px-4 py-3 text-sm',
+            'absolute top-3 left-1/2 -translate-x-1/2 max-w-md bg-rose-50 border border-rose-200 text-rose-900 rounded-xl shadow-sm px-4 py-3 text-sm',
           ),
         ],
         [
@@ -699,7 +699,7 @@ const boundsBadgeView = (maybeBounds: Option.Option<Bounds>): Html => {
       h.div(
         [
           h.Class(
-            'absolute bottom-3 right-3 bg-white/90 backdrop-blur-sm rounded-md shadow-sm px-3 py-2 text-xs font-mono text-slate-700 border border-slate-200',
+            'absolute bottom-3 right-3 bg-white/90 backdrop-blur-sm rounded-xl shadow-sm px-3 py-2 text-xs font-mono text-slate-700 border border-slate-200',
           ),
         ],
         [
@@ -748,7 +748,7 @@ const geolocateLocatingContentView = (): Html => {
     'Geolocate()-locating',
     [
       h.Class(
-        'bg-white rounded-lg shadow-lg max-w-sm w-full mx-4 px-6 py-5 text-center',
+        'bg-white rounded-2xl shadow-xl border border-slate-200 max-w-sm w-full mx-4 px-6 py-6 text-center',
       ),
     ],
     [
@@ -769,7 +769,7 @@ const geolocateFailedContentView = (reason: string): Html => {
     'Geolocate()-failed',
     [
       h.Class(
-        'bg-white rounded-lg shadow-lg max-w-sm w-full mx-4 px-6 py-5 text-center',
+        'bg-white rounded-2xl shadow-xl border border-slate-200 max-w-sm w-full mx-4 px-6 py-6 text-center',
       ),
     ],
     [

--- a/examples/map/src/main.ts
+++ b/examples/map/src/main.ts
@@ -497,7 +497,7 @@ const sidebarView = (model: Model, h: HtmlBuilder<Message>): Html => {
   return h.aside(
     [
       h.Class(
-        'w-80 shrink-0 border-r border-slate-200 bg-white flex flex-col h-full',
+        'w-72 lg:w-80 shrink-0 border-r border-slate-200 bg-white/95 backdrop-blur flex flex-col h-full shadow-lg z-10',
       ),
     ],
     [
@@ -529,7 +529,7 @@ const sidebarView = (model: Model, h: HtmlBuilder<Message>): Html => {
                   ...attributes.input,
                   h.AriaLabel('Filter locations'),
                   h.Class(
-                    'w-full px-3 py-2 text-sm rounded-md border border-slate-300 outline-none focus:border-slate-500 focus:ring-2 focus:ring-slate-200',
+                    'w-full px-3 py-2.5 text-sm rounded-xl border border-slate-300 bg-slate-50 outline-none focus:bg-white focus:border-emerald-600 focus:ring-2 focus:ring-emerald-100',
                   ),
                 ]),
             },
@@ -659,7 +659,7 @@ const mapErrorBannerView = (
         [
           h.AriaLabel('Map failed to load'),
           h.Class(
-            'absolute top-3 left-1/2 -translate-x-1/2 max-w-md bg-rose-50 border border-rose-200 text-rose-900 rounded-md shadow-sm px-4 py-3 text-sm',
+            'absolute top-3 left-1/2 -translate-x-1/2 max-w-md bg-rose-50 border border-rose-200 text-rose-900 rounded-xl shadow-sm px-4 py-3 text-sm',
           ),
         ],
         [
@@ -679,7 +679,7 @@ const boundsBadgeView = (
       h.div(
         [
           h.Class(
-            'absolute bottom-3 right-3 bg-white/90 backdrop-blur-sm rounded-md shadow-sm px-3 py-2 text-xs font-mono text-slate-700 border border-slate-200',
+            'absolute bottom-3 right-3 bg-white/90 backdrop-blur-sm rounded-xl shadow-sm px-3 py-2 text-xs font-mono text-slate-700 border border-slate-200',
           ),
         ],
         [
@@ -723,7 +723,7 @@ const geolocateLocatingContentView = (h: HtmlBuilder<Message>): Html =>
   h.article(
     [
       h.Class(
-        'bg-white rounded-lg shadow-lg max-w-sm w-full mx-4 px-6 py-5 text-center',
+        'bg-white rounded-2xl shadow-xl border border-slate-200 max-w-sm w-full mx-4 px-6 py-6 text-center',
       ),
     ],
     [
@@ -743,7 +743,7 @@ const geolocateFailedContentView = (
   h.article(
     [
       h.Class(
-        'bg-white rounded-lg shadow-lg max-w-sm w-full mx-4 px-6 py-5 text-center',
+        'bg-white rounded-2xl shadow-xl border border-slate-200 max-w-sm w-full mx-4 px-6 py-6 text-center',
       ),
     ],
     [

--- a/examples/map/src/styles.css
+++ b/examples/map/src/styles.css
@@ -1,2 +1,7 @@
 @import 'tailwindcss';
 @import 'maplibre-gl/dist/maplibre-gl.css';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #059669;
+}

--- a/examples/pixel-art/src/styles.css
+++ b/examples/pixel-art/src/styles.css
@@ -1,1 +1,7 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #8b5cf6;
+  --app-glow-strength: 18%;
+}

--- a/examples/pixel-art/src/view/canvas.ts
+++ b/examples/pixel-art/src/view/canvas.ts
@@ -73,7 +73,9 @@ export const canvasView = (model: Model, theme: PaletteTheme): Html => {
           html<Message>().keyed('div')(
             `canvas-${model.gridSize}`,
             [
-              Class('cursor-crosshair select-none w-full aspect-square'),
+              Class(
+                'cursor-crosshair select-none w-full aspect-square overflow-hidden rounded-xl shadow-2xl ring-1 ring-white/15',
+              ),
               Style({
                 display: 'flex',
                 'flex-direction': 'column',

--- a/examples/pixel-art/src/view/canvas.ts
+++ b/examples/pixel-art/src/view/canvas.ts
@@ -73,7 +73,9 @@ export const canvasView = (
         [
           h.div(
             [
-              h.Class('cursor-crosshair select-none w-full aspect-square'),
+              h.Class(
+                'cursor-crosshair select-none w-full aspect-square overflow-hidden rounded-xl shadow-2xl ring-1 ring-white/15',
+              ),
               h.Style({
                 display: 'flex',
                 'flex-direction': 'column',

--- a/examples/pixel-art/src/view/view.ts
+++ b/examples/pixel-art/src/view/view.ts
@@ -42,7 +42,7 @@ const downloadIcon = (className: string): Html => {
 }
 
 const secondaryButtonStyle =
-  'px-3 py-1.5 rounded text-sm bg-gray-800 text-gray-200 transition motion-reduce:transition-none'
+  'px-3 py-2 rounded-lg text-sm bg-gray-800 text-gray-200 transition motion-reduce:transition-none'
 
 const lazyHeader = createLazy()
 const lazyToolPanel = createLazy()
@@ -79,7 +79,7 @@ const headerView = (): Html => {
   return h.div(
     [
       h.Class(
-        'flex items-center justify-between px-4 py-3 border-b border-gray-800',
+        'flex items-center justify-between px-4 py-3 border-b border-gray-800 bg-gray-950/70 backdrop-blur',
       ),
     ],
     [
@@ -87,7 +87,7 @@ const headerView = (): Html => {
         [h.Class('flex flex-col')],
         [
           h.h1(
-            [h.Class('text-lg font-bold tracking-tight leading-none mb-1')],
+            [h.Class('text-lg font-semibold tracking-tight leading-none mb-1')],
             ['PixelForge'],
           ),
           h.div(

--- a/examples/pixel-art/src/view/view.ts
+++ b/examples/pixel-art/src/view/view.ts
@@ -41,7 +41,7 @@ const downloadIcon = (className: string, h: HtmlBuilder<Message>): Html =>
   )
 
 const secondaryButtonStyle =
-  'px-3 py-1.5 rounded text-sm bg-gray-800 text-gray-200 transition motion-reduce:transition-none'
+  'px-3 py-2 rounded-lg text-sm bg-gray-800 text-gray-200 transition motion-reduce:transition-none'
 
 const lazyHeader = createLazy()
 const lazyToolPanel = createLazy()
@@ -74,7 +74,7 @@ const headerView = (h: HtmlBuilder<Message>): Html =>
   h.div(
     [
       h.Class(
-        'flex items-center justify-between px-4 py-3 border-b border-gray-800',
+        'flex items-center justify-between px-4 py-3 border-b border-gray-800 bg-gray-950/70 backdrop-blur',
       ),
     ],
     [
@@ -82,7 +82,7 @@ const headerView = (h: HtmlBuilder<Message>): Html =>
         [h.Class('flex flex-col')],
         [
           h.h1(
-            [h.Class('text-lg font-bold tracking-tight leading-none mb-1')],
+            [h.Class('text-lg font-semibold tracking-tight leading-none mb-1')],
             ['PixelForge'],
           ),
           h.div(

--- a/examples/query-sync/src/main.ts
+++ b/examples/query-sync/src/main.ts
@@ -703,7 +703,7 @@ const browseView = (model: Model, route: typeof BrowseRoute.Type): Html => {
     [h.Class('max-w-6xl mx-auto px-4')],
     [
       h.h1(
-        [h.Class('text-3xl font-bold text-gray-800 mb-2')],
+        [h.Class('text-4xl font-semibold tracking-tight text-gray-900 mb-2')],
         ['Dinosaur Explorer'],
       ),
       h.p(
@@ -809,7 +809,11 @@ const browseView = (model: Model, route: typeof BrowseRoute.Type): Html => {
           ),
         onNonEmpty: rows =>
           h.div(
-            [h.Class('overflow-x-auto rounded-lg border border-gray-200')],
+            [
+              h.Class(
+                'overflow-x-auto rounded-2xl border border-gray-200 bg-white shadow-sm',
+              ),
+            ],
             [
               h.table(
                 [h.Class('w-full')],
@@ -906,7 +910,11 @@ export const view = (model: Model): Document => {
     [h.Class('min-h-screen bg-gray-50')],
     [
       h.header(
-        [h.Class('bg-emerald-600 text-white px-6 py-4 mb-8 shadow-sm')],
+        [
+          h.Class(
+            'bg-emerald-700/95 text-white px-6 py-4 mb-10 shadow-sm backdrop-blur',
+          ),
+        ],
         [
           h.div(
             [h.Class('max-w-6xl mx-auto flex items-center gap-3')],

--- a/examples/query-sync/src/main.ts
+++ b/examples/query-sync/src/main.ts
@@ -673,7 +673,7 @@ const browseView = (
     [h.Class('max-w-6xl mx-auto px-4')],
     [
       h.h1(
-        [h.Class('text-3xl font-bold text-gray-800 mb-2')],
+        [h.Class('text-4xl font-semibold tracking-tight text-gray-900 mb-2')],
         ['Dinosaur Explorer'],
       ),
       h.p(
@@ -780,7 +780,11 @@ const browseView = (
           ),
         onNonEmpty: rows =>
           h.div(
-            [h.Class('overflow-x-auto rounded-lg border border-gray-200')],
+            [
+              h.Class(
+                'overflow-x-auto rounded-2xl border border-gray-200 bg-white shadow-sm',
+              ),
+            ],
             [
               h.table(
                 [h.Class('w-full')],
@@ -890,7 +894,11 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
     [h.Class('min-h-screen bg-gray-50')],
     [
       h.header(
-        [h.Class('bg-emerald-600 text-white px-6 py-4 mb-8 shadow-sm')],
+        [
+          h.Class(
+            'bg-emerald-700/95 text-white px-6 py-4 mb-10 shadow-sm backdrop-blur',
+          ),
+        ],
         [
           h.div(
             [h.Class('max-w-6xl mx-auto flex items-center gap-3')],

--- a/examples/query-sync/src/styles.css
+++ b/examples/query-sync/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #059669;
+}

--- a/examples/routing/src/main.ts
+++ b/examples/routing/src/main.ts
@@ -169,10 +169,14 @@ const navigationView = (currentRoute: AppRoute): Html => {
   const h = html<Message>()
 
   const navLinkClassName = (isActive: boolean) =>
-    `hover:bg-blue-600 font-medium px-3 py-1 rounded transition ${isActive ? 'bg-blue-700 bg-opacity-50' : ''}`
+    `hover:bg-blue-700 font-medium px-3 py-1.5 rounded-lg ${isActive ? 'bg-blue-800/70' : ''}`
 
   return h.nav(
-    [h.Class('bg-blue-500 text-white p-4 mb-6')],
+    [
+      h.Class(
+        'bg-blue-700/95 text-white px-4 py-3 mb-8 shadow-sm backdrop-blur',
+      ),
+    ],
     [
       h.ul(
         [h.Class('max-w-4xl mx-auto flex gap-6 list-none')],
@@ -600,7 +604,7 @@ export const view = (model: Model): Document => {
   return {
     title: routeTitle(model.route),
     body: h.div(
-      [h.Class('min-h-screen bg-gray-100')],
+      [h.Class('min-h-screen bg-gray-50')],
       [
         h.header([], [navigationView(model.route)]),
         h.main(

--- a/examples/routing/src/main.ts
+++ b/examples/routing/src/main.ts
@@ -169,10 +169,14 @@ const navigationView = (
   h: HtmlBuilder<Message>,
 ): Html => {
   const navLinkClassName = (isActive: boolean) =>
-    `hover:bg-blue-600 font-medium px-3 py-1 rounded transition ${isActive ? 'bg-blue-700 bg-opacity-50' : ''}`
+    `hover:bg-blue-700 font-medium px-3 py-1.5 rounded-lg ${isActive ? 'bg-blue-800/70' : ''}`
 
   return h.nav(
-    [h.Class('bg-blue-500 text-white p-4 mb-6')],
+    [
+      h.Class(
+        'bg-blue-700/95 text-white px-4 py-3 mb-8 shadow-sm backdrop-blur',
+      ),
+    ],
     [
       h.ul(
         [h.Class('max-w-4xl mx-auto flex gap-6 list-none')],
@@ -574,7 +578,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
   return {
     title: routeTitle(model.route),
     body: h.div(
-      [h.Class('min-h-screen bg-gray-100')],
+      [h.Class('min-h-screen bg-gray-50')],
       [
         h.header([], [navigationView(model.route, h)]),
         h.main([h.Class('py-8')], [routeContent]),

--- a/examples/routing/src/page/people.ts
+++ b/examples/routing/src/page/people.ts
@@ -255,7 +255,11 @@ const personListItemView = (person: Person): Html => {
 
   return h.keyed('li')(
     person.id.toString(),
-    [h.Class('border border-gray-200 rounded-lg hover:bg-gray-50')],
+    [
+      h.Class(
+        'border border-gray-200 rounded-xl bg-white hover:bg-blue-50/50 shadow-sm',
+      ),
+    ],
     [
       h.a(
         [h.Href(personRouter({ personId: person.id })), h.Class('block p-4')],
@@ -308,7 +312,7 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
                         ...input,
                         h.Autocomplete('off'),
                         h.Class(
-                          'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                          'w-full px-4 py-3 border border-gray-300 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500',
                         ),
                       ]),
                       h.span([...description], []),
@@ -322,7 +326,7 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
                     [
                       ...button,
                       h.Class(
-                        'px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition cursor-pointer',
+                        'px-4 py-3 bg-blue-700 text-white rounded-xl hover:bg-blue-800 shadow-sm cursor-pointer',
                       ),
                     ],
                     ['Search'],

--- a/examples/routing/src/page/people.ts
+++ b/examples/routing/src/page/people.ts
@@ -251,7 +251,11 @@ const recentSearchesView = (
 const personListItemView = (person: Person, h: HtmlBuilder<Message>): Html =>
   h.keyed('li')(
     person.id.toString(),
-    [h.Class('border border-gray-200 rounded-lg hover:bg-gray-50')],
+    [
+      h.Class(
+        'border border-gray-200 rounded-xl bg-white hover:bg-blue-50/50 shadow-sm',
+      ),
+    ],
     [
       h.a(
         [h.Href(personRouter({ personId: person.id })), h.Class('block p-4')],
@@ -303,7 +307,7 @@ export const view = Submodel.defineView<Model, Message>(
                             ...input,
                             h.Autocomplete('off'),
                             h.Class(
-                              'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                              'w-full px-4 py-3 border border-gray-300 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500',
                             ),
                           ]),
                           h.span([...description]),
@@ -320,7 +324,7 @@ export const view = Submodel.defineView<Model, Message>(
                         [
                           ...button,
                           h.Class(
-                            'px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition cursor-pointer',
+                            'px-4 py-3 bg-blue-700 text-white rounded-xl hover:bg-blue-800 shadow-sm cursor-pointer',
                           ),
                         ],
                         ['Search'],

--- a/examples/routing/src/styles.css
+++ b/examples/routing/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #2563eb;
+}

--- a/examples/shared/styles.css
+++ b/examples/shared/styles.css
@@ -1,0 +1,189 @@
+@theme {
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --font-mono:
+    'SFMono-Regular', 'Cascadia Code', 'Roboto Mono', ui-monospace, monospace;
+  --color-gray-50: #f7f7f5;
+  --color-gray-100: #efefec;
+  --color-gray-200: #dfdfda;
+  --color-gray-300: #c9c8c0;
+  --color-gray-400: #a4a299;
+  --color-gray-500: #77756d;
+  --color-gray-600: #57554f;
+  --color-gray-700: #403f3a;
+  --color-gray-800: #292825;
+  --color-gray-900: #1d1c1a;
+  --color-gray-950: #11110f;
+  --color-slate-50: #f6f7f8;
+  --color-slate-100: #eceff1;
+  --color-slate-200: #d9dee2;
+  --color-slate-300: #bcc5cb;
+  --color-slate-400: #89969f;
+  --color-slate-500: #65737d;
+  --color-slate-600: #4a5760;
+  --color-slate-700: #374149;
+  --color-slate-800: #242c31;
+  --color-slate-900: #171d21;
+  --color-slate-950: #0c1013;
+  --color-zinc-50: #f8f7f7;
+  --color-zinc-100: #f0eeee;
+  --color-zinc-200: #e2dfdf;
+  --color-zinc-300: #ccc7c7;
+  --color-zinc-400: #a59d9d;
+  --color-zinc-500: #7d7474;
+  --color-zinc-600: #5d5555;
+  --color-zinc-700: #443e3e;
+  --color-zinc-800: #2d2929;
+  --color-zinc-900: #1f1c1c;
+  --color-zinc-950: #121010;
+}
+
+:root {
+  --app-accent: #4f46e5;
+  --app-accent-contrast: #ffffff;
+  --app-glow-strength: 12%;
+  color-scheme: light;
+  text-rendering: optimizeLegibility;
+}
+
+@layer base {
+  *,
+  *::before,
+  *::after {
+    border-color: color-mix(in srgb, currentColor 14%, transparent);
+  }
+
+  html {
+    min-width: 20rem;
+    min-height: 100%;
+    background: #f6f7f8;
+  }
+
+  body {
+    min-height: 100vh;
+    margin: 0;
+    font-family: var(--font-sans);
+    font-weight: 400;
+    letter-spacing: 0.01em;
+    color: var(--color-slate-900);
+    background:
+      radial-gradient(
+        circle at 10% 0%,
+        color-mix(
+          in srgb,
+          var(--app-accent) var(--app-glow-strength),
+          transparent
+        ),
+        transparent 34rem
+      ),
+      #f6f7f8;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  ::selection {
+    color: var(--app-accent-contrast);
+    background: color-mix(in srgb, var(--app-accent) 82%, black);
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--app-accent);
+    outline-offset: 3px;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+  }
+
+  button,
+  [role='button'],
+  a {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  button,
+  [role='button'] {
+    transition-property:
+      color, background-color, border-color, box-shadow, opacity;
+    transition-duration: 160ms;
+    transition-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+
+  button:not(:disabled):not([data-disabled]),
+  [role='button']:not([aria-disabled='true']):not([data-disabled]) {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  button[data-disabled],
+  [role='button'][aria-disabled='true'],
+  [role='button'][data-disabled] {
+    cursor: not-allowed;
+  }
+
+  input:not([type='range']):not([type='checkbox']):not([type='radio']),
+  select,
+  textarea {
+    transition-property: border-color, box-shadow, background-color;
+    transition-duration: 160ms;
+    transition-timing-function: ease-out;
+  }
+
+  input:not([type='range']):not([type='checkbox']):not([type='radio']):focus,
+  select:focus,
+  textarea:focus {
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--app-accent) 14%, transparent);
+  }
+
+  input[type='checkbox'],
+  input[type='radio'],
+  input[type='range'] {
+    accent-color: var(--app-accent);
+  }
+
+  a {
+    text-decoration-thickness: 0.08em;
+    text-underline-offset: 0.18em;
+  }
+}
+
+[class~='shadow-sm'] {
+  box-shadow:
+    0 1px 2px rgb(15 23 42 / 0.05),
+    0 6px 18px rgb(15 23 42 / 0.035);
+}
+
+[class~='shadow'],
+[class~='shadow-md'] {
+  box-shadow:
+    0 2px 4px rgb(15 23 42 / 0.05),
+    0 12px 28px rgb(15 23 42 / 0.07);
+}
+
+[class~='shadow-lg'] {
+  box-shadow:
+    0 2px 6px rgb(15 23 42 / 0.05),
+    0 24px 56px rgb(15 23 42 / 0.11);
+}
+
+[class~='shadow-xl'],
+[class~='shadow-2xl'] {
+  box-shadow:
+    0 4px 10px rgb(15 23 42 / 0.07),
+    0 32px 80px rgb(15 23 42 / 0.16);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/examples/shopping-cart/src/main.ts
+++ b/examples/shopping-cart/src/main.ts
@@ -226,10 +226,14 @@ const navigationView = (currentRoute: AppRoute, cartCount: number): Html => {
   const h = html<Message>()
 
   const navLinkClassName = (isActive: boolean) =>
-    `hover:bg-blue-600 font-medium px-3 py-1 rounded transition ${isActive ? 'bg-blue-700 bg-opacity-50' : ''}`
+    `hover:bg-orange-600 font-medium px-3 py-1.5 rounded-lg ${isActive ? 'bg-orange-800/60' : ''}`
 
   return h.nav(
-    [h.Class('bg-blue-500 text-white p-4 mb-6')],
+    [
+      h.Class(
+        'bg-orange-700/95 text-white px-4 py-3 mb-8 shadow-sm backdrop-blur',
+      ),
+    ],
     [
       h.ul(
         [h.Class('max-w-6xl mx-auto flex gap-6 justify-center list-none')],
@@ -345,7 +349,7 @@ export const view = (model: Model): Document => {
   return {
     title: routeTitle(model.route),
     body: h.div(
-      [h.Class('min-h-screen bg-gray-100')],
+      [h.Class('min-h-screen bg-gray-50')],
       [
         h.header(
           [],

--- a/examples/shopping-cart/src/main.ts
+++ b/examples/shopping-cart/src/main.ts
@@ -213,10 +213,14 @@ const navigationView = (
   h: HtmlBuilder<Message>,
 ): Html => {
   const navLinkClassName = (isActive: boolean) =>
-    `hover:bg-blue-600 font-medium px-3 py-1 rounded transition ${isActive ? 'bg-blue-700 bg-opacity-50' : ''}`
+    `hover:bg-orange-600 font-medium px-3 py-1.5 rounded-lg ${isActive ? 'bg-orange-800/60' : ''}`
 
   return h.nav(
-    [h.Class('bg-blue-500 text-white p-4 mb-6')],
+    [
+      h.Class(
+        'bg-orange-700/95 text-white px-4 py-3 mb-8 shadow-sm backdrop-blur',
+      ),
+    ],
     [
       h.ul(
         [h.Class('max-w-6xl mx-auto flex gap-6 justify-center list-none')],
@@ -319,7 +323,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
   return {
     title: routeTitle(model.route),
     body: h.div(
-      [h.Class('min-h-screen bg-gray-100')],
+      [h.Class('min-h-screen bg-gray-50')],
       [
         h.header(
           [],

--- a/examples/shopping-cart/src/page/cart.ts
+++ b/examples/shopping-cart/src/page/cart.ts
@@ -26,7 +26,7 @@ export const view = (cart: Cart.Cart): Html => {
         ['Shopping Cart'],
       ),
       h.div(
-        [h.Class('bg-white rounded-lg shadow p-6')],
+        [h.Class('bg-white rounded-2xl border border-gray-200/80 shadow p-6')],
         [
           h.div(
             [],
@@ -43,7 +43,7 @@ export const view = (cart: Cart.Cart): Html => {
                       [
                         h.Href(productsRouter({ searchText: Option.none() })),
                         h.Class(
-                          'bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg font-medium inline-block',
+                          'bg-orange-700 hover:bg-orange-800 text-white px-6 py-2.5 rounded-xl font-medium inline-block shadow-sm',
                         ),
                       ],
                       ['Continue Shopping'],
@@ -59,7 +59,7 @@ export const view = (cart: Cart.Cart): Html => {
                       cartItem.item.id,
                       [
                         h.Class(
-                          'flex items-center justify-between p-4 border rounded-lg',
+                          'flex items-center justify-between p-4 border rounded-xl',
                         ),
                       ],
                       [
@@ -161,7 +161,7 @@ export const view = (cart: Cart.Cart): Html => {
                       [
                         h.Href(productsRouter({ searchText: Option.none() })),
                         h.Class(
-                          'bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-lg font-medium',
+                          'bg-gray-600 hover:bg-gray-700 text-white px-6 py-2.5 rounded-xl font-medium',
                         ),
                       ],
                       ['Continue Shopping'],
@@ -173,7 +173,7 @@ export const view = (cart: Cart.Cart): Html => {
                           [
                             ...attributes.button,
                             h.Class(
-                              'bg-red-500 hover:bg-red-600 text-white px-6 py-2 rounded-lg font-medium',
+                              'bg-red-600 hover:bg-red-700 text-white px-6 py-2.5 rounded-xl font-medium',
                             ),
                           ],
                           ['Clear Cart'],
@@ -183,7 +183,7 @@ export const view = (cart: Cart.Cart): Html => {
                       [
                         h.Href(checkoutRouter()),
                         h.Class(
-                          'bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg font-medium',
+                          'bg-green-700 hover:bg-green-800 text-white px-6 py-2.5 rounded-xl font-medium shadow-sm',
                         ),
                       ],
                       ['Proceed to Checkout'],

--- a/examples/shopping-cart/src/page/cart.ts
+++ b/examples/shopping-cart/src/page/cart.ts
@@ -24,7 +24,7 @@ export const view = (cart: Cart.Cart, h: HtmlBuilder<Message>): Html =>
         ['Shopping Cart'],
       ),
       h.div(
-        [h.Class('bg-white rounded-lg shadow p-6')],
+        [h.Class('bg-white rounded-2xl border border-gray-200/80 shadow p-6')],
         [
           h.div(
             [],
@@ -41,7 +41,7 @@ export const view = (cart: Cart.Cart, h: HtmlBuilder<Message>): Html =>
                       [
                         h.Href(productsRouter({ searchText: Option.none() })),
                         h.Class(
-                          'bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg font-medium inline-block',
+                          'bg-orange-700 hover:bg-orange-800 text-white px-6 py-2.5 rounded-xl font-medium inline-block shadow-sm',
                         ),
                       ],
                       ['Continue Shopping'],
@@ -57,7 +57,7 @@ export const view = (cart: Cart.Cart, h: HtmlBuilder<Message>): Html =>
                       cartItem.item.id,
                       [
                         h.Class(
-                          'flex items-center justify-between p-4 border rounded-lg',
+                          'flex items-center justify-between p-4 border rounded-xl',
                         ),
                       ],
                       [
@@ -168,7 +168,7 @@ export const view = (cart: Cart.Cart, h: HtmlBuilder<Message>): Html =>
                       [
                         h.Href(productsRouter({ searchText: Option.none() })),
                         h.Class(
-                          'bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-lg font-medium',
+                          'bg-gray-600 hover:bg-gray-700 text-white px-6 py-2.5 rounded-xl font-medium',
                         ),
                       ],
                       ['Continue Shopping'],
@@ -181,7 +181,7 @@ export const view = (cart: Cart.Cart, h: HtmlBuilder<Message>): Html =>
                             [
                               ...attributes.button,
                               h.Class(
-                                'bg-red-500 hover:bg-red-600 text-white px-6 py-2 rounded-lg font-medium',
+                                'bg-red-600 hover:bg-red-700 text-white px-6 py-2.5 rounded-xl font-medium',
                               ),
                             ],
                             ['Clear Cart'],
@@ -193,7 +193,7 @@ export const view = (cart: Cart.Cart, h: HtmlBuilder<Message>): Html =>
                       [
                         h.Href(checkoutRouter()),
                         h.Class(
-                          'bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg font-medium',
+                          'bg-green-700 hover:bg-green-800 text-white px-6 py-2.5 rounded-xl font-medium shadow-sm',
                         ),
                       ],
                       ['Proceed to Checkout'],

--- a/examples/shopping-cart/src/page/checkout.ts
+++ b/examples/shopping-cart/src/page/checkout.ts
@@ -29,7 +29,7 @@ export const view = (
           ['Order placed successfully!'],
         ),
         h.article(
-          [h.Class('bg-green-50 border border-green-200 rounded-lg p-6 mb-6')],
+          [h.Class('bg-green-50 border border-green-200 rounded-2xl p-6 mb-6')],
           [
             h.p(
               [h.Class('text-lg text-gray-700 mb-4')],
@@ -45,7 +45,7 @@ export const view = (
           [
             h.Href(productsRouter({ searchText: Option.none() })),
             h.Class(
-              'bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg font-medium inline-block',
+              'bg-orange-700 hover:bg-orange-800 text-white px-6 py-2.5 rounded-xl font-medium inline-block shadow-sm',
             ),
           ],
           ['Continue Shopping'],
@@ -59,7 +59,7 @@ export const view = (
     [
       h.h1([h.Class('text-4xl font-bold text-gray-800 mb-8')], ['Checkout']),
       h.div(
-        [h.Class('bg-white rounded-lg shadow p-6')],
+        [h.Class('bg-white rounded-2xl border border-gray-200/80 shadow p-6')],
         Array.match(cart, {
           onEmpty: () => [
             h.p(
@@ -73,7 +73,7 @@ export const view = (
                   [
                     h.Href(productsRouter({ searchText: Option.none() })),
                     h.Class(
-                      'bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg font-medium inline-block',
+                      'bg-orange-700 hover:bg-orange-800 text-white px-6 py-2.5 rounded-xl font-medium inline-block shadow-sm',
                     ),
                   ],
                   ['Start Shopping'],
@@ -163,7 +163,7 @@ export const view = (
                       [
                         ...attributes.textarea,
                         h.Class(
-                          'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 h-24 resize-none',
+                          'w-full px-4 py-3 border border-gray-300 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-orange-500 h-24 resize-none',
                         ),
                       ],
                       [],
@@ -178,7 +178,7 @@ export const view = (
                   [
                     h.Href(cartRouter()),
                     h.Class(
-                      'bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-lg font-medium',
+                      'bg-gray-600 hover:bg-gray-700 text-white px-6 py-2.5 rounded-xl font-medium',
                     ),
                   ],
                   ['Back to Cart'],
@@ -190,7 +190,7 @@ export const view = (
                       [
                         ...attributes.button,
                         h.Class(
-                          'bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg font-medium',
+                          'bg-green-700 hover:bg-green-800 text-white px-6 py-2.5 rounded-xl font-medium shadow-sm',
                         ),
                       ],
                       ['Place Order'],

--- a/examples/shopping-cart/src/page/checkout.ts
+++ b/examples/shopping-cart/src/page/checkout.ts
@@ -28,7 +28,7 @@ export const view = (
           ['Order placed successfully!'],
         ),
         h.article(
-          [h.Class('bg-green-50 border border-green-200 rounded-lg p-6 mb-6')],
+          [h.Class('bg-green-50 border border-green-200 rounded-2xl p-6 mb-6')],
           [
             h.p(
               [h.Class('text-lg text-gray-700 mb-4')],
@@ -44,7 +44,7 @@ export const view = (
           [
             h.Href(productsRouter({ searchText: Option.none() })),
             h.Class(
-              'bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg font-medium inline-block',
+              'bg-orange-700 hover:bg-orange-800 text-white px-6 py-2.5 rounded-xl font-medium inline-block shadow-sm',
             ),
           ],
           ['Continue Shopping'],
@@ -58,7 +58,7 @@ export const view = (
     [
       h.h1([h.Class('text-4xl font-bold text-gray-800 mb-8')], ['Checkout']),
       h.div(
-        [h.Class('bg-white rounded-lg shadow p-6')],
+        [h.Class('bg-white rounded-2xl border border-gray-200/80 shadow p-6')],
         Array.match(cart, {
           onEmpty: () => [
             h.p(
@@ -72,7 +72,7 @@ export const view = (
                   [
                     h.Href(productsRouter({ searchText: Option.none() })),
                     h.Class(
-                      'bg-blue-500 hover:bg-blue-600 text-white px-6 py-2 rounded-lg font-medium inline-block',
+                      'bg-orange-700 hover:bg-orange-800 text-white px-6 py-2.5 rounded-xl font-medium inline-block shadow-sm',
                     ),
                   ],
                   ['Start Shopping'],
@@ -162,7 +162,7 @@ export const view = (
                       h.textarea([
                         ...attributes.textarea,
                         h.Class(
-                          'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 h-24 resize-none',
+                          'w-full px-4 py-3 border border-gray-300 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-orange-500 h-24 resize-none',
                         ),
                       ]),
                     ],
@@ -177,7 +177,7 @@ export const view = (
                   [
                     h.Href(cartRouter()),
                     h.Class(
-                      'bg-gray-500 hover:bg-gray-600 text-white px-6 py-2 rounded-lg font-medium',
+                      'bg-gray-600 hover:bg-gray-700 text-white px-6 py-2.5 rounded-xl font-medium',
                     ),
                   ],
                   ['Back to Cart'],
@@ -190,7 +190,7 @@ export const view = (
                         [
                           ...attributes.button,
                           h.Class(
-                            'bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg font-medium',
+                            'bg-green-700 hover:bg-green-800 text-white px-6 py-2.5 rounded-xl font-medium shadow-sm',
                           ),
                         ],
                         ['Place Order'],

--- a/examples/shopping-cart/src/page/products.ts
+++ b/examples/shopping-cart/src/page/products.ts
@@ -143,7 +143,11 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
       [
         h.h1([h.Class('text-4xl font-bold text-gray-800 mb-8')], ['Products']),
         h.div(
-          [h.Class('bg-white rounded-lg shadow p-6')],
+          [
+            h.Class(
+              'bg-white rounded-2xl border border-gray-200/80 shadow p-6',
+            ),
+          ],
           [
             h.search(
               [h.Class('mb-6')],
@@ -158,7 +162,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                       ...attributes.input,
                       h.AriaLabel('Search products'),
                       h.Class(
-                        'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                        'w-full px-4 py-3 border border-gray-300 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-orange-500',
                       ),
                     ]),
                 }),
@@ -171,7 +175,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                   product.id,
                   [
                     h.Class(
-                      'flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50',
+                      'flex items-center justify-between p-4 border rounded-xl hover:bg-orange-50/50',
                     ),
                   ],
                   [
@@ -196,7 +200,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                               [
                                 ...attributes.button,
                                 h.Class(
-                                  'bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg font-medium',
+                                  'bg-orange-700 hover:bg-orange-800 text-white px-4 py-2 rounded-xl font-medium shadow-sm',
                                 ),
                               ],
                               ['Add to Cart'],
@@ -259,7 +263,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                       [
                         h.Href(cartRouter()),
                         h.Class(
-                          'bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg font-medium inline-block',
+                          'bg-green-700 hover:bg-green-800 text-white px-6 py-2.5 rounded-xl font-medium inline-block shadow-sm',
                         ),
                       ],
                       [`Go to Cart (${Cart.totalItems(cart)})`],

--- a/examples/shopping-cart/src/page/products.ts
+++ b/examples/shopping-cart/src/page/products.ts
@@ -141,7 +141,11 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
       [
         h.h1([h.Class('text-4xl font-bold text-gray-800 mb-8')], ['Products']),
         h.div(
-          [h.Class('bg-white rounded-lg shadow p-6')],
+          [
+            h.Class(
+              'bg-white rounded-2xl border border-gray-200/80 shadow p-6',
+            ),
+          ],
           [
             h.search(
               [h.Class('mb-6')],
@@ -157,7 +161,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                         ...attributes.input,
                         h.AriaLabel('Search products'),
                         h.Class(
-                          'w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                          'w-full px-4 py-3 border border-gray-300 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-orange-500',
                         ),
                       ]),
                   },
@@ -172,7 +176,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                   product.id,
                   [
                     h.Class(
-                      'flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50',
+                      'flex items-center justify-between p-4 border rounded-xl hover:bg-orange-50/50',
                     ),
                   ],
                   [
@@ -198,7 +202,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                                 [
                                   ...attributes.button,
                                   h.Class(
-                                    'bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg font-medium',
+                                    'bg-orange-700 hover:bg-orange-800 text-white px-4 py-2 rounded-xl font-medium shadow-sm',
                                   ),
                                 ],
                                 ['Add to Cart'],
@@ -269,7 +273,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                       [
                         h.Href(cartRouter()),
                         h.Class(
-                          'bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg font-medium inline-block',
+                          'bg-green-700 hover:bg-green-800 text-white px-6 py-2.5 rounded-xl font-medium inline-block shadow-sm',
                         ),
                       ],
                       [`Go to Cart (${Cart.totalItems(cart)})`],

--- a/examples/shopping-cart/src/styles.css
+++ b/examples/shopping-cart/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #ea580c;
+}

--- a/examples/slow-warnings/src/main.ts
+++ b/examples/slow-warnings/src/main.ts
@@ -328,7 +328,7 @@ const scenarioCard = ({
   const h = html<Message>()
 
   return h.article(
-    [h.Class(`rounded-lg border p-4 shadow-sm ${phaseAccentClass(phase)}`)],
+    [h.Class(`rounded-2xl border p-5 shadow-sm ${phaseAccentClass(phase)}`)],
     [
       h.div(
         [h.Class('mb-4')],
@@ -361,7 +361,7 @@ const warningView = (warning: SlowWarning): Html => {
     warning.id.toString(),
     [
       h.Class(
-        `rounded-lg border p-4 shadow-sm ${phaseAccentClass(warning.phase)}`,
+        `rounded-2xl border p-5 shadow-sm ${phaseAccentClass(warning.phase)}`,
       ),
     ],
     [
@@ -390,7 +390,7 @@ const warningsView = (warnings: ReadonlyArray<SlowWarning>): Html => {
   const h = html<Message>()
 
   return h.section(
-    [h.Class('rounded-lg border border-zinc-200 bg-white p-4 shadow-sm')],
+    [h.Class('rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm')],
     [
       h.div(
         [h.Class('mb-4 flex flex-wrap items-center justify-between gap-3')],
@@ -477,7 +477,7 @@ const patchSurfaceView = (model: Model): Html => {
   const h = html<Message>()
 
   return h.section(
-    [h.Class('rounded-lg border border-zinc-200 bg-white p-4 shadow-sm')],
+    [h.Class('rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm')],
     [
       h.div(
         [h.Class('mb-4 flex flex-wrap items-center justify-between gap-3')],
@@ -513,13 +513,21 @@ export const view = (model: Model): Document => {
       [h.Class('min-h-screen bg-zinc-50 text-zinc-950')],
       [
         h.header(
-          [h.Class('border-b border-zinc-200 bg-white')],
+          [
+            h.Class(
+              'border-b border-zinc-200 bg-white/90 backdrop-blur shadow-sm',
+            ),
+          ],
           [
             h.div(
               [h.Class('mx-auto max-w-6xl px-5 py-6')],
               [
                 h.h1(
-                  [h.Class('text-3xl font-bold tracking-normal text-zinc-950')],
+                  [
+                    h.Class(
+                      'text-3xl font-semibold tracking-tight text-zinc-950',
+                    ),
+                  ],
                   ['Slow Warnings Lab'],
                 ),
                 h.p(

--- a/examples/slow-warnings/src/main.ts
+++ b/examples/slow-warnings/src/main.ts
@@ -329,7 +329,7 @@ const scenarioCard = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.article(
-    [h.Class(`rounded-lg border p-4 shadow-sm ${phaseAccentClass(phase)}`)],
+    [h.Class(`rounded-2xl border p-5 shadow-sm ${phaseAccentClass(phase)}`)],
     [
       h.div(
         [h.Class('mb-4')],
@@ -359,7 +359,7 @@ const warningView = (warning: SlowWarning, h: HtmlBuilder<Message>): Html =>
     warning.id.toString(),
     [
       h.Class(
-        `rounded-lg border p-4 shadow-sm ${phaseAccentClass(warning.phase)}`,
+        `rounded-2xl border p-5 shadow-sm ${phaseAccentClass(warning.phase)}`,
       ),
     ],
     [
@@ -388,7 +388,7 @@ const warningsView = (
   h: HtmlBuilder<Message>,
 ): Html =>
   h.section(
-    [h.Class('rounded-lg border border-zinc-200 bg-white p-4 shadow-sm')],
+    [h.Class('rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm')],
     [
       h.div(
         [h.Class('mb-4 flex flex-wrap items-center justify-between gap-3')],
@@ -473,7 +473,7 @@ const patchRowsView = (
 
 const patchSurfaceView = (model: Model, h: HtmlBuilder<Message>): Html =>
   h.section(
-    [h.Class('rounded-lg border border-zinc-200 bg-white p-4 shadow-sm')],
+    [h.Class('rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm')],
     [
       h.div(
         [h.Class('mb-4 flex flex-wrap items-center justify-between gap-3')],
@@ -506,13 +506,21 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
       [h.Class('min-h-screen bg-zinc-50 text-zinc-950')],
       [
         h.header(
-          [h.Class('border-b border-zinc-200 bg-white')],
+          [
+            h.Class(
+              'border-b border-zinc-200 bg-white/90 backdrop-blur shadow-sm',
+            ),
+          ],
           [
             h.div(
               [h.Class('mx-auto max-w-6xl px-5 py-6')],
               [
                 h.h1(
-                  [h.Class('text-3xl font-bold tracking-normal text-zinc-950')],
+                  [
+                    h.Class(
+                      'text-3xl font-semibold tracking-tight text-zinc-950',
+                    ),
+                  ],
                   ['Slow Warnings Lab'],
                 ),
                 h.p(

--- a/examples/slow-warnings/src/styles.css
+++ b/examples/slow-warnings/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #d97706;
+}

--- a/examples/snake/src/main.ts
+++ b/examples/snake/src/main.ts
@@ -301,7 +301,11 @@ const gridView = (model: Model): Html => {
   const h = html<Message>()
 
   return h.div(
-    [h.Class('inline-block border-2 border-gray-600')],
+    [
+      h.Class(
+        'inline-block overflow-hidden rounded-xl border border-gray-700 shadow-2xl ring-1 ring-white/10',
+      ),
+    ],
     Array.makeBy(GAME.GRID_SIZE, y =>
       h.div(
         [h.Class('flex')],
@@ -343,11 +347,14 @@ export const view = (model: Model): Document => {
     body: h.div(
       [
         h.Class(
-          'flex flex-col items-center justify-center min-h-screen bg-black text-white p-8',
+          'flex flex-col items-center justify-center min-h-screen bg-gray-950 text-white p-6 sm:p-8',
         ),
       ],
       [
-        h.h1([h.Class('text-4xl font-bold mb-4')], ['Snake Game']),
+        h.h1(
+          [h.Class('text-4xl font-semibold tracking-tight mb-4')],
+          ['Snake Game'],
+        ),
         h.div(
           [h.Class('flex gap-8 mb-4')],
           [

--- a/examples/snake/src/main.ts
+++ b/examples/snake/src/main.ts
@@ -301,7 +301,11 @@ const cellClass = (x: number, y: number, model: Model): string => {
 
 const gridView = (model: Model, h: HtmlBuilder<Message>): Html =>
   h.div(
-    [h.Class('inline-block border-2 border-gray-600')],
+    [
+      h.Class(
+        'inline-block overflow-hidden rounded-xl border border-gray-700 shadow-2xl ring-1 ring-white/10',
+      ),
+    ],
     Array.makeBy(GAME.GRID_SIZE, y =>
       h.div(
         [h.Class('flex')],
@@ -336,11 +340,14 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   body: h.div(
     [
       h.Class(
-        'flex flex-col items-center justify-center min-h-screen bg-black text-white p-8',
+        'flex flex-col items-center justify-center min-h-screen bg-gray-950 text-white p-6 sm:p-8',
       ),
     ],
     [
-      h.h1([h.Class('text-4xl font-bold mb-4')], ['Snake Game']),
+      h.h1(
+        [h.Class('text-4xl font-semibold tracking-tight mb-4')],
+        ['Snake Game'],
+      ),
       h.div(
         [h.Class('flex gap-8 mb-4')],
         [

--- a/examples/snake/src/styles.css
+++ b/examples/snake/src/styles.css
@@ -1,1 +1,7 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #22c55e;
+  --app-glow-strength: 18%;
+}

--- a/examples/state-machine/src/styles.css
+++ b/examples/state-machine/src/styles.css
@@ -1,53 +1,17 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
 
 :root {
-  color-scheme: light;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
+  --app-accent: #9a3412;
+  --app-glow-strength: 8%;
 }
 
 html {
   @apply bg-stone-100;
 }
 
-body {
-  min-width: 320px;
-  margin: 0;
-}
-
-button,
-input {
-  font: inherit;
-}
-
-button {
-  -webkit-tap-highlight-color: transparent;
-}
-
-::selection {
-  @apply bg-orange-800 text-white;
-}
-
 .font-serif {
   font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, serif;
   font-weight: 500;
   letter-spacing: -0.025em;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    scroll-behavior: auto !important;
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
 }

--- a/examples/statechart-checkout/src/styles.css
+++ b/examples/statechart-checkout/src/styles.css
@@ -1,53 +1,17 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
 
 :root {
-  color-scheme: light;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
+  --app-accent: #9a3412;
+  --app-glow-strength: 8%;
 }
 
 html {
   @apply bg-stone-100;
 }
 
-body {
-  min-width: 320px;
-  margin: 0;
-}
-
-button,
-input {
-  font: inherit;
-}
-
-button {
-  -webkit-tap-highlight-color: transparent;
-}
-
-::selection {
-  @apply bg-orange-800 text-white;
-}
-
 .font-serif {
   font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, serif;
   font-weight: 500;
   letter-spacing: -0.025em;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    scroll-behavior: auto !important;
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
 }

--- a/examples/stopwatch/src/main.ts
+++ b/examples/stopwatch/src/main.ts
@@ -186,13 +186,21 @@ export const view = (model: Model): Document => {
   return {
     title: `Stopwatch ${formatTime(model.elapsedMs)}`,
     body: h.div(
-      [h.Class('min-h-screen bg-gray-200 flex items-center justify-center')],
+      [h.Class('min-h-screen bg-gray-50 flex items-center justify-center p-6')],
       [
         h.div(
-          [h.Class('bg-white text-center')],
+          [
+            h.Class(
+              'w-full max-w-md overflow-hidden rounded-3xl border border-gray-200/80 bg-white text-center shadow-xl',
+            ),
+          ],
           [
             h.div(
-              [h.Class('text-6xl font-mono font-bold text-gray-800 p-8')],
+              [
+                h.Class(
+                  'text-5xl sm:text-6xl font-mono font-semibold tracking-tight tabular-nums text-gray-900 px-6 py-12',
+                ),
+              ],
               [formatTime(model.elapsedMs)],
             ),
             h.div(
@@ -249,5 +257,4 @@ const startStopButton = (isRunning: boolean): Html => {
 
 // STYLE
 
-const buttonStyle =
-  'px-6 py-4 flex-1 font-semibold text-white transition-colors'
+const buttonStyle = 'px-6 py-4 flex-1 font-semibold text-white cursor-pointer'

--- a/examples/stopwatch/src/main.ts
+++ b/examples/stopwatch/src/main.ts
@@ -181,13 +181,21 @@ const floorAndPad = flow(Math.floor, v => v.toString(), String.padStart(2, '0'))
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   title: `Stopwatch ${formatTime(model.elapsedMs)}`,
   body: h.div(
-    [h.Class('min-h-screen bg-gray-200 flex items-center justify-center')],
+    [h.Class('min-h-screen bg-gray-50 flex items-center justify-center p-6')],
     [
       h.div(
-        [h.Class('bg-white text-center')],
+        [
+          h.Class(
+            'w-full max-w-md overflow-hidden rounded-3xl border border-gray-200/80 bg-white text-center shadow-xl',
+          ),
+        ],
         [
           h.div(
-            [h.Class('text-6xl font-mono font-bold text-gray-800 p-8')],
+            [
+              h.Class(
+                'text-5xl sm:text-6xl font-mono font-semibold tracking-tight tabular-nums text-gray-900 px-6 py-12',
+              ),
+            ],
             [formatTime(model.elapsedMs)],
           ),
           h.div(
@@ -249,5 +257,4 @@ const startStopButton = (isRunning: boolean, h: HtmlBuilder<Message>): Html =>
 
 // STYLE
 
-const buttonStyle =
-  'px-6 py-4 flex-1 font-semibold text-white transition-colors'
+const buttonStyle = 'px-6 py-4 flex-1 font-semibold text-white cursor-pointer'

--- a/examples/stopwatch/src/styles.css
+++ b/examples/stopwatch/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #0f766e;
+}

--- a/examples/todo/src/main.ts
+++ b/examples/todo/src/main.ts
@@ -585,13 +585,21 @@ export const view = (model: Model): Document => {
   const completedCount = Array.length(model.todos) - activeCount
 
   const body = h.div(
-    [h.Class('min-h-screen bg-gray-100 py-8')],
+    [h.Class('min-h-screen bg-gray-50 px-4 py-12')],
     [
       h.div(
-        [h.Class('max-w-md mx-auto bg-white rounded-xl shadow-lg p-6')],
+        [
+          h.Class(
+            'max-w-lg mx-auto bg-white rounded-3xl border border-gray-200/80 shadow-xl p-7 sm:p-8',
+          ),
+        ],
         [
           h.h1(
-            [h.Class('text-3xl font-bold text-gray-800 text-center mb-8')],
+            [
+              h.Class(
+                'text-3xl font-semibold tracking-tight text-gray-900 text-center mb-8',
+              ),
+            ],
             ['Todo App'],
           ),
 
@@ -611,7 +619,7 @@ export const view = (model: Model): Document => {
                         ...attributes.input,
                         h.AriaLabel('New todo'),
                         h.Class(
-                          'flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                          'flex-1 min-w-0 px-4 py-3 border border-gray-300 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500',
                         ),
                       ]),
                   }),
@@ -622,7 +630,7 @@ export const view = (model: Model): Document => {
                         [
                           ...attributes.button,
                           h.Class(
-                            'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500',
+                            'px-6 py-3 bg-blue-600 text-white font-medium rounded-xl hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm',
                           ),
                         ],
                         ['Add'],

--- a/examples/todo/src/main.ts
+++ b/examples/todo/src/main.ts
@@ -603,13 +603,21 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
   const completedCount = Array.length(model.todos) - activeCount
 
   const body = h.div(
-    [h.Class('min-h-screen bg-gray-100 py-8')],
+    [h.Class('min-h-screen bg-gray-50 px-4 py-12')],
     [
       h.div(
-        [h.Class('max-w-md mx-auto bg-white rounded-xl shadow-lg p-6')],
+        [
+          h.Class(
+            'max-w-lg mx-auto bg-white rounded-3xl border border-gray-200/80 shadow-xl p-7 sm:p-8',
+          ),
+        ],
         [
           h.h1(
-            [h.Class('text-3xl font-bold text-gray-800 text-center mb-8')],
+            [
+              h.Class(
+                'text-3xl font-semibold tracking-tight text-gray-900 text-center mb-8',
+              ),
+            ],
             ['Todo App'],
           ),
 
@@ -630,7 +638,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
                           ...attributes.input,
                           h.AriaLabel('New todo'),
                           h.Class(
-                            'flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500',
+                            'flex-1 min-w-0 px-4 py-3 border border-gray-300 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500',
                           ),
                         ]),
                     },
@@ -644,7 +652,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
                           [
                             ...attributes.button,
                             h.Class(
-                              'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500',
+                              'px-6 py-3 bg-blue-600 text-white font-medium rounded-xl hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm',
                             ),
                           ],
                           ['Add'],

--- a/examples/todo/src/styles.css
+++ b/examples/todo/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #4f46e5;
+}

--- a/examples/ui-showcase/src/main.ts
+++ b/examples/ui-showcase/src/main.ts
@@ -419,7 +419,7 @@ const sidebarView = (currentRoute: AppRoute): Html => {
       [
         ...nav,
         h.Class(
-          'hidden md:flex w-56 shrink-0 border-r border-gray-200 bg-gray-50 p-4 flex-col',
+          'hidden md:flex w-60 shrink-0 border-r border-gray-200 bg-white/80 p-5 flex-col backdrop-blur',
         ),
       ],
       [
@@ -430,7 +430,11 @@ const sidebarView = (currentRoute: AppRoute): Html => {
               [h.Href(homeRouter()), h.Class('block')],
               [
                 h.h1(
-                  [h.Class('text-lg font-bold text-gray-900')],
+                  [
+                    h.Class(
+                      'text-lg font-semibold tracking-tight text-gray-900',
+                    ),
+                  ],
                   ['Foldkit UI'],
                 ),
               ],
@@ -511,7 +515,7 @@ const mobileHeaderView = (model: Model): Html => {
   return h.header(
     [
       h.Class(
-        'md:hidden sticky top-0 z-40 flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3',
+        'md:hidden sticky top-0 z-40 flex items-center justify-between border-b border-gray-200 bg-white/90 px-4 py-3 backdrop-blur shadow-sm',
       ),
     ],
     [
@@ -584,7 +588,11 @@ const homeView = (): Html => {
     [h.Class('max-w-2xl')],
     [
       h.h1(
-        [h.Class('text-2xl md:text-3xl font-bold text-gray-900 mb-4')],
+        [
+          h.Class(
+            'text-3xl md:text-4xl font-semibold tracking-tight text-gray-900 mb-4',
+          ),
+        ],
         ['Foldkit UI Showcase'],
       ),
       h.p(
@@ -680,13 +688,13 @@ export const view = (model: Model): Document => {
   return {
     title: routeTitle(model.route),
     body: h.div(
-      [h.Class('flex flex-col md:flex-row min-h-screen bg-white')],
+      [h.Class('flex flex-col md:flex-row min-h-screen bg-gray-50')],
       [
         mobileHeaderView(model),
         mobileMenuView(model),
         sidebarView(model.route),
         h.main(
-          [h.Class('flex-1 p-4 md:p-8 overflow-auto')],
+          [h.Class('flex-1 p-5 md:p-10 overflow-auto')],
           [h.keyed('div')(model.route._tag, [], [contentView(model)])],
         ),
       ],

--- a/examples/ui-showcase/src/main.ts
+++ b/examples/ui-showcase/src/main.ts
@@ -417,7 +417,7 @@ const sidebarView = (currentRoute: AppRoute, h: HtmlBuilder<Message>): Html =>
       [
         ...nav,
         h.Class(
-          'hidden md:flex w-56 shrink-0 border-r border-gray-200 bg-gray-50 p-4 flex-col',
+          'hidden md:flex w-60 shrink-0 border-r border-gray-200 bg-white/80 p-5 flex-col backdrop-blur',
         ),
       ],
       [
@@ -428,7 +428,11 @@ const sidebarView = (currentRoute: AppRoute, h: HtmlBuilder<Message>): Html =>
               [h.Href(homeRouter()), h.Class('block')],
               [
                 h.h1(
-                  [h.Class('text-lg font-bold text-gray-900')],
+                  [
+                    h.Class(
+                      'text-lg font-semibold tracking-tight text-gray-900',
+                    ),
+                  ],
                   ['Foldkit UI'],
                 ),
               ],
@@ -504,7 +508,7 @@ const mobileHeaderView = (model: Model, h: HtmlBuilder<Message>): Html =>
   h.header(
     [
       h.Class(
-        'md:hidden sticky top-0 z-40 flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3',
+        'md:hidden sticky top-0 z-40 flex items-center justify-between border-b border-gray-200 bg-white/90 px-4 py-3 backdrop-blur shadow-sm',
       ),
     ],
     [
@@ -571,7 +575,11 @@ const homeView = (h: HtmlBuilder<Message>): Html =>
     [h.Class('max-w-2xl')],
     [
       h.h1(
-        [h.Class('text-2xl md:text-3xl font-bold text-gray-900 mb-4')],
+        [
+          h.Class(
+            'text-3xl md:text-4xl font-semibold tracking-tight text-gray-900 mb-4',
+          ),
+        ],
         ['Foldkit UI Showcase'],
       ),
       h.p(
@@ -658,13 +666,13 @@ const routeTitle = (route: Model['route']): string =>
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   title: routeTitle(model.route),
   body: h.div(
-    [h.Class('flex flex-col md:flex-row min-h-screen bg-white')],
+    [h.Class('flex flex-col md:flex-row min-h-screen bg-gray-50')],
     [
       mobileHeaderView(model, h),
       mobileMenuView(model, h),
       sidebarView(model.route, h),
       h.main(
-        [h.Class('flex-1 p-4 md:p-8 overflow-auto')],
+        [h.Class('flex-1 p-5 md:p-10 overflow-auto')],
         [contentView(model, h)],
       ),
     ],

--- a/examples/ui-showcase/src/styles.css
+++ b/examples/ui-showcase/src/styles.css
@@ -1,5 +1,10 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
 @source "../../../packages/foldkit/src";
+
+:root {
+  --app-accent: #4f46e5;
+}
 
 @layer base {
   [tabindex='-1']:focus {

--- a/examples/weather/src/main.ts
+++ b/examples/weather/src/main.ts
@@ -239,11 +239,14 @@ export const view = (model: Model): Document => {
     body: h.div(
       [
         h.Class(
-          'min-h-screen bg-gradient-to-br from-blue-100 to-blue-300 flex flex-col items-center justify-center gap-6 p-6',
+          'min-h-screen bg-gradient-to-br from-sky-50 via-blue-100 to-indigo-200 flex flex-col items-center justify-center gap-6 p-6',
         ),
       ],
       [
-        h.h1([h.Class('text-4xl font-bold text-blue-900 mb-8')], ['Weather']),
+        h.h1(
+          [h.Class('text-4xl font-semibold tracking-tight text-blue-950 mb-6')],
+          ['Weather'],
+        ),
 
         h.form(
           [
@@ -263,7 +266,7 @@ export const view = (model: Model): Document => {
                   h.DataAttribute('1p-ignore', ''),
                   h.AriaLabel('Zip code'),
                   h.Class(
-                    'w-full px-4 py-2 rounded-lg border-2 border-blue-300 focus:border-blue-500 outline-none',
+                    'w-full px-4 py-3 rounded-xl border border-blue-200 bg-white/90 shadow-sm focus:border-blue-500 outline-none',
                   ),
                 ]),
             }),
@@ -275,7 +278,7 @@ export const view = (model: Model): Document => {
                   [
                     ...attributes.button,
                     h.Class(
-                      'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition data-[disabled]:opacity-50',
+                      'px-6 py-3 bg-blue-600 text-white font-medium rounded-xl hover:bg-blue-700 shadow-sm data-[disabled]:opacity-50',
                     ),
                   ],
                   [
@@ -322,7 +325,11 @@ const weatherView = (weather: WeatherData): Html => {
   const h = html<Message>()
 
   return h.article(
-    [h.Class('bg-white rounded-xl shadow-lg p-8 w-full')],
+    [
+      h.Class(
+        'bg-white/95 backdrop-blur rounded-3xl border border-white/80 shadow-xl p-8 w-full',
+      ),
+    ],
     [
       h.h2(
         [h.Class('text-2xl font-bold text-gray-800 mb-3 text-center')],

--- a/examples/weather/src/main.ts
+++ b/examples/weather/src/main.ts
@@ -236,11 +236,14 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   body: h.div(
     [
       h.Class(
-        'min-h-screen bg-gradient-to-br from-blue-100 to-blue-300 flex flex-col items-center justify-center gap-6 p-6',
+        'min-h-screen bg-gradient-to-br from-sky-50 via-blue-100 to-indigo-200 flex flex-col items-center justify-center gap-6 p-6',
       ),
     ],
     [
-      h.h1([h.Class('text-4xl font-bold text-blue-900 mb-8')], ['Weather']),
+      h.h1(
+        [h.Class('text-4xl font-semibold tracking-tight text-blue-950 mb-6')],
+        ['Weather'],
+      ),
 
       h.form(
         [
@@ -261,7 +264,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
                   h.DataAttribute('1p-ignore', ''),
                   h.AriaLabel('Zip code'),
                   h.Class(
-                    'w-full px-4 py-2 rounded-lg border-2 border-blue-300 focus:border-blue-500 outline-none',
+                    'w-full px-4 py-3 rounded-xl border border-blue-200 bg-white/90 shadow-sm focus:border-blue-500 outline-none',
                   ),
                 ]),
             },
@@ -276,7 +279,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
                   [
                     ...attributes.button,
                     h.Class(
-                      'px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition data-[disabled]:opacity-50',
+                      'px-6 py-3 bg-blue-600 text-white font-medium rounded-xl hover:bg-blue-700 shadow-sm data-[disabled]:opacity-50',
                     ),
                   ],
                   [
@@ -316,7 +319,11 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
 
 const weatherView = (weather: WeatherData, h: HtmlBuilder<Message>): Html =>
   h.article(
-    [h.Class('bg-white rounded-xl shadow-lg p-8 w-full')],
+    [
+      h.Class(
+        'bg-white/95 backdrop-blur rounded-3xl border border-white/80 shadow-xl p-8 w-full',
+      ),
+    ],
     [
       h.h2(
         [h.Class('text-2xl font-bold text-gray-800 mb-3 text-center')],

--- a/examples/weather/src/styles.css
+++ b/examples/weather/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #0284c7;
+}

--- a/examples/web-components/src/main.ts
+++ b/examples/web-components/src/main.ts
@@ -107,7 +107,7 @@ export const view = (model: Model): Document => {
     body: h.div(
       [
         h.Class(
-          'min-h-screen bg-slate-50 text-slate-900 px-6 py-10 flex flex-col items-center',
+          'min-h-screen bg-slate-50 text-slate-900 px-4 py-12 sm:px-6 flex flex-col items-center',
         ),
       ],
       [
@@ -135,7 +135,7 @@ const headerView = (): Html => {
   return h.header(
     [h.Class('flex flex-col gap-2')],
     [
-      h.h1([h.Class('text-3xl font-bold tracking-tight')], ['QR Designer']),
+      h.h1([h.Class('text-4xl font-semibold tracking-tight')], ['QR Designer']),
       h.p(
         [h.Class('text-sm text-slate-600 leading-relaxed')],
         [
@@ -179,7 +179,7 @@ const designerView = (model: Model): Html => {
   return h.div(
     [
       h.Class(
-        'grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6 bg-white rounded-xl shadow-sm border border-slate-200 p-6',
+        'grid grid-cols-1 md:grid-cols-[1fr_auto] gap-7 bg-white rounded-3xl shadow-lg border border-slate-200 p-6 sm:p-8',
       ),
     ],
     [controlsView(model), previewView(model)],

--- a/examples/web-components/src/main.ts
+++ b/examples/web-components/src/main.ts
@@ -101,7 +101,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   body: h.div(
     [
       h.Class(
-        'min-h-screen bg-slate-50 text-slate-900 px-6 py-10 flex flex-col items-center',
+        'min-h-screen bg-slate-50 text-slate-900 px-4 py-12 sm:px-6 flex flex-col items-center',
       ),
     ],
     [
@@ -120,7 +120,7 @@ const headerView = (h: HtmlBuilder<Message>): Html =>
   h.header(
     [h.Class('flex flex-col gap-2')],
     [
-      h.h1([h.Class('text-3xl font-bold tracking-tight')], ['QR Designer']),
+      h.h1([h.Class('text-4xl font-semibold tracking-tight')], ['QR Designer']),
       h.p(
         [h.Class('text-sm text-slate-600 leading-relaxed')],
         [
@@ -161,7 +161,7 @@ const designerView = (model: Model, h: HtmlBuilder<Message>): Html =>
   h.div(
     [
       h.Class(
-        'grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6 bg-white rounded-xl shadow-sm border border-slate-200 p-6',
+        'grid grid-cols-1 md:grid-cols-[1fr_auto] gap-7 bg-white rounded-3xl shadow-lg border border-slate-200 p-6 sm:p-8',
       ),
     ],
     [controlsView(model, h), previewView(model, h)],

--- a/examples/web-components/src/styles.css
+++ b/examples/web-components/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #0891b2;
+}

--- a/examples/websocket-chat/src/main.ts
+++ b/examples/websocket-chat/src/main.ts
@@ -368,14 +368,14 @@ export const view = (model: Model): Document => {
     body: h.div(
       [
         h.Class(
-          'min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex flex-col items-center justify-center p-6',
+          'min-h-screen bg-gradient-to-br from-violet-100 via-purple-50 to-blue-100 flex flex-col items-center justify-center p-4 sm:p-6',
         ),
       ],
       [
         h.div(
           [
             h.Class(
-              'bg-white rounded-xl shadow-2xl w-full max-w-2xl flex flex-col h-[600px]',
+              'bg-white/95 backdrop-blur rounded-3xl border border-white shadow-2xl w-full max-w-2xl flex flex-col h-[min(680px,calc(100vh-2rem))] overflow-hidden',
             ),
           ],
           [
@@ -390,7 +390,11 @@ export const view = (model: Model): Document => {
                   [],
                   [
                     h.div(
-                      [h.Class('text-2xl font-bold text-gray-800')],
+                      [
+                        h.Class(
+                          'text-2xl font-semibold tracking-tight text-gray-900',
+                        ),
+                      ],
                       ['WebSocket Chat'],
                     ),
                     h.div(

--- a/examples/websocket-chat/src/main.ts
+++ b/examples/websocket-chat/src/main.ts
@@ -364,14 +364,14 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
   body: h.div(
     [
       h.Class(
-        'min-h-screen bg-gradient-to-br from-purple-100 to-blue-100 flex flex-col items-center justify-center p-6',
+        'min-h-screen bg-gradient-to-br from-violet-100 via-purple-50 to-blue-100 flex flex-col items-center justify-center p-4 sm:p-6',
       ),
     ],
     [
       h.div(
         [
           h.Class(
-            'bg-white rounded-xl shadow-2xl w-full max-w-2xl flex flex-col h-[600px]',
+            'bg-white/95 backdrop-blur rounded-3xl border border-white shadow-2xl w-full max-w-2xl flex flex-col h-[min(680px,calc(100vh-2rem))] overflow-hidden',
           ),
         ],
         [
@@ -386,7 +386,11 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
                 [],
                 [
                   h.div(
-                    [h.Class('text-2xl font-bold text-gray-800')],
+                    [
+                      h.Class(
+                        'text-2xl font-semibold tracking-tight text-gray-900',
+                      ),
+                    ],
                     ['WebSocket Chat'],
                   ),
                   h.div(

--- a/examples/websocket-chat/src/styles.css
+++ b/examples/websocket-chat/src/styles.css
@@ -1,1 +1,6 @@
 @import 'tailwindcss';
+@import '../../shared/styles.css';
+
+:root {
+  --app-accent: #7c3aed;
+}


### PR DESCRIPTION
## Summary

- add a shared visual foundation and refine layouts across all 27 example apps
- use a system font stack with consistent focus, pointer, disabled, shadow, and reduced-motion treatments
- remove hover-lift motion while preserving each app's interaction behavior
- keep the Charting example usable when GitHub restricts stargazer history by showing the current total and omitting incomplete historical series
- preserve app-specific gradients and improve Shopping Cart action contrast

## Validation

- full Foldkit pre-push suite passed
- all 27 example production builds passed
- all workspace builds, typechecks, unit tests, and website end-to-end tests passed
- live browser QA covered Todo interactions, Charting fallback behavior, the routing file browser, Shopping Cart styles, preserved gradients, and 390px responsive layouts