### PR TITLE
ci: speed up affected validation and deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Plan change-scoped checks
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/plan-ci.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
@@ -64,28 +71,62 @@ jobs:
         run: pnpm changeset status --since=origin/main
 
       - name: Lint
-        run: pnpm lint
+        run: pnpm --filter @foldkit/oxlint-plugin build && pnpm lint:ci
 
       - name: Check dead code
         run: pnpm check:dead-code
 
       - name: Check circular dependencies
+        if: steps.scope.outputs.typing_game == 'true'
         run: pnpm check:circular-deps
 
-      - name: Build packages
-        run: pnpm -r --filter './packages/**' build
+      - name: Build reusable packages
+        if: steps.scope.outputs.workspace_packages == 'true' || steps.scope.outputs.create_foldkit_smoke == 'true' || steps.scope.outputs.website == 'true' || steps.scope.outputs.typing_game == 'true'
+        run: pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/vite-plugin --filter create-foldkit-app --filter @foldkit/devtools-mcp --filter @typing-game/shared build
+
+      - name: Typecheck scripts
+        run: pnpm typecheck:scripts
 
       - name: Typecheck
+        if: steps.scope.outputs.full_workspace_checks == 'true'
         run: pnpm -r typecheck
 
+      - name: Typecheck affected packages
+        if: steps.scope.outputs.full_workspace_checks == 'false'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: pnpm -r --filter "...[$BASE_SHA]" run --if-present typecheck
+
       - name: Smoke test create-foldkit-app
-        run: pnpm check:create-foldkit-app-smoke
+        if: steps.scope.outputs.create_foldkit_smoke == 'true'
+        run: pnpm check:create-foldkit-app-smoke:ci
+
+      - name: Build website
+        if: steps.scope.outputs.website == 'true'
+        run: pnpm --filter website exec vite build
+
+      - name: Build typing game client
+        if: steps.scope.outputs.typing_game == 'true'
+        run: pnpm --filter @typing-game/client build
+
+      - name: Build typing game server
+        if: steps.scope.outputs.typing_game == 'true'
+        run: pnpm --filter @typing-game/server build
 
       - name: Test
+        if: steps.scope.outputs.full_workspace_checks == 'true'
         run: pnpm test
 
+      - name: Test affected packages
+        if: steps.scope.outputs.full_workspace_checks == 'false'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: pnpm -r --filter "...[$BASE_SHA]" run --if-present test
+
       - name: Install Playwright browsers
+        if: steps.scope.outputs.website == 'true'
         run: pnpm --filter website exec playwright install --with-deps chromium
 
       - name: E2E smoke test
+        if: steps.scope.outputs.website == 'true'
         run: pnpm --filter website test:e2e

--- a/.github/workflows/deploy-pixel-art.yml
+++ b/.github/workflows/deploy-pixel-art.yml
@@ -11,6 +11,10 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-pixel-art.yml'
 
+concurrency:
+  group: deploy-pixel-art-production
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,20 +33,20 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter pixel-art-example...
 
       - name: Build foldkit and vite plugin
         run: pnpm --filter foldkit build && pnpm --filter @foldkit/vite-plugin build
 
       - name: Build pixel art
         working-directory: examples/pixel-art
-        run: npx vite build
+        run: pnpm exec vite build
 
       - name: Deploy to Vercel
         working-directory: examples/pixel-art
         run: |
-          npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+          pnpm dlx vercel@55.0.0 pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+          pnpm dlx vercel@55.0.0 deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.PIXEL_ART_VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-typing-game.yml
+++ b/.github/workflows/deploy-typing-game.yml
@@ -8,9 +8,13 @@ on:
       - 'packages/typing-game/client/**'
       - 'packages/typing-game/shared/**'
       - 'packages/foldkit/**'
-      - 'packages/foldkit-vite-plugin/**'
+      - 'packages/vite-plugin-foldkit/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-typing-game.yml'
+
+concurrency:
+  group: deploy-typing-game-production
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -30,7 +34,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter @typing-game/client...
 
       - name: Build typing game client
         run: pnpm build:typing-game:client
@@ -40,8 +44,8 @@ jobs:
       - name: Deploy to Vercel
         working-directory: packages/typing-game/client
         run: |
-          npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+          pnpm dlx vercel@55.0.0 pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+          pnpm dlx vercel@55.0.0 deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -11,9 +11,15 @@ on:
       - 'packages/devtools/**'
       - 'packages/vite-plugin-foldkit/**'
       - 'examples/**'
-      - 'scripts/**'
+      - 'scripts/build-examples.ts'
+      - 'scripts/example-bridge.js'
+      - 'scripts/restore-website-fonts.sh'
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-website.yml'
+
+concurrency:
+  group: deploy-website-production
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -33,10 +39,10 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter . --filter website... --filter '{examples/**}...'
 
       - name: Build core packages
-        run: pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/vite-plugin... build
+        run: pnpm --filter 'website^...' build
 
       - name: Build examples
         run: pnpm build:examples
@@ -48,7 +54,7 @@ jobs:
           ABC_FAVORIT_LIGHT_WOFF2_BASE64: ${{ secrets.ABC_FAVORIT_LIGHT_WOFF2_BASE64 }}
 
       - name: Build website
-        run: pnpm build:website
+        run: pnpm --filter website build
 
       - name: Install Playwright chromium
         run: pnpm --filter website exec playwright install --with-deps chromium
@@ -139,7 +145,7 @@ jobs:
           EOF
 
       - name: Deploy to Vercel
-        run: npx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@55.0.0 deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -13,38 +13,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      example-count: ${{ steps.plan.outputs.example-count }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Plan affected examples
+        id: plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/plan-examples-e2e.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
   examples-e2e:
-    name: ${{ matrix.example }}
+    name: Shard ${{ matrix.shard }}
+    needs: plan
+    if: needs.plan.outputs.example-count != '0'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        example:
-          - counter
-          - counters
-          - todo
-          - stopwatch
-          - crash-view
-          - slow-warnings
-          - form
-          - job-application
-          - weather
-          - api-cache
-          - routing
-          - query-sync
-          - snake
-          - auth
-          - shopping-cart
-          - statechart-checkout
-          - pixel-art
-          - websocket-chat
-          - kanban
-          - map
-          - canvas-art
-          - generative-art
-          - web-components
-          - embedding
-          - ui-showcase
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,23 +54,62 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        env:
+          EXAMPLES: ${{ matrix.examples }}
+        run: |
+          filters=(--filter '@foldkit/examples-e2e...')
+          for example in $EXAMPLES; do
+            filters+=(--filter "{examples/$example}...")
+          done
+          pnpm install --frozen-lockfile "${filters[@]}"
 
-      - name: Build workspace packages
-        run: pnpm -r --filter './packages/**' build
+      - name: Build E2E prerequisites
+        run: pnpm --filter foldkit --filter @foldkit/vite-plugin build
 
       - name: Install Playwright browsers
         run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium
 
-      - name: Run examples e2e for ${{ matrix.example }}
+      - name: Run example E2E shard
         env:
-          EXAMPLE_SLUG: ${{ matrix.example }}
-        run: pnpm --filter @foldkit/examples-e2e test:e2e
+          EXAMPLES: ${{ matrix.examples }}
+        run: |
+          failed_examples=()
+          for example in $EXAMPLES; do
+            if ! EXAMPLE_SLUG="$example" pnpm --filter @foldkit/examples-e2e test:e2e; then
+              failed_examples+=("$example")
+            fi
+          done
 
-      - name: Upload Playwright report on failure
+          if [ "${#failed_examples[@]}" -gt 0 ]; then
+            echo "Failed examples: ${failed_examples[*]}"
+            exit 1
+          fi
+
+      - name: Upload Playwright traces on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.example }}
-          path: packages/examples-e2e/playwright-report/
+          name: playwright-traces-shard-${{ matrix.shard }}
+          path: packages/examples-e2e/test-results/
           retention-days: 7
+
+  result:
+    name: Examples E2E
+    needs:
+      - plan
+      - examples-e2e
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check E2E result
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          E2E_RESULT: ${{ needs.examples-e2e.result }}
+        run: |
+          if [ "$PLAN_RESULT" != 'success' ]; then
+            exit 1
+          fi
+
+          if [ "$E2E_RESULT" != 'success' ] && [ "$E2E_RESULT" != 'skipped' ]; then
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,22 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.changeset/**'
+      - 'packages/foldkit/**'
+      - 'packages/ui/**'
+      - 'packages/devtools/**'
+      - 'packages/vite-plugin-foldkit/**'
+      - 'packages/create-foldkit-app/**'
+      - 'packages/oxlint-plugin-foldkit/**'
+      - 'packages/devtools-mcp/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'scripts/check-changeset-ignore.ts'
+      - 'scripts/check-create-foldkit-app-smoke.ts'
+      - 'scripts/reset-peer-deps.ts'
+      - '.github/workflows/release.yml'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -39,7 +55,7 @@ jobs:
           npm --version
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Verify changeset ignore list
         run: pnpm check:changeset-ignore

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {
-      "entry": ["scripts/*.{ts,js,sh}"],
+      "entry": ["scripts/*.{ts,js,mjs,sh}"],
       "project": ["scripts/**"]
     },
     "packages/foldkit": {
@@ -70,5 +70,5 @@
   },
   "ignore": ["**/*.css", "packages/website/public/**"],
   "ignoreDependencies": ["@foldkit/oxlint-plugin", "tailwindcss", "madge"],
-  "ignoreBinaries": ["typecheck", "vercel"]
+  "ignoreBinaries": ["typecheck"]
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "scripts": {
     "prepare": "test -z \"$CI\" && simple-git-hooks || true",
     "build": "pnpm -r --if-present build",
+    "build:packages": "pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/vite-plugin --filter create-foldkit-app --filter @foldkit/oxlint-plugin --filter @foldkit/devtools-mcp build",
     "check": "pnpm -F foldkit -F @foldkit/vite-plugin -F @typing-game/shared build && pnpm typecheck:scripts && pnpm -r typecheck && pnpm lint && pnpm check:dead-code && pnpm check:effect-prebundle",
     "lint": "pnpm --filter @foldkit/oxlint-plugin build && oxlint --disable-nested-config",
+    "lint:ci": "oxlint --disable-nested-config",
     "check:dead-code": "knip --no-progress --include files,dependencies,unlisted,unresolved,binaries,duplicates,catalog --treat-config-hints-as-errors",
     "check:effect-prebundle": "tsx scripts/check-effect-prebundle.ts",
     "check:changeset-ignore": "tsx scripts/check-changeset-ignore.ts",
@@ -19,6 +21,7 @@
     "check:changeset-unwrapped": "tsx scripts/check-changeset-unwrapped.ts",
     "check:circular-deps": "bash scripts/check-circular-deps.sh",
     "check:create-foldkit-app-smoke": "tsx scripts/check-create-foldkit-app-smoke.ts",
+    "check:create-foldkit-app-smoke:ci": "tsx scripts/check-create-foldkit-app-smoke.ts --skip-build",
     "pre-push": "pnpm check:no-claude-comments && pnpm check:commit-message-line-length && pnpm check:changeset-unwrapped && pnpm format:check && pnpm check:skill-version && pnpm check:no-major-changesets && pnpm check:changeset-ignore && pnpm changeset status --since=origin/main && pnpm lint && pnpm check:dead-code && pnpm typecheck:scripts && pnpm check:effect-prebundle && pnpm check:circular-deps && pnpm build && pnpm -r typecheck && pnpm test && bash scripts/run-website-e2e.sh",
     "test": "pnpm -r --filter './examples/*' --filter './packages/*' run --if-present test",
     "typecheck:scripts": "tsc -p scripts/tsconfig.json --noEmit",
@@ -63,7 +66,7 @@
     "dev:example:ui-showcase": "pnpm --filter ui-showcase dev",
     "changeset": "changeset",
     "version-packages": "changeset version && tsx scripts/reset-peer-deps.ts && pnpm install --no-frozen-lockfile",
-    "release": "pnpm -r build && changeset publish"
+    "release": "pnpm build:packages && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/packages/examples-e2e/playwright.config.ts
+++ b/packages/examples-e2e/playwright.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   forbidOnly: Boolean(process.env['CI']),
   retries: process.env['CI'] ? 2 : 1,
   reporter: process.env['CI'] ? 'github' : 'list',
+  outputDir: `./test-results/${exampleSlug}`,
   timeout: 60_000,
   use: {
     baseURL: BASE_URL,

--- a/scripts/build-examples.ts
+++ b/scripts/build-examples.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import {
   copyFileSync,
   existsSync,
@@ -21,29 +21,45 @@ const OUTPUT_DIR = resolve(
 )
 const BRIDGE_SCRIPT_PATH = resolve(REPO_ROOT, 'scripts/example-bridge.js')
 const BRIDGE_SCRIPT_TAG = '<script src="bridge.js"></script></head>'
+const MAX_CONCURRENT_EXAMPLE_BUILDS = 4
 
-const buildExample = (slug: string): void => {
+const runViteBuild = (
+  exampleDir: string,
+  slug: string,
+  outputDir: string,
+): Promise<void> =>
+  new Promise((resolvePromise, rejectPromise) => {
+    const childProcess = spawn(
+      'pnpm',
+      [
+        'exec',
+        'vite',
+        'build',
+        '--base',
+        `/example-apps-embed/${slug}/`,
+        '--outDir',
+        outputDir,
+      ],
+      { cwd: exampleDir, stdio: 'inherit' },
+    )
+
+    childProcess.once('error', rejectPromise)
+    childProcess.once('close', exitCode => {
+      if (exitCode === 0) {
+        resolvePromise()
+      } else {
+        rejectPromise(new Error(`Example build failed: ${slug}`))
+      }
+    })
+  })
+
+const buildExample = async (slug: string): Promise<void> => {
   console.log(`Building example: ${slug}`)
 
   const exampleDir = resolve(EXAMPLES_DIR, slug)
   const outputDir = resolve(OUTPUT_DIR, slug)
 
-  const result = spawnSync(
-    'npx',
-    [
-      'vite',
-      'build',
-      '--base',
-      `/example-apps-embed/${slug}/`,
-      '--outDir',
-      outputDir,
-    ],
-    { cwd: exampleDir, stdio: 'inherit' },
-  )
-
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1)
-  }
+  await runViteBuild(exampleDir, slug, outputDir)
 
   copyFileSync(BRIDGE_SCRIPT_PATH, resolve(outputDir, 'bridge.js'))
 
@@ -57,14 +73,31 @@ const buildExample = (slug: string): void => {
   console.log(`  → ${outputDir}`)
 }
 
-if (existsSync(OUTPUT_DIR)) {
-  rmSync(OUTPUT_DIR, { recursive: true, force: true })
-}
-mkdirSync(OUTPUT_DIR, { recursive: true })
+const main = async (): Promise<void> => {
+  if (existsSync(OUTPUT_DIR)) {
+    rmSync(OUTPUT_DIR, { recursive: true, force: true })
+  }
+  mkdirSync(OUTPUT_DIR, { recursive: true })
 
-for (const slug of exampleSlugs) {
-  buildExample(slug)
+  const batchCount = Math.ceil(
+    exampleSlugs.length / MAX_CONCURRENT_EXAMPLE_BUILDS,
+  )
+  const exampleBatches = Array.from({ length: batchCount }, (_, batchIndex) =>
+    exampleSlugs.slice(
+      batchIndex * MAX_CONCURRENT_EXAMPLE_BUILDS,
+      (batchIndex + 1) * MAX_CONCURRENT_EXAMPLE_BUILDS,
+    ),
+  )
+
+  for (const exampleBatch of exampleBatches) {
+    await Promise.all(exampleBatch.map(buildExample))
+  }
+
+  console.log('')
+  console.log(`Built ${exampleSlugs.length} examples into ${OUTPUT_DIR}`)
 }
 
-console.log('')
-console.log(`Built ${exampleSlugs.length} examples into ${OUTPUT_DIR}`)
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/check-create-foldkit-app-smoke.ts
+++ b/scripts/check-create-foldkit-app-smoke.ts
@@ -27,6 +27,7 @@ const PNPM_WORKSPACE_POLICY_PATH = join(
 const PNPM_WORKSPACE_POLICY = `allowBuilds:
   msgpackr-extract: false
 `
+const isSkipBuild = process.argv.includes('--skip-build')
 const LINT_SMOKE_SOURCE = `const Command = {
   define: (name: string) => () => ({ name }),
 }
@@ -348,18 +349,20 @@ const main = (): void => {
   try {
     assertTemplateTooling()
     assertPnpmWorkspacePolicy()
-    runRequired(
-      'Building create-foldkit-app...',
-      'pnpm',
-      ['--filter', 'create-foldkit-app', 'build'],
-      { inherit: true },
-    )
-    runRequired(
-      'Building @foldkit/oxlint-plugin...',
-      'pnpm',
-      ['--filter', '@foldkit/oxlint-plugin', 'build'],
-      { inherit: true },
-    )
+    if (!isSkipBuild) {
+      runRequired(
+        'Building create-foldkit-app...',
+        'pnpm',
+        ['--filter', 'create-foldkit-app', 'build'],
+        { inherit: true },
+      )
+      runRequired(
+        'Building @foldkit/oxlint-plugin...',
+        'pnpm',
+        ['--filter', '@foldkit/oxlint-plugin', 'build'],
+        { inherit: true },
+      )
+    }
 
     const tarballPath = packPackage(
       'Packing create-foldkit-app tarball...',

--- a/scripts/plan-ci.mjs
+++ b/scripts/plan-ci.mjs
@@ -1,0 +1,88 @@
+import { spawnSync } from 'node:child_process'
+
+const [baseSha, headSha, ...providedChangedFiles] = process.argv.slice(2)
+const isChangedFileListProvided = providedChangedFiles.at(0) !== undefined
+const isUnknownBase =
+  !baseSha || !headSha || /^0+$/.test(baseSha) || /^0+$/.test(headSha)
+const diffResult =
+  isUnknownBase || isChangedFileListProvided
+    ? undefined
+    : spawnSync('git', ['diff', '--name-only', '-z', baseSha, headSha], {
+        encoding: 'utf8',
+      })
+const changedFiles = isChangedFileListProvided
+  ? providedChangedFiles
+  : diffResult?.status === 0
+    ? diffResult.stdout.split('\0').filter(fileName => fileName !== '')
+    : []
+const isUnknownDiff =
+  !isChangedFileListProvided && (isUnknownBase || diffResult?.status !== 0)
+
+const hasChanged = ({ files = [], prefixes = [] }) =>
+  isUnknownDiff ||
+  changedFiles.some(
+    fileName =>
+      files.includes(fileName) ||
+      prefixes.some(prefix => fileName.startsWith(prefix)),
+  )
+
+const createFoldkitSmoke = hasChanged({
+  files: [
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'scripts/check-create-foldkit-app-smoke.ts',
+  ],
+  prefixes: ['packages/create-foldkit-app/', 'packages/oxlint-plugin-foldkit/'],
+})
+const typingGame = hasChanged({
+  files: ['scripts/check-circular-deps.sh'],
+  prefixes: [
+    'packages/typing-game/client/',
+    'packages/typing-game/server/',
+    'packages/typing-game/shared/',
+    'packages/foldkit/',
+    'packages/devtools/',
+    'packages/vite-plugin-foldkit/',
+  ],
+})
+const website = hasChanged({
+  files: ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml'],
+  prefixes: [
+    'packages/website/',
+    'packages/foldkit/',
+    'packages/ui/',
+    'packages/devtools/',
+    'packages/vite-plugin-foldkit/',
+  ],
+})
+const fullWorkspaceChecks = hasChanged({
+  files: [
+    '.github/workflows/ci.yml',
+    '.npmrc',
+    'examples/vite.aliases.ts',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'scripts/plan-ci.mjs',
+    'tsconfig.base.json',
+  ],
+})
+const workspacePackages = hasChanged({
+  files: [
+    '.github/workflows/ci.yml',
+    '.npmrc',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'scripts/plan-ci.mjs',
+    'tsconfig.base.json',
+  ],
+  prefixes: ['comparisons/', 'examples/', 'internal/', 'packages/'],
+})
+
+process.stdout.write(`create_foldkit_smoke=${createFoldkitSmoke}\n`)
+process.stdout.write(`typing_game=${typingGame}\n`)
+process.stdout.write(`website=${website}\n`)
+process.stdout.write(`full_workspace_checks=${fullWorkspaceChecks}\n`)
+process.stdout.write(`workspace_packages=${workspacePackages}\n`)

--- a/scripts/plan-examples-e2e.mjs
+++ b/scripts/plan-examples-e2e.mjs
@@ -1,0 +1,94 @@
+import { spawnSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+
+const MAX_SHARD_COUNT = 5
+const SPEC_SUFFIX = '.spec.ts'
+const ALL_EXAMPLES_FILES = new Set([
+  '.github/workflows/examples-e2e.yml',
+  '.npmrc',
+  'examples/vite.aliases.ts',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'scripts/plan-examples-e2e.mjs',
+  'tsconfig.base.json',
+])
+const ALL_EXAMPLES_PREFIXES = [
+  'packages/devtools/',
+  'packages/foldkit/',
+  'packages/ui/',
+  'packages/vite-plugin-foldkit/',
+]
+
+const [baseSha, headSha, ...providedChangedFiles] = process.argv.slice(2)
+const isChangedFileListProvided = providedChangedFiles.at(0) !== undefined
+
+const exampleSlugs = readdirSync('packages/examples-e2e/e2e')
+  .filter(fileName => fileName.endsWith(SPEC_SUFFIX))
+  .map(fileName => fileName.slice(0, -SPEC_SUFFIX.length))
+  .sort()
+
+const isUnknownBase =
+  !baseSha || !headSha || /^0+$/.test(baseSha) || /^0+$/.test(headSha)
+
+const diffResult =
+  isUnknownBase || isChangedFileListProvided
+    ? undefined
+    : spawnSync('git', ['diff', '--name-only', '-z', baseSha, headSha], {
+        encoding: 'utf8',
+      })
+
+const changedFiles = isChangedFileListProvided
+  ? providedChangedFiles
+  : diffResult?.status === 0
+    ? diffResult.stdout.split('\0').filter(fileName => fileName !== '')
+    : []
+const isUnknownDiff =
+  !isChangedFileListProvided && (isUnknownBase || diffResult?.status !== 0)
+
+const isE2eHarnessFile = changedFiles.some(
+  fileName =>
+    fileName.startsWith('packages/examples-e2e/') &&
+    !(
+      fileName.startsWith('packages/examples-e2e/e2e/') &&
+      fileName.endsWith(SPEC_SUFFIX)
+    ),
+)
+
+const isAllExamplesAffected =
+  isUnknownDiff ||
+  isE2eHarnessFile ||
+  changedFiles.some(
+    fileName =>
+      ALL_EXAMPLES_FILES.has(fileName) ||
+      ALL_EXAMPLES_PREFIXES.some(prefix => fileName.startsWith(prefix)),
+  )
+
+const affectedExampleSlugs = isAllExamplesAffected
+  ? exampleSlugs
+  : exampleSlugs.filter(exampleSlug =>
+      changedFiles.some(
+        fileName =>
+          fileName.startsWith(`examples/${exampleSlug}/`) ||
+          fileName === `packages/examples-e2e/e2e/${exampleSlug}${SPEC_SUFFIX}`,
+      ),
+    )
+
+const shardCount = Math.max(
+  1,
+  Math.min(MAX_SHARD_COUNT, affectedExampleSlugs.length),
+)
+const shards = Array.from({ length: shardCount }, (_, shardIndex) =>
+  affectedExampleSlugs.filter(
+    (_, exampleIndex) => exampleIndex % shardCount === shardIndex,
+  ),
+)
+const matrix = {
+  include: shards.map((exampleShard, shardIndex) => ({
+    shard: shardIndex + 1,
+    examples: exampleShard.join(' '),
+  })),
+}
+
+process.stdout.write(`matrix=${JSON.stringify(matrix)}\n`)
+process.stdout.write(`example-count=${affectedExampleSlugs.length}\n`)


### PR DESCRIPTION
Replace per-example E2E jobs with affected, bounded shards and reuse narrow package builds across validation.

Gate expensive checks by changed paths, parallelize embedded example builds, and avoid redundant package, TypeDoc, release, and deployment work.