### PR TITLE
docs: address documentation audit findings across website and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Every Foldkit application is an [Effect](https://effect.website/) program. Your 
 
 ## Get Started
 
-`create-foldkit-app` is the recommended way to start a new project. It scaffolds a complete setup with Tailwind, TypeScript, ESLint, Prettier, and the Vite plugin for state-preserving HMR — and lets you choose from a set of examples as your starting point.
+`create-foldkit-app` is the recommended way to start a new project. It scaffolds a complete setup with Tailwind, TypeScript, [Oxlint](https://foldkit.dev/tooling/oxlint-plugin), Prettier, and the Vite plugin for state-preserving HMR. You choose from a set of examples as your starting point.
 
 ```bash
 npx create-foldkit-app@latest

--- a/packages/website/scripts/markdown.test.ts
+++ b/packages/website/scripts/markdown.test.ts
@@ -75,6 +75,17 @@ const y = 2</code></pre>
     expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe('1. one\n2. two')
   })
 
+  it('prefixes labeled code blocks with a bold label line', () => {
+    setBody(`
+      <div data-llm-label="pnpm">
+        <pre><code class="language-bash">pnpm dev</code></pre>
+      </div>
+    `)
+    expect(extractMarkdownFromCurrentDocument(SITE_URL)).toBe(
+      '**pnpm**\n\n```bash\npnpm dev\n```',
+    )
+  })
+
   it('skips elements marked data-llm-ignore', () => {
     setBody(`
       <p>kept paragraph</p>

--- a/packages/website/scripts/markdown.ts
+++ b/packages/website/scripts/markdown.ts
@@ -118,7 +118,10 @@ export const extractMarkdownFromCurrentDocument = (siteUrl: string): string => {
     const source = codeElement ?? element
     const text = (source.textContent ?? '').replace(/\n+$/, '')
     const language = detectLanguage(element)
-    return `\`\`\`${language}\n${text}\n\`\`\``
+    const labelCarrier = element.closest('[data-llm-label]')
+    const label = labelCarrier?.getAttribute('data-llm-label') ?? ''
+    const labelPrefix = label.length > 0 ? `**${label}**\n\n` : ''
+    return `${labelPrefix}\`\`\`${language}\n${text}\n\`\`\``
   }
 
   const indentBlock = (text: string, indent: string): string =>

--- a/packages/website/src/link.ts
+++ b/packages/website/src/link.ts
@@ -1,7 +1,7 @@
 const exampleBase = 'https://github.com/foldkit/foldkit/tree/main/examples'
 
 export const exampleSourceHref = (slug: string): string =>
-  `${exampleBase}/${slug}/src/main.ts`
+  `${exampleBase}/${slug}/src`
 
 export const uiShowcaseViewSourceHref = (slug: string): string =>
   `https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/ui/view/${slug}.ts`
@@ -53,5 +53,5 @@ export const Link = {
   changelog:
     'https://github.com/foldkit/foldkit/blob/main/packages/foldkit/CHANGELOG.md',
   dragAndDropDocumentStyles:
-    'https://github.com/foldkit/foldkit/blob/main/packages/foldkit/src/ui/dragAndDrop/index.ts#L679-L701',
+    'https://github.com/foldkit/foldkit/blob/main/packages/ui/src/dragAndDrop/index.ts#L663-L689',
 }

--- a/packages/website/src/page/apiReference/domain.ts
+++ b/packages/website/src/page/apiReference/domain.ts
@@ -36,6 +36,7 @@ export const ApiParameter = S.Struct({
   name: S.String,
   type: S.String,
   isOptional: S.Boolean,
+  isRest: S.Boolean,
   defaultValue: NullableString,
   description: NullableString,
 })
@@ -279,6 +280,7 @@ const parseParameter =
     name: parameter.name,
     type: typeToString(parameter.type, 0, namedSchemas),
     isOptional: parameter.flags.isOptional,
+    isRest: parameter.flags.isRest,
     defaultValue: parameter.defaultValue,
     description: pipe(
       parameter.comment,

--- a/packages/website/src/page/apiReference/typedoc.ts
+++ b/packages/website/src/page/apiReference/typedoc.ts
@@ -4,6 +4,7 @@ export const TypeDocFlags = S.Struct({
   isOptional: S.Boolean.pipe(S.withDecodingDefaultKey(Effect.succeed(false))),
   isPrivate: S.Boolean.pipe(S.withDecodingDefaultKey(Effect.succeed(false))),
   isProtected: S.Boolean.pipe(S.withDecodingDefaultKey(Effect.succeed(false))),
+  isRest: S.Boolean.pipe(S.withDecodingDefaultKey(Effect.succeed(false))),
   isStatic: S.Boolean.pipe(S.withDecodingDefaultKey(Effect.succeed(false))),
 })
 
@@ -13,6 +14,7 @@ const defaultFlags: TypeDocFlags = {
   isOptional: false,
   isPrivate: false,
   isProtected: false,
+  isRest: false,
   isStatic: false,
 }
 

--- a/packages/website/src/page/apiReference/view.ts
+++ b/packages/website/src/page/apiReference/view.ts
@@ -288,6 +288,7 @@ const parameterView = (parameter: ApiParameter): ReadonlyArray<Html> => {
   const h = html<Message>()
 
   return [
+    ...(parameter.isRest ? [punctuation('...')] : []),
     h.span(
       [h.Class('font-normal text-gray-900 dark:text-gray-200')],
       [parameter.name],

--- a/packages/website/src/page/core/http.ts
+++ b/packages/website/src/page/core/http.ts
@@ -79,6 +79,13 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('Http.layer'),
         ' at the edge of its Effect.',
       ),
+      para(
+        'The snippet on this page imports from ',
+        inlineCode('effect/unstable/http'),
+        '. In the Effect v4 beta that Foldkit pins, the ',
+        inlineCode('HttpClient'),
+        ' modules live under the unstable namespace, so that import path is expected and matches what Foldkit projects use.',
+      ),
       tableOfContentsEntryToHeader(propagationHeader),
       para(
         'Effect’s ',

--- a/packages/website/src/page/core/runtime.ts
+++ b/packages/website/src/page/core/runtime.ts
@@ -8,7 +8,7 @@ import {
   para,
   tableOfContentsEntryToHeader,
 } from '../../prose'
-import { routingAndNavigationRouter } from '../../route'
+import { coreEmbeddingRouter, routingAndNavigationRouter } from '../../route'
 import * as Snippet from '../../snippet'
 import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
 
@@ -42,12 +42,19 @@ const makeElementHeader: TableOfContentsEntry = {
   text: 'makeElement',
 }
 
+const embedHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'embed',
+  text: 'embed',
+}
+
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
   makeApplicationHeader,
   withoutRoutingHeader,
   withRoutingHeader,
   makeElementHeader,
+  embedHeader,
 ]
 
 export const view = (copiedSnippets: CopiedSnippets): Html => {
@@ -189,6 +196,20 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         'Copy makeElement example to clipboard',
         copiedSnippets,
         'mb-8',
+      ),
+      tableOfContentsEntryToHeader(embedHeader),
+      para(
+        inlineCode('makeElement'),
+        ' mounts a self-contained app in a container. ',
+        inlineCode('Runtime.embed'),
+        ' goes further for a widget embedded in a host application, whether that host is React or anything else. The host starts the runtime, seeds it with Flags, exchanges values through Schema-typed Ports, and tears it down with ',
+        inlineCode('dispose'),
+        '. The handle is the whole boundary: the host never reads the Model or dispatches Messages.',
+      ),
+      para(
+        'The ',
+        link(coreEmbeddingRouter(), 'Embedding'),
+        ' guide has the full walkthrough.',
       ),
     ],
   )

--- a/packages/website/src/page/gettingStarted.ts
+++ b/packages/website/src/page/gettingStarted.ts
@@ -1,4 +1,5 @@
 import { Html, html } from 'foldkit/html'
+import { effectVersion } from 'virtual:landing-data'
 
 import { Link } from '../link'
 import type { TableOfContentsEntry } from '../main'
@@ -23,10 +24,17 @@ import { type CopiedSnippets, codeBlock } from '../view/codeBlock'
 import { comparisonTable } from '../view/table'
 
 const CREATE_FOLDKIT_APP_COMMAND = 'npx create-foldkit-app@latest'
+const MANUAL_INSTALL_COMMAND = `npm install foldkit effect@${effectVersion} @effect/platform-browser@${effectVersion}`
 const DEV_PNPM = 'pnpm dev'
 const DEV_NPM = 'npm run dev'
 const DEV_YARN = 'yarn dev'
 const DEV_BUN = 'bun dev'
+
+const requirementsHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'requirements',
+  text: 'Requirements',
+}
 
 const quickStartHeader: TableOfContentsEntry = {
   level: 'h2',
@@ -41,6 +49,7 @@ const projectStructureHeader: TableOfContentsEntry = {
 }
 
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
+  requirementsHeader,
   quickStartHeader,
   projectStructureHeader,
 ]
@@ -61,6 +70,29 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         link(coreArchitectureRouter(), 'Architecture'),
         '.',
       ),
