### PR TITLE
fix(route-transitions): align Effect pins with the beta.97 workspace override

### DIFF
--- a/examples/route-transitions/package.json
+++ b/examples/route-transitions/package.json
@@ -9,10 +9,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-browser": "4.0.0-beta.88",
+    "@effect/platform-browser": "4.0.0-beta.97",
     "@foldkit/devtools": "workspace:*",
     "@tailwindcss/vite": "^4.3.1",
-    "effect": "4.0.0-beta.88",
+    "effect": "4.0.0-beta.97",
     "foldkit": "workspace:*",
     "tailwindcss": "^4.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -919,8 +919,8 @@ importers:
   examples/route-transitions:
     dependencies:
       '@effect/platform-browser':
-        specifier: 4.0.0-beta.88
-        version: 4.0.0-beta.88(effect@4.0.0-beta.88)
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97(effect@4.0.0-beta.97)
       '@foldkit/devtools':
         specifier: workspace:*
         version: link:../../packages/devtools
@@ -928,8 +928,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       effect:
-        specifier: 4.0.0-beta.88
-        version: 4.0.0-beta.88
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97
       foldkit:
         specifier: workspace:*
         version: link:../../packages/foldkit


### PR DESCRIPTION
## Summary

The Effect `4.0.0-beta.97` upgrade (`96167d1`) bumped the `pnpm-workspace.yaml` overrides and every package manifest except `examples/route-transitions/package.json`, which still pins `4.0.0-beta.88`. With the override applied, pnpm computes the example's effective manifest as beta.97 while the lockfile importer entry still records beta.88, so `pnpm install --frozen-lockfile` fails immediately on every CI job — for every PR and for main itself.

Bump the two pins and regenerate the lockfile importer entry. The lockfile change alone satisfies the frozen check (the override controls the effective specifier); the manifest bumps keep the file consistent with how the upgrade treated every other package.

## Test plan

- [x] `pnpm install --frozen-lockfile` passes (previously failed with the exact error CI reports)
- [x] `route-transitions-example` typechecks
- [x] `route-transitions-example` tests pass (10/10)
- [x] Full pre-push suite (build, monorepo typecheck, all tests, website e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvaHe77U4bm5T9i3UsLpiw

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvaHe77U4bm5T9i3UsLpiw)_