### PR TITLE
feat: add an upload example for interruptible Commands

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -47,6 +47,7 @@
     "@foldkit/lustre-benchmark",
     "charting-example",
     "checkout-machine-example",
-    "personal-blog-example"
+    "personal-blog-example",
+    "upload-example"
   ]
 }

--- a/.changeset/interrupt-commands-pending-in-tests.md
+++ b/.changeset/interrupt-commands-pending-in-tests.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Allow Interrupt Commands to stay pending across Messages in Story and Scene, matching the existing exemption for keyed Commands. A story can now keep sending Messages (for example further keystrokes) while a cancellation is in flight, resolving the Interrupt when the test is ready. Interrupt Commands must still be resolved by the end of the test.

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -32,6 +32,7 @@ jobs:
           - api-cache
           - routing
           - route-transitions
+          - upload
           - query-sync
           - snake
           - auth

--- a/examples/form/src/main.ts
+++ b/examples/form/src/main.ts
@@ -4,7 +4,6 @@ import {
   Duration,
   Effect,
   Match as M,
-  Number,
   Random,
   Schema as S,
 } from 'effect'
@@ -59,7 +58,6 @@ type Submission = typeof Submission.Type
 export const Model = S.Struct({
   name: Field(S.String),
   email: Field(S.String),
-  emailValidationId: S.Number,
   messageText: Field(S.String),
   submission: Submission,
 })
@@ -70,7 +68,6 @@ export type Model = typeof Model.Type
 export const UpdatedName = m('UpdatedName', { value: S.String })
 export const UpdatedEmail = m('UpdatedEmail', { value: S.String })
 export const ValidatedEmail = m('ValidatedEmail', {
-  validationId: S.Number,
   field: Field(S.String),
 })
 export const UpdatedMessageText = m('UpdatedMessageText', { value: S.String })
@@ -97,7 +94,6 @@ export type Message = typeof Message.Type
 export const initialModel: Model = {
   name: NotValidated({ value: '' }),
   email: NotValidated({ value: '' }),
-  emailValidationId: 0,
   messageText: NotValidated({ value: '' }),
   submission: NotSubmitted(),
 }