+      tableOfContentsEntryToHeader(requirementsHeader),
+      para(
+        inlineCode('create-foldkit-app'),
+        ' requires Node.js 22.22.2 or newer.',
+      ),
+      para(
+        'Foldkit is built on the Effect v4 beta and pins its peer dependencies to an exact version: ',
+        inlineCode(`effect@${effectVersion}`),
+        ' and ',
+        inlineCode(`@effect/platform-browser@${effectVersion}`),
+        '. Stable Effect v3 does not satisfy the pin, so adding Foldkit to a project that already uses Effect v3 will produce peer dependency conflicts, and upgrading Foldkit can require upgrading the Effect beta in lockstep. Projects scaffolded with ',
+        inlineCode('create-foldkit-app'),
+        ' get the correct versions automatically.',
+      ),
+      para(
+        'To add Foldkit to an existing project instead of scaffolding a new one, install it together with its pinned peer dependencies:',
+      ),
+      codeBlock(
+        MANUAL_INSTALL_COMMAND,
+        'Copy manual install command',
+        copiedSnippets,
+        'mb-8',
+      ),
       tableOfContentsEntryToHeader(quickStartHeader),
       para(
         link(Link.createFoldkitApp, 'Create Foldkit app'),
@@ -75,15 +107,27 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         'mb-8',
       ),
       para(
-        'Once the project is created, navigate to the project directory and start the dev server:',
+        'Once the project is created, navigate to the project directory and start the dev server. Each command below is the same step for a different package manager, so pick the one you use:',
       ),
       h.div(
         [h.Class('flex gap-2 flex-wrap mb-8')],
         [
-          codeBlock(DEV_PNPM, 'Copy pnpm command', copiedSnippets),
-          codeBlock(DEV_NPM, 'Copy npm command', copiedSnippets),
-          codeBlock(DEV_YARN, 'Copy yarn command', copiedSnippets),
-          codeBlock(DEV_BUN, 'Copy bun command', copiedSnippets),
+          h.div(
+            [h.DataAttribute('llm-label', 'pnpm')],
+            [codeBlock(DEV_PNPM, 'Copy pnpm command', copiedSnippets)],
+          ),
+          h.div(
+            [h.DataAttribute('llm-label', 'npm')],
+            [codeBlock(DEV_NPM, 'Copy npm command', copiedSnippets)],
+          ),
+          h.div(
+            [h.DataAttribute('llm-label', 'yarn')],
+            [codeBlock(DEV_YARN, 'Copy yarn command', copiedSnippets)],
+          ),
+          h.div(
+            [h.DataAttribute('llm-label', 'bun')],
+            [codeBlock(DEV_BUN, 'Copy bun command', copiedSnippets)],
+          ),
         ],
       ),
       infoCallout(

--- a/packages/website/src/page/ui/overviewPage.ts
+++ b/packages/website/src/page/ui/overviewPage.ts
@@ -1,8 +1,8 @@
 import { Array } from 'effect'
 import { Html, html } from 'foldkit/html'
 
-import type { TableOfContentsEntry } from '../../main'
-import { heading, link, pageTitle, para } from '../../prose'
+import { Message, type TableOfContentsEntry } from '../../main'
+import { heading, inlineCode, link, pageTitle, para } from '../../prose'
 import {
   coreSubmodelRouter,
   exampleDetailRouter,
@@ -29,6 +29,9 @@ import {
   uiTabsRouter,
   uiTextareaRouter,
 } from '../../route'
+import { type CopiedSnippets, codeBlock } from '../../view/codeBlock'
+
+const INSTALL_COMMAND = 'npm install @foldkit/ui'
 
 // TABLE OF CONTENTS
 
@@ -36,6 +39,12 @@ const whatIsFoldkitUiHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'what-is-foldkit-ui',
   text: 'What is Foldkit UI?',
+}
+
+const installationHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'installation',
+  text: 'Installation',
 }
 
 const twoCategoriesHeader: TableOfContentsEntry = {
@@ -58,6 +67,7 @@ const showcaseHeader: TableOfContentsEntry = {
 
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   whatIsFoldkitUiHeader,
+  installationHeader,
   twoCategoriesHeader,
   componentsHeader,
   showcaseHeader,
@@ -262,8 +272,8 @@ const headerCellClassName =
 
 // VIEW
 
-export const view = (): Html => {
-  const h = html()
+export const view = (copiedSnippets: CopiedSnippets): Html => {
+  const h = html<Message>()
 
   const kindBadgeClassName = (kind: ComponentKind): string =>
     kind === 'Submodel'
@@ -330,6 +340,29 @@ export const view = (): Html => {
       ),
       para(
         'Foldkit UI is a set of headless, accessible UI components. Each component is renderless. You provide the markup and styling through a toView callback, and Foldkit UI provides the accessibility attributes, keyboard navigation, and (where applicable) state management.',
+      ),
+      heading(
+        installationHeader.level,
+        installationHeader.id,
+        installationHeader.text,
+      ),
+      para(
+        inlineCode('@foldkit/ui'),
+        ' is a separate package from ',
+        inlineCode('foldkit'),
+        '. Projects scaffolded by ',
+        inlineCode('create-foldkit-app'),
+        ' from an example that uses UI components already include it. Its peer dependencies are ',
+        inlineCode('foldkit'),
+        ' and ',
+        inlineCode('effect'),
+        ', which every Foldkit project already has. Add it to any other project with:',
+      ),
+      codeBlock(
+        INSTALL_COMMAND,
+        'Copy install command to clipboard',
+        copiedSnippets,
+        'mb-8',
       ),
       heading(
         twoCategoriesHeader.level,

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -729,7 +729,9 @@ export const docsView = (model: Model, docsRoute: DocsRoute) => {
         ),
       UiOverview: () =>
         withTableOfContents(
-          Page.UiPages.OverviewPage.view(),
+          lazyDocsContent(Page.UiPages.OverviewPage.view, [
+            model.copiedSnippets,
+          ]),
           Page.UiPages.OverviewPage.tableOfContents,
         ),
       UiSelectionSubmodels: () =>

--- a/packages/website/src/vite-env.d.ts
+++ b/packages/website/src/vite-env.d.ts
@@ -57,6 +57,7 @@ declare module 'virtual:parsed-api' {
 
 declare module 'virtual:landing-data' {
   export const foldkitVersion: string
+  export const effectVersion: string
 }
 
 declare module 'virtual:counter-demo-code' {

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -718,7 +718,10 @@ const landingDataPlugin = (): Plugin => ({
       await readFile(resolve(__dirname, '../foldkit/package.json'), 'utf-8'),
     )
 
-    return `export const foldkitVersion = ${JSON.stringify(packageJson.version)}`
+    return [
+      `export const foldkitVersion = ${JSON.stringify(packageJson.version)}`,
+      `export const effectVersion = ${JSON.stringify(packageJson.peerDependencies.effect)}`,
+    ].join('\n')
   },
 })
 


### PR DESCRIPTION
An external documentation audit surfaced eight issues. This PR fixes the seven that are docs and website changes. The eighth (GitHub releases lagging npm's latest by five versions) is a publish pipeline concern and is not addressed here.

## What changed

**Effect version requirement was undocumented (the audit's critical finding).** Getting Started gains a Requirements section stating the Node version for `create-foldkit-app` and the exact Effect v4 beta peer pin (`effect@4.0.0-beta.88` and `@effect/platform-browser@4.0.0-beta.88`), why stable Effect v3 will not work, and a copyable manual install command for adding Foldkit to an existing project. The version string is sourced from `packages/foldkit/package.json` through the existing `virtual:landing-data` Vite plugin, so the docs cannot drift when the pin bumps. The Http page also gains a short note explaining the `effect/unstable/http` import path its snippet uses.

**API reference dropped rest parameters.** `Command.define` rendered as `(name: Name, results: Results)` even though the source declares `...results: Results`, contradicting every guide example. The site's TypeDoc schema was discarding the `isRest` parameter flag. It now flows through `TypeDocFlags`, `ApiParameter`, and the signature view, which renders the `...` prefix. Verified in the regenerated `api.json` that `Command.define` and `Mount.define` carry `isRest: true`.

**README said ESLint.** The scaffolder ships Oxlint with `@foldkit/oxlint-plugin`. The Get Started sentence now says Oxlint and links the Oxlint Plugin docs page.

**Two dead GitHub source links.** The Subscriptions page's `documentDragStyles` link pointed at `packages/foldkit/src/ui`, which moved to `packages/ui`; it now points at the current location and line range. `exampleSourceHref` hardcoded `src/main.ts`, which 404s for the charting example; it now links each example's `src` directory, which stays valid regardless of how an example is split into files.

**No install instructions for `@foldkit/ui`.** The UI overview gains an Installation section with the install command and a note on peer dependencies. The overview view now takes `copiedSnippets` so the command gets the standard copy button.

**Runtime guide omitted `Runtime.embed`.** The guide presented `makeApplication` and `makeElement` only. A new embed section describes the host-controlled lifecycle (Flags in, Ports across, `dispose` out) and links the Embedding guide.

**Markdown export flattened the package manager tabs.** The four dev server commands on Getting Started exported as four consecutive unlabeled fences. The extractor now honors a `data-llm-label` attribute (mirroring the existing `data-llm-ignore`) and emits a bold label above each fence; the four blocks are labeled pnpm/npm/yarn/bun, and the connecting prose says they are alternatives. Covered by a new unit test.

## Deliberately not included

The audit also suggested pinning deep source links to commit SHAs and adding a CI link checker. Both are worth doing but are infrastructure changes beyond a docs fix, so the repointed links keep the repo's existing `blob/main` convention.

## Verification

`pnpm --filter website test` (138 passing, including the new markdown label test), `pnpm --filter website typecheck`, root `pnpm lint`, prettier clean on all touched files, and the full pre-push suite (build, all package typechecks, tests) passed locally; website e2e was skipped locally for lack of the pinned Playwright browser build and runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4eNiKDpADaHUpHvVoc4m7)_