### PR TITLE
fix(website): keep wide tables from scrolling the whole page on mobile

### DIFF
--- a/packages/website/src/page/aiMcp.ts
+++ b/packages/website/src/page/aiMcp.ts
@@ -246,7 +246,7 @@ const toolsTable = (): Html => {
   const h = html<Message>()
 
   return h.div(
-    [h.Class('mb-6')],
+    [h.Class('mb-6 overflow-x-auto')],
     [
       h.table(
         [h.Class('w-full text-sm')],

--- a/packages/website/src/page/examples.ts
+++ b/packages/website/src/page/examples.ts
@@ -88,7 +88,7 @@ const examplesTable = (): Html => {
   const h = html<Message>()
 
   return h.div(
-    [h.Class('mb-8')],
+    [h.Class('mb-8 overflow-x-auto')],
     [
       h.table(
         [h.Class('w-full text-sm')],

--- a/packages/website/src/page/patterns/subscriptionOrganization.ts
+++ b/packages/website/src/page/patterns/subscriptionOrganization.ts
@@ -165,7 +165,7 @@ const verbsTable = (): Html => {
   const h = html<Message>()
 
   return h.div(
-    [h.Class('mb-6')],
+    [h.Class('mb-6 overflow-x-auto')],
     [
       h.table(
         [h.Class('w-full text-sm')],

--- a/packages/website/src/page/ui/overviewPage.ts
+++ b/packages/website/src/page/ui/overviewPage.ts
@@ -305,7 +305,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
     )
 
   const componentTable: Html = h.div(
-    [h.Class('mb-8')],
+    [h.Class('mb-8 overflow-x-auto')],
     [
       h.table(
         [h.Class('w-full text-sm')],


### PR DESCRIPTION
## What

On mobile, several documentation tables were wider than the viewport and made the **whole page** scroll sideways. The reported case is the DevTools MCP page, but the same defect existed on three other pages. Now the table scrolls sideways within its own container and the page stays fixed at the viewport width.

## Why

Four pages build their own table markup instead of using the shared table components in `view/docTable.ts` and `view/table.ts`. Those shared components wrap every table in an `overflow-x-auto` container, but these four bespoke tables did not. Each table is `w-full` with `whitespace-nowrap` cells (tool names, verb names, component names, kind badges), so its intrinsic width exceeds a phone viewport. With no overflow container, the overflowing table widened the document and the fixed header stretched with it, so the entire page scrolled horizontally.

## What changed

Added `overflow-x-auto` to the wrapper `div` of each affected table, matching the pattern the shared table components already use:

- `page/aiMcp.ts` (DevTools MCP tools table, the reported page)
- `page/patterns/subscriptionOrganization.ts` (composition verbs table)
- `page/examples.ts` (examples table)
- `page/ui/overviewPage.ts` (component overview table)

I considered extracting a shared table-wrapper helper, but these tables hold different bespoke content and column shapes, and the shared typed helpers (`PropEntry`, `KeyboardEntry`, and so on) do not fit them. Adding the one class each keeps the fix minimal and consistent with the existing components. No changeset: the `website` package is in the Changesets `ignore` list.

## How I verified

Drove Chromium against the dev server at mobile widths (320, 375, 414px) and measured `document.documentElement.scrollWidth` against the viewport, before and after.

Before, page horizontal overflow:

| Page | 320px | 375px | 414px |
| --- | --- | --- | --- |
| `/ai/mcp` | 462 | 462 | 462 |
| `/patterns/subscription-organization` | 506 | 506 | 506 |
| `/example-apps` | 380 | 380 | fits |
| `/ui/overview` | 357 | fits | fits |

After, every page reports `scrollWidth == viewport` at all three widths (no page overflow), and each table scrolls within its own `overflow-x: auto` wrapper when it is wider than the screen. Desktop (1280px) is unchanged: the tables fit, so no scrollbar appears. Format, lint, typecheck, build, and the website test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1cqeBVqkmSpcAkNayZxjr)_