### PR TITLE
feat(foldkit): add restString catch-all string param

### DIFF
--- a/.changeset/rest-string-catch-all-param.md
+++ b/.changeset/rest-string-catch-all-param.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `restString`, a terminal catch-all route param that captures the raw remaining URL path, slashes and dots included, as a single `string` and round-trips bidirectionally: `/vault/a/b/c.md` parses into `{ path: 'a/b/c.md' }` and builds back from it. Where `rest` yields a `NonEmptyArray` of segments, `restString` rejoins the tail into one path string, so file-tree and docs routes can carry a repository-relative path as `{ path: S.String }` route data. Printing requires a normalized path, non-empty with no leading, trailing, or repeated slashes; any other value would build a URL that parses back differently, so printing fails with a `ParseError` instead. Exported from `foldkit/route`.

--- a/.changeset/restring-catch-all-param.md
+++ b/.changeset/restring-catch-all-param.md
@@ -1,5 +1,0 @@
----
-'foldkit': minor
----
-
-Add `restString`, a terminal catch-all route param that captures the raw remaining URL path — slashes and dots included — as a single `string` and round-trips bidirectionally (`/vault/a/b/c.md` ⇄ `{ path: 'a/b/c.md' }`). Where `rest` yields a `NonEmptyArray` of segments, `restString` rejoins the tail into one path string, so file-tree and docs routes can carry a repository-relative path as clean `{ path: S.String }` route data. Exported from `foldkit/route`.

--- a/.changeset/restring-catch-all-param.md
+++ b/.changeset/restring-catch-all-param.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `restString`, a terminal catch-all route param that captures the raw remaining URL path — slashes and dots included — as a single `string` and round-trips bidirectionally (`/vault/a/b/c.md` ⇄ `{ path: 'a/b/c.md' }`). Where `rest` yields a `NonEmptyArray` of segments, `restString` rejoins the tail into one path string, so file-tree and docs routes can carry a repository-relative path as clean `{ path: S.String }` route data. Exported from `foldkit/route`.

--- a/packages/foldkit/src/route/parser.test.ts
+++ b/packages/foldkit/src/route/parser.test.ts
@@ -14,6 +14,7 @@ import {
   parseUrlWithFallback,
   query,
   rest,
+  restString,
   root,
   schemaSegment,
   slash,
@@ -323,6 +324,124 @@ describe('rest', () => {
       expect(filesRouter({ path: parsed.path })).toBe('/files/documents/taxes')
     }),
   )
