### PR TITLE
feat(foldkit): add keyboardShortcuts Subscription helper

### DIFF
--- a/.changeset/keyboard-shortcuts-subscription.md
+++ b/.changeset/keyboard-shortcuts-subscription.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `Subscription.keyboardShortcuts`, a declarative keyboard-shortcut Stream helper over `fromEventFilterMap`. Bindings are either a bare key or `mod` combo (`{ keys: 'mod+k' }`) or a vim-style prefix chord (`{ chord: ['g', 'l'] }`) mapped to a Message. Shortcuts are `inField`-aware by default, so they never fire while the user types in an `input`, `textarea`, `select`, or `contentEditable` element, and `whileTyping: 'Allow'` opts a binding back in. The pending chord prefix lives inside the Stream, not the Model, so apps drop the hand-written `keydown` subscription, the `inField` guard, and the `goPending` state. `preventDefault` runs synchronously inside the browser's dispatch, defaulting on for `mod` combos and off for bare keys and chords.

--- a/examples/routing/src/entry.ts
+++ b/examples/routing/src/entry.ts
@@ -8,6 +8,7 @@ import {
   Message,
   Model,
   init,
+  subscriptions,
   update,
   view,
 } from './main'
@@ -17,6 +18,7 @@ const application = Runtime.makeApplication({
   init,
   update,
   view,
+  subscriptions,
   container: document.getElementById('root'),
   routing: {
     onUrlRequest: request => ClickedLink({ request }),

--- a/examples/routing/src/main.ts
+++ b/examples/routing/src/main.ts
@@ -1,5 +1,5 @@
 import { Array, Effect, Match as M, Option, Schema as S } from 'effect'
-import { Command, Runtime } from 'foldkit'
+import { Command, Runtime, Subscription } from 'foldkit'
 import { Document, Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { UrlRequest, load, pushUrl } from 'foldkit/navigation'
@@ -53,6 +53,7 @@ export const ClickedLink = m('ClickedLink', {
   request: UrlRequest,
 })
 export const ChangedUrl = m('ChangedUrl', { url: Url })
+export const RequestedNavigation = m('RequestedNavigation', { url: S.String })
 export const GotPeopleMessage = m('GotPeopleMessage', {
   message: People.Message,
 })
@@ -62,6 +63,7 @@ export const Message = S.Union([
   CompletedLoadExternal,
   ClickedLink,
   ChangedUrl,
+  RequestedNavigation,
   GotPeopleMessage,
 ])
 export type Message = typeof Message.Type
@@ -148,6 +150,8 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         )
       },
 
+      RequestedNavigation: ({ url }) => [model, [NavigateInternal({ url })]],
+
       GotPeopleMessage: ({ message }) => {
         const [nextPeoplePage, peopleCommands] = People.update(
           model.peoplePage,
@@ -162,6 +166,36 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       },
     }),
   )
+
+// SUBSCRIPTION
+
+export const subscriptions = Subscription.make<Model, Message>()(() => ({
+  shortcuts: Subscription.persistent(
+    Subscription.keyboardShortcuts<Message>({
+      bindings: [
+        {
+          chord: ['g', 'h'],
+          message: () => RequestedNavigation({ url: homeRouter() }),
+        },
+        {
+          chord: ['g', 'p'],
+          message: () =>
+            RequestedNavigation({
+              url: peopleRouter({ searchText: Option.none() }),
+            }),
+        },
+        {
+          chord: ['g', 'f'],
+          message: () => RequestedNavigation({ url: filesIndexRouter() }),
+        },
+        {
+          chord: ['g', 'n'],
+          message: () => RequestedNavigation({ url: nestedRouter() }),
+        },
+      ],
+    }),
+  ),
+}))
 
 // VIEW
 