@@ -123,13 +119,12 @@ const isEmailOnWaitlist = (email: string): Effect.Effect<boolean> =>
 
 export const ValidateEmail = Command.define(
   'ValidateEmail',
-  { email: S.String, validationId: S.Number },
+  { email: S.String },
   ValidatedEmail,
-)(({ email, validationId }) =>
+)(({ email }) =>
   Effect.gen(function* () {
     if (yield* isEmailOnWaitlist(email)) {
       return ValidatedEmail({
-        validationId,
         field: Invalid({
           value: email,
           errors: ['This email is already on our waitlist'],
@@ -137,7 +132,6 @@ export const ValidateEmail = Command.define(
       })
     } else {
       return ValidatedEmail({
-        validationId,
         field: Valid({ value: email }),
       })
     }
@@ -173,29 +167,26 @@ export const update = (
 
       UpdatedEmail: ({ value }) => {
         const validateEmailResult = validateEmail(value)
-        const validationId = Number.increment(model.emailValidationId)
 
         if (validateEmailResult._tag === 'Valid') {
           return [
             evo(model, {
               email: () => Validating({ value }),
-              emailValidationId: () => validationId,
             }),
-            [ValidateEmail({ email: value, validationId })],
+            [ValidateEmail({ email: value })],
           ]
         } else {
           return [
             evo(model, {
               email: () => validateEmailResult,
-              emailValidationId: () => validationId,
             }),
             [],
           ]
         }
       },
 
-      ValidatedEmail: ({ validationId, field }) => {
-        if (validationId === model.emailValidationId) {
+      ValidatedEmail: ({ field }) => {
+        if (field.value === model.email.value) {
           return [
             evo(model, {
               email: () => field,

--- a/examples/form/src/scene.test.ts
+++ b/examples/form/src/scene.test.ts
@@ -72,7 +72,6 @@ describe('view', () => {
       Scene.Command.resolve(
         ValidateEmail,
         ValidatedEmail({
-          validationId: 1,
           field: FieldValidation.Valid({ value: 'alice@example.com' }),
         }),
       ),
@@ -91,7 +90,6 @@ describe('view', () => {
       Scene.Command.resolve(
         ValidateEmail,
         ValidatedEmail({
-          validationId: 1,
           field: FieldValidation.Invalid({
             value: 'test@example.com',
             errors: ['This email is already on our waitlist'],

--- a/examples/form/src/story.test.ts
+++ b/examples/form/src/story.test.ts
@@ -60,13 +60,11 @@ describe('update', () => {
         Story.message(UpdatedEmail({ value: 'alice@example.com' })),
         Story.model(model => {
           expect(model.email._tag).toBe('Validating')
-          expect(model.emailValidationId).toBe(1)
         }),
         Story.Command.expectHas(ValidateEmail),
         Story.Command.resolve(
           ValidateEmail,
           ValidatedEmail({
-            validationId: 1,
             field: FieldValidation.Valid({ value: 'alice@example.com' }),
           }),
         ),
@@ -88,11 +86,10 @@ describe('update', () => {
       )
     })
 
-    test('stale ValidatedEmail responses are ignored', () => {
+    test('a validation result for a superseded email value is ignored', () => {
       const inFlightModel: Model = {
         ...initialModel,
         email: FieldValidation.Validating({ value: 'alice@example.com' }),
-        emailValidationId: 5,
       }
 
       Story.story(
@@ -100,22 +97,19 @@ describe('update', () => {
         Story.with(inFlightModel),
         Story.message(
           ValidatedEmail({
-            validationId: 3,
             field: FieldValidation.Valid({ value: 'old@example.com' }),
           }),
         ),
         Story.model(model => {
           expect(model.email._tag).toBe('Validating')
-          expect(model.emailValidationId).toBe(5)
         }),
       )
     })
 
-    test('async result for the current validationId updates the email field', () => {
+    test('a validation result for the current email value updates the field', () => {
       const inFlightModel: Model = {
         ...initialModel,
         email: FieldValidation.Validating({ value: 'taken@example.com' }),
-        emailValidationId: 2,
       }
 
       Story.story(
@@ -123,7 +117,6 @@ describe('update', () => {
         Story.with(inFlightModel),
         Story.message(
           ValidatedEmail({
-            validationId: 2,
             field: FieldValidation.Invalid({
               value: 'taken@example.com',
               errors: ['This email is already on our waitlist'],

--- a/examples/upload/index.html
+++ b/examples/upload/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/src/styles.css" rel="stylesheet" />
+    <title>File Uploads</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/entry.ts"></script>
+  </body>
+</html>

--- a/examples/upload/package.json
+++ b/examples/upload/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "upload-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@effect/platform-browser": "4.0.0-beta.97",
+    "@foldkit/devtools": "workspace:*",
+    "@tailwindcss/vite": "^4.3.1",
+    "clsx": "^2.1.1",
+    "effect": "4.0.0-beta.97",
+    "foldkit": "workspace:*",
+    "tailwindcss": "^4.3.1"
+  },
+  "devDependencies": {
+    "@foldkit/vite-plugin": "workspace:*",
+    "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "happy-dom": "^20.10.4",
+    "prettier": "^3.8.4",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
+  }
+}

--- a/examples/upload/src/entry.ts
+++ b/examples/upload/src/entry.ts
@@ -1,0 +1,19 @@
+import { Runtime } from 'foldkit'
+
+import { overlay } from '@foldkit/devtools'
+
+import { Message, Model, init, update, view } from './main'
+
+const application = Runtime.makeApplication({
+  Model,
+  init,
+  update,
+  view,
+  container: document.getElementById('root'),
+  devTools: {
+    overlay,
+    Message,
+  },
+})
+
+Runtime.run(application)

--- a/examples/upload/src/main.ts
+++ b/examples/upload/src/main.ts
@@ -1,0 +1,377 @@
+import clsx from 'clsx'
+import {
+  Array,
+  Duration,
+  Effect,
+  Match as M,
+  Number,
+  Option,
+  Schema as S,
+  pipe,
+} from 'effect'
+import { Command, Runtime } from 'foldkit'
+import { Document, Html, html } from 'foldkit/html'
+import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
+
+// MODEL
+
+export const UploadStatus = S.Literals(['Uploading', 'Done', 'Cancelled'])
+export type UploadStatus = typeof UploadStatus.Type
+
+export const Upload = S.Struct({
+  id: S.Number,
+  fileName: S.String,
+  sizeMegabytes: S.Number,
+  status: UploadStatus,
+})
+export type Upload = typeof Upload.Type
+
+export const Model = S.Struct({
+  uploadId: S.Number,
+  uploads: S.Array(Upload),
+})
+export type Model = typeof Model.Type
+
+// MESSAGE
+
+export const ClickedStartUpload = m('ClickedStartUpload')
+export const ClickedCancelUpload = m('ClickedCancelUpload', {
+  uploadId: S.Number,
+})
+export const ClickedCancelAllUploads = m('ClickedCancelAllUploads')
+export const ClickedRestartUpload = m('ClickedRestartUpload', {
+  uploadId: S.Number,
+})
+export const SucceededUploadFile = m('SucceededUploadFile', {
+  uploadId: S.Number,
+})
+export const CompletedCancelUploadFile = m('CompletedCancelUploadFile', {
+  uploadId: S.Number,
+  outcome: Command.Interruptible.Outcome,
+})
+
+export const Message = S.Union([
+  ClickedStartUpload,
+  ClickedCancelUpload,
+  ClickedCancelAllUploads,
+  ClickedRestartUpload,
+  SucceededUploadFile,
+  CompletedCancelUploadFile,
+])
+export type Message = typeof Message.Type
+
+// INIT
+
+export const initialModel: Model = {
+  uploadId: 0,
+  uploads: [],
+}
+
+export const init: Runtime.ApplicationInit<Model, Message> = () => [
+  initialModel,
+  [],
+]
+
+// FAKE FILES
+
+export const FakeFile = S.Struct({ name: S.String, sizeMegabytes: S.Number })
+export type FakeFile = typeof FakeFile.Type
+
+export const FAKE_FILES: Array.NonEmptyReadonlyArray<FakeFile> = [
+  { name: 'vacation-photos.zip', sizeMegabytes: 48 },
+  { name: 'demo-recording.mp4', sizeMegabytes: 87 },
+  { name: 'quarterly-report.pdf', sizeMegabytes: 12 },
+  { name: 'design-assets.sketch', sizeMegabytes: 34 },
+  { name: 'database-backup.sql', sizeMegabytes: 61 },
+]
+
+const fakeFileForUpload = (uploadId: number): FakeFile =>
+  pipe(
+    FAKE_FILES,
+    Array.get(uploadId % Array.length(FAKE_FILES)),
+    Option.getOrElse(() => Array.headNonEmpty(FAKE_FILES)),
+  )
+
+// COMMAND
+
+const MILLISECONDS_PER_MEGABYTE = 100
+
+export const UploadKey = S.Struct({ uploadId: S.Number })
+export type UploadKey = typeof UploadKey.Type
+
+export const UploadFile = Command.Interruptible.define(
+  'UploadFile',
+  { ...UploadKey.fields, sizeMegabytes: S.Number },
+  ({ uploadId }: UploadKey) => String(uploadId),
+  SucceededUploadFile,
+)(({ uploadId, sizeMegabytes }) =>
+  Effect.gen(function* () {
+    yield* Effect.sleep(
+      Duration.millis(sizeMegabytes * MILLISECONDS_PER_MEGABYTE),
+    )
+    return SucceededUploadFile({ uploadId })
+  }),
+)
+
+export const CancelUploadFile = ({ uploadId }: UploadKey) =>
+  UploadFile.Interrupt({ uploadId }, outcome =>
+    CompletedCancelUploadFile({ uploadId, outcome }),
+  )
+
+// UPDATE
+
+const setStatusForId = (uploadId: number, status: UploadStatus) =>
+  Array.map((upload: Upload) =>
+    upload.id === uploadId ? evo(upload, { status: () => status }) : upload,
+  )
+
+export const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    M.tagsExhaustive({
+      ClickedStartUpload: () => {
+        const fakeFile = fakeFileForUpload(model.uploadId)
+        const startedUpload = Upload.make({
+          id: model.uploadId,
+          fileName: fakeFile.name,
+          sizeMegabytes: fakeFile.sizeMegabytes,
+          status: 'Uploading',
+        })
+        return [
+          evo(model, {
+            uploadId: Number.increment,
+            uploads: Array.append(startedUpload),
+          }),
+          [
+            UploadFile({
+              uploadId: startedUpload.id,
+              sizeMegabytes: startedUpload.sizeMegabytes,
+            }),
+          ],
+        ]
+      },
+
+      ClickedCancelUpload: ({ uploadId }) => [
+        model,
+        [CancelUploadFile({ uploadId })],
+      ],
+
+      ClickedCancelAllUploads: () => [
+        model,
+        pipe(
+          model.uploads,
+          Array.filter(upload => upload.status === 'Uploading'),
+          Array.map(upload => CancelUploadFile({ uploadId: upload.id })),
+        ),
+      ],
+
+      ClickedRestartUpload: ({ uploadId }) =>
+        pipe(
+          model.uploads,
+          Array.findFirst(
+            upload => upload.id === uploadId && upload.status === 'Cancelled',
+          ),
+          Option.match({
+            onNone: () => [model, []],
+            onSome: upload => [
+              evo(model, { uploads: setStatusForId(uploadId, 'Uploading') }),
+              [UploadFile({ uploadId, sizeMegabytes: upload.sizeMegabytes })],
+            ],
+          }),
+        ),
+
+      SucceededUploadFile: ({ uploadId }) => [
+        evo(model, { uploads: setStatusForId(uploadId, 'Done') }),
+        [],
+      ],
+
+      CompletedCancelUploadFile: ({ uploadId, outcome }) =>
+        M.value(outcome).pipe(
+          M.withReturnType<
+            readonly [Model, ReadonlyArray<Command.Command<Message>>]
+          >(),
+          M.tagsExhaustive({
+            Interrupted: () => [
+              evo(model, { uploads: setStatusForId(uploadId, 'Cancelled') }),
+              [],
+            ],
+            NotFound: () => [model, []],
+          }),
+        ),
+    }),
+  )
+
+// VIEW
+
+const badgeClass = (status: UploadStatus): string =>
+  M.value(status).pipe(
+    M.when('Uploading', () => 'bg-blue-100 text-blue-700'),
+    M.when('Done', () => 'bg-green-100 text-green-700'),
+    M.when('Cancelled', () => 'bg-gray-200 text-gray-600'),
+    M.exhaustive,
+  )
+
+const ACTION_BUTTON_CLASS =
+  'px-3 py-1 text-sm font-medium rounded-md border transition'
+
+const uploadActionView = (upload: Upload): Html => {
+  const h = html<Message>()
+
+  return M.value(upload.status).pipe(
+    M.when('Uploading', () =>
+      h.keyed('button')(
+        'Uploading',
+        [
+          h.OnClick(ClickedCancelUpload({ uploadId: upload.id })),
+          h.AriaLabel(`Cancel upload ${upload.id}`),
+          h.Class(
+            clsx(
+              ACTION_BUTTON_CLASS,
+              'border-red-300 text-red-600 hover:bg-red-50',
+            ),
+          ),
+        ],
+        ['Cancel'],
+      ),
+    ),
+    M.when('Cancelled', () =>
+      h.keyed('button')(
+        'Cancelled',
+        [
+          h.OnClick(ClickedRestartUpload({ uploadId: upload.id })),
+          h.AriaLabel(`Restart upload ${upload.id}`),
+          h.Class(
+            clsx(
+              ACTION_BUTTON_CLASS,
+              'border-blue-300 text-blue-600 hover:bg-blue-50',
+            ),
+          ),
+        ],
+        ['Restart'],
+      ),
+    ),
+    M.when('Done', () => h.empty),
+    M.exhaustive,
+  )
+}
+
+const uploadView = (upload: Upload): Html => {
+  const h = html<Message>()
+
+  return h.keyed('li')(
+    String(upload.id),
+    [h.Class('p-4 bg-white rounded-lg shadow flex flex-col gap-2')],
+    [
+      h.div(
+        [h.Class('flex items-center justify-between gap-3')],
+        [
+          h.div(
+            [h.Class('flex items-baseline gap-2 min-w-0')],
+            [
+              h.span(
+                [h.Class('font-medium text-gray-800 truncate')],
+                [upload.fileName],
+              ),
+              h.span(
+                [h.Class('text-sm text-gray-500 shrink-0')],
+                [`${upload.sizeMegabytes} MB`],
+              ),
+            ],
+          ),
+          h.div(
+            [h.Class('flex items-center gap-3 shrink-0')],
+            [
+              h.span(
+                [
+                  h.Class(
+                    clsx(
+                      'px-2 py-0.5 text-xs font-semibold rounded-full',
+                      badgeClass(upload.status),
+                    ),
+                  ),
+                ],
+                [upload.status],
+              ),
+              uploadActionView(upload),
+            ],
+          ),
+        ],
+      ),
+      upload.status === 'Uploading'
+        ? h.div([h.Class('h-1.5 rounded-full bg-blue-400 animate-pulse')], [])
+        : h.empty,
+    ],
+  )
+}
+
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  const isAnyUploadRunning = Array.some(
+    model.uploads,
+    upload => upload.status === 'Uploading',
+  )
+
+  const body = h.div(
+    [h.Class('min-h-screen bg-gray-100 py-8')],
+    [
+      h.div(
+        [h.Class('max-w-lg mx-auto flex flex-col gap-6 px-4')],
+        [
+          h.h1(
+            [h.Class('text-3xl font-bold text-gray-800 text-center')],
+            ['File Uploads'],
+          ),
+          h.div(
+            [h.Class('flex justify-center gap-3')],
+            [
+              h.button(
+                [
+                  h.OnClick(ClickedStartUpload()),
+                  h.Class(
+                    'px-4 py-2 rounded-md bg-blue-500 text-white font-medium hover:bg-blue-600 transition',
+                  ),
+                ],
+                ['Upload a file'],
+              ),
+              isAnyUploadRunning
+                ? h.keyed('button')(
+                    'CancelAll',
+                    [
+                      h.OnClick(ClickedCancelAllUploads()),
+                      h.Class(
+                        'px-4 py-2 rounded-md border border-red-300 text-red-600 font-medium hover:bg-red-50 transition',
+                      ),
+                    ],
+                    ['Cancel all'],
+                  )
+                : h.empty,
+            ],
+          ),
+          Array.match(model.uploads, {
+            onEmpty: () =>
+              h.keyed('p')(
+                'NoUploads',
+                [h.Class('text-center text-gray-500')],
+                ['Nothing here yet. Start an upload.'],
+              ),
+            onNonEmpty: uploads =>
+              h.keyed('ul')(
+                'UploadList',
+                [h.Class('flex flex-col gap-3')],
+                Array.map(uploads, uploadView),
+              ),
+          }),
+        ],
+      ),
+    ],
+  )
+
+  return { title: 'Foldkit Upload Example', body }
+}

--- a/examples/upload/src/scene.test.ts
+++ b/examples/upload/src/scene.test.ts
@@ -1,0 +1,91 @@
+import { Array } from 'effect'
+import { Command, Scene } from 'foldkit'
+import { describe, test } from 'vitest'
+
+import {
+  CancelUploadFile,
+  CompletedCancelUploadFile,
+  FAKE_FILES,
+  SucceededUploadFile,
+  UploadFile,
+  initialModel,
+  update,
+  view,
+} from './main'
+
+const firstFile = Array.headNonEmpty(FAKE_FILES)
+
+describe('view', () => {
+  test('initial view shows the start button and an empty state', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initialModel),
+      Scene.expect(Scene.role('heading', { name: 'File Uploads' })).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Upload a file' })).toExist(),
+      Scene.expect(Scene.text('Nothing here yet. Start an upload.')).toExist(),
+    )
+  })
+
+  test('starting an upload shows an Uploading row with a cancel button', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initialModel),
+      Scene.click(Scene.role('button', { name: 'Upload a file' })),
+      Scene.expect(Scene.text(firstFile.name)).toExist(),
+      Scene.expect(Scene.text('Uploading')).toExist(),
+      Scene.expect(Scene.role('button', { name: 'Cancel upload 0' })).toExist(),
+      Scene.Command.resolve(
+        UploadFile({ uploadId: 0, sizeMegabytes: firstFile.sizeMegabytes }),
+        SucceededUploadFile({ uploadId: 0 }),
+      ),
+      Scene.expect(Scene.text('Done')).toExist(),
+    )
+  })
+
+  test('cancelling an upload marks it Cancelled and offers a restart', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initialModel),
+      Scene.click(Scene.role('button', { name: 'Upload a file' })),
+      Scene.click(Scene.role('button', { name: 'Cancel upload 0' })),
+      Scene.Command.resolve(
+        CancelUploadFile({ uploadId: 0 }),
+        CompletedCancelUploadFile({
+          uploadId: 0,
+          outcome: Command.Interruptible.Interrupted(),
+        }),
+      ),
+      Scene.expect(Scene.text('Cancelled')).toExist(),
+      Scene.expect(
+        Scene.role('button', { name: 'Restart upload 0' }),
+      ).toExist(),
+      Scene.click(Scene.role('button', { name: 'Restart upload 0' })),
+      Scene.expect(Scene.text('Uploading')).toExist(),
+      Scene.Command.resolve(
+        UploadFile({ uploadId: 0, sizeMegabytes: firstFile.sizeMegabytes }),
+        SucceededUploadFile({ uploadId: 0 }),
+      ),
+      Scene.expect(Scene.text('Done')).toExist(),
+    )
+  })
+
+  test('the cancel all button appears only while an upload is running', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initialModel),
+      Scene.expect(Scene.role('button', { name: 'Cancel all' })).toBeAbsent(),
+      Scene.click(Scene.role('button', { name: 'Upload a file' })),
+      Scene.expect(Scene.role('button', { name: 'Cancel all' })).toExist(),
+      Scene.click(Scene.role('button', { name: 'Cancel all' })),
+      Scene.Command.resolve(
+        CancelUploadFile({ uploadId: 0 }),
+        CompletedCancelUploadFile({
+          uploadId: 0,
+          outcome: Command.Interruptible.Interrupted(),
+        }),
+      ),
+      Scene.expect(Scene.role('button', { name: 'Cancel all' })).toBeAbsent(),
+      Scene.expect(Scene.text('Cancelled')).toExist(),
+    )
+  })
+})

--- a/examples/upload/src/story.test.ts
+++ b/examples/upload/src/story.test.ts
@@ -1,0 +1,228 @@
+import { Array, Option } from 'effect'
+import { Command, Story } from 'foldkit'
+import { describe, expect, test } from 'vitest'
+
+import {
+  CancelUploadFile,
+  ClickedCancelAllUploads,
+  ClickedCancelUpload,
+  ClickedRestartUpload,
+  ClickedStartUpload,
+  CompletedCancelUploadFile,
+  FAKE_FILES,
+  SucceededUploadFile,
+  UploadFile,
+  initialModel,
+  update,
+} from './main'
+
+const firstFile = Array.headNonEmpty(FAKE_FILES)
+const secondFile = Option.getOrThrow(Array.get(FAKE_FILES, 1))
+
+describe('update', () => {
+  test('starting an upload appends an Uploading entry and fires UploadFile', () => {
+    Story.story(
+      update,
+      Story.with(initialModel),
+      Story.message(ClickedStartUpload()),
+      Story.model(model => {
+        expect(model.uploads).toEqual([
+          {
+            id: 0,
+            fileName: firstFile.name,
+            sizeMegabytes: firstFile.sizeMegabytes,
+            status: 'Uploading',
+          },
+        ])
+        expect(model.uploadId).toBe(1)
+      }),
+      Story.Command.expectExact(
+        UploadFile({ uploadId: 0, sizeMegabytes: firstFile.sizeMegabytes }),
+      ),
+      Story.Command.resolve(
+        UploadFile({ uploadId: 0, sizeMegabytes: firstFile.sizeMegabytes }),
+        SucceededUploadFile({ uploadId: 0 }),
+      ),
+      Story.model(model => {
+        expect(Array.map(model.uploads, upload => upload.status)).toEqual([
+          'Done',
+        ])
+      }),
+    )
+  })
+
+  test('cancelling an upload interrupts it and marks it Cancelled', () => {
+    Story.story(
+      update,
+      Story.with(initialModel),
+      Story.message(ClickedStartUpload()),
+      Story.message(ClickedCancelUpload({ uploadId: 0 })),
+      Story.Command.resolve(
+        CancelUploadFile({ uploadId: 0 }),
+        CompletedCancelUploadFile({
+          uploadId: 0,
+          outcome: Command.Interruptible.Interrupted(),
+        }),
+      ),
+      Story.Command.expectNone(),
+      Story.model(model => {
+        expect(Array.map(model.uploads, upload => upload.status)).toEqual([
+          'Cancelled',
+        ])
+      }),
+    )
+  })
+
+  test('a cancel that lands after completion resolves NotFound and changes nothing', () => {
+    Story.story(
+      update,
+      Story.with(initialModel),
+      Story.message(ClickedStartUpload()),
+      Story.Command.resolve(
+        UploadFile({ uploadId: 0, sizeMegabytes: firstFile.sizeMegabytes }),
+        SucceededUploadFile({ uploadId: 0 }),
+      ),
+      Story.message(ClickedCancelUpload({ uploadId: 0 })),
+      Story.Command.resolve(
+        CancelUploadFile({ uploadId: 0 }),
+        CompletedCancelUploadFile({
+          uploadId: 0,
+          outcome: Command.Interruptible.NotFound(),
+        }),
+      ),
+      Story.model(model => {
+        expect(Array.map(model.uploads, upload => upload.status)).toEqual([
+          'Done',
+        ])
+      }),
+    )
+  })
+
+  test('cancelling one upload leaves the other running', () => {
+    Story.story(
+      update,
+      Story.with(initialModel),
+      Story.message(ClickedStartUpload()),
+      Story.message(ClickedStartUpload()),
+      Story.message(ClickedCancelUpload({ uploadId: 0 })),
+      Story.Command.resolve(
+        CancelUploadFile({ uploadId: 0 }),
+        CompletedCancelUploadFile({
+          uploadId: 0,
+          outcome: Command.Interruptible.Interrupted(),
+        }),
+      ),
+      Story.Command.expectExact(
+        UploadFile({ uploadId: 1, sizeMegabytes: secondFile.sizeMegabytes }),
+      ),
+      Story.Command.resolve(
+        UploadFile({ uploadId: 1, sizeMegabytes: secondFile.sizeMegabytes }),
+        SucceededUploadFile({ uploadId: 1 }),
+      ),
+      Story.model(model => {
+        expect(Array.map(model.uploads, upload => upload.status)).toEqual([
+          'Cancelled',
+          'Done',
+        ])
+      }),
+    )
+  })
+
+  test('a new upload can start while a cancellation is still pending', () => {
+    Story.story(
+      update,
+      Story.with(initialModel),
+      Story.message(ClickedStartUpload()),
+      Story.message(ClickedCancelUpload({ uploadId: 0 })),
+      Story.message(ClickedStartUpload()),
+      Story.Command.resolve(
+        CancelUploadFile({ uploadId: 0 }),
+        CompletedCancelUploadFile({
+          uploadId: 0,
+          outcome: Command.Interruptible.Interrupted(),
+        }),
+      ),
+      Story.Command.resolve(
+        UploadFile({ uploadId: 1, sizeMegabytes: secondFile.sizeMegabytes }),
+        SucceededUploadFile({ uploadId: 1 }),
+      ),
+      Story.model(model => {
+        expect(Array.map(model.uploads, upload => upload.status)).toEqual([
+          'Cancelled',
+          'Done',
+        ])
+      }),
+    )
+  })
+
+  test('restarting a cancelled upload reuses its id and file', () => {
+    Story.story(
+      update,
+      Story.with(initialModel),
+      Story.message(ClickedStartUpload()),
+      Story.message(ClickedCancelUpload({ uploadId: 0 })),
+      Story.Command.resolve(
+        CancelUploadFile({ uploadId: 0 }),
+        CompletedCancelUploadFile({
+          uploadId: 0,
+          outcome: Command.Interruptible.Interrupted(),
+        }),
+      ),
+      Story.message(ClickedRestartUpload({ uploadId: 0 })),
+      Story.model(model => {
+        expect(Array.map(model.uploads, upload => upload.status)).toEqual([
+          'Uploading',
+        ])
+      }),
+      Story.Command.expectExact(
+        UploadFile({ uploadId: 0, sizeMegabytes: firstFile.sizeMegabytes }),
+      ),
+      Story.Command.resolve(
+        UploadFile({ uploadId: 0, sizeMegabytes: firstFile.sizeMegabytes }),
+        SucceededUploadFile({ uploadId: 0 }),
+      ),
+      Story.model(model => {
+        expect(Array.map(model.uploads, upload => upload.status)).toEqual([
+          'Done',
+        ])
+      }),
+    )
+  })
+
+  test('cancel all interrupts every running upload and only those', () => {
+    Story.story(
+      update,
+      Story.with(initialModel),
+      Story.message(ClickedStartUpload()),
+      Story.message(ClickedStartUpload()),
+      Story.message(ClickedStartUpload()),
+      Story.Command.resolve(
+        UploadFile({ uploadId: 1, sizeMegabytes: secondFile.sizeMegabytes }),
+        SucceededUploadFile({ uploadId: 1 }),
+      ),
+      Story.message(ClickedCancelAllUploads()),
+      Story.Command.resolve(
+        CancelUploadFile({ uploadId: 0 }),
+        CompletedCancelUploadFile({
+          uploadId: 0,
+          outcome: Command.Interruptible.Interrupted(),
+        }),
+      ),
+      Story.Command.resolve(
+        CancelUploadFile({ uploadId: 2 }),
+        CompletedCancelUploadFile({
+          uploadId: 2,
+          outcome: Command.Interruptible.Interrupted(),
+        }),
+      ),
+      Story.Command.expectNone(),
+      Story.model(model => {
+        expect(Array.map(model.uploads, upload => upload.status)).toEqual([
+          'Cancelled',
+          'Done',
+          'Cancelled',
+        ])
+      }),
+    )
+  })
+})

--- a/examples/upload/src/styles.css
+++ b/examples/upload/src/styles.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/examples/upload/src/vitest-setup.ts
+++ b/examples/upload/src/vitest-setup.ts
@@ -1,0 +1,3 @@
+import { setup } from 'foldkit/test/vitest'
+
+setup()

--- a/examples/upload/tsconfig.json
+++ b/examples/upload/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "vite.config.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist", "../../packages/foldkit/src"]
+}

--- a/examples/upload/vite.config.ts
+++ b/examples/upload/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+
+import { foldkit } from '@foldkit/vite-plugin'
+import tailwindcss from '@tailwindcss/vite'
+
+import { foldkitAliases } from '../vite.aliases'
+
+export default defineConfig({
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9993 })],
+  resolve: {
+    alias: foldkitAliases(__dirname),
+  },
+  server: {
+    fs: {
+      allow: ['../../'],
+    },
+  },
+})

--- a/examples/upload/vitest.config.ts
+++ b/examples/upload/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['./src/vitest-setup.ts'],
+    server: {
+      deps: {
+        inline: ['foldkit', '@foldkit/devtools'],
+      },
+    },
+  },
+})

--- a/packages/examples-e2e/e2e/upload.spec.ts
+++ b/packages/examples-e2e/e2e/upload.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('upload example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('an upload runs to completion', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Upload a file' }).click()
+    await expect(page.getByText('vacation-photos.zip')).toBeVisible()
+    await expect(page.getByText('Uploading').first()).toBeVisible()
+    await expect(page.getByText('Done')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('an upload can be cancelled and restarted', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Upload a file' }).click()
+    await page.getByRole('button', { name: 'Cancel upload 0' }).click()
+    await expect(page.getByText('Cancelled')).toBeVisible()
+    await page.getByRole('button', { name: 'Restart upload 0' }).click()
+    await expect(page.getByText('Uploading').first()).toBeVisible()
+    await expect(page.getByText('Done')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('cancelling one upload leaves the other running', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Upload a file' }).click()
+    await page.getByRole('button', { name: 'Upload a file' }).click()
+    await page.getByRole('button', { name: 'Cancel upload 0' }).click()
+    await expect(page.getByText('Cancelled')).toBeVisible()
+    await expect(page.getByText('Done')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('demo-recording.mp4')).toBeVisible()
+  })
+
+  test('cancel all stops every running upload', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Upload a file' }).click()
+    await page.getByRole('button', { name: 'Upload a file' }).click()
+    await page.getByRole('button', { name: 'Cancel all' }).click()
+    await expect(page.getByText('Cancelled')).toHaveCount(2)
+    await expect(page.getByRole('button', { name: 'Cancel all' })).toBeHidden()
+  })
+})

--- a/packages/foldkit/src/test/internal.ts
+++ b/packages/foldkit/src/test/internal.ts
@@ -464,16 +464,21 @@ export const assertZeroCommands = (
 }
 
 /** Throws when trying to send a message with unresolved Commands. Keyed
- *  Commands (built with `Command.Interruptible.define`) are exempt: they model
- *  long-running work that legitimately stays in flight while later Messages
- *  arrive, so a story can dispatch the Message that interrupts them. They
- *  must still be resolved or interrupted by the end of the test. */
+ *  Commands (built with `Command.Interruptible.define`) and Interrupt
+ *  Commands are exempt: they model in-flight async work that legitimately
+ *  stays pending while later Messages arrive, so a story can dispatch the
+ *  Message that interrupts a keyed Command, or keep typing while a
+ *  cancellation is in flight. They must still be resolved by the end of the
+ *  test. */
 export const assertNoUnresolvedCommands = (
   commands: ReadonlyArray<AnyCommand>,
   context: string,
 ): void => {
-  const unresolvable = Array.filter(commands, command =>
-    Predicate.isUndefined(command.key),
+  const unresolvable = Array.filter(
+    commands,
+    command =>
+      Predicate.isUndefined(command.key) &&
+      Predicate.isUndefined(command.interruptsKey),
   )
   if (Array.isReadonlyArrayNonEmpty(unresolvable)) {
     throw new Error(

--- a/packages/website/src/page/comingFromTanStackQuery.ts
+++ b/packages/website/src/page/comingFromTanStackQuery.ts
@@ -138,7 +138,10 @@ const conceptTable: Html = comparisonTable(
     ],
     [
       ['Out-of-order response handling'],
-      ['A request id in the Model, checked in ', inlineCode('update')],
+      [
+        'The request context threaded through the result Message, judged against the Model in ',
+        inlineCode('update'),
+      ],
     ],
     [
       [inlineCode('invalidateQueries')],
@@ -355,9 +358,9 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ' tells you what state a field is in. It does not, and cannot, order the responses that arrive to fill it. Here is a bug that is easy to hit. Fire a request for A, then fire a request for B before A returns. A is slow, B is fast, so B resolves first, then A resolves last and overwrites it. Now you are showing A’s data when the user asked for B.',
       ),
       para(
-        'Foldkit does not auto-cancel in-flight effects, and there is no ordering guarantee between independent requests, so this is reachable. You handle it the same way TanStack Query does internally: track the latest request and ignore any response that is not it. Keep a request id in the Model, thread it through the Command into the result Message, and in ',
+        'Foldkit does not auto-cancel in-flight effects, and there is no ordering guarantee between independent requests, so this is reachable. You handle it the same way TanStack Query does internally: track what the Model currently wants and ignore any response that is not it. Thread the query through the Command into the result Message, and in ',
         inlineCode('update'),
-        ' discard any result whose id is no longer current:',
+        ' discard any result whose query no longer matches the Model:',
       ),
       highlightedCodeBlock(
         h.div(
@@ -373,15 +376,15 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         'mb-6',
       ),
       para(
-        'The late response for an earlier query sees that ',
-        inlineCode('requestId'),
+        'The late response for an earlier query sees that its ',
+        inlineCode('query'),
         ' no longer matches ',
-        inlineCode('latestRequestId'),
+        inlineCode('queryInput'),
         ' and is dropped. The newest query stays on screen. Everything around the guard is the standard shape: the Command settles the fetch into a ',
         inlineCode('Result'),
         ', and ',
         inlineCode('AsyncData.settle'),
-        ' folds it into the field.',
+        ' folds it into the field. The comparison uses data the Model already holds; there is no synthetic request counter to maintain.',
       ),
       para(
         'This snippet also shows where ',
@@ -398,7 +401,19 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       ),
       infoCallout(
         'This is the solution, not a workaround',
-        'It is tempting to read the request id as boilerplate you tolerate until something better comes along. It is not. The behavior you want, newest request wins, has to live somewhere. Here it lives in the Model as a value you can read, and in update as a comparison you can test. That visibility is the point, not a tax on it. The shape generalizes: tag each async result with what the Model wanted when you started it, then ignore any result that no longer matches. The same few lines that resolve this fetch race also resolve a debounced search box firing on every keystroke, because the question is identical: is this result still the one the Model is waiting for?',
+        'It is tempting to read the guard as boilerplate you tolerate until something better comes along. It is not. The behavior you want, newest request wins, has to live somewhere. Here it lives in update as a comparison against the Model you can read and test. That visibility is the point, not a tax on it. The shape generalizes: tag each async result with what the Model wanted when you started it, then ignore any result that no longer matches. The same few lines that resolve this fetch race also resolve a debounced search box firing on every keystroke, because the question is identical: is this result still the one the Model is waiting for?',
+      ),
+      para(
+        'Judging at receipt is the correctness layer, and it is never optional. There is a second, situational layer: when the superseded request is worth stopping, because the fetch is expensive or the user gets a Cancel button, define the Command with ',
+        inlineCode('Command.Interruptible.define'),
+        ' and dispatch its ',
+        inlineCode('Interrupt'),
+        ' Command to stop the in-flight work explicitly. The guard stays either way: a result can already be in the queue when the interrupt lands. See ',
+        link(
+          `${coreCommandsRouter()}#interrupting-commands`,
+          'Interrupting Commands',
+        ),
+        '.',
       ),
       tableOfContentsEntryToHeader(faqHeader),
       faqQuestion('faq-where-is-usequery', 'Where is useQuery?'),
@@ -442,7 +457,9 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('Refreshing'),
         ') it yields ',
         inlineCode('None'),
-        ', so you make no transition and return no Command. Because every request starts as a decision made in one place, not firing twice is a branch, not a feature. Note this is a different thing from out-of-order handling above: dedup avoids starting redundant work, the request-id guard resolves work that finishes out of order.',
+        ', so you make no transition and return no Command. Because every request starts as a decision made in one place, not firing twice is a branch, not a feature. Note this is a different thing from out-of-order handling above: dedup avoids starting redundant work, the judgment in ',
+        inlineCode('update'),
+        ' resolves work that finishes out of order.',
       ),
       faqQuestion('faq-keep-previous-data', 'What about keepPreviousData?'),
       para(

--- a/packages/website/src/page/core/commands.ts
+++ b/packages/website/src/page/core/commands.ts
@@ -280,6 +280,14 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         'Derive the key from the Model identity that owns the in-flight work, for example a list item id or an entity id. The update function is pure, so keys are never generated. If two invocations are distinguishable enough to cancel one and not the other, the Model already holds the fact that distinguishes them, and that fact is the key. Two uploads of the same file still get different keys, because the Model tracks each upload as its own entity with its own id.',
       ),
       para(
+        'The Command name is the interrupt namespace, so interruptible Command names must be unique across the app. Two definitions that share a name share a key space, and an Interrupt stops every holder of its key regardless of which definition dispatched it. Unique names are already the rule in practice, because DevTools traces, Story matchers, and span names all identify Commands by name.',
+      ),
+      para(
+        'The same reasoning covers reusable Submodels. Two instances of one Submodel running the same Command share a key unless something distinguishes them, so include the instance identity in the key args, for example ',
+        inlineCode('({ instanceId }) => instanceId'),
+        '. A Submodel that appears in a list already threads an instance id through its Message lifting; the Command args carry the same id. A Submodel with a single instance needs no scoping.',
+      ),
+      para(
         'The definition carries an ',
         inlineCode('Interrupt'),
         ' constructor. It takes the key args and a function from the interrupt outcome to a Message, and returns an ordinary Command: update stays pure, DevTools shows the dispatch, and tests resolve it like any other Command. The outcome is ',
@@ -314,6 +322,32 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ' and ',
         inlineCode('NotFound'),
         ' agree on the fact that matters: the key is free now.',
+      ),
+      para(
+        'When the same Command can be cancelled with more than one meaning, for example a Cancel button and a fresh keystroke that supersedes the in-flight work, give each meaning its own result Message, named for its cause: ',
+        inlineCode('CompletedCancelUploadFileDueToClickedCancel'),
+        ' from one handler, ',
+        inlineCode('CompletedCancelUploadFileDueToSelectedNewFile'),
+        ' from the other. The ',
+        inlineCode('toMessage'),
+        ' function is written at the dispatch site and closes over it, so each handler builds its own Message. Name the cause that happened, never the action the handler intends next: a Message is a fact about the past, and the follow-up is a decision update makes at handling time. Messages are already tags, so two meanings get two Messages, not one Message carrying a cause field that update has to match a second time. Payload fields are for data the handler needs, for example the ',
+        inlineCode('uploadId'),
+        ', not for selecting behavior. When every cancelling context records the same meaning, one plain ',
+        inlineCode('CompletedCancel<CommandName>'),
+        ' serves them all: a per-upload Cancel button and a Cancel all button differ only in how many keys they interrupt, so both dispatch sites share one Message.',
+      ),
+      para(
+        'When the cancelling contexts can interleave on the same key, anything chosen at dispatch time is a snapshot that can go stale: the user clicks Cancel, then types again before the acknowledgment arrives, and honoring the click would now be wrong. Keep the current intent in the Model instead, as a union such as ',
+        inlineCode('CancellingToStop | CancellingToRevalidate'),
+        ', let later Messages update it, and have a single acknowledgment handler read it from the Model. Intent-first names are right here for the same reason cause-first names were right for Messages: a Message records what happened, while this Model field records what the app has decided to do next, and the Model is allowed to change its mind. The acknowledgment is only the fact that the key is free; what happens next is a function of the newest state, not of whichever context happened to dispatch the Interrupt.',
+      ),
+      para(
+        'The ',
+        link(
+          'https://github.com/foldkit/foldkit/tree/main/examples/upload',
+          'upload example',
+        ),
+        ' puts the whole pattern in one small app: concurrent uploads keyed by upload id, a per-upload Cancel that interrupts a single key, a Cancel all that returns one Interrupt per running upload, and a Restart that reuses a freed key.',
       ),
       infoCallout(
         'Interruption is for one-shot work',

--- a/packages/website/src/snippet/commandInterruptible.ts
+++ b/packages/website/src/snippet/commandInterruptible.ts
@@ -30,7 +30,7 @@ const UploadFile = Command.Interruptible.define(
   ),
 )
 
-const setStatusById = (uploadId: number, status: UploadStatus) =>
+const setStatusForId = (uploadId: number, status: UploadStatus) =>
   Array.map((upload: Upload) =>
     upload.id === uploadId ? evo(upload, { status: () => status }) : upload,
   )
@@ -62,7 +62,7 @@ const update = (
             // The upload was stopped. Its result Message will never arrive,
             // so this branch owns the state transition.
             Interrupted: () => [
-              evo(model, { uploads: setStatusById(uploadId, 'Cancelled') }),
+              evo(model, { uploads: setStatusForId(uploadId, 'Cancelled') }),
               [],
             ],
             // Nothing held the key: the upload already completed (or never
@@ -71,11 +71,11 @@ const update = (
           }),
         ),
       SucceededUploadFile: ({ uploadId }) => [
-        evo(model, { uploads: setStatusById(uploadId, 'Done') }),
+        evo(model, { uploads: setStatusForId(uploadId, 'Done') }),
         [],
       ],
       FailedUploadFile: ({ uploadId }) => [
-        evo(model, { uploads: setStatusById(uploadId, 'Failed') }),
+        evo(model, { uploads: setStatusForId(uploadId, 'Failed') }),
         [],
       ],
     }),

--- a/packages/website/src/snippet/responseRaceGuard.ts
+++ b/packages/website/src/snippet/responseRaceGuard.ts
@@ -13,7 +13,6 @@ const SearchResultsData = AsyncData.Schema(S.Array(SearchResult), S.String)
 const Model = S.Struct({
   queryInput: S.String,
   searchResults: SearchResultsData.schema,
-  latestRequestId: S.Number,
 })
 type Model = typeof Model.Type
 
@@ -21,7 +20,7 @@ type Model = typeof Model.Type
 
 const ChangedQuery = m('ChangedQuery', { query: S.String })
 const SettledSearch = m('SettledSearch', {
-  requestId: S.Number,
+  query: S.String,
   result: S.Result(S.Array(SearchResult), S.String),
 })
 
@@ -32,9 +31,9 @@ type Message = typeof Message.Type
 
 const Search = Command.define(
   'Search',
-  { requestId: S.Number, query: S.String },
+  { query: S.String },
   SettledSearch,
-)(({ requestId, query }) =>
+)(({ query }) =>
   pipe(
     Effect.gen(function* () {
       const client = yield* HttpClient.HttpClient
@@ -48,7 +47,7 @@ const Search = Command.define(
     }),
     Effect.mapError(error => String(error)),
     Effect.result,
-    Effect.map(result => SettledSearch({ requestId, result })),
+    Effect.map(result => SettledSearch({ query, result })),
     Effect.provide(Http.layer),
   ),
 )
@@ -64,21 +63,16 @@ const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ChangedQuery: ({ query }) => {
-        const requestId = model.latestRequestId + 1
+      ChangedQuery: ({ query }) => [
+        evo(model, {
+          queryInput: () => query,
+          searchResults: () => SearchResultsData.Loading(),
+        }),
+        [Search({ query })],
+      ],
 
-        return [
-          evo(model, {
-            queryInput: () => query,
-            searchResults: () => SearchResultsData.Loading(),
-            latestRequestId: () => requestId,
-          }),
-          [Search({ requestId, query })],
-        ]
-      },
-
-      SettledSearch: ({ requestId, result }) => {
-        if (requestId !== model.latestRequestId) {
+      SettledSearch: ({ query, result }) => {
+        if (query !== model.queryInput) {
           return [model, []]
         }
         return [evo(model, { searchResults: AsyncData.settle(result) }), []]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1333,6 +1333,52 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.4)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  examples/upload:
+    dependencies:
+      '@effect/platform-browser':
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97(effect@4.0.0-beta.97)
+      '@foldkit/devtools':
+        specifier: workspace:*
+        version: link:../../packages/devtools
+      '@tailwindcss/vite':
+        specifier: ^4.3.1
+        version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      effect:
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97
+      foldkit:
+        specifier: workspace:*
+        version: link:../../packages/foldkit
+      tailwindcss:
+        specifier: ^4.3.1
+        version: 4.3.1
+    devDependencies:
+      '@foldkit/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-foldkit
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^6.0.2
+        version: 6.0.2(@vue/compiler-sfc@3.5.38)(prettier@3.8.4)
+      happy-dom:
+        specifier: ^20.10.4
+        version: 20.10.4
+      prettier:
+        specifier: ^3.8.4
+        version: 3.8.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.4)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   examples/weather:
     dependencies:
       '@effect/platform-browser':


### PR DESCRIPTION
Showcases interruptible Commands in a dedicated example where interruption is unambiguously warranted (expensive work with a user-facing cancel affordance), simplifies the form example's stale-result guard, and aligns the docs guidance with the two-layer rule: judging results at receipt against current Model data is always required, and interruption is the situational layer for stopping in-flight work that is expensive or user-cancellable.

Earlier revisions of this PR converted the form and route-transitions examples to interruptible Commands instead. Review concluded interruption was not warranted in either (the coordination state machines outweighed the lessons those examples teach), so both keep their pre-existing shape and the feature is demonstrated by the new example.

## examples/upload (new)

A small app built around cancellation: concurrent fake uploads keyed by upload id via `Command.Interruptible.define`, a per-upload Cancel that interrupts a single key, a Cancel all that returns one Interrupt per running upload, a Restart that reuses a freed key, and a `CompletedCancelUploadFile` handler that folds the `Interrupted` / `NotFound` outcomes. Covered by Story and Scene tests plus a Playwright e2e suite (added to the examples-e2e CI matrix), and linked from the Interrupting Commands docs section.

## form

The `emailValidationId` generation counter is deleted; `ValidatedEmail` results are judged by comparing the validated value against the Model's current email. The example stays interruption-free on purpose: the check is cheap and nothing user-facing cancels it, so judgment at receipt alone is the right amount of machinery.

## website

The response race guard snippet on the TanStack Query page now judges by the query itself instead of a `latestRequestId` counter, and the section gains a paragraph introducing the situational interruption layer with a link to Interrupting Commands. The Interrupting Commands section gains guidance on choosing the cancellation's result Message (cause-named `DueTo*` Messages for distinct contexts, payload fields for data, Model-held intent when contexts can interleave on one key), on the Command name being the interrupt namespace and therefore app-unique, and on scoping keys by instance identity in reusable Submodels, plus a link to the upload example.

## foldkit

Story and Scene now let Interrupt Commands stay pending across Messages, matching the existing exemption for keyed Commands (a story that keeps acting while a cancellation is in flight tripped the unresolved-commands assertion). Ships with a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkVkVTcXCofrt4GfVkcPxM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a complete File Uploads example with progress tracking, per-upload cancellation, restart, and “cancel all” behavior.
  - Added end-to-end coverage for the upload flows (including concurrent uploads).

- **Bug Fixes**
  - Improved async email validation to ignore stale validation results.
  - Updated out-of-order response handling to use newest-request-wins based on the latest query.
  - Refined test handling so Interrupt Commands may remain pending across messages while still being resolved by the end of tests.

- **Documentation**
  - Expanded guidance for interrupting asynchronous work, including naming and cancellation-intent interleaving patterns.

- **Tests**
  - Added upload scene/story unit tests; updated existing story/scene tests for validation and cancellation semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->