+})
+
+describe('restString', () => {
+  const Vault = r('Vault', { path: S.String })
+  const NotFound = r('NotFound', { path: S.String })
+
+  const vaultRouter = pipe(
+    literal('vault'),
+    slash(restString('path')),
+    mapTo(Vault),
+  )
+
+  it.effect('captures all remaining segments as one slash-joined string', () =>
+    Effect.gen(function* () {
+      const [value, remaining] = yield* restString('path').parse([
+        'a',
+        'b',
+        'c.md',
+      ])
+      expect(value).toStrictEqual({ path: 'a/b/c.md' })
+      expect(remaining).toStrictEqual([])
+    }),
+  )
+
+  it.effect('captures a single-segment tail', () =>
+    Effect.gen(function* () {
+      const [value] = yield* restString('path').parse(['notes.md'])
+      expect(value).toStrictEqual({ path: 'notes.md' })
+    }),
+  )
+
+  it.effect('fails on empty segments', () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(restString('path').parse([]))
+      expect(error._tag).toBe('ParseError')
+      expect(error.actual).toBe('end of path')
+    }),
+  )
+
+  it.effect('prints the raw path as a single segment', () =>
+    Effect.gen(function* () {
+      const state = yield* restString('path').print(
+        { path: 'documents/taxes/2024.pdf' },
+        { segments: ['vault'], queryParams: new URLSearchParams() },
+      )
+      expect(state.segments).toStrictEqual([
+        'vault',
+        'documents/taxes/2024.pdf',
+      ])
+    }),
+  )
+
+  it.effect('composes after literals', () =>
+    Effect.gen(function* () {
+      const parser = pipe(literal('vault'), slash(restString('path')))
+      const [value, remaining] = yield* parser.parse(['vault', 'a', 'b.md'])
+      expect(value).toStrictEqual({ path: 'a/b.md' })
+      expect(remaining).toStrictEqual([])
+    }),
+  )
+
+  it.effect('combines with query parameters', () =>
+    Effect.gen(function* () {
+      const parser = pipe(
+        literal('vault'),
+        slash(restString('path')),
+        query(S.Struct({ sort: S.String })),
+      )
+      const [value] = yield* parser.parse(['vault', 'a.md'], 'sort=name')
+      expect(value).toStrictEqual({ path: 'a.md', sort: 'name' })
+    }),
+  )
+
+  it('cannot be extended with slash', () => {
+    // @ts-expect-error slash cannot follow a terminal parser
+    const invalidParser = pipe(restString('path'), slash(literal('x')))
+    expect(invalidParser).toBeDefined()
+  })
+
+  it('builds a URL from restString route data', () => {
+    const url = vaultRouter({
+      path: '20-upgrade/teach/the-elm-architecture.md',
+    })
+    expect(url).toBe('/vault/20-upgrade/teach/the-elm-architecture.md')
+  })
+
+  it.effect('parse then build round-trips a path with slashes and dots', () =>
+    Effect.gen(function* () {
+      const [parsed] = yield* vaultRouter.parse(['vault', 'a', 'b', 'c.md'])
+      expect(vaultRouter({ path: parsed.path })).toBe('/vault/a/b/c.md')
+    }),
+  )
+
+  it('parses a full URL through the router', () => {
+    const parser = oneOf(vaultRouter)
+    const route = parseUrlWithFallback(
+      parser,
+      NotFound,
+    )(makeUrl('/vault/a/b/c.md'))
+    expect(route).toStrictEqual(Vault.make({ path: 'a/b/c.md' }))
+  })
+
+  it('normalizes a trailing slash away', () => {
+    const parser = oneOf(vaultRouter)
+    const route = parseUrlWithFallback(parser, NotFound)(makeUrl('/vault/a/b/'))
+    expect(route).toStrictEqual(Vault.make({ path: 'a/b' }))
+  })
+
+  it('round-trips a percent-encoded tail unchanged', () => {
+    const parser = oneOf(vaultRouter)
+    const encodedPath = 'a%20b/c.md'
+    const route = parseUrlWithFallback(
+      parser,
+      NotFound,
+    )(makeUrl(`/vault/${encodedPath}`))
+    expect(route).toStrictEqual(Vault.make({ path: encodedPath }))
+    expect(vaultRouter({ path: encodedPath })).toBe(`/vault/${encodedPath}`)
+  })
 })
 
 describe('slash', () => {

--- a/packages/foldkit/src/route/parser.test.ts
+++ b/packages/foldkit/src/route/parser.test.ts
@@ -376,6 +376,43 @@ describe('restString', () => {
     }),
   )
 
+  it.effect('fails to print an empty path', () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        restString('path').print(
+          { path: '' },
+          { segments: ['vault'], queryParams: new URLSearchParams() },
+        ),
+      )
+      expect(error._tag).toBe('ParseError')
+      expect(error.actual).toBe('empty string')
+    }),
+  )
+
+  it.effect('fails to print a path that would not parse back the same', () =>
+    Effect.gen(function* () {
+      const printPath = (path: string) =>
+        Effect.flip(
+          restString('path').print(
+            { path },
+            { segments: ['vault'], queryParams: new URLSearchParams() },
+          ),
+        )
+
+      const repeatedSlash = yield* printPath('a//b')
+      const leadingSlash = yield* printPath('/a/b')
+      const trailingSlash = yield* printPath('a/b/')
+
+      expect(repeatedSlash._tag).toBe('ParseError')
+      expect(leadingSlash._tag).toBe('ParseError')
+      expect(trailingSlash._tag).toBe('ParseError')
+    }),
+  )
+
+  it('throws when building a URL from a non-normalized path', () => {
+    expect(() => vaultRouter({ path: '/a/b' })).toThrow()
+  })
+
   it.effect('composes after literals', () =>
     Effect.gen(function* () {
       const parser = pipe(literal('vault'), slash(restString('path')))

--- a/packages/foldkit/src/route/parser.ts
+++ b/packages/foldkit/src/route/parser.ts
@@ -392,6 +392,63 @@ export const rest = <K extends string>(
 }
 
 /**
+ * Creates a parser that captures all remaining URL segments as a single
+ * named string field, preserving the slashes between them.
+ *
+ * Where `rest` yields a `NonEmptyArray` of segments, `restString` rejoins
+ * the tail into one raw path string, so a value that itself contains both
+ * slashes and dots — like a repository-relative file path
+ * `documents/taxes/2024.pdf` — round-trips through the bidirectional router
+ * as clean `{ path: string }` route data. It is the greedy catch-all every
+ * file-tree or docs router eventually needs.
+ *
+ * Requires at least one remaining segment. A bare prefix like `/vault`
+ * does not match; give it its own route alongside the restString route.
+ *
+ * A restString route also matches every URL that a more specific route under
+ * the same prefix accepts, so in `oneOf` the specific route must come first.
+ *
+ * Nothing can follow `restString` in the path, so the result is a
+ * `TerminalParser`. It can still be extended with `query`.
+ *
+ * @example
+ * ```ts
+ * pipe(literal('vault'), slash(restString('path')))
+ * // parses /vault/a/b/c.md   into { path: 'a/b/c.md' }
+ * // builds { path: 'a/b/c.md' } into /vault/a/b/c.md
+ * ```
+ */
+export const restString = <K extends string>(
+  name: K,
+): TerminalParser<Record<K, string>> => {
+  const parser: Biparser<Record<K, string>> = {
+    parse: segments =>
+      Array.match(segments, {
+        onEmpty: () =>
+          Effect.fail(
+            new ParseError({
+              message: `Expected remaining path (${name})`,
+              expected: `remaining path (${name})`,
+              actual: 'end of path',
+              position: 0,
+            }),
+          ),
+        onNonEmpty: remainingSegments =>
+          Effect.succeed([
+            Record.singleton(name, Array.join(remainingSegments, '/')),
+            [],
+          ]),
+      }),
+    print: (value, state) =>
+      Effect.succeed({
+        ...state,
+        segments: [...state.segments, value[name]],
+      }),
+  }
+  return makeTerminalParser(parser)
+}
+
+/**
  * A parse-only parser with no print/build capabilities.
  *
  * Returned by `oneOf`, which combines multiple parsers whose print

--- a/packages/foldkit/src/route/parser.ts
+++ b/packages/foldkit/src/route/parser.ts
@@ -391,22 +391,28 @@ export const rest = <K extends string>(
   return makeTerminalParser(parser)
 }
 
+const isNormalizedPath = (path: string): boolean =>
+  String.isNonEmpty(path) && Array.join(pathToSegments(path), '/') === path
+
 /**
  * Creates a parser that captures all remaining URL segments as a single
  * named string field, preserving the slashes between them.
  *
  * Where `rest` yields a `NonEmptyArray` of segments, `restString` rejoins
  * the tail into one raw path string, so a value that itself contains both
- * slashes and dots — like a repository-relative file path
- * `documents/taxes/2024.pdf` — round-trips through the bidirectional router
- * as clean `{ path: string }` route data. It is the greedy catch-all every
- * file-tree or docs router eventually needs.
+ * slashes and dots, like a repository-relative file path
+ * `documents/taxes/2024.pdf`, round-trips through the bidirectional router
+ * as `{ path: string }` route data.
  *
  * Requires at least one remaining segment. A bare prefix like `/vault`
  * does not match; give it its own route alongside the restString route.
  *
  * A restString route also matches every URL that a more specific route under
  * the same prefix accepts, so in `oneOf` the specific route must come first.
+ *
+ * Printing requires a normalized path: non-empty, with no leading,
+ * trailing, or repeated slashes. Any other value would build a URL that
+ * parses back differently, so printing fails instead of building it.
  *
  * Nothing can follow `restString` in the path, so the result is a
  * `TerminalParser`. It can still be extended with `query`.
@@ -439,11 +445,24 @@ export const restString = <K extends string>(
             [],
           ]),
       }),
-    print: (value, state) =>
-      Effect.succeed({
-        ...state,
-        segments: [...state.segments, value[name]],
-      }),
+    print: (value, state) => {
+      const path = value[name]
+
+      if (isNormalizedPath(path)) {
+        return Effect.succeed({
+          ...state,
+          segments: [...state.segments, path],
+        })
+      } else {
+        return Effect.fail(
+          new ParseError({
+            message: `Expected a normalized path for ${name}`,
+            expected: `non-empty path without leading, trailing, or repeated slashes (${name})`,
+            actual: String.isEmpty(path) ? 'empty string' : path,
+          }),
+        )
+      }
+    },
   }
   return makeTerminalParser(parser)
 }

--- a/packages/foldkit/src/route/public.ts
+++ b/packages/foldkit/src/route/public.ts
@@ -7,6 +7,7 @@ export {
   schemaSegment,
   root,
   rest,
+  restString,
   oneOf,
   mapTo,
   slash,

--- a/packages/website/src/page/routing.ts
+++ b/packages/website/src/page/routing.ts
@@ -241,6 +241,13 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
           ),
           h.li(
             [],
+            [
+              inlineCode("restString('path')"),
+              ': captures all remaining segments as one path string',
+            ],
+          ),
+          h.li(
+            [],
             [inlineCode('slash(...)'), ': chains path segments together'],
           ),
           h.li(
@@ -463,6 +470,37 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ' cannot extend it. TypeScript rejects the composition. ',
         inlineCode('query'),
         ' can still follow, since query parameters live after the path.',
+      ),
+      para(
+        'When the path itself is the value, ',
+        inlineCode('restString'),
+        ' captures the same tail as a single string, slashes included, so the route schema declares the field with ',
+        inlineCode('S.String'),
+        '. A repository-relative file path like ',
+        inlineCode('20-upgrade/teach/the-elm-architecture.md'),
+        ' round-trips as one value instead of an array of segments.',
+      ),
+      highlightedCodeBlock(
+        h.div(
+          [
+            h.Class('text-sm'),
+            h.InnerHTML(Snippet.routingRestStringHighlighted),
+          ],
+          [],
+        ),
+        Snippet.routingRestStringRaw,
+        'Copy restString example to clipboard',
+        copiedSnippets,
+        'mb-8',
+      ),
+      para(
+        'Everything above about ',
+        inlineCode('rest'),
+        ' applies to ',
+        inlineCode('restString'),
+        ' as well: it requires at least one segment, a more specific route under the same prefix must come first in ',
+        inlineCode('oneOf'),
+        ', and nothing can follow it in the path. Building requires a normalized path, non-empty with no leading, trailing, or repeated slashes. Any other value would build a URL that parses back differently, so the build fails instead.',
       ),
       para(
         'The ',

--- a/packages/website/src/snippet/index.ts
+++ b/packages/website/src/snippet/index.ts
@@ -54,6 +54,8 @@ export { default as routingSchemaSegmentRefinementRaw } from './routingSchemaSeg
 export { default as routingSchemaSegmentRefinementHighlighted } from './routingSchemaSegmentRefinement.ts?highlighted'
 export { default as routingRestRaw } from './routingRest.ts?raw'
 export { default as routingRestHighlighted } from './routingRest.ts?highlighted'
+export { default as routingRestStringRaw } from './routingRestString.ts?raw'
+export { default as routingRestStringHighlighted } from './routingRestString.ts?highlighted'
 export { default as routingKeyedRaw } from './routingKeyed.ts?raw'
 export { default as routingKeyedHighlighted } from './routingKeyed.ts?highlighted'
 export { default as routingColdLoadRaw } from './routingColdLoad.ts?raw'

--- a/packages/website/src/snippet/routingRestString.ts
+++ b/packages/website/src/snippet/routingRestString.ts
@@ -1,0 +1,22 @@
+import { Schema as S, pipe } from 'effect'
+import { Route } from 'foldkit'
+import { literal, r, restString, slash } from 'foldkit/route'
+
+const VaultIndexRoute = r('VaultIndex')
+const VaultNoteRoute = r('VaultNote', { path: S.String })
+
+// Matches: /vault
+const vaultIndexRouter = pipe(literal('vault'), Route.mapTo(VaultIndexRoute))
+
+// Matches: /vault/20-upgrade/teach/the-elm-architecture.md
+// path: '20-upgrade/teach/the-elm-architecture.md'
+const vaultNoteRouter = pipe(
+  literal('vault'),
+  slash(restString('path')),
+  Route.mapTo(VaultNoteRoute),
+)
+
+// Builds: /vault/20-upgrade/teach/the-elm-architecture.md
+const noteUrl = vaultNoteRouter({
+  path: '20-upgrade/teach/the-elm-architecture.md',
+})


### PR DESCRIPTION
Closes #617. Supersedes #625, keeping @artile's original commit and authorship; review fixes and docs are stacked on top so the whole feature lands as one squash commit.

## What

Adds `restString`, a terminal route parser combinator that captures the raw remaining URL path, slashes and dots included, as a single `string`, and round-trips bidirectionally:

```ts
pipe(literal('vault'), slash(restString('path')), mapTo(VaultNoteRoute))
// parse: /vault/a/b/c.md      -> { path: 'a/b/c.md' }
// build: { path: 'a/b/c.md' } -> /vault/a/b/c.md
```

Where `rest` yields a `NonEmptyArray` of segments, `restString` rejoins the tail into one path string, so file-tree and docs routes can carry a repository-relative path as `{ path: S.String }` route data instead of a `?path=` query workaround.

## Changes on top of #625

- Printing now requires a normalized path: non-empty, with no leading, trailing, or repeated slashes. Any other value (`''`, `'a//b'`, `'/a'`, `'a/'`) would build a URL that parses back differently or not at all, so `print` fails with a `ParseError` instead of silently building a broken link. Precedent: `schemaSegment`'s failable print.
- Tests for the print validation, including a router-level build failure.
- Documented `restString` on the website routing page: primitives list entry, a new snippet, and paragraphs in the Rest Segments section covering the normalized-path contract.
- Changeset and TSDoc reworded to house prose style.

## Verification

Full pre-push pipeline green: format, lint, dead-code, circular-deps, build, all package typechecks, all tests (including 68 route parser tests), website e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Munzh5qfLxmy24AjZkWQbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Munzh5qfLxmy24AjZkWQbF)_