### PR TITLE
feat(checkout-machine): log the last 20 transitions in the inspector

### DIFF
--- a/examples/checkout-machine/src/main.ts
+++ b/examples/checkout-machine/src/main.ts
@@ -3,13 +3,16 @@ import {
   Duration,
   Effect,
   Match as M,
+  Number,
   Option,
   Schema as S,
   String,
+  flow,
   pipe,
 } from 'effect'
 import { Command, Runtime } from 'foldkit'
 import { Machine } from 'foldkit/experimental'
+import { otherwise, to, when } from 'foldkit/experimental/machine'
 import { m } from 'foldkit/message'
 import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
@@ -62,9 +65,16 @@ export const CheckoutState = S.Union([
   Cancelled,
 ])
 
+export const TransitionLogEntry = S.Struct({
+  id: S.Number,
+  summary: S.String,
+})
+export type TransitionLogEntry = typeof TransitionLogEntry.Type
+
 export const Model = S.Struct({
   checkout: CheckoutState,
-  maybeLastTransitionSummary: S.Option(S.String),
+  transitionLog: S.Array(TransitionLogEntry),
+  nextTransitionLogId: S.Number,
 })
 export type Model = typeof Model.Type
 
@@ -163,18 +173,18 @@ export const checkoutMachine = Machine.define({
   states: {
     Cart: {
       on: {
-        SelectedEdition: Machine.to('Cart', ({ state, message }) =>
+        SelectedEdition: to('Cart', ({ state, message }) =>
           evo(state, { isShippingRequired: () => message.isShippingRequired }),
         ),
         ClickedContinue: [
-          Machine.when(
+          when(
             state => state.isShippingRequired,
             'Shipping',
             ({ state }) =>
               Shipping({ isShippingRequired: state.isShippingRequired }),
           ),
-          Machine.otherwise(
-            Machine.to('Payment', ({ state }) =>
+          otherwise(
+            to('Payment', ({ state }) =>
               Payment({
                 isPaymentMethodSelected: false,
                 isShippingRequired: state.isShippingRequired,
@@ -182,33 +192,33 @@ export const checkoutMachine = Machine.define({
             ),
           ),
         ],
-        ClickedCancel: Machine.to('Cancelled', ({ state }) =>
+        ClickedCancel: to('Cancelled', ({ state }) =>
           Cancelled({ isShippingRequired: state.isShippingRequired }),
         ),
       },
     },
     Shipping: {
       on: {
-        ClickedContinue: Machine.to('Payment', ({ state }) =>
+        ClickedContinue: to('Payment', ({ state }) =>
           Payment({
             isPaymentMethodSelected: false,
             isShippingRequired: state.isShippingRequired,
           }),
         ),
-        ClickedBack: Machine.to('Cart', ({ state }) =>
+        ClickedBack: to('Cart', ({ state }) =>
           Cart({ isShippingRequired: state.isShippingRequired }),
         ),
-        ClickedCancel: Machine.to('Cancelled', ({ state }) =>
+        ClickedCancel: to('Cancelled', ({ state }) =>
           Cancelled({ isShippingRequired: state.isShippingRequired }),
         ),
       },
     },
     Payment: {
       on: {
-        ToggledPaymentMethod: Machine.to('Payment', ({ state, message }) =>
+        ToggledPaymentMethod: to('Payment', ({ state, message }) =>
           evo(state, { isPaymentMethodSelected: () => message.isSelected }),
         ),
-        ClickedContinue: Machine.to('Review', ({ state }) =>
+        ClickedContinue: to('Review', ({ state }) =>
           Review({
             isPaymentMethodSelected: state.isPaymentMethodSelected,
             isShippingRequired: state.isShippingRequired,
@@ -218,32 +228,32 @@ export const checkoutMachine = Machine.define({
           }),
         ),
         ClickedBack: [
-          Machine.when(
+          when(
             state => state.isShippingRequired,
             'Shipping',
             ({ state }) =>
               Shipping({ isShippingRequired: state.isShippingRequired }),
           ),
-          Machine.otherwise(
-            Machine.to('Cart', ({ state }) =>
+          otherwise(
+            to('Cart', ({ state }) =>
               Cart({ isShippingRequired: state.isShippingRequired }),
             ),
           ),
         ],
-        ClickedCancel: Machine.to('Cancelled', ({ state }) =>
+        ClickedCancel: to('Cancelled', ({ state }) =>
           Cancelled({ isShippingRequired: state.isShippingRequired }),
         ),
       },
     },
     Review: {
       on: {
-        ToggledPaymentMethod: Machine.to('Review', ({ state, message }) =>
+        ToggledPaymentMethod: to('Review', ({ state, message }) =>
           evo(state, { isPaymentMethodSelected: () => message.isSelected }),
         ),
-        ToggledTermsAccepted: Machine.to('Review', ({ state, message }) =>
+        ToggledTermsAccepted: to('Review', ({ state, message }) =>
           evo(state, { isTermsAccepted: () => message.isAccepted }),
         ),
-        UpdatedPromoCode: Machine.to('Review', ({ state, message }) =>
+        UpdatedPromoCode: to('Review', ({ state, message }) =>
           evo(state, {
             promoCodeInput: () => message.value,
             promo: currentPromo =>
@@ -251,20 +261,20 @@ export const checkoutMachine = Machine.define({
           }),
         ),
         SubmittedPromoCode: [
-          Machine.when(
+          when(
             reviewToMaybeDiscount,
             'Review',
             ({ state, guardValue: discount }) =>
               evo(state, { promo: () => AppliedPromo({ discount }) }),
           ),
-          Machine.otherwise(
-            Machine.to('Review', ({ state }) =>
+          otherwise(
+            to('Review', ({ state }) =>
               evo(state, { promo: () => RejectedPromo() }),
             ),
           ),
         ],
         ClickedPlaceOrder: [
-          Machine.when(
+          when(
             isReviewReady,
             'Placing',
             ({ state }) =>
@@ -277,20 +287,20 @@ export const checkoutMachine = Machine.define({
             ],
           ),
         ],
-        ClickedBack: Machine.to('Payment', ({ state }) =>
+        ClickedBack: to('Payment', ({ state }) =>
           Payment({
             isPaymentMethodSelected: state.isPaymentMethodSelected,
             isShippingRequired: state.isShippingRequired,
           }),
         ),
-        ClickedCancel: Machine.to('Cancelled', ({ state }) =>
+        ClickedCancel: to('Cancelled', ({ state }) =>
           Cancelled({ isShippingRequired: state.isShippingRequired }),
         ),
       },
     },
     Placing: {
       on: {
-        SucceededPlaceOrder: Machine.to('Confirmed', ({ state, message }) =>
+        SucceededPlaceOrder: to('Confirmed', ({ state, message }) =>
           Confirmed({
             isShippingRequired: state.isShippingRequired,
             maybeDiscount: state.maybeDiscount,
@@ -301,14 +311,14 @@ export const checkoutMachine = Machine.define({
     },
     Confirmed: {
       on: {
-        ClickedStartOver: Machine.to('Cart', ({ state }) =>
+        ClickedStartOver: to('Cart', ({ state }) =>
           Cart({ isShippingRequired: state.isShippingRequired }),
         ),
       },
     },
     Cancelled: {
       on: {
-        ClickedStartOver: Machine.to('Cart', ({ state }) =>
+        ClickedStartOver: to('Cart', ({ state }) =>
           Cart({ isShippingRequired: state.isShippingRequired }),
         ),
       },
@@ -320,7 +330,8 @@ export const checkoutMachine = Machine.define({
 
 export const initialModel: Model = {
   checkout: checkoutMachine.initial,
-  maybeLastTransitionSummary: Option.none(),
+  transitionLog: [],
+  nextTransitionLogId: 0,
 }
 
 export const init: Runtime.ApplicationInit<Model, Message> = () => [
@@ -331,6 +342,8 @@ export const init: Runtime.ApplicationInit<Model, Message> = () => [
 // UPDATE
 
 type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>]
+
+export const TRANSITION_LOG_LIMIT = 20
 
 const resultToTransitionSummary = (
   result: Machine.TransitionResult<typeof CheckoutState.Type, Message>,
@@ -356,14 +369,19 @@ export const update = (model: Model, message: Message): UpdateReturn => {
     }),
   )
 
-  const nextMaybeLastTransitionSummary = Option.some(
-    resultToTransitionSummary(result),
-  )
+  const transitionLogEntry: TransitionLogEntry = {
+    id: model.nextTransitionLogId,
+    summary: resultToTransitionSummary(result),
+  }
 
   return [
     evo(model, {
       checkout: () => nextCheckout,
-      maybeLastTransitionSummary: () => nextMaybeLastTransitionSummary,
+      transitionLog: flow(
+        Array.prepend(transitionLogEntry),
+        Array.take(TRANSITION_LOG_LIMIT),
+      ),
+      nextTransitionLogId: Number.increment,
     }),
     transitionCommands,
   ]

--- a/examples/checkout-machine/src/story.test.ts
+++ b/examples/checkout-machine/src/story.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Fiber, Option, Ref } from 'effect'
+import { Array, Effect, Fiber, Option, Ref, pipe } from 'effect'
 import { TestClock } from 'effect/testing'
 import { Story } from 'foldkit'
 import { describe, expect, test } from 'vitest'
@@ -16,12 +16,20 @@ import {
   SelectedEdition,
   SubmittedPromoCode,
   SucceededPlaceOrder,
+  TRANSITION_LOG_LIMIT,
   ToggledPaymentMethod,
   ToggledTermsAccepted,
   UpdatedPromoCode,
   initialModel,
   update,
 } from './main'
+import type { Model } from './main'
+
+const maybeLatestTransitionSummary = (model: Model): Option.Option<string> =>
+  pipe(
+    Array.head(model.transitionLog),
+    Option.map(entry => entry.summary),
+  )
 
 describe('update', () => {
   test('PlaceOrder waits before succeeding', () =>
@@ -53,13 +61,17 @@ describe('update', () => {
       Story.Command.expectNone(),
       Story.model(model => {
         expect(model.checkout._tag).toBe('Shipping')
-        expect(model.maybeLastTransitionSummary).toEqual(
+        expect(maybeLatestTransitionSummary(model)).toEqual(
           Option.some('Cart -> Shipping on ClickedContinue'),
         )
       }),
       Story.message(ClickedContinue()),
       Story.model(model => {
         expect(model.checkout._tag).toBe('Payment')
+        expect(Array.map(model.transitionLog, entry => entry.summary)).toEqual([
+          'Shipping -> Payment on ClickedContinue',
+          'Cart -> Shipping on ClickedContinue',
+        ])
       }),
     )
   })
@@ -122,7 +134,7 @@ describe('update', () => {
         if (model.checkout._tag === 'Review') {
           expect(model.checkout.promo).toEqual(RejectedPromo())
         }
-        expect(model.maybeLastTransitionSummary).toEqual(
+        expect(maybeLatestTransitionSummary(model)).toEqual(
           Option.some('Review -> Review on SubmittedPromoCode'),
         )
       }),
@@ -141,7 +153,7 @@ describe('update', () => {
       Story.Command.expectNone(),
       Story.model(model => {
         expect(model.checkout._tag).toBe('Review')
-        expect(model.maybeLastTransitionSummary).toEqual(
+        expect(maybeLatestTransitionSummary(model)).toEqual(
           Option.some('ClickedPlaceOrder ignored in Review'),
         )
       }),
@@ -170,5 +182,27 @@ describe('update', () => {
         }
       }),
     )
+  })
+
+  test('the transition log truncates to the newest twenty entries', () => {
+    const messageCount = TRANSITION_LOG_LIMIT + 5
+
+    const finalModel = pipe(
+      Array.makeBy(messageCount, index =>
+        SelectedEdition({ isShippingRequired: index % 2 === 0 }),
+      ),
+      Array.reduce(initialModel, (model, message) => {
+        const [nextModel] = update(model, message)
+        return nextModel
+      }),
+    )
+
+    expect(finalModel.transitionLog).toHaveLength(TRANSITION_LOG_LIMIT)
+    expect(
+      Option.map(Array.head(finalModel.transitionLog), entry => entry.id),
+    ).toEqual(Option.some(messageCount - 1))
+    expect(
+      Option.map(Array.last(finalModel.transitionLog), entry => entry.id),
+    ).toEqual(Option.some(messageCount - TRANSITION_LOG_LIMIT))
   })
 })

--- a/examples/checkout-machine/src/view.ts
+++ b/examples/checkout-machine/src/view.ts
@@ -1460,23 +1460,31 @@ const formatTags = (tags: ReadonlyArray<string>): string =>
     onNonEmpty: Array.join(', '),
   })
 
-const transitionStatusView = (model: Model): Html => {
+const transitionLogView = (model: Model): Html => {
   const h = html<Message>()
 
-  return h.div(
-    [
-      h.Role('status'),
-      h.Class(
-        'border-l-2 border-orange-700 pl-3 font-mono text-xs leading-5 text-stone-300 lg:col-span-3',
+  const transitionLogClassName =
+    'border-l-2 border-orange-700 pl-3 font-mono text-xs leading-5 text-stone-300 lg:col-span-3'
+
+  return Array.match(model.transitionLog, {
+    onEmpty: () =>
+      h.keyed('div')(
+        'transition-log-empty',
+        [h.Role('status'), h.Class(transitionLogClassName)],
+        ['Waiting for the first checkout event'],
       ),
-    ],
-    [
-      Option.getOrElse(
-        model.maybeLastTransitionSummary,
-        () => 'Waiting for the first checkout event',
+    onNonEmpty: transitionLog =>
+      h.keyed('ol')(
+        'transition-log-entries',
+        [
+          h.Role('log'),
+          h.Class(clsx(transitionLogClassName, 'max-h-40 overflow-y-auto')),
+        ],
+        Array.map(transitionLog, entry =>
+          h.keyed('li')(String(entry.id), [], [entry.summary]),
+        ),
       ),
-    ],
-  )
+  })
 }
 
 const analysisView = (model: Model): Html => {
@@ -1548,7 +1556,7 @@ const analysisView = (model: Model): Html => {
         [h.Class('grid gap-5 border-t border-stone-700 px-5 py-5 sm:px-7')],
         [
           h.div(
-            [h.Class('grid gap-3 lg:grid-cols-4 lg:items-center')],
+            [h.Class('grid gap-3 lg:grid-cols-4 lg:items-start')],
             [
               h.div(
                 [
@@ -1556,9 +1564,9 @@ const analysisView = (model: Model): Html => {
                     'text-xs font-bold uppercase tracking-widest text-stone-400',
                   ),
                 ],
-                ['Last transition'],
+                ['Recent transitions'],
               ),
-              transitionStatusView(model),
+              transitionLogView(model),
             ],
           ),
           h.ol(


### PR DESCRIPTION
## What

Two improvements to the checkout-machine example app.

The inspector's single last-transition line becomes a log of the 20 most recent transitions, newest first. The machine table vocabulary (`to`, `when`, `otherwise`) is now imported bare from `foldkit/experimental/machine`, while `Machine.define` and `Machine.TransitionResult` keep the namespace import from `foldkit/experimental`.

## Why

A single summary line undersells the machine's step-by-step behavior: by the time you look at the inspector, the interesting sequence (including automatically ignored Messages) is gone. A capped log shows the recent history, which is the point of the demo.

The bare vocabulary imports remove the `Machine.` prefix from every Edge in the transition table, which is where legibility matters most. The namespaced form stays for `define`, matching the `Command.define` / `Mount.define` pattern.

## Changes

- `main.ts`: `TransitionLogEntry` Schema (`id`, `summary`), Model fields `transitionLog` and `nextTransitionLogId` replace `maybeLastTransitionSummary`, `TRANSITION_LOG_LIMIT = 20`, update prepends and truncates with `Array.prepend` / `Array.take`. Import style switched as described.
- `view.ts`: `transitionStatusView` becomes `transitionLogView`. Empty and non-empty branches are separately keyed; the list uses `role="log"` with items keyed by the entry's stable id (never by position), capped height with scroll. Row label becomes "Recent transitions".
- `story.test.ts`: assertions move to the head of the log via a shared `maybeLatestTransitionSummary` helper, plus a newest-first ordering assertion and a truncation test driving `TRANSITION_LOG_LIMIT + 5` messages through update.

## Changeset

None. The example is not part of any published package: create-foldkit-app fetches example sources from GitHub main at scaffold time (its published artifact ships only `dist` and `templates`), and `checkout-machine-example` is in the changeset ignore list. `pnpm changeset status --since=origin/main` reports no packages to bump.

## Verification

- checkout-machine example typecheck and tests: pass (11 tests, including the new ordering and truncation coverage)
- `pnpm lint`, `pnpm format:check`: pass
- Full pre-push suite (format, changeset status, lint, dead-code, build, all-package typecheck, test, website e2e) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7CgbBMrh5rkhGRKUpQTSz)_