--- a/packages/foldkit/src/subscription/keyboardShortcuts.test.ts
+++ b/packages/foldkit/src/subscription/keyboardShortcuts.test.ts
@@ -1,0 +1,254 @@
+import { Effect, Fiber, Stream } from 'effect'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { keyboardShortcuts } from './keyboardShortcuts.js'
+
+const tick = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0))
+
+const drain = <Message>(
+  stream: Stream.Stream<Message>,
+  sink: Array<Message>,
+): Effect.Effect<void> =>
+  Stream.runForEach(stream, message =>
+    Effect.sync(() => {
+      sink.push(message)
+    }),
+  )
+
+const keydown = (init: KeyboardEventInit): KeyboardEvent =>
+  new KeyboardEvent('keydown', { cancelable: true, ...init })
+
+const focusInput = (): HTMLInputElement => {
+  const input = document.createElement('input')
+  document.body.appendChild(input)
+  input.focus()
+  return input
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.blur()
+  }
+})
+
+describe('keyboardShortcuts', () => {
+  it('emits the Message for a bare key with no modifier', async () => {
+    const received: Array<string> = []
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [{ keys: 'c', message: () => 'Created' }],
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    document.dispatchEvent(keydown({ key: 'c' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual(['Created'])
+  })
+
+  it('does not fire a bare key when a modifier is held', async () => {
+    const received: Array<string> = []
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [{ keys: 'c', message: () => 'Created' }],
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    document.dispatchEvent(keydown({ key: 'c', metaKey: true }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual([])
+  })
+
+  it('matches a mod combo on either metaKey or ctrlKey', async () => {
+    const received: Array<string> = []
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [{ keys: 'mod+k', message: () => 'Toggled' }],
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    document.dispatchEvent(keydown({ key: 'k', metaKey: true }))
+    document.dispatchEvent(keydown({ key: 'k', ctrlKey: true }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual(['Toggled', 'Toggled'])
+  })
+
+  it('calls preventDefault for a mod combo but not for a bare key', async () => {
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [
+            { keys: 'mod+k', message: () => 'Toggled' },
+            { keys: '/', message: () => 'Slash' },
+          ],
+        }),
+        [],
+      ),
+    )
+
+    await tick()
+    const modEvent = keydown({ key: 'k', metaKey: true })
+    const bareEvent = keydown({ key: '/' })
+    document.dispatchEvent(modEvent)
+    document.dispatchEvent(bareEvent)
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(modEvent.defaultPrevented).toBe(true)
+    expect(bareEvent.defaultPrevented).toBe(false)
+  })
+
+  it('honors a per-binding preventDefault override', async () => {
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [
+            { keys: '/', message: () => 'Slash', preventDefault: true },
+          ],
+        }),
+        [],
+      ),
+    )
+
+    await tick()
+    const event = keydown({ key: '/' })
+    document.dispatchEvent(event)
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('suppresses a bare key while typing in a field by default', async () => {
+    const received: Array<string> = []
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [{ keys: 'c', message: () => 'Created' }],
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    focusInput()
+    document.dispatchEvent(keydown({ key: 'c' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual([])
+  })
+
+  it('fires a binding while typing when whileTyping is Allow', async () => {
+    const received: Array<string> = []
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [
+            { keys: 'mod+k', message: () => 'Toggled', whileTyping: 'Allow' },
+          ],
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    focusInput()
+    document.dispatchEvent(keydown({ key: 'k', metaKey: true }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual(['Toggled'])
+  })
+
+  it('resolves a two-key chord and emits only on the second key', async () => {
+    const received: Array<string> = []
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [{ chord: ['g', 'l'], message: () => 'NavigatedList' }],
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    document.dispatchEvent(keydown({ key: 'g' }))
+    expect(received).toEqual([])
+    document.dispatchEvent(keydown({ key: 'l' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual(['NavigatedList'])
+  })
+
+  it('clears a pending chord prefix when the second key does not match', async () => {
+    const received: Array<string> = []
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [{ chord: ['g', 'l'], message: () => 'NavigatedList' }],
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    document.dispatchEvent(keydown({ key: 'g' }))
+    document.dispatchEvent(keydown({ key: 'x' }))
+    document.dispatchEvent(keydown({ key: 'l' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual([])
+  })
+
+  it('does not arm a chord prefix while typing in a field', async () => {
+    const received: Array<string> = []
+    const fiber = Effect.runFork(
+      drain(
+        keyboardShortcuts<string>({
+          target: document,
+          bindings: [{ chord: ['g', 'l'], message: () => 'NavigatedList' }],
+        }),
+        received,
+      ),
+    )
+
+    await tick()
+    focusInput()
+    document.dispatchEvent(keydown({ key: 'g' }))
+    document.dispatchEvent(keydown({ key: 'l' }))
+    await tick()
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(received).toEqual([])
+  })
+})

--- a/packages/foldkit/src/subscription/keyboardShortcuts.ts
+++ b/packages/foldkit/src/subscription/keyboardShortcuts.ts
@@ -1,0 +1,272 @@
+import { Array, Effect, Option, Stream, String, pipe } from 'effect'
+
+import { fromEventFilterMap } from './fromEvent.js'
+
+/**
+ * Whether a binding fires while the user is typing in a form field.
+ *
+ * `'Suppress'` (the default) drops the shortcut when focus is inside an
+ * `input`, `textarea`, `select`, or `contentEditable` element, so typing an
+ * `s` never triggers a bare `s` shortcut. `'Allow'` opts a binding back in,
+ * typically a `mod` combo like `mod+k` that should open a palette from
+ * anywhere.
+ */
+export type WhileTyping = 'Suppress' | 'Allow'
+
+/**
+ * A single-key or `mod`-combo binding. `keys` is a `+`-joined chord string
+ * where the token `mod` means "meta on macOS or ctrl elsewhere" and the final
+ * token is the key, matched case-insensitively (`'mod+k'`, `'/'`, `'Escape'`).
+ *
+ * A `mod`-combo matches only when a modifier is held, and a bare key matches
+ * only when no modifier is held, so `c` never fires on `mod+c`. `preventDefault`
+ * defaults to on for `mod` combos and off for bare keys.
+ */
+export type KeyBinding<Message> = Readonly<{
+  keys: string
+  message: () => Message
+  whileTyping?: WhileTyping
+  preventDefault?: boolean
+}>
+
+/**
+ * A vim-style prefix chord: press the first key, then the second, to fire.
+ * The pending prefix lives inside the Subscription, not the Model, so consumers
+ * never carry a `goPending` flag. A non-matching second key clears the prefix
+ * and is handled as a fresh key. `preventDefault` defaults to off.
+ */
+export type ChordBinding<Message> = Readonly<{
+  chord: readonly [string, string]
+  message: () => Message
+  whileTyping?: WhileTyping
+  preventDefault?: boolean
+}>
+
+export type Binding<Message> = KeyBinding<Message> | ChordBinding<Message>
+
+/**
+ * Configuration for the `keyboardShortcuts` Stream helper.
+ *
+ * `target` defaults to `document`. Pass a thunk when the target may not exist
+ * until the Subscription's scope opens.
+ */
+export type KeyboardShortcutsConfig<Message> = Readonly<{
+  bindings: ReadonlyArray<Binding<Message>>
+  target?: EventTarget | (() => EventTarget)
+}>
+
+const MOD_TOKEN = 'mod'
+
+type KeyDescriptor<Message> = Readonly<{
+  requiresMod: boolean
+  key: string
+  whileTyping: WhileTyping
+  preventDefault: boolean
+  message: () => Message
+}>
+
+type ChordDescriptor<Message> = Readonly<{
+  prefix: string
+  second: string
+  whileTyping: WhileTyping
+  preventDefault: boolean
+  message: () => Message
+}>
+
+const isChordBinding = <Message>(
+  binding: Binding<Message>,
+): binding is ChordBinding<Message> => 'chord' in binding
+
+const isKeyBinding = <Message>(
+  binding: Binding<Message>,
+): binding is KeyBinding<Message> => !('chord' in binding)
+
+const parseKeys = (keys: string): { requiresMod: boolean; key: string } => {
+  const tokens = String.split(keys, '+')
+  const requiresMod = Array.contains(tokens, MOD_TOKEN)
+  const key = pipe(
+    tokens,
+    Array.findLast(token => token !== MOD_TOKEN),
+    Option.getOrElse(() => keys),
+  )
+  return { requiresMod, key: key.toLowerCase() }
+}
+
+const toKeyDescriptor = <Message>(
+  binding: KeyBinding<Message>,
+): KeyDescriptor<Message> => {
+  const { requiresMod, key } = parseKeys(binding.keys)
+  return {
+    requiresMod,
+    key,
+    whileTyping: binding.whileTyping ?? 'Suppress',
+    preventDefault: binding.preventDefault ?? requiresMod,
+    message: binding.message,
+  }
+}
+
+const toChordDescriptor = <Message>(
+  binding: ChordBinding<Message>,
+): ChordDescriptor<Message> => {
+  const [prefix, second] = binding.chord
+  return {
+    prefix: prefix.toLowerCase(),
+    second: second.toLowerCase(),
+    whileTyping: binding.whileTyping ?? 'Suppress',
+    preventDefault: binding.preventDefault ?? false,
+    message: binding.message,
+  }
+}
+
+const isTypingTarget = (element: Element | null): boolean => {
+  if (element === null) {
+    return false
+  }
+  const tagName = element.tagName.toLowerCase()
+  const isFieldTag =
+    tagName === 'input' || tagName === 'textarea' || tagName === 'select'
+  const isEditable = element instanceof HTMLElement && element.isContentEditable
+  return isFieldTag || isEditable
+}
+
+const isSuppressed = (whileTyping: WhileTyping, inField: boolean): boolean =>
+  inField && whileTyping === 'Suppress'
+
+/**
+ * Build a Stream that maps global keyboard shortcuts to Messages from a
+ * declarative binding table, registering a `keydown` listener when the Stream's
+ * scope opens and removing it when the scope closes.
+ *
+ * Bindings come in two shapes: `keys` (a bare key or `mod` combo like `'mod+k'`)
+ * and `chord` (a vim-style prefix pair like `['g', 'l']`). Shortcuts are
+ * `inField`-aware by default, so they never fire while the user types in a form
+ * field. `preventDefault` runs synchronously inside the browser's dispatch,
+ * defaulting to on for `mod` combos and off for bare keys and chords.
+ *
+ * The pending chord prefix lives inside this Stream, not the consumer's Model,
+ * so apps drop the hand-written `keydown` subscription, the `inField` guard, and
+ * the `goPending` state that every non-trivial app otherwise rebuilds.
+ *
+ * This is a Stream, not a Subscription entry. Wrap it with
+ * `Subscription.persistent` for a listener whose lifetime spans the whole
+ * Subscriptions record, or plug it into a `Subscription.make` entry's
+ * `dependenciesToStream` (typically behind `Stream.when`) to gate it on a Model
+ * condition.
+ *
+ * @example
+ * ```typescript
+ * const subscriptions = Subscription.make<Model, Message>()(() => ({
+ *   shortcuts: Subscription.persistent(
+ *     Subscription.keyboardShortcuts<Message>({
+ *       bindings: [
+ *         { keys: 'mod+k', message: () => ToggledPalette(), whileTyping: 'Allow' },
+ *         { keys: '/', message: () => OpenedPalette() },
+ *         { chord: ['g', 'l'], message: () => Navigated({ to: listRouter() }) },
+ *         { keys: 'c', message: () => Navigated({ to: createRouter() }) },
+ *       ],
+ *     }),
+ *   ),
+ * }))
+ * ```
+ */
+export const keyboardShortcuts = <Message>(
+  config: KeyboardShortcutsConfig<Message>,
+): Stream.Stream<Message> =>
+  Stream.unwrap(
+    Effect.sync(() => {
+      const keyDescriptors = pipe(
+        config.bindings,
+        Array.filter(isKeyBinding),
+        Array.map(toKeyDescriptor),
+      )
+      const chordDescriptors = pipe(
+        config.bindings,
+        Array.filter(isChordBinding),
+        Array.map(toChordDescriptor),
+      )
+
+      // NOTE: The pending chord prefix is per-scope mutable state. A fresh
+      // closure is created on each materialization via `Stream.unwrap`, so
+      // re-subscribing never inherits a stale prefix.
+      let maybePendingPrefix: Option.Option<string> = Option.none()
+
+      const matchKey = (
+        key: string,
+        hasMod: boolean,
+        inField: boolean,
+      ): Option.Option<KeyDescriptor<Message>> =>
+        pipe(
+          keyDescriptors,
+          Array.findFirst(
+            descriptor =>
+              descriptor.requiresMod === hasMod &&
+              descriptor.key === key &&
+              !isSuppressed(descriptor.whileTyping, inField),
+          ),
+        )
+
+      const matchChord = (
+        prefix: string,
+        second: string,
+        inField: boolean,
+      ): Option.Option<ChordDescriptor<Message>> =>
+        pipe(
+          chordDescriptors,
+          Array.findFirst(
+            descriptor =>
+              descriptor.prefix === prefix &&
+              descriptor.second === second &&
+              !isSuppressed(descriptor.whileTyping, inField),
+          ),
+        )
+
+      const startsChord = (key: string): boolean =>
+        pipe(
+          chordDescriptors,
+          Array.some(descriptor => descriptor.prefix === key),
+        )
+
+      const emit = (
+        descriptor: KeyDescriptor<Message> | ChordDescriptor<Message>,
+        event: KeyboardEvent,
+      ): Option.Option<Message> => {
+        if (descriptor.preventDefault) {
+          event.preventDefault()
+        }
+        return Option.some(descriptor.message())
+      }
+
+      const toMessage = (event: KeyboardEvent): Option.Option<Message> => {
+        const key = event.key.toLowerCase()
+        const hasMod = event.metaKey || event.ctrlKey
+        const inField = isTypingTarget(document.activeElement)
+
+        if (Option.isSome(maybePendingPrefix) && !hasMod) {
+          const prefix = maybePendingPrefix.value
+          maybePendingPrefix = Option.none()
+          const maybeChord = matchChord(prefix, key, inField)
+          if (Option.isSome(maybeChord)) {
+            return emit(maybeChord.value, event)
+          }
+        }
+
+        const maybeKey = matchKey(key, hasMod, inField)
+        if (Option.isSome(maybeKey)) {
+          return emit(maybeKey.value, event)
+        }
+
+        if (!hasMod && !inField && startsChord(key)) {
+          maybePendingPrefix = Option.some(key)
+          return Option.none()
+        }
+
+        return Option.none()
+      }
+
+      return fromEventFilterMap<KeyboardEvent, Message>({
+        target: config.target ?? document,
+        type: 'keydown',
+        toMessage,
+      })
+    }),
+  )

--- a/packages/foldkit/src/subscription/public.ts
+++ b/packages/foldkit/src/subscription/public.ts
@@ -13,3 +13,13 @@ export type { AnimationFrameConfig } from './animationFrame.js'
 export { fromEvent, fromEventFilterMap } from './fromEvent.js'
 
 export type { FromEventConfig, FromEventFilterMapConfig } from './fromEvent.js'
+
+export { keyboardShortcuts } from './keyboardShortcuts.js'
+
+export type {
+  Binding,
+  ChordBinding,
+  KeyBinding,
+  KeyboardShortcutsConfig,
+  WhileTyping,
+} from './keyboardShortcuts.js'


### PR DESCRIPTION
## Summary

Adds `Subscription.keyboardShortcuts`, the keyboard-shortcut half of #615. It's a thin declarative layer over the existing `fromEventFilterMap`, so `preventDefault` still runs synchronously inside the browser's dispatch. The command-palette Submodel (the other half of #615) will follow as a separate PR, since the two are additive and independent.

```ts
Subscription.keyboardShortcuts<Message>({
  bindings: [
    { keys: 'mod+k', message: () => ToggledPalette(), whileTyping: 'Allow' },
    { keys: '/', message: () => OpenedPalette() },
    { chord: ['g', 'l'], message: () => Navigated({ to: listRouter() }) },
    { keys: 'c', message: () => Navigated({ to: createRouter() }) },
  ],
})
```

## Design

- **Two binding shapes.** `keys` is a bare key or `mod` combo (`'mod+k'`, `'/'`, `'Escape'`); `chord` is a vim-style prefix pair (`['g', 'l']`). A `mod` combo matches only when a modifier is held and a bare key only when none is, so `c` never fires on `mod+c`.
- **`inField`-aware by default** (`whileTyping: 'Suppress'`), computed from `document.activeElement` (`input` / `textarea` / `select` / `contentEditable`). `whileTyping: 'Allow'` opts a binding back in, typically the `mod+k` toggle. This makes the "don't fire while typing" guard the default instead of a thing you remember.
- **Chord state lives inside the Stream, not the Model.** The pending prefix is per-scope closure state (fresh on each materialization via `Stream.unwrap`), so consumers drop the hand-written `keydown` subscription, the `inField` guard, and the `goPending` field. A non-matching second key clears the prefix and is handled as a fresh key. v1 matches the current hand-built behavior (the prefix holds until the next key); an optional timeout window can follow.
- **`preventDefault`** runs synchronously inside the dispatch, defaulting on for `mod` combos and off for bare keys and chords, overridable per binding.
- Returns a `Stream`, wrap with `Subscription.persistent` or gate via `Stream.when`, same shape as `fromEvent`.

## Living proof

Wired into the `routing` example as a `g`-prefix navigation layer (`g h/p/f/n` jump between Home / People / Files / Nested). Focus the People search box and type a `g` and it does not navigate, demonstrating the `inField` guard.

## Tests

`packages/foldkit/src/subscription/keyboardShortcuts.test.ts` covers bare keys, `mod` combos (meta or ctrl), the no-modifier and while-typing guards, `whileTyping: 'Allow'`, `preventDefault` defaults + override, chord resolution, prefix-clearing on a non-match, and not arming a chord while typing. Full `foldkit` suite green; changeset included (`minor`).

Refs #615.
