### PR TITLE
fix(website): bake GitHub star count at build time

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -47,8 +47,23 @@ jobs:
           ABC_FAVORIT_BOOK_WOFF2_BASE64: ${{ secrets.ABC_FAVORIT_BOOK_WOFF2_BASE64 }}
           ABC_FAVORIT_LIGHT_WOFF2_BASE64: ${{ secrets.ABC_FAVORIT_LIGHT_WOFF2_BASE64 }}
 
+      - name: Resolve GitHub star count
+        id: github-stars
+        env:
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(curl -sfL --connect-timeout 10 --max-time 30 \
+            -H "Authorization: Bearer ${GH_API_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "User-Agent: foldkit-website-build" \
+            https://api.github.com/repos/foldkit/foldkit \
+            | jq -r '.stargazers_count // empty') || count=""
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+
       - name: Build website
         run: pnpm build:website
+        env:
+          FOLDKIT_GITHUB_STAR_COUNT: ${{ steps.github-stars.outputs.count }}
 
       - name: Install Playwright chromium
         run: pnpm --filter website exec playwright install --with-deps chromium

--- a/packages/website/src/githubStars.test.ts
+++ b/packages/website/src/githubStars.test.ts
@@ -1,0 +1,32 @@
+import { Option } from 'effect'
+import { AsyncData } from 'foldkit'
+import { describe, expect, test } from 'vitest'
+
+import { formatStarCount, initialGitHubStars } from './githubStars'
+
+describe('initialGitHubStars', () => {
+  test('a baked count seeds Success so the badge renders immediately', () => {
+    const stars = initialGitHubStars(4242)
+    expect(stars._tag).toBe('Success')
+    expect(Option.getOrNull(AsyncData.getData(stars))).toBe(4242)
+  })
+
+  test('an absent baked count seeds Loading', () => {
+    const stars = initialGitHubStars(null)
+    expect(stars._tag).toBe('Loading')
+    expect(Option.isNone(AsyncData.getData(stars))).toBe(true)
+  })
+})
+
+describe('formatStarCount', () => {
+  test.each([
+    [0, '0'],
+    [42, '42'],
+    [999, '999'],
+    [1000, '1k'],
+    [1200, '1.2k'],
+    [4242, '4.2k'],
+  ])('formats %i as %s', (count, expected) => {
+    expect(formatStarCount(count)).toBe(expected)
+  })
+})

--- a/packages/website/src/githubStars.ts
+++ b/packages/website/src/githubStars.ts
@@ -16,6 +16,17 @@ export const formatStarCount = (count: number): string => {
   }
 }
 
-export const maybeStarCount = (
-  stars: GitHubStarsAsyncData,
-): Option.Option<number> => AsyncData.getData(stars)
+/**
+ * Seeds the star state from the count baked into the page at build time. A
+ * baked count starts as `Success`, so the badge renders the real number
+ * straight from the prerendered HTML with no loading flash. An absent count
+ * (the build-time fetch failed) starts `Loading`, leaving the client fetch to
+ * fill it in.
+ */
+export const initialGitHubStars = (
+  bakedStarCount: number | null,
+): GitHubStarsAsyncData =>
+  Option.match(Option.fromNullishOr(bakedStarCount), {
+    onNone: () => GitHubStarsAsyncData.Loading(),
+    onSome: data => GitHubStarsAsyncData.Success({ data }),
+  })

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -8,6 +8,7 @@ import {
   Number as Number_,
   Option,
   Record as Record_,
+  Result,
   Schema as S,
   pipe,
 } from 'effect'
@@ -28,6 +29,7 @@ import { type Document, html } from 'foldkit/html'
 import { load, pushUrl } from 'foldkit/navigation'
 import { evo } from 'foldkit/struct'
 import { Url, toString as urlToString } from 'foldkit/url'
+import { githubStarCount } from 'virtual:landing-data'
 
 import { BrowserKeyValueStore } from '@effect/platform-browser'
 import { Dialog, Menu, Tabs } from '@foldkit/ui'
@@ -41,7 +43,7 @@ import {
   allPages,
   findActiveSectionKey,
 } from './docsNav'
-import { GitHubStarsAsyncData } from './githubStars'
+import { GitHubStarsAsyncData, initialGitHubStars } from './githubStars'
 import {
   CompletedApplyTheme,
   CompletedInjectAnalytics,
@@ -238,7 +240,7 @@ export const Model = S.Struct({
   copiedSnippets: S.HashSet(S.String),
   emailField: FieldValidation.Field(S.String),
   emailSubscriptionStatus: EmailSubscriptionStatus,
-  githubStars: GitHubStarsAsyncData.schema,
+  githubStarsAsyncData: GitHubStarsAsyncData.schema,
   currentYear: S.Number,
   mobileMenuDialog: Dialog.Model,
   isMobileTableOfContentsOpen: S.Boolean,
@@ -423,7 +425,7 @@ export const init: Runtime.RoutingApplicationInit<
       copiedSnippets: HashSet.empty(),
       emailField: FieldValidation.NotValidated({ value: '' }),
       emailSubscriptionStatus: 'Idle',
-      githubStars: GitHubStarsAsyncData.Loading(),
+      githubStarsAsyncData: initialGitHubStars(githubStarCount),
       currentYear: flags.currentYear,
       mobileMenuDialog: Dialog.init({ id: 'mobile-menu' }),
       isMobileTableOfContentsOpen: false,
@@ -716,14 +718,16 @@ export const update = (
 
       SucceededFetchGitHubStars: ({ count }) => [
         evo(model, {
-          githubStars: () => GitHubStarsAsyncData.Success({ data: count }),
+          githubStarsAsyncData: () =>
+            GitHubStarsAsyncData.Success({ data: count }),
         }),
         [],
       ],
 
       FailedFetchGitHubStars: ({ error }) => [
         evo(model, {
-          githubStars: () => GitHubStarsAsyncData.Failure({ error }),
+          githubStarsAsyncData: previousGitHubStarsAsyncData =>
+            AsyncData.settle(previousGitHubStarsAsyncData, Result.fail(error)),
         }),
         [],
       ],

--- a/packages/website/src/page/landing.ts
+++ b/packages/website/src/page/landing.ts
@@ -15,6 +15,7 @@ import { Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { foldkitVersion } from 'virtual:landing-data'
 
+import { GitHubStarsAsyncData } from '../githubStars'
 import { Icon } from '../icon'
 import { Link } from '../link'
 import { type Message } from '../message'
@@ -87,14 +88,14 @@ export const view = (
   emailSignupView: Html,
   playgroundMenuView: Html,
   aiHeadingToggleCount: number,
-  maybeStarCount: Option.Option<number>,
+  githubStarsAsyncData: GitHubStarsAsyncData,
 ): Html => {
   const h = html<Message>()
 
   return h.div(
     [h.Class('isolate overflow-x-hidden')],
     [
-      heroSection(copiedSnippets, playgroundMenuView, maybeStarCount),
+      heroSection(copiedSnippets, playgroundMenuView, githubStarsAsyncData),
       glyph('{ }'),
       promiseSection(),
       glyph('=>'),
@@ -116,12 +117,14 @@ export const view = (
       glyph('...', '-translate-y-1/3'),
       trustSection(),
       glyph('->'),
-      finalCtaSection(emailSignupView, maybeStarCount),
+      finalCtaSection(emailSignupView, githubStarsAsyncData),
     ],
   )
 }
 
-const viewOnGitHubButton = (maybeStarCount: Option.Option<number>): Html => {
+const viewOnGitHubButton = (
+  githubStarsAsyncData: GitHubStarsAsyncData,
+): Html => {
   const h = html<Message>()
 
   return h.a(
@@ -129,7 +132,7 @@ const viewOnGitHubButton = (maybeStarCount: Option.Option<number>): Html => {
     [
       Icon.github('w-5 h-5'),
       h.span([h.Class('mr-2')], ['View on GitHub']),
-      githubStarBadge(maybeStarCount),
+      githubStarBadge(githubStarsAsyncData),
     ],
   )
 }
@@ -179,7 +182,7 @@ const INSTALL_COMMAND = 'npx create-foldkit-app@latest'
 const heroSection = (
   copiedSnippets: CopiedSnippets,
   playgroundMenuView: Html,
-  maybeStarCount: Option.Option<number>,
+  githubStarsAsyncData: GitHubStarsAsyncData,
 ): Html => {
   const h = html<Message>()
 
@@ -256,7 +259,7 @@ const heroSection = (
                 ['Dive In', Icon.arrowRight('w-5 h-5')],
               ),
               playgroundMenuView,
-              viewOnGitHubButton(maybeStarCount),
+              viewOnGitHubButton(githubStarsAsyncData),
             ],
           ),
         ],
@@ -1289,7 +1292,7 @@ const aiSection = (aiHeadingToggleCount: number): Html => {
 
 const finalCtaSection = (
   emailSignupView: Html,
-  maybeStarCount: Option.Option<number>,
+  githubStarsAsyncData: GitHubStarsAsyncData,
 ): Html => {
   const h = html<Message>()
 
@@ -1335,7 +1338,7 @@ const finalCtaSection = (
                         ],
                         ['Dive In', Icon.arrowRight('w-5 h-5')],
                       ),
-                      viewOnGitHubButton(maybeStarCount),
+                      viewOnGitHubButton(githubStarsAsyncData),
                     ],
                   ),
                 ],

--- a/packages/website/src/view/landing.ts
+++ b/packages/website/src/view/landing.ts
@@ -5,7 +5,6 @@ import { Html, childAttributes, createLazy, html } from 'foldkit/html'
 import { Menu } from '@foldkit/ui'
 
 import * as DemoTab from '../demoTab'
-import { maybeStarCount } from '../githubStars'
 import { Icon } from '../icon'
 import { Link } from '../link'
 import { type Model } from '../main'
@@ -371,7 +370,7 @@ export const landingView = (model: Model) => {
             emailSignupView,
             playgroundMenu,
             model.aiHeadingToggleCount,
-            maybeStarCount(model.githubStars),
+            model.githubStarsAsyncData,
           ),
         ],
       ),

--- a/packages/website/src/view/shared.ts
+++ b/packages/website/src/view/shared.ts
@@ -1,9 +1,10 @@
 import { clsx } from 'clsx'
-import { Array, Match as M, Option } from 'effect'
+import { Array, Match as M } from 'effect'
+import { AsyncData } from 'foldkit'
 import type { Field } from 'foldkit/fieldValidation'
 import { Html, html } from 'foldkit/html'
 
-import { formatStarCount } from '../githubStars'
+import { GitHubStarsAsyncData, formatStarCount } from '../githubStars'
 import { Icon } from '../icon'
 import { type EmailSubscriptionStatus } from '../main'
 import { type Message, SubmittedEmailForm, UpdatedEmailField } from '../message'
@@ -42,37 +43,44 @@ export const iconLink = (link: string, ariaLabel: string, icon: Html) => {
 const STAR_COUNT_WIDTH = 'w-[3ch]'
 const STAR_COUNT_PLACEHOLDER = '···'
 
-export const githubStarBadge = (maybeCount: Option.Option<number>): Html => {
+export const githubStarBadge = (
+  githubStarsAsyncData: GitHubStarsAsyncData,
+): Html => {
   const h = html<Message>()
 
-  const countLabel = Option.match(maybeCount, {
-    onNone: () =>
-      h.span([h.Class('animate-pulse opacity-60')], [STAR_COUNT_PLACEHOLDER]),
-    onSome: count => h.span([], [formatStarCount(count)]),
-  })
-
-  return h.span(
-    [
-      h.Class(
-        'inline-flex items-center gap-1 rounded-full bg-gray-900 dark:bg-white px-2 pt-0.5 pb-0.75 text-xs font-semibold text-white dark:text-gray-900',
-      ),
-      h.AriaHidden(true),
-    ],
-    [
-      Icon.star('w-3.5 h-3.5'),
-      h.span(
-        [
-          h.Class(
-            clsx(
-              'mt-px inline-flex justify-center tabular-nums',
-              STAR_COUNT_WIDTH,
+  const badge = (label: Html): Html =>
+    h.span(
+      [
+        h.Class(
+          'inline-flex items-center gap-1 rounded-full bg-gray-900 dark:bg-white px-2 pt-0.5 pb-0.75 text-xs font-semibold text-white dark:text-gray-900',
+        ),
+        h.AriaHidden(true),
+      ],
+      [
+        Icon.star('w-3.5 h-3.5'),
+        h.span(
+          [
+            h.Class(
+              clsx(
+                'mt-px inline-flex justify-center tabular-nums',
+                STAR_COUNT_WIDTH,
+              ),
             ),
-          ),
-        ],
-        [countLabel],
+          ],
+          [label],
+        ),
+      ],
+    )
+
+  return AsyncData.matchDataSplitEmpty(githubStarsAsyncData, {
+    onData: count => badge(h.span([], [formatStarCount(count)])),
+    onLoading: () =>
+      badge(
+        h.span([h.Class('animate-pulse opacity-60')], [STAR_COUNT_PLACEHOLDER]),
       ),
-    ],
-  )
+    onFailure: () => h.empty,
+    onIdle: () => h.empty,
+  })
 }
 
 export const skipNavLink: Html = (() => {

--- a/packages/website/src/vite-env.d.ts
+++ b/packages/website/src/vite-env.d.ts
@@ -58,6 +58,7 @@ declare module 'virtual:parsed-api' {
 declare module 'virtual:landing-data' {
   export const foldkitVersion: string
   export const effectVersion: string
+  export const githubStarCount: number | null
 }
 
 declare module 'virtual:counter-demo-code' {

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -700,6 +700,15 @@ const notePlayerDemoCodePlugin = (): Plugin => ({
 const LANDING_DATA_ID = 'virtual:landing-data'
 const RESOLVED_LANDING_DATA_ID = '\0' + LANDING_DATA_ID
 
+const readBakedStarCount = (): number | null => {
+  const raw = process.env['FOLDKIT_GITHUB_STAR_COUNT']
+  if (raw === undefined || raw === '') {
+    return null
+  }
+  const parsed = Number(raw)
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null
+}
+
 const landingDataPlugin = (): Plugin => ({
   name: 'landing-data',
   resolveId(id) {
@@ -718,9 +727,12 @@ const landingDataPlugin = (): Plugin => ({
       await readFile(resolve(__dirname, '../foldkit/package.json'), 'utf-8'),
     )
 
+    const githubStarCount = readBakedStarCount()
+
     return [
       `export const foldkitVersion = ${JSON.stringify(packageJson.version)}`,
       `export const effectVersion = ${JSON.stringify(packageJson.peerDependencies.effect)}`,
+      `export const githubStarCount = ${JSON.stringify(githubStarCount)}`,
     ].join('\n')
   },
 })


### PR DESCRIPTION
The star badge fetched api.github.com from the browser on every visit.
Unauthenticated GitHub API calls are capped at 60 per hour per IP, so a
rate-limited 403 tripped the failure arm and the badge sat on its
loading placeholder.

Fetch the count once at build time in the landing-data plugin and bake
it into the page next to foldkitVersion, so the prerendered badge ships
the real number with no request. The client still refreshes on load: a
success updates the count, and a failure now settles to Stale, keeping
the baked value on screen instead of dropping to Failure. If the
build-time fetch fails it bakes null and the client fetch takes over.
Pass GITHUB_TOKEN (or GH_TOKEN) in CI to lift the unauthenticated limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Website deployment now resolves repository GitHub star count during build and seeds the site so the badge can show the baked value when available.
  * Star-count badge rendering moved to use the page’s async state (with compact “k” formatting).

* **Bug Fixes**
  * Star-count failures no longer overwrite an already-successful value.
  * Missing/unparseable star counts are treated as unavailable to avoid incorrect badge output.

* **Tests**
  * Added unit tests for initial star-count seeding and “k” formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->