### PR TITLE
feat(markdown): add @foldkit/markdown and the personal-blog example

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -46,6 +46,7 @@
     "@foldkit/examples-e2e",
     "@foldkit/lustre-benchmark",
     "charting-example",
-    "checkout-machine-example"
+    "checkout-machine-example",
+    "personal-blog-example"
   ]
 }

--- a/.changeset/markdown-package.md
+++ b/.changeset/markdown-package.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/markdown': minor
+---
+
+New package: markdown compiled at build time into typed Foldkit views. The Vite plugin (`@foldkit/markdown/vite`) parses imported `.md` files with remark, validates them against an Effect Schema vocabulary (CommonMark minus raw HTML, plus GFM tables, strikethrough, and directives), and emits typed document modules, so no parser ships to the browser. The runtime entry ships the AST schemas, `decodeDocument`, and a `view` fold with unstyled semantic defaults, per-node view overrides, and island directives that place live application views, including stateful Submodels, between paragraphs. Islands declare their attributes as Schema structs: the plugin's `islands` option validates every directive against them at build time (unknown names, unknown attributes, and malformed values all fail with file and line), and `islandsFor` pairs the same definitions with typed views whose attributes arrive already decoded.

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build core packages
-        run: pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/vite-plugin... build
+        run: pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/markdown --filter @foldkit/vite-plugin... build
 
       - name: Build examples
         run: pnpm build:examples

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -46,6 +46,7 @@ jobs:
           - web-components
           - embedding
           - ui-showcase
+          - personal-blog
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ If a Mount factory doesn't read or write its element, you've misidentified the c
 ## Commits and Releases
 
 - Conventional Commits. Add `!` after the scope for breaking changes (e.g. `refactor(schema)!:`).
-- Valid scopes: package directories (`foldkit`, `ui`, `devtools`, `create-foldkit-app`, `vite-plugin`, `devtools-mcp`, `oxlint-plugin`, `website`, `typing-game`, `examples-e2e`), example directory names, `skills`, `ci`, and `release`. Never internal module names.
+- Valid scopes: package directories (`foldkit`, `ui`, `devtools`, `create-foldkit-app`, `vite-plugin`, `devtools-mcp`, `oxlint-plugin`, `markdown`, `website`, `typing-game`, `examples-e2e`), example directory names, `skills`, `ci`, and `release`. Never internal module names.
 - Before choosing or amending a commit subject, inspect the full staged diff or the full commit diff with `git diff --cached --stat` / `git diff --cached --name-status` or `git show --stat --name-status HEAD`. The subject must describe the whole change set, not just one file or the most recent edit.
 - Do not invent broad scopes such as `tooling` or `infrastructure`. Use the literal valid scopes above.
 - Do not co-author or mention Claude in commit messages or release notes.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ This is what makes Foldkit unusually AI-friendly. The same property that makes t
 - **[Web Components](https://foldkit.dev/example-apps/web-components)**: QR code designer using typed CustomElement integration with third-party web components
 - **[Embedding](https://foldkit.dev/example-apps/embedding)**: A Foldkit widget embedded in a plain TypeScript host page via `Runtime.embed`, with typed Ports in both directions and `dispose` on unmount
 - **[UI Showcase](https://foldkit.dev/example-apps/ui-showcase)**: Interactive showcase of every Foldkit UI component
+- **[Personal Blog](https://foldkit.dev/example-apps/personal-blog)**: Markdown compiled at build time into typed Foldkit views via `@foldkit/markdown`, with live Submodel islands between paragraphs
 - **[Typing Game](packages/typing-game)**: Multiplayer typing game with Effect RPC backend ([play it live](https://typingterminal.com))
 
 ## Development

--- a/examples/personal-blog/index.html
+++ b/examples/personal-blog/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/src/styles.css" rel="stylesheet" />
+    <title>Personal Blog</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entry.ts"></script>
+  </body>
+</html>

--- a/examples/personal-blog/package.json
+++ b/examples/personal-blog/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "personal-blog-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@effect/platform-browser": "4.0.0-beta.97",
+    "@foldkit/devtools": "workspace:*",
+    "@foldkit/markdown": "workspace:*",
+    "@foldkit/ui": "workspace:*",
+    "@tailwindcss/vite": "^4.3.1",
+    "clsx": "^2.1.1",
+    "effect": "4.0.0-beta.97",
+    "foldkit": "workspace:*",
+    "tailwindcss": "^4.3.1"
+  },
+  "devDependencies": {
+    "@foldkit/vite-plugin": "workspace:*",
+    "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "happy-dom": "^20.10.4",
+    "prettier": "^3.8.4",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
+  }
+}

--- a/examples/personal-blog/src/content/about.md
+++ b/examples/personal-blog/src/content/about.md
@@ -1,0 +1,9 @@
+I’m a human man living in Boston, Massachusetts. I created and maintain [Foldkit](https://foldkit.dev), a frontend framework built on Effect. I like functional programming and building systems that are as beautiful on the inside as they are on the outside. Professionally, I make software at [August Health](https://www.augusthealth.com).
+
+I routinely produce mechanical tension in my muscles to make them stronger. I also run around outdoors because it feels so frickin’ sick to go fast for a long time.
+
+I play guitar, sing, and cover songs by The Weakerthans, Death Cab for Cutie, Stars, and the like. I listen to a lot of Tycho, Aphex Twin, Boards of Canada, etc.
+
+I’m currently making my way through _Blindsight_ by Peter Watts and _Masters of Atlantis_ by Charles Portis. Some of my favorite books are _Waking Up_ by Sam Harris and Cixin Liu’s Remembrance of Earth’s Past trilogy.
+
+I take photographs on 35mm film and am considering acquiring a medium-format camera.

--- a/examples/personal-blog/src/content/content.ts
+++ b/examples/personal-blog/src/content/content.ts
@@ -1,0 +1,39 @@
+import { Array, Option, Schema as S } from 'effect'
+
+import { MarkdownDocument, decodeDocument } from '@foldkit/markdown'
+
+import aboutRaw from './about.md'
+import makingThisBlogRaw from './making-this-blog.md'
+import shootingFilmRaw from './shooting-film.md'
+
+export const about: MarkdownDocument = decodeDocument(aboutRaw)
+
+export const Post = S.Struct({
+  slug: S.String,
+  title: S.String,
+  publishedOn: S.String,
+  summary: S.String,
+  document: MarkdownDocument,
+})
+export type Post = typeof Post.Type
+
+export const posts: ReadonlyArray<Post> = [
+  {
+    slug: 'making-this-blog',
+    title: 'Making This Blog',
+    publishedOn: 'July 12, 2026',
+    summary:
+      'Markdown compiled into typed Foldkit views, with a live counter nestled between paragraphs.',
+    document: decodeDocument(makingThisBlogRaw),
+  },
+  {
+    slug: 'shooting-film',
+    title: 'Shooting Film',
+    publishedOn: 'June 28, 2026',
+    summary: 'Thirty-six chances per roll, and why worse is better.',
+    document: decodeDocument(shootingFilmRaw),
+  },
+]
+
+export const findPost = (slug: string): Option.Option<Post> =>
+  Array.findFirst(posts, post => post.slug === slug)

--- a/examples/personal-blog/src/content/index.ts
+++ b/examples/personal-blog/src/content/index.ts
@@ -1,0 +1,1 @@
+export * from './content'

--- a/examples/personal-blog/src/content/making-this-blog.md
+++ b/examples/personal-blog/src/content/making-this-blog.md
@@ -1,0 +1,42 @@
+The words you are reading live in a markdown file. At build time, a Vite plugin from `@foldkit/markdown` parses that file, checks it against a Schema, and emits a typed tree of blocks. The view folds the tree into real Foldkit Html. No parser ships to the browser, and the prose participates in the vdom like everything else on this site.
+
+## Why bother
+
+I wanted three things at once:
+
+- Writing in plain markdown, with nothing between me and the words
+- Real Foldkit views, so DevTools and time travel keep working
+- A build that fails loudly when a file uses syntax the site does not support
+
+That last one is my favorite. The vocabulary is a contract. Write a footnote and the build stops with the file and line, not a silently empty `div`.
+
+## The fold
+
+Rendering is one pure function from document to Html. Every node type has an unstyled semantic default, and this site overrides the ones it wants to dress up:
+
+```ts
+const proseView = (
+  document: Markdown.MarkdownDocument,
+  islands: Markdown.Islands,
+): Html =>
+  h.div(
+    [h.Class('space-y-5')],
+    Markdown.viewBlocks(document, { islands, views: blogViews }),
+  )
+```
+
+## Proof that it is alive
+
+Markdown is data here, so a post can reserve space for something that lives in the Model. This counter is a real Submodel nestled between two paragraphs:
+
+::Counter{label="Clicks while reading this post"}
+
+Navigate away, come back, and the count survives. Open the DevTools overlay and scrub the history, and you can watch every click replay.
+
+:::Note
+Islands can wrap markdown too. This callout is a container directive, and _this_ emphasis renders through the same fold as everything else.
+:::
+
+> A blog post that can hold live components is an app wearing prose.
+
+That is the whole trick.

--- a/examples/personal-blog/src/content/shooting-film.md
+++ b/examples/personal-blog/src/content/shooting-film.md
@@ -1,0 +1,19 @@
+Every frame of 35mm costs real money. That constraint is the entire appeal. My phone will happily take two hundred photographs of the same sandwich, and I will feel nothing. On film, you get 36 chances per roll.
+
+## The rotation
+
+1. Portra 400 for people
+2. Ektar 100 for daylight and saturated color
+3. HP5 pushed to 1600 when the light gives up
+
+| Stock      | ISO | Best at           |
+| :--------- | --: | :---------------- |
+| Portra 400 | 400 | People            |
+| Ektar 100  | 100 | Color             |
+| HP5 Plus   | 400 | Low light, pushed |
+
+I took thousands upon thousands of photos on digital cameras thoughout college and I never look at them, because I don't like the way they look. Film is pleasing.
+
+---
+
+I am considering purchasing a medium-format camera.

--- a/examples/personal-blog/src/entry.ts
+++ b/examples/personal-blog/src/entry.ts
@@ -1,0 +1,31 @@
+import { Runtime } from 'foldkit'
+
+import { overlay } from '@foldkit/devtools'
+
+import {
+  ChangedUrl,
+  ClickedLink,
+  Message,
+  Model,
+  init,
+  update,
+  view,
+} from './main'
+
+const application = Runtime.makeApplication({
+  Model,
+  init,
+  update,
+  view,
+  container: document.getElementById('root'),
+  routing: {
+    onUrlRequest: request => ClickedLink({ request }),
+    onUrlChange: url => ChangedUrl({ url }),
+  },
+  devTools: {
+    overlay,
+    Message,
+  },
+})
+
+Runtime.run(application)

--- a/examples/personal-blog/src/island/counter.ts
+++ b/examples/personal-blog/src/island/counter.ts
@@ -1,0 +1,66 @@
+import { Match as M, Schema as S } from 'effect'
+import { Command, Submodel } from 'foldkit'
+import { html } from 'foldkit/html'
+import { m } from 'foldkit/message'
+
+import { Button } from '@foldkit/ui'
+
+// MODEL
+
+export const Model = S.Struct({ count: S.Number })
+export type Model = typeof Model.Type
+
+export const init: Model = { count: 0 }
+
+// MESSAGE
+
+export const ClickedDecrement = m('ClickedDecrement')
+export const ClickedIncrement = m('ClickedIncrement')
+
+export const Message = S.Union([ClickedDecrement, ClickedIncrement])
+export type Message = typeof Message.Type
+
+// UPDATE
+
+export const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    M.tagsExhaustive({
+      ClickedDecrement: () => [{ count: model.count - 1 }, []],
+      ClickedIncrement: () => [{ count: model.count + 1 }, []],
+    }),
+  )
+
+// VIEW
+
+const buttonStyle =
+  'h-9 w-9 rounded-full border border-stone-300 text-lg leading-none text-stone-700 hover:bg-stone-100 transition cursor-pointer'
+
+export const view = Submodel.defineView<Model, Message>(model => {
+  const h = html<Message>()
+
+  return h.div(
+    [h.Class('flex items-center gap-4')],
+    [
+      Button.view<Message>({
+        onClick: ClickedDecrement(),
+        toView: attributes =>
+          h.button([...attributes.button, h.Class(buttonStyle)], ['-']),
+      }),
+      h.span(
+        [h.Class('w-12 text-center font-mono text-2xl tabular-nums')],
+        [model.count.toString()],
+      ),
+      Button.view<Message>({
+        onClick: ClickedIncrement(),
+        toView: attributes =>
+          h.button([...attributes.button, h.Class(buttonStyle)], ['+']),
+      }),
+    ],
+  )
+})

--- a/examples/personal-blog/src/island/index.ts
+++ b/examples/personal-blog/src/island/index.ts
@@ -1,0 +1,2 @@
+export * as Counter from './counter'
+export * from './islandAttributes'

--- a/examples/personal-blog/src/island/islandAttributes.ts
+++ b/examples/personal-blog/src/island/islandAttributes.ts
@@ -1,0 +1,6 @@
+import { Schema as S } from 'effect'
+
+export const islandAttributes = {
+  Counter: S.Struct({ label: S.optionalKey(S.String) }),
+  Note: S.Struct({}),
+}

--- a/examples/personal-blog/src/main.ts
+++ b/examples/personal-blog/src/main.ts
@@ -1,0 +1,383 @@
+import { clsx } from 'clsx'
+import { Effect, Match as M, Option, Schema as S } from 'effect'
+import { Command, Runtime } from 'foldkit'
+import { Document, Html, html } from 'foldkit/html'
+import { m } from 'foldkit/message'
+import { UrlRequest, load, pushUrl } from 'foldkit/navigation'
+import { evo } from 'foldkit/struct'
+import { Url, toString as urlToString } from 'foldkit/url'
+
+import * as Markdown from '@foldkit/markdown'
+
+import { Post, about, findPost, posts } from './content'
+import { Counter, islandAttributes } from './island'
+import { proseView } from './prose'
+import * as Route from './route'
+
+export { HomeRoute, NotFoundRoute, PostRoute, PostsRoute } from './route'
+
+// MODEL
+
+export const Model = S.Struct({
+  route: Route.AppRoute,
+  counter: Counter.Model,
+})
+export type Model = typeof Model.Type
+
+// MESSAGE
+
+export const CompletedNavigateInternal = m('CompletedNavigateInternal')
+export const CompletedLoadExternal = m('CompletedLoadExternal')
+export const ClickedLink = m('ClickedLink', { request: UrlRequest })
+export const ChangedUrl = m('ChangedUrl', { url: Url })
+export const GotCounterMessage = m('GotCounterMessage', {
+  message: Counter.Message,
+})
+
+export const Message = S.Union([
+  CompletedNavigateInternal,
+  CompletedLoadExternal,
+  ClickedLink,
+  ChangedUrl,
+  GotCounterMessage,
+])
+export type Message = typeof Message.Type
+
+// INIT
+
+export const init: Runtime.RoutingApplicationInit<Model, Message> = (
+  url: Url,
+) => [{ route: Route.urlToAppRoute(url), counter: Counter.init }, []]
+
+// COMMAND
+
+const NavigateInternal = Command.define(
+  'NavigateInternal',
+  { url: S.String },
+  CompletedNavigateInternal,
+)(({ url }) => pushUrl(url).pipe(Effect.as(CompletedNavigateInternal())))
+
+const LoadExternal = Command.define(
+  'LoadExternal',
+  { href: S.String },
+  CompletedLoadExternal,
+)(({ href }) => load(href).pipe(Effect.as(CompletedLoadExternal())))
+
+// UPDATE
+
+type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>]
+const withUpdateReturn = M.withReturnType<UpdateReturn>()
+
+export const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tags({
+      ClickedLink: ({ request }) =>
+        M.value(request).pipe(
+          withUpdateReturn,
+          M.tagsExhaustive({
+            Internal: ({ url }) => [
+              model,
+              [NavigateInternal({ url: urlToString(url) })],
+            ],
+            External: ({ href }) => [model, [LoadExternal({ href })]],
+          }),
+        ),
+
+      ChangedUrl: ({ url }) => {
+        const nextRoute = Route.urlToAppRoute(url)
+        return [evo(model, { route: () => nextRoute }), []]
+      },
+
+      GotCounterMessage: ({ message }) => {
+        const [nextCounter, counterCommands] = Counter.update(
+          model.counter,
+          message,
+        )
+        return [
+          evo(model, { counter: () => nextCounter }),
+          Command.mapMessages(counterCommands, childMessage =>
+            GotCounterMessage({ message: childMessage }),
+          ),
+        ]
+      },
+    }),
+    M.tag('CompletedNavigateInternal', 'CompletedLoadExternal', () => [
+      model,
+      [],
+    ]),
+    M.exhaustive,
+  )
+
+// VIEW
+
+const islandViews = (model: Model): Markdown.Islands => {
+  const h = html<Message>()
+
+  return Markdown.islandsFor(islandAttributes, {
+    Counter: ({ label }, _content, occurrenceIndex) =>
+      h.div(
+        [
+          h.Class(
+            'my-2 flex flex-col items-center gap-3 rounded-xl border border-stone-200 py-6',
+          ),
+        ],
+        [
+          h.span([h.Class('text-sm text-stone-500')], [label ?? 'Counter']),
+          h.submodel({
+            slotId: `counter-${occurrenceIndex}`,
+            model: model.counter,
+            view: Counter.view,
+            toParentMessage: message => GotCounterMessage({ message }),
+          }),
+        ],
+      ),
+
+    Note: (_attributes, content) =>
+      h.aside(
+        [
+          h.Class(
+            'space-y-4 rounded-lg border border-stone-200 bg-stone-50 p-4',
+          ),
+        ],
+        content,
+      ),
+  })
+}
+
+const navLinkClassName = ({ isActive }: { isActive: boolean }): string =>
+  clsx('text-sm transition hover:text-stone-900', {
+    'font-semibold text-stone-900': isActive,
+    'text-stone-500': !isActive,
+  })
+
+const headerView = (currentRoute: Route.AppRoute): Html => {
+  const h = html<Message>()
+
+  return h.header(
+    [h.Class('border-b border-stone-200')],
+    [
+      h.div(
+        [
+          h.Class(
+            'mx-auto flex max-w-2xl items-baseline justify-between px-6 py-6',
+          ),
+        ],
+        [
+          h.a(
+            [
+              h.Href(Route.homeRouter()),
+              h.Class('font-semibold text-stone-900'),
+            ],
+            ['Devin Jameson'],
+          ),
+          h.nav(
+            [],
+            [
+              h.ul(
+                [h.Class('flex list-none gap-6')],
+                [
+                  h.li(
+                    [],
+                    [
+                      h.a(
+                        [
+                          h.Href(Route.homeRouter()),
+                          h.Class(
+                            navLinkClassName({
+                              isActive: currentRoute._tag === 'Home',
+                            }),
+                          ),
+                        ],
+                        ['About'],
+                      ),
+                    ],
+                  ),
+                  h.li(
+                    [],
+                    [
+                      h.a(
+                        [
+                          h.Href(Route.postsRouter()),
+                          h.Class(
+                            navLinkClassName({
+                              isActive: Route.isPostOrPosts(currentRoute),
+                            }),
+                          ),
+                        ],
+                        ['Posts'],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+const homeView = (model: Model): Html => proseView(about, islandViews(model))
+
+const postCardView = (post: Post): Html => {
+  const h = html<Message>()
+
+  return h.keyed('li')(
+    post.slug,
+    [],
+    [
+      h.a(
+        [h.Href(Route.postRouter({ slug: post.slug })), h.Class('group block')],
+        [
+          h.h2(
+            [
+              h.Class(
+                'text-xl font-semibold text-stone-900 group-hover:underline',
+              ),
+            ],
+            [post.title],
+          ),
+          h.p([h.Class('mt-1 text-sm text-stone-500')], [post.publishedOn]),
+          h.p([h.Class('mt-2 leading-relaxed text-stone-700')], [post.summary]),
+        ],
+      ),
+    ],
+  )
+}
+
+const postsView = (): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [],
+    [
+      h.h1([h.Class('mb-8 text-3xl font-bold text-stone-900')], ['Posts']),
+      h.ul([h.Class('list-none space-y-8')], posts.map(postCardView)),
+    ],
+  )
+}
+
+const missingPostView = (slug: string): Html => {
+  const h = html()
+
+  return h.div(
+    [],
+    [
+      h.h1([h.Class('text-3xl font-bold text-stone-900')], ['Post Not Found']),
+      h.p(
+        [h.Class('mt-4 leading-relaxed text-stone-700')],
+        [`There is no post named "${slug}".`],
+      ),
+    ],
+  )
+}
+
+const postView = (slug: string, model: Model): Html => {
+  const h = html()
+
+  const maybePost = findPost(slug)
+
+  const contentKey = Option.match(maybePost, {
+    onNone: () => 'Missing',
+    onSome: post => `Post-${post.slug}`,
+  })
+
+  const content = Option.match(maybePost, {
+    onNone: () => missingPostView(slug),
+    onSome: post =>
+      h.article(
+        [],
+        [
+          h.h1([h.Class('text-3xl font-bold text-stone-900')], [post.title]),
+          h.p(
+            [h.Class('mt-2 mb-8 text-sm text-stone-500')],
+            [post.publishedOn],
+          ),
+          proseView(post.document, islandViews(model)),
+        ],
+      ),
+  })
+
+  return h.div(
+    [],
+    [
+      h.a(
+        [
+          h.Href(Route.postsRouter()),
+          h.Class(
+            'mb-8 inline-block text-sm text-stone-500 hover:text-stone-900',
+          ),
+        ],
+        ['← All posts'],
+      ),
+      h.keyed('div')(contentKey, [], [content]),
+    ],
+  )
+}
+
+const notFoundView = (path: string): Html => {
+  const h = html()
+
+  return h.div(
+    [],
+    [
+      h.h1([h.Class('text-3xl font-bold text-stone-900')], ['404']),
+      h.p(
+        [h.Class('mt-4 leading-relaxed text-stone-700')],
+        [`The path "${path}" was not found.`],
+      ),
+      h.a(
+        [
+          h.Href(Route.homeRouter()),
+          h.Class(
+            'mt-4 inline-block text-sm text-stone-500 hover:text-stone-900',
+          ),
+        ],
+        ['← Go home'],
+      ),
+    ],
+  )
+}
+
+const routeTitle = (route: Route.AppRoute): string =>
+  M.value(route).pipe(
+    M.tagsExhaustive({
+      Home: () => 'Devin Jameson',
+      Posts: () => 'Posts | Devin Jameson',
+      Post: ({ slug }) =>
+        Option.match(findPost(slug), {
+          onNone: () => 'Post Not Found | Devin Jameson',
+          onSome: post => `${post.title} | Devin Jameson`,
+        }),
+      NotFound: () => 'Not Found | Devin Jameson',
+    }),
+  )
+
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  const routeContent = M.value(model.route).pipe(
+    M.tagsExhaustive({
+      Home: () => homeView(model),
+      Posts: postsView,
+      Post: ({ slug }) => postView(slug, model),
+      NotFound: ({ path }) => notFoundView(path),
+    }),
+  )
+
+  return {
+    title: routeTitle(model.route),
+    body: h.div(
+      [h.Class('min-h-screen bg-white text-stone-800')],
+      [
+        headerView(model.route),
+        h.main(
+          [h.Class('mx-auto max-w-2xl px-6 py-10')],
+          [h.keyed('div')(model.route._tag, [], [routeContent])],
+        ),
+      ],
+    ),
+  }
+}

--- a/examples/personal-blog/src/prose.ts
+++ b/examples/personal-blog/src/prose.ts
@@ -1,0 +1,166 @@
+import { Match as M, Option } from 'effect'
+import { Html, html } from 'foldkit/html'
+
+import * as Markdown from '@foldkit/markdown'
+
+const h = html()
+
+const headingView = (
+  heading: Markdown.Heading,
+  content: Markdown.InlineContent,
+): Html =>
+  M.value(heading.level).pipe(
+    M.when(1, () =>
+      h.h1([h.Class('text-3xl font-bold text-stone-900')], content),
+    ),
+    M.when(2, () =>
+      h.h2([h.Class('mt-10 text-2xl font-semibold text-stone-900')], content),
+    ),
+    M.when(3, () =>
+      h.h3([h.Class('mt-8 text-xl font-semibold text-stone-900')], content),
+    ),
+    M.when(4, () =>
+      h.h4([h.Class('mt-6 text-lg font-semibold text-stone-900')], content),
+    ),
+    M.when(5, () =>
+      h.h5([h.Class('mt-6 font-semibold text-stone-900')], content),
+    ),
+    M.when(6, () =>
+      h.h6([h.Class('mt-6 text-sm font-semibold text-stone-900')], content),
+    ),
+    M.exhaustive,
+  )
+
+const codeBlockView = (codeBlock: Markdown.CodeBlock): Html =>
+  h.div(
+    [h.Class('overflow-hidden rounded-lg bg-stone-900')],
+    [
+      ...Option.match(codeBlock.maybeLanguage, {
+        onNone: () => [],
+        onSome: language => [
+          h.keyed('div')(
+            'Language',
+            [
+              h.Class(
+                'border-b border-stone-700 px-4 py-1.5 font-mono text-xs text-stone-400',
+              ),
+            ],
+            [language],
+          ),
+        ],
+      }),
+      h.pre(
+        [h.Class('overflow-x-auto p-4')],
+        [
+          h.code(
+            [h.Class('font-mono text-sm text-stone-100')],
+            [codeBlock.value],
+          ),
+        ],
+      ),
+    ],
+  )
+
+const listView = (list: Markdown.List, items: ReadonlyArray<Html>): Html => {
+  const startAttributes = Option.match(list.maybeStartNumber, {
+    onNone: () => [],
+    onSome: startNumber => [h.Start(startNumber)],
+  })
+
+  if (list.isOrdered) {
+    return h.ol(
+      [...startAttributes, h.Class('list-decimal space-y-1 pl-6')],
+      items,
+    )
+  } else {
+    return h.ul([h.Class('list-disc space-y-1 pl-6')], items)
+  }
+}
+
+const alignmentClass = (alignment: Markdown.Alignment): string =>
+  M.value(alignment).pipe(
+    M.when('Right', () => 'text-right'),
+    M.when('Center', () => 'text-center'),
+    M.orElse(() => 'text-left'),
+  )
+
+const tableCellView = (
+  _tableCell: Markdown.TableCell,
+  content: Markdown.InlineContent,
+  alignment: Markdown.Alignment,
+  isHeader: boolean,
+): Html => {
+  const cellClass = `px-3 py-2 ${alignmentClass(alignment)}`
+
+  if (isHeader) {
+    return h.th([h.Class(`${cellClass} font-semibold text-stone-900`)], content)
+  } else {
+    return h.td([h.Class(`${cellClass} text-stone-700`)], content)
+  }
+}
+
+export const blogViews: Markdown.Views = {
+  ...Markdown.defaultViews,
+
+  Heading: headingView,
+
+  Paragraph: (_paragraph, content) =>
+    h.p([h.Class('leading-relaxed text-stone-700')], content),
+
+  Link: (link, content) =>
+    h.a(
+      [
+        h.Href(link.url),
+        h.Class(
+          'text-stone-900 underline decoration-stone-300 underline-offset-2 hover:decoration-stone-900',
+        ),
+      ],
+      content,
+    ),
+
+  InlineCode: inlineCode =>
+    h.code(
+      [h.Class('rounded bg-stone-100 px-1.5 py-0.5 font-mono text-[0.9em]')],
+      [inlineCode.value],
+    ),
+
+  CodeBlock: codeBlockView,
+
+  List: listView,
+
+  ListItem: (_listItem, blocks) =>
+    h.li([h.Class('leading-relaxed text-stone-700')], blocks),
+
+  Blockquote: (_blockquote, blocks) =>
+    h.blockquote(
+      [h.Class('space-y-4 border-l-4 border-stone-200 pl-4 text-stone-600')],
+      blocks,
+    ),
+
+  ThematicBreak: () => h.hr([h.Class('my-8 border-stone-200')]),
+
+  Table: (_table, headerRow, bodyRows) =>
+    h.div(
+      [h.Class('overflow-x-auto')],
+      [
+        h.table(
+          [h.Class('w-full border-collapse text-sm')],
+          [h.thead([], [headerRow]), h.tbody([], bodyRows)],
+        ),
+      ],
+    ),
+
+  TableRow: (_tableRow, cells) =>
+    h.tr([h.Class('border-b border-stone-200')], cells),
+
+  TableCell: tableCellView,
+}
+
+export const proseView = (
+  document: Markdown.MarkdownDocument,
+  islands: Markdown.Islands,
+): Html =>
+  h.div(
+    [h.Class('space-y-5')],
+    Markdown.viewBlocks(document, { islands, views: blogViews }),
+  )

--- a/examples/personal-blog/src/route.ts
+++ b/examples/personal-blog/src/route.ts
@@ -1,0 +1,43 @@
+import { Schema as S, pipe } from 'effect'
+import { Route } from 'foldkit'
+import { literal, r, slash, string } from 'foldkit/route'
+
+export const HomeRoute = r('Home')
+export const PostsRoute = r('Posts')
+export const PostRoute = r('Post', { slug: S.String })
+export const NotFoundRoute = r('NotFound', { path: S.String })
+
+export const AppRoute = S.Union([
+  HomeRoute,
+  PostsRoute,
+  PostRoute,
+  NotFoundRoute,
+])
+
+export type HomeRoute = typeof HomeRoute.Type
+export type PostsRoute = typeof PostsRoute.Type
+export type PostRoute = typeof PostRoute.Type
+export type NotFoundRoute = typeof NotFoundRoute.Type
+export type AppRoute = typeof AppRoute.Type
+
+export const homeRouter = pipe(Route.root, Route.mapTo(HomeRoute))
+
+export const postsRouter = pipe(literal('posts'), Route.mapTo(PostsRoute))
+
+export const postRouter = pipe(
+  literal('posts'),
+  slash(string('slug')),
+  Route.mapTo(PostRoute),
+)
+
+const routeParser = Route.oneOf(postRouter, postsRouter, homeRouter)
+
+export const urlToAppRoute = Route.parseUrlWithFallback(
+  routeParser,
+  NotFoundRoute,
+)
+
+export const isPostOrPosts = (
+  route: AppRoute,
+): route is PostsRoute | PostRoute =>
+  route._tag === 'Posts' || route._tag === 'Post'

--- a/examples/personal-blog/src/scene.test.ts
+++ b/examples/personal-blog/src/scene.test.ts
@@ -1,0 +1,126 @@
+import { Scene } from 'foldkit'
+import { describe, test } from 'vitest'
+
+import { Counter } from './island'
+import {
+  HomeRoute,
+  Model,
+  NotFoundRoute,
+  PostRoute,
+  PostsRoute,
+  update,
+  view,
+} from './main'
+
+const home = Model.make({ route: HomeRoute(), counter: Counter.init })
+const postsIndex = Model.make({ route: PostsRoute(), counter: Counter.init })
+const post = (slug: string) =>
+  Model.make({ route: PostRoute({ slug }), counter: Counter.init })
+const notFound = (path: string) =>
+  Model.make({ route: NotFoundRoute({ path }), counter: Counter.init })
+
+describe('view', () => {
+  test('the header renders the site title and navigation on every route', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(home),
+      Scene.expect(Scene.role('link', { name: 'Devin Jameson' })).toExist(),
+      Scene.expect(Scene.role('link', { name: 'About' })).toExist(),
+      Scene.expect(Scene.role('link', { name: 'Posts' })).toExist(),
+    )
+  })
+
+  test('the Home route renders the about prose from markdown', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(home),
+      Scene.expect(
+        Scene.text('human man living in Boston', { exact: false }),
+      ).toExist(),
+      Scene.expect(Scene.role('link', { name: 'Foldkit' })).toExist(),
+      Scene.expect(Scene.role('link', { name: 'August Health' })).toExist(),
+    )
+  })
+
+  test('the Posts route lists every post with its summary', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(postsIndex),
+      Scene.expect(
+        Scene.role('heading', { name: 'Making This Blog' }),
+      ).toExist(),
+      Scene.expect(Scene.role('heading', { name: 'Shooting Film' })).toExist(),
+      Scene.expect(
+        Scene.text('why worse is better', { exact: false }),
+      ).toExist(),
+    )
+  })
+
+  test('a post renders markdown headings, code, and blockquotes', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(post('making-this-blog')),
+      Scene.expect(
+        Scene.role('heading', { name: 'Making This Blog' }),
+      ).toExist(),
+      Scene.expect(Scene.role('heading', { name: 'Why bother' })).toExist(),
+      Scene.expect(Scene.role('heading', { name: 'The fold' })).toExist(),
+      Scene.expect(Scene.text('proseView', { exact: false })).toExist(),
+      Scene.expect(
+        Scene.text('an app wearing prose', { exact: false }),
+      ).toExist(),
+    )
+  })
+
+  test('the Counter island renders live inside the post prose', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(post('making-this-blog')),
+      Scene.expect(Scene.text('Clicks while reading this post')).toExist(),
+      Scene.expect(Scene.role('button', { name: '+' })).toExist(),
+      Scene.expect(Scene.role('button', { name: '-' })).toExist(),
+    )
+  })
+
+  test('the Note island wraps nested markdown content', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(post('making-this-blog')),
+      Scene.expect(
+        Scene.text('Islands can wrap markdown too', { exact: false }),
+      ).toExist(),
+    )
+  })
+
+  test('a post renders markdown tables and ordered lists', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(post('shooting-film')),
+      Scene.expect(Scene.role('table')).toExist(),
+      Scene.expect(Scene.text('Low light, pushed')).toExist(),
+      Scene.expect(
+        Scene.text('renders skin like it loves them', { exact: false }),
+      ).toExist(),
+    )
+  })
+
+  test('an unknown post slug renders the missing panel', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(post('missing-post')),
+      Scene.expect(Scene.role('heading', { name: 'Post Not Found' })).toExist(),
+      Scene.expect(
+        Scene.text('There is no post named "missing-post".'),
+      ).toExist(),
+    )
+  })
+
+  test('an unmatched URL renders the NotFound view', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(notFound('/missing')),
+      Scene.expect(Scene.role('heading', { name: '404' })).toExist(),
+      Scene.expect(Scene.role('link', { name: '← Go home' })).toExist(),
+    )
+  })
+})

--- a/examples/personal-blog/src/story.test.ts
+++ b/examples/personal-blog/src/story.test.ts
@@ -1,0 +1,119 @@
+import { Option } from 'effect'
+import { Story } from 'foldkit'
+import { fromString } from 'foldkit/url'
+import { describe, expect, test } from 'vitest'
+
+import { Counter } from './island'
+import { ChangedUrl, GotCounterMessage, HomeRoute, Model, update } from './main'
+
+const home = Model.make({ route: HomeRoute(), counter: Counter.init })
+
+const urlOrThrow = (raw: string) =>
+  Option.getOrThrowWith(
+    fromString(raw),
+    () => new Error(`Failed to parse url: ${raw}`),
+  )
+
+describe('update', () => {
+  describe('ChangedUrl', () => {
+    test('navigating to / parses to the Home route', () => {
+      Story.story(
+        update,
+        Story.with(home),
+        Story.message(ChangedUrl({ url: urlOrThrow('http://localhost/') })),
+        Story.model(model => {
+          expect(model.route._tag).toBe('Home')
+        }),
+      )
+    })
+
+    test('navigating to /posts parses to the Posts route', () => {
+      Story.story(
+        update,
+        Story.with(home),
+        Story.message(
+          ChangedUrl({ url: urlOrThrow('http://localhost/posts') }),
+        ),
+        Story.model(model => {
+          expect(model.route._tag).toBe('Posts')
+        }),
+      )
+    })
+
+    test('navigating to /posts/making-this-blog captures the slug', () => {
+      Story.story(
+        update,
+        Story.with(home),
+        Story.message(
+          ChangedUrl({
+            url: urlOrThrow('http://localhost/posts/making-this-blog'),
+          }),
+        ),
+        Story.model(model => {
+          if (model.route._tag === 'Post') {
+            expect(model.route.slug).toBe('making-this-blog')
+          } else {
+            throw new Error('Expected Post route')
+          }
+        }),
+      )
+    })
+
+    test('an unknown path falls through to NotFound with the path captured', () => {
+      Story.story(
+        update,
+        Story.with(home),
+        Story.message(
+          ChangedUrl({ url: urlOrThrow('http://localhost/missing') }),
+        ),
+        Story.model(model => {
+          if (model.route._tag === 'NotFound') {
+            expect(model.route.path).toBe('/missing')
+          } else {
+            throw new Error('Expected NotFound route')
+          }
+        }),
+      )
+    })
+  })
+
+  describe('GotCounterMessage', () => {
+    test('increments route through the Counter submodel without commands', () => {
+      Story.story(
+        update,
+        Story.with(home),
+        Story.message(
+          GotCounterMessage({ message: Counter.ClickedIncrement() }),
+        ),
+        Story.message(
+          GotCounterMessage({ message: Counter.ClickedIncrement() }),
+        ),
+        Story.Command.expectNone(),
+        Story.model(model => {
+          expect(model.counter.count).toBe(2)
+        }),
+      )
+    })
+
+    test('the count survives navigating between routes', () => {
+      Story.story(
+        update,
+        Story.with(home),
+        Story.message(
+          GotCounterMessage({ message: Counter.ClickedIncrement() }),
+        ),
+        Story.message(
+          ChangedUrl({ url: urlOrThrow('http://localhost/posts') }),
+        ),
+        Story.message(
+          ChangedUrl({
+            url: urlOrThrow('http://localhost/posts/making-this-blog'),
+          }),
+        ),
+        Story.model(model => {
+          expect(model.counter.count).toBe(1)
+        }),
+      )
+    })
+  })
+})

--- a/examples/personal-blog/src/styles.css
+++ b/examples/personal-blog/src/styles.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/examples/personal-blog/src/vite-env.d.ts
+++ b/examples/personal-blog/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@foldkit/markdown/content" />

--- a/examples/personal-blog/src/vitest-setup.ts
+++ b/examples/personal-blog/src/vitest-setup.ts
@@ -1,0 +1,3 @@
+import { setup } from 'foldkit/test/vitest'
+
+setup()

--- a/examples/personal-blog/tsconfig.json
+++ b/examples/personal-blog/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "vite.config.ts",
+    "vite.config.playground.ts",
+    "vitest.config.ts"
+  ],
+  "exclude": ["node_modules", "dist", "../../packages/foldkit/src"]
+}

--- a/examples/personal-blog/vite.config.playground.ts
+++ b/examples/personal-blog/vite.config.playground.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+
+import { markdown } from '@foldkit/markdown/vite'
+import { foldkit } from '@foldkit/vite-plugin'
+import tailwindcss from '@tailwindcss/vite'
+
+import { islandAttributes } from './src/island/islandAttributes'
+
+export default defineConfig({
+  plugins: [tailwindcss(), foldkit(), markdown({ islands: islandAttributes })],
+})

--- a/examples/personal-blog/vite.config.ts
+++ b/examples/personal-blog/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite'
+
+import { markdown } from '@foldkit/markdown/vite'
+import { foldkit } from '@foldkit/vite-plugin'
+import tailwindcss from '@tailwindcss/vite'
+
+import { foldkitAliases } from '../vite.aliases'
+import { islandAttributes } from './src/island/islandAttributes'
+
+export default defineConfig({
+  plugins: [
+    tailwindcss(),
+    foldkit({ devToolsMcpPort: 9988 }),
+    markdown({ islands: islandAttributes }),
+  ],
+  resolve: {
+    alias: foldkitAliases(__dirname),
+  },
+  server: {
+    fs: {
+      allow: ['../../'],
+    },
+  },
+})

--- a/examples/personal-blog/vitest.config.ts
+++ b/examples/personal-blog/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+
+import { markdown } from '@foldkit/markdown/vite'
+
+import { islandAttributes } from './src/island/islandAttributes'
+
+export default defineConfig({
+  plugins: [markdown({ islands: islandAttributes })],
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['./src/vitest-setup.ts'],
+    server: {
+      deps: {
+        inline: ['foldkit', '@foldkit/ui', '@foldkit/devtools'],
+      },
+    },
+  },
+})

--- a/examples/vite.aliases.ts
+++ b/examples/vite.aliases.ts
@@ -182,6 +182,14 @@ export const foldkitAliases = (dirname: string) => ({
     '../../packages/ui/src/virtualList/public',
   ),
   '@foldkit/ui': path.resolve(dirname, '../../packages/ui/src/index'),
+  '@foldkit/markdown/vite': path.resolve(
+    dirname,
+    '../../packages/markdown/src/vite/public',
+  ),
+  '@foldkit/markdown': path.resolve(
+    dirname,
+    '../../packages/markdown/src/index',
+  ),
   '@foldkit/devtools': path.resolve(
     dirname,
     '../../packages/devtools/src/index',

--- a/knip.json
+++ b/knip.json
@@ -26,6 +26,9 @@
     "packages/devtools": {
       "entry": ["src/index.ts"]
     },
+    "packages/markdown": {
+      "entry": ["src/index.ts", "src/vite/public.ts"]
+    },
     "packages/examples-e2e": {
       "entry": ["page.ts", "e2e/**/*.spec.ts"],
       "ignoreFiles": ["playwright.config.ts"],
@@ -51,6 +54,15 @@
     },
     "examples/charting": {
       "entry": [],
+      "ignoreDependencies": [
+        "@trivago/prettier-plugin-sort-imports",
+        "prettier",
+        "tailwindcss"
+      ]
+    },
+    "examples/personal-blog": {
+      "entry": ["src/**/*.test.ts", "src/vitest-*.ts"],
+      "ignoreFiles": ["vite.config.playground.ts"],
       "ignoreDependencies": [
         "@trivago/prettier-plugin-sort-imports",
         "prettier",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:e2e": "pnpm --filter website test:e2e",
     "format": "prettier -w .",
     "format:check": "prettier --check .",
-    "dev:libs": "pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --parallel watch",
+    "dev:libs": "pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/markdown --parallel watch",
     "dev:website": "pnpm --filter website dev",
     "build:examples": "tsx scripts/build-examples.ts",
     "build:website": "pnpm --filter website... build",
@@ -62,6 +62,7 @@
     "dev:example:web-components": "pnpm --filter web-components-example dev",
     "dev:example:embedding": "pnpm --filter embedding-example dev",
     "dev:example:ui-showcase": "pnpm --filter ui-showcase dev",
+    "dev:example:personal-blog": "pnpm --filter personal-blog-example dev",
     "changeset": "changeset",
     "version-packages": "changeset version && tsx scripts/reset-peer-deps.ts && pnpm install --no-frozen-lockfile",
     "release": "pnpm -r build && changeset publish"

--- a/packages/examples-e2e/e2e/personal-blog.spec.ts
+++ b/packages/examples-e2e/e2e/personal-blog.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test'
+
+import * as Page from '../page'
+
+test.describe('personal-blog example', () => {
+  test('loads cleanly', async ({ page }) => {
+    await Page.assertLoadedCleanly(page)
+  })
+
+  test('renders the about prose from markdown', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText('human man living in Boston')).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: 'August Health' }),
+    ).toBeVisible()
+  })
+
+  test('a markdown island counts clicks inside a post', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('link', { name: 'Posts' }).click()
+    await page.getByRole('link', { name: 'Making This Blog' }).click()
+    await expect(
+      page.getByRole('heading', { name: 'Making This Blog' }),
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: '+' }).click()
+    await page.getByRole('button', { name: '+' }).click()
+    await expect(page.getByText('2', { exact: true })).toBeVisible()
+  })
+
+  test('the island count survives navigating away and back', async ({
+    page,
+  }) => {
+    await page.goto('/posts/making-this-blog')
+    await page.getByRole('button', { name: '+' }).click()
+    await page.getByRole('link', { name: 'About' }).click()
+    await expect(page.getByText('human man living in Boston')).toBeVisible()
+
+    await page.goBack()
+    await expect(page.getByText('1', { exact: true })).toBeVisible()
+  })
+
+  test('renders markdown tables', async ({ page }) => {
+    await page.goto('/posts/shooting-film')
+    await expect(page.getByRole('table')).toBeVisible()
+    await expect(page.getByText('Low light, pushed')).toBeVisible()
+  })
+})

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -1,0 +1,127 @@
+# @foldkit/markdown
+
+Markdown compiled at build time into typed Foldkit views, with live component islands.
+
+A Vite plugin parses each imported `.md` file with remark, validates it against an Effect Schema vocabulary, and emits a typed document module. The browser receives data, never a parser. A pure fold renders the document as Foldkit `Html`, so markdown content participates in the vdom, DevTools, and time travel like any other view.
+
+## Install
+
+```bash
+pnpm add @foldkit/markdown
+```
+
+## Setup
+
+Add the plugin to `vite.config.ts`:
+
+```typescript
+import { markdown } from '@foldkit/markdown/vite'
+
+export default defineConfig({
+  plugins: [tailwindcss(), foldkit(), markdown()],
+})
+```
+
+Type `.md` imports by adding the ambient declaration to your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["@foldkit/markdown/content"]
+  }
+}
+```
+
+If you run tests with Vitest, add `markdown()` with the same options to the `plugins` in `vitest.config.ts` as well, so test runs compile and validate `.md` imports exactly the way the app build does.
+
+## Render a document
+
+```typescript
+import * as Markdown from '@foldkit/markdown'
+
+import aboutRaw from './content/about.md'
+
+const about = Markdown.decodeDocument(aboutRaw)
+
+const view = (model: Model): Html => h.div([], [Markdown.view(about)])
+```
+
+`Markdown.view` renders every node through unstyled semantic defaults. Restyle any node by overriding its view:
+
+```typescript
+Markdown.view(about, {
+  views: {
+    Paragraph: (paragraph, content) =>
+      h.p([h.Class('leading-relaxed text-stone-700')], content),
+    Link: ({ url }, content) =>
+      h.a([h.Href(url), h.Class('underline underline-offset-2')], content),
+  },
+})
+```
+
+`Markdown.viewBlocks` returns one `Html` per top-level block instead, for when the blocks should land directly inside your own container element.
+
+## Islands
+
+Directives reserve space in the prose for live application views. A leaf directive stands alone; a container directive wraps nested markdown:
+
+```markdown
+The count lives in the Model like everything else on this page.
+
+::Counter{label="Clicks while reading"}
+
+:::Note{tone="calm"}
+Islands can wrap _markdown_ too.
+:::
+```
+
+Declare each island's attributes as a Schema struct, once, in a module both your Vite config and your views import:
+
+```typescript
+export const islandAttributes = {
+  Counter: S.Struct({ label: S.optionalKey(S.String) }),
+  Note: S.Struct({ tone: S.optionalKey(S.String) }),
+}
+```
+
+Pass the definitions to the plugin and every directive validates at build time. An unknown island name, an unknown attribute, or an attribute value outside its schema fails the build with the file and line:
+
+```typescript
+markdown({ islands: islandAttributes })
+```
+
+`islandsFor` pairs the same definitions with typed views: attributes arrive decoded through each island's schema, and the record must cover every declared name. State stays in your Model; the markdown only decides placement. The third argument is the zero-based occurrence of that island name in the document, for identifiers that must be unique per instance, like an `h.submodel` slotId:
+
+```typescript
+Markdown.view(post, {
+  islands: Markdown.islandsFor(islandAttributes, {
+    Counter: ({ label }, _content, occurrenceIndex) =>
+      h.submodel({
+        slotId: `counter-${occurrenceIndex}`,
+        model: model.counter,
+        view: Counter.view,
+        toParentMessage: message => GotCounterMessage({ message }),
+      }),
+    Note: (_attributes, content) =>
+      h.aside([h.Class('rounded border p-4')], content),
+  }),
+})
+```
+
+Attribute values are strings on the wire, so transforming field schemas decode past them: `S.NumberFromString` turns `::Chart{height="240"}` into `height: number`. A plain `islands` record of untyped views (`Readonly<Record<string, IslandView>>`) also works when you want to skip the schemas.
+
+## Vocabulary
+
+The schema accepts CommonMark plus GFM tables and strikethrough: headings, paragraphs, emphasis, strong, strikethrough, inline code, links, images, hard breaks, nested lists, code blocks, blockquotes, thematic breaks, and tables. Directives (`::Name`, `:::Name`) become Island nodes.
+
+Anything outside the vocabulary fails the build with an error naming the construct and its line. Raw HTML is rejected by design; islands are the escape hatch. Reference-style links, footnotes, task lists, YAML frontmatter, and directive labels (`::Name[label]`) are not supported; keep document metadata in application code. Link and image URLs must be relative or use the `http:`, `https:`, `mailto:`, or `tel:` schemes; executable schemes like `javascript:` fail the build.
+
+## One-off compilation
+
+`parseMarkdown` runs the same parse-and-validate pipeline outside Vite, for scripts and tests:
+
+```typescript
+import { parseMarkdown } from '@foldkit/markdown/vite'
+
+const document = parseMarkdown('# Title', { islands: islandAttributes })
+```

--- a/packages/markdown/content.d.ts
+++ b/packages/markdown/content.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const document: unknown
+  export default document
+}

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@foldkit/markdown",
+  "version": "0.0.0",
+  "description": "Markdown compiled at build time into typed Foldkit views, with live component islands",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./vite": {
+      "types": "./dist/vite/public.d.ts",
+      "import": "./dist/vite/public.js"
+    },
+    "./content": {
+      "types": "./content.d.ts"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "content.d.ts"
+  ],
+  "scripts": {
+    "clean": "rimraf dist *.tsbuildinfo",
+    "build": "pnpm run clean && tsc -b tsconfig.build.json",
+    "watch": "tsc -b tsconfig.build.json --watch",
+    "lint": "pnpm --filter @foldkit/oxlint-plugin build && oxlint src",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "effect": "4.0.0-beta.97",
+    "foldkit": "workspace:^0",
+    "vite": "^7.0.0 || ^8.0.0"
+  },
+  "dependencies": {
+    "remark-directive": "^4.0.0",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5"
+  },
+  "devDependencies": {
+    "@types/mdast": "^4.0.4",
+    "@types/unist": "^3.0.3",
+    "effect": "4.0.0-beta.97",
+    "foldkit": "workspace:*",
+    "happy-dom": "^20.10.4",
+    "mdast-util-directive": "^3.1.0",
+    "rimraf": "^6.1.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
+  },
+  "keywords": [
+    "foldkit",
+    "markdown",
+    "vite-plugin",
+    "islands",
+    "mdast"
+  ],
+  "author": "Devin Jameson",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/foldkit/foldkit.git",
+    "directory": "packages/markdown"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/markdown/src/ast/ast.ts
+++ b/packages/markdown/src/ast/ast.ts
@@ -1,0 +1,372 @@
+import { Option, Schema as S } from 'effect'
+import type { Array } from 'effect'
+import { ts } from 'foldkit/schema'
+
+// INLINE
+
+/** Plain text. */
+export type Text = Readonly<{ _tag: 'Text'; value: string }>
+
+/** Inline code span. */
+export type InlineCode = Readonly<{ _tag: 'InlineCode'; value: string }>
+
+/** Hard line break. */
+export type HardBreak = Readonly<{ _tag: 'HardBreak' }>
+
+/** Emphasized content, usually rendered as `em`. */
+export type Emphasis = Readonly<{
+  _tag: 'Emphasis'
+  content: ReadonlyArray<Inline>
+}>
+
+/** Strongly emphasized content, usually rendered as `strong`. */
+export type Strong = Readonly<{
+  _tag: 'Strong'
+  content: ReadonlyArray<Inline>
+}>
+
+/** Struck-through content, usually rendered as `del`. */
+export type Strikethrough = Readonly<{
+  _tag: 'Strikethrough'
+  content: ReadonlyArray<Inline>
+}>
+
+/** Hyperlink with inline content. */
+export type Link = Readonly<{
+  _tag: 'Link'
+  url: string
+  maybeTitle: Option.Option<string>
+  content: ReadonlyArray<Inline>
+}>
+
+/** Image with alt text. */
+export type Image = Readonly<{
+  _tag: 'Image'
+  url: string
+  alt: string
+  maybeTitle: Option.Option<string>
+}>
+
+/** Any inline node. */
+export type Inline =
+  | Text
+  | InlineCode
+  | HardBreak
+  | Emphasis
+  | Strong
+  | Strikethrough
+  | Link
+  | Image
+
+/** The wire form of {@link Inline}, as emitted into compiled markdown modules. */
+export type InlineEncoded =
+  | Readonly<{ _tag: 'Text'; value: string }>
+  | Readonly<{ _tag: 'InlineCode'; value: string }>
+  | Readonly<{ _tag: 'HardBreak' }>
+  | Readonly<{ _tag: 'Emphasis'; content: ReadonlyArray<InlineEncoded> }>
+  | Readonly<{ _tag: 'Strong'; content: ReadonlyArray<InlineEncoded> }>
+  | Readonly<{ _tag: 'Strikethrough'; content: ReadonlyArray<InlineEncoded> }>
+  | Readonly<{
+      _tag: 'Link'
+      url: string
+      maybeTitle: string | null | undefined
+      content: ReadonlyArray<InlineEncoded>
+    }>
+  | Readonly<{
+      _tag: 'Image'
+      url: string
+      alt: string
+      maybeTitle: string | null | undefined
+    }>
+
+/** Schema for {@link Text}. */
+export const Text = ts('Text', { value: S.String })
+
+/** Schema for {@link InlineCode}. */
+export const InlineCode = ts('InlineCode', { value: S.String })
+
+/** Schema for {@link HardBreak}. */
+export const HardBreak = ts('HardBreak')
+
+// NOTE: Manual type definitions and the explicit annotation are required
+// because TypeScript cannot infer types for self-recursive schemas built
+// through S.suspend. Deriving the member types from their schemas instead
+// (`type Emphasis = typeof Emphasis.Type`) recreates the circularity through
+// the union alias and fails with TS2456, so the unions and their members stay
+// hand-written.
+/** Schema for {@link Inline}. */
+export const Inline: S.Codec<Inline, InlineEncoded> = S.suspend(() =>
+  S.Union([
+    Text,
+    InlineCode,
+    HardBreak,
+    Emphasis,
+    Strong,
+    Strikethrough,
+    Link,
+    Image,
+  ]),
+)
+
+/** Schema for {@link Emphasis}. */
+export const Emphasis = ts('Emphasis', { content: S.Array(Inline) })
+
+/** Schema for {@link Strong}. */
+export const Strong = ts('Strong', { content: S.Array(Inline) })
+
+/** Schema for {@link Strikethrough}. */
+export const Strikethrough = ts('Strikethrough', { content: S.Array(Inline) })
+
+/** Schema for {@link Link}. */
+export const Link = ts('Link', {
+  url: S.String,
+  maybeTitle: S.OptionFromNullishOr(S.String, { onNoneEncoding: null }),
+  content: S.Array(Inline),
+})
+
+/** Schema for {@link Image}. */
+export const Image = ts('Image', {
+  url: S.String,
+  alt: S.String,
+  maybeTitle: S.OptionFromNullishOr(S.String, { onNoneEncoding: null }),
+})
+
+// BLOCK
+
+/** Heading depth, `1` through `6`. */
+export const HeadingLevel = S.Literals([1, 2, 3, 4, 5, 6])
+export type HeadingLevel = typeof HeadingLevel.Type
+
+/** Column alignment of a table, from the delimiter row of the source. */
+export const Alignment = S.Literals(['None', 'Left', 'Center', 'Right'])
+export type Alignment = typeof Alignment.Type
+
+/** Section heading. */
+export type Heading = Readonly<{
+  _tag: 'Heading'
+  level: HeadingLevel
+  content: ReadonlyArray<Inline>
+}>
+
+/** Paragraph of inline content. */
+export type Paragraph = Readonly<{
+  _tag: 'Paragraph'
+  content: ReadonlyArray<Inline>
+}>
+
+/** Fenced code block. `maybeMeta` carries everything after the language on the opening fence. */
+export type CodeBlock = Readonly<{
+  _tag: 'CodeBlock'
+  maybeLanguage: Option.Option<string>
+  maybeMeta: Option.Option<string>
+  value: string
+}>
+
+/** Single list item holding block content, so lists nest. */
+export type ListItem = Readonly<{
+  _tag: 'ListItem'
+  blocks: ReadonlyArray<Block>
+}>
+
+/** Ordered or unordered list. */
+export type List = Readonly<{
+  _tag: 'List'
+  isOrdered: boolean
+  maybeStartNumber: Option.Option<number>
+  items: Array.NonEmptyReadonlyArray<ListItem>
+}>
+
+/** Block quotation holding block content. */
+export type Blockquote = Readonly<{
+  _tag: 'Blockquote'
+  blocks: ReadonlyArray<Block>
+}>
+
+/** Thematic break, usually rendered as `hr`. */
+export type ThematicBreak = Readonly<{ _tag: 'ThematicBreak' }>
+
+/** Single table cell of inline content. */
+export type TableCell = Readonly<{
+  _tag: 'TableCell'
+  content: ReadonlyArray<Inline>
+}>
+
+/** Single table row. */
+export type TableRow = Readonly<{
+  _tag: 'TableRow'
+  cells: ReadonlyArray<TableCell>
+}>
+
+/** GFM table. The first source row is the header row. */
+export type Table = Readonly<{
+  _tag: 'Table'
+  alignments: ReadonlyArray<Alignment>
+  headerRow: TableRow
+  bodyRows: ReadonlyArray<TableRow>
+}>
+
+/**
+ * Directive node reserved for live application views. A leaf directive
+ * (`::Name{attr="value"}`) has no blocks; a container directive
+ * (`:::Name` ... `:::`) carries its nested markdown as blocks.
+ */
+export type Island = Readonly<{
+  _tag: 'Island'
+  name: string
+  attributes: Readonly<Record<string, string>>
+  blocks: ReadonlyArray<Block>
+}>
+
+/** Any block node. */
+export type Block =
+  | Heading
+  | Paragraph
+  | CodeBlock
+  | List
+  | Blockquote
+  | ThematicBreak
+  | Table
+  | Island
+
+/** The wire form of {@link ListItem}. */
+export type ListItemEncoded = Readonly<{
+  _tag: 'ListItem'
+  blocks: ReadonlyArray<BlockEncoded>
+}>
+
+/** The wire form of {@link TableCell}. */
+export type TableCellEncoded = Readonly<{
+  _tag: 'TableCell'
+  content: ReadonlyArray<InlineEncoded>
+}>
+
+/** The wire form of {@link TableRow}. */
+export type TableRowEncoded = Readonly<{
+  _tag: 'TableRow'
+  cells: ReadonlyArray<TableCellEncoded>
+}>
+
+/** The wire form of {@link Block}, as emitted into compiled markdown modules. */
+export type BlockEncoded =
+  | Readonly<{
+      _tag: 'Heading'
+      level: HeadingLevel
+      content: ReadonlyArray<InlineEncoded>
+    }>
+  | Readonly<{ _tag: 'Paragraph'; content: ReadonlyArray<InlineEncoded> }>
+  | Readonly<{
+      _tag: 'CodeBlock'
+      maybeLanguage: string | null | undefined
+      maybeMeta: string | null | undefined
+      value: string
+    }>
+  | Readonly<{
+      _tag: 'List'
+      isOrdered: boolean
+      maybeStartNumber: number | null | undefined
+      items: Array.NonEmptyReadonlyArray<ListItemEncoded>
+    }>
+  | Readonly<{ _tag: 'Blockquote'; blocks: ReadonlyArray<BlockEncoded> }>
+  | Readonly<{ _tag: 'ThematicBreak' }>
+  | Readonly<{
+      _tag: 'Table'
+      alignments: ReadonlyArray<Alignment>
+      headerRow: TableRowEncoded
+      bodyRows: ReadonlyArray<TableRowEncoded>
+    }>
+  | Readonly<{
+      _tag: 'Island'
+      name: string
+      attributes: Readonly<Record<string, string>>
+      blocks: ReadonlyArray<BlockEncoded>
+    }>
+
+// NOTE: Manual type definitions and the explicit annotation are required
+// because TypeScript cannot infer types for self-recursive schemas built
+// through S.suspend. Deriving the member types from their schemas instead
+// (`type Emphasis = typeof Emphasis.Type`) recreates the circularity through
+// the union alias and fails with TS2456, so the unions and their members stay
+// hand-written.
+/** Schema for {@link Block}. */
+export const Block: S.Codec<Block, BlockEncoded> = S.suspend(() =>
+  S.Union([
+    Heading,
+    Paragraph,
+    CodeBlock,
+    List,
+    Blockquote,
+    ThematicBreak,
+    Table,
+    Island,
+  ]),
+)
+
+/** Schema for {@link Heading}. */
+export const Heading = ts('Heading', {
+  level: HeadingLevel,
+  content: S.Array(Inline),
+})
+
+/** Schema for {@link Paragraph}. */
+export const Paragraph = ts('Paragraph', { content: S.Array(Inline) })
+
+/** Schema for {@link CodeBlock}. */
+export const CodeBlock = ts('CodeBlock', {
+  maybeLanguage: S.OptionFromNullishOr(S.String, { onNoneEncoding: null }),
+  maybeMeta: S.OptionFromNullishOr(S.String, { onNoneEncoding: null }),
+  value: S.String,
+})
+
+/** Schema for {@link ListItem}. */
+export const ListItem = ts('ListItem', { blocks: S.Array(Block) })
+
+/** Schema for {@link List}. */
+export const List = ts('List', {
+  isOrdered: S.Boolean,
+  maybeStartNumber: S.OptionFromNullishOr(S.Number, { onNoneEncoding: null }),
+  items: S.NonEmptyArray(ListItem),
+})
+
+/** Schema for {@link Blockquote}. */
+export const Blockquote = ts('Blockquote', { blocks: S.Array(Block) })
+
+/** Schema for {@link ThematicBreak}. */
+export const ThematicBreak = ts('ThematicBreak')
+
+/** Schema for {@link TableCell}. */
+export const TableCell = ts('TableCell', { content: S.Array(Inline) })
+
+/** Schema for {@link TableRow}. */
+export const TableRow = ts('TableRow', { cells: S.Array(TableCell) })
+
+/** Schema for {@link Table}. */
+export const Table = ts('Table', {
+  alignments: S.Array(Alignment),
+  headerRow: TableRow,
+  bodyRows: S.Array(TableRow),
+})
+
+/** Schema for {@link Island}. */
+export const Island = ts('Island', {
+  name: S.String,
+  attributes: S.Record(S.String, S.String),
+  blocks: S.Array(Block),
+})
+
+// DOCUMENT
+
+/** A compiled markdown document: the block sequence of one source file. */
+export const MarkdownDocument = S.Struct({ blocks: S.Array(Block) })
+export type MarkdownDocument = typeof MarkdownDocument.Type
+
+/** The wire form of {@link MarkdownDocument}. */
+export type MarkdownDocumentEncoded = typeof MarkdownDocument.Encoded
+
+/**
+ * Decodes the default export of a compiled markdown module into a typed
+ * {@link MarkdownDocument}. Throws on input outside the markdown vocabulary.
+ */
+export const decodeDocument = S.decodeUnknownSync(MarkdownDocument)
+
+/** Encodes a {@link MarkdownDocument} into its JSON-safe wire form. */
+export const encodeDocument = S.encodeSync(MarkdownDocument)

--- a/packages/markdown/src/ast/index.ts
+++ b/packages/markdown/src/ast/index.ts
@@ -1,0 +1,1 @@
+export * from './ast.js'

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -1,0 +1,3 @@
+export * from './ast/index.js'
+export * from './island/index.js'
+export * from './view/index.js'

--- a/packages/markdown/src/island/index.ts
+++ b/packages/markdown/src/island/index.ts
@@ -1,0 +1,1 @@
+export * from './island.js'

--- a/packages/markdown/src/island/island.ts
+++ b/packages/markdown/src/island/island.ts
@@ -1,0 +1,19 @@
+import { Schema as S } from 'effect'
+
+/**
+ * Schema for one island's attributes: a struct that decodes the directive's
+ * string attributes into typed values. Use transforming field schemas to
+ * decode past strings, for example `S.NumberFromString` for numeric
+ * attributes.
+ */
+export type IslandDefinition = S.Struct<S.Struct.Fields> &
+  Readonly<{ DecodingServices: never; EncodingServices: never }>
+
+/**
+ * Attribute schemas by island directive name. One definition record serves
+ * both halves of the pipeline: the Vite plugin validates every directive
+ * against it at build time (unknown names, unknown attributes, and attribute
+ * values outside the schema all fail the build), and `islandsFor` decodes
+ * attributes with it before dispatching to the matching typed island view.
+ */
+export type IslandDefinitions = Readonly<Record<string, IslandDefinition>>

--- a/packages/markdown/src/view/index.ts
+++ b/packages/markdown/src/view/index.ts
@@ -1,0 +1,1 @@
+export * from './view.js'

--- a/packages/markdown/src/view/view.test.ts
+++ b/packages/markdown/src/view/view.test.ts
@@ -1,0 +1,279 @@
+import { Array, Option, Schema as S } from 'effect'
+import { html } from 'foldkit/html'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { parseMarkdown } from '../vite/vite.js'
+import { defaultViews, islandsFor, view } from './view.js'
+
+type TestVNode = Readonly<{
+  sel?: string | undefined
+  key?: string | undefined
+  text?: string | undefined
+  data?:
+    | Readonly<{
+        props?: Readonly<Record<string, unknown>> | undefined
+        style?: Readonly<Record<string, unknown>> | undefined
+      }>
+    | undefined
+  children?: ReadonlyArray<TestVNode | string> | undefined
+}>
+
+const asElement = (node: unknown): TestVNode => {
+  if (node === null || node === undefined || typeof node === 'string') {
+    throw new Error(`Expected an element vnode, got: ${String(node)}`)
+  }
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  return node as TestVNode
+}
+
+const childAt = (node: TestVNode, index: number): TestVNode =>
+  Option.match(Array.get(node.children ?? [], index), {
+    onNone: () => {
+      throw new Error(`Expected a child at index ${index} of <${node.sel}>`)
+    },
+    onSome: asElement,
+  })
+
+const textOf = (node: TestVNode): string =>
+  (node.children ?? [])
+    .map(child => {
+      if (typeof child === 'string') {
+        return child
+      }
+      if (child.text !== undefined) {
+        return child.text
+      }
+      return textOf(child)
+    })
+    .join('')
+
+const lines = (...sourceLines: ReadonlyArray<string>): string =>
+  sourceLines.join('\n')
+
+describe('view', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the default semantic elements in document order', () => {
+    const document = parseMarkdown(
+      lines('# Title', '', 'A paragraph.', '', '---'),
+    )
+
+    const root = asElement(view(document))
+
+    expect(root.sel).toBe('div')
+    expect(childAt(root, 0).sel).toBe('h1')
+    expect(textOf(childAt(root, 0))).toBe('Title')
+    expect(childAt(root, 1).sel).toBe('p')
+    expect(textOf(childAt(root, 1))).toBe('A paragraph.')
+    expect(childAt(root, 2).sel).toBe('hr')
+  })
+
+  it('renders every heading level to its matching element', () => {
+    const document = parseMarkdown(
+      lines(
+        '# one',
+        '## two',
+        '### three',
+        '#### four',
+        '##### five',
+        '###### six',
+      ),
+    )
+
+    const root = asElement(view(document))
+
+    expect(
+      (root.children ?? []).map(child => asElement(child).sel),
+    ).toStrictEqual(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+  })
+
+  it('renders nested inline content through the default views', () => {
+    const document = parseMarkdown(
+      'Some *emphasis*, `code`, and a [link](https://example.com).',
+    )
+
+    const paragraph = childAt(asElement(view(document)), 0)
+    const [, emphasis, , inlineCode, , link] = paragraph.children ?? []
+
+    expect(asElement(emphasis).sel).toBe('em')
+    expect(asElement(inlineCode).sel).toBe('code')
+    expect(asElement(link).sel).toBe('a')
+    expect(asElement(link).data?.props).toMatchObject({
+      href: 'https://example.com',
+    })
+  })
+
+  it('renders unordered and ordered lists', () => {
+    const unordered = parseMarkdown(lines('- one', '- two'))
+    const ordered = parseMarkdown(lines('3. three', '4. four'))
+
+    const unorderedList = childAt(asElement(view(unordered)), 0)
+    const orderedList = childAt(asElement(view(ordered)), 0)
+
+    expect(unorderedList.sel).toBe('ul')
+    expect(orderedList.sel).toBe('ol')
+    expect(orderedList.data?.props).toMatchObject({ start: 3 })
+    expect(childAt(orderedList, 0).sel).toBe('li')
+  })
+
+  it('renders table header and body cells with alignment styles', () => {
+    const document = parseMarkdown(
+      lines('| Stock | Speed |', '| :--- | ---: |', '| Portra | 400 |'),
+    )
+
+    const table = childAt(asElement(view(document)), 0)
+    const headerRow = childAt(childAt(table, 0), 0)
+    const bodyRow = childAt(childAt(table, 1), 0)
+
+    expect(table.sel).toBe('table')
+    expect(childAt(headerRow, 0).sel).toBe('th')
+    expect(childAt(headerRow, 0).data?.style).toMatchObject({
+      'text-align': 'left',
+    })
+    expect(childAt(bodyRow, 1).sel).toBe('td')
+    expect(childAt(bodyRow, 1).data?.style).toMatchObject({
+      'text-align': 'right',
+    })
+  })
+
+  it('renders islands through the registered view with attributes and nested content', () => {
+    const h = html()
+    const document = parseMarkdown(
+      lines(':::Note{tone="calm"}', 'Inside the island.', ':::'),
+    )
+
+    const root = asElement(
+      view(document, {
+        islands: {
+          Note: (attributes, content) =>
+            h.aside(
+              [h.Class(`note-${attributes['tone'] ?? 'plain'}`)],
+              content,
+            ),
+        },
+      }),
+    )
+
+    const island = childAt(root, 0)
+    expect(island.sel).toBe('aside')
+    expect(textOf(childAt(island, 0))).toBe('Inside the island.')
+  })
+
+  it('passes each island its per-name occurrence index in document order', () => {
+    const h = html()
+    const document = parseMarkdown(
+      lines('::Slot', '', 'Between.', '', '::Slot'),
+    )
+
+    const receivedIndexes: Array<number> = []
+    view(document, {
+      islands: {
+        Slot: (_attributes, _content, occurrenceIndex) => {
+          receivedIndexes.push(occurrenceIndex)
+          return h.div([], [])
+        },
+      },
+    })
+
+    expect(receivedIndexes).toStrictEqual([0, 1])
+  })
+
+  it('ignores inherited object members when resolving island views', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const document = parseMarkdown('::constructor')
+
+    const root = asElement(view(document, { islands: {} }))
+
+    expect(root.children ?? []).toHaveLength(0)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('No island view registered for "constructor"'),
+    )
+  })
+
+  it('warns once and renders nothing for an unregistered island', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const document = parseMarkdown(lines('::Missing', '', '::Missing'))
+
+    const root = asElement(view(document))
+    view(document)
+
+    expect(root.children ?? []).toHaveLength(0)
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('No island view registered for "Missing"'),
+    )
+  })
+
+  it('applies view overrides over the defaults', () => {
+    const h = html()
+    const document = parseMarkdown('A paragraph.')
+
+    const root = asElement(
+      view(document, {
+        views: {
+          Paragraph: (_paragraph, content) =>
+            h.p([h.Class('leading-relaxed')], content),
+        },
+      }),
+    )
+
+    expect(childAt(root, 0).data).toMatchObject({
+      class: { 'leading-relaxed': true },
+    })
+  })
+
+  it('islandsFor decodes attributes through the island schema before dispatch', () => {
+    const h = html()
+    const document = parseMarkdown('::Badge{label="hi"}')
+
+    const root = asElement(
+      view(document, {
+        islands: islandsFor(
+          { Badge: S.Struct({ label: S.optionalKey(S.String) }) },
+          {
+            Badge: ({ label }, _content, occurrenceIndex) =>
+              h.span([], [label ?? 'none', String(occurrenceIndex)]),
+          },
+        ),
+      }),
+    )
+
+    expect(textOf(childAt(root, 0))).toBe('hi0')
+  })
+
+  it('islandsFor warns and renders nothing when attributes fail the schema', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const h = html()
+    const document = parseMarkdown('::Gauge')
+
+    const root = asElement(
+      view(document, {
+        islands: islandsFor(
+          { Gauge: S.Struct({ level: S.String }) },
+          { Gauge: ({ level }) => h.span([], [level]) },
+        ),
+      }),
+    )
+
+    expect(root.children ?? []).toHaveLength(0)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid attributes for island "Gauge"'),
+    )
+  })
+
+  it('exposes the default views for reuse inside overrides', () => {
+    const document = parseMarkdown('# Title')
+
+    const root = asElement(
+      view(document, {
+        views: {
+          Heading: (heading, content) => defaultViews.Heading(heading, content),
+        },
+      }),
+    )
+
+    expect(childAt(root, 0).sel).toBe('h1')
+  })
+})

--- a/packages/markdown/src/view/view.ts
+++ b/packages/markdown/src/view/view.ts
@@ -1,0 +1,423 @@
+import {
+  Array,
+  Match as M,
+  Option,
+  Record as Record_,
+  Schema as S,
+} from 'effect'
+import { Html, html } from 'foldkit/html'
+
+import {
+  Alignment,
+  Block,
+  Blockquote,
+  CodeBlock,
+  Emphasis,
+  HardBreak,
+  Heading,
+  Image,
+  Inline,
+  InlineCode,
+  Island,
+  Link,
+  List,
+  ListItem,
+  MarkdownDocument,
+  Paragraph,
+  Strikethrough,
+  Strong,
+  Table,
+  TableCell,
+  TableRow,
+  Text,
+  ThematicBreak,
+} from '../ast/index.js'
+import type { IslandDefinitions } from '../island/index.js'
+
+const h = html()
+
+/** Rendered inline content, ready to pass as element children. */
+export type InlineContent = ReadonlyArray<Html | string>
+
+/**
+ * Renders one island directive. Receives the directive's attributes, the
+ * rendered nested blocks (empty for leaf directives), and the zero-based
+ * occurrence of this island name in the document, in document order. Use the
+ * occurrence index to derive identifiers that must be unique per instance,
+ * such as an `h.submodel` slotId.
+ */
+export type IslandView = (
+  attributes: Readonly<Record<string, string>>,
+  content: ReadonlyArray<Html>,
+  occurrenceIndex: number,
+) => Html
+
+/** Island views by directive name. */
+export type Islands = Readonly<Record<string, IslandView>>
+
+/**
+ * One typed island view per definition. Each view receives its attributes
+ * already decoded through the island's schema, so the record is exhaustive
+ * over the declared island names by construction.
+ */
+export type IslandViewsFor<Definitions extends IslandDefinitions> = Readonly<{
+  [Name in keyof Definitions]: (
+    attributes: Definitions[Name]['Type'],
+    content: ReadonlyArray<Html>,
+    occurrenceIndex: number,
+  ) => Html
+}>
+
+/**
+ * One view function per markdown node. Container nodes receive their already
+ * rendered content alongside the node itself.
+ */
+export type Views = Readonly<{
+  Text: (text: Text) => Html | string
+  InlineCode: (inlineCode: InlineCode) => Html
+  HardBreak: (hardBreak: HardBreak) => Html
+  Emphasis: (emphasis: Emphasis, content: InlineContent) => Html
+  Strong: (strong: Strong, content: InlineContent) => Html
+  Strikethrough: (strikethrough: Strikethrough, content: InlineContent) => Html
+  Link: (link: Link, content: InlineContent) => Html
+  Image: (image: Image) => Html
+  Heading: (heading: Heading, content: InlineContent) => Html
+  Paragraph: (paragraph: Paragraph, content: InlineContent) => Html
+  CodeBlock: (codeBlock: CodeBlock) => Html
+  List: (list: List, items: ReadonlyArray<Html>) => Html
+  ListItem: (listItem: ListItem, blocks: ReadonlyArray<Html>) => Html
+  Blockquote: (blockquote: Blockquote, blocks: ReadonlyArray<Html>) => Html
+  ThematicBreak: (thematicBreak: ThematicBreak) => Html
+  Table: (table: Table, headerRow: Html, bodyRows: ReadonlyArray<Html>) => Html
+  TableRow: (tableRow: TableRow, cells: ReadonlyArray<Html>) => Html
+  TableCell: (
+    tableCell: TableCell,
+    content: InlineContent,
+    alignment: Alignment,
+    isHeader: boolean,
+  ) => Html
+}>
+
+/** Configuration for {@link view} and {@link viewBlocks}. */
+export type ViewConfig = Readonly<{
+  islands?: Islands | undefined
+  views?: Partial<Views> | undefined
+}>
+
+const titleAttribute = (maybeTitle: Option.Option<string>) =>
+  Option.match(maybeTitle, {
+    onNone: () => [],
+    onSome: title => [h.Title(title)],
+  })
+
+const startAttribute = (maybeStartNumber: Option.Option<number>) =>
+  Option.match(maybeStartNumber, {
+    onNone: () => [],
+    onSome: startNumber => [h.Start(startNumber)],
+  })
+
+const alignmentAttribute = (alignment: Alignment) =>
+  M.value(alignment).pipe(
+    M.when('None', () => []),
+    M.when('Left', () => [h.Style({ 'text-align': 'left' })]),
+    M.when('Center', () => [h.Style({ 'text-align': 'center' })]),
+    M.when('Right', () => [h.Style({ 'text-align': 'right' })]),
+    M.exhaustive,
+  )
+
+/**
+ * Unstyled semantic defaults for every markdown node. Spread these into your
+ * own record and replace the nodes you want to restyle:
+ *
+ * @example
+ * ```typescript
+ * const blogViews: Markdown.Views = {
+ *   ...Markdown.defaultViews,
+ *   Paragraph: (paragraph, content) =>
+ *     h.p([h.Class('leading-relaxed text-stone-700')], content),
+ * }
+ * ```
+ */
+// NOTE: These views deliberately render without vdom keys. A markdown document
+// is immutable data, so a given position never switches branches within one
+// document, and per-branch keys like 'Ordered' or 'Header' would repeat across
+// sibling lists and cells, which corrupts snabbdom's keyed diff. Identity for a
+// whole document belongs on the consumer's key around the rendered output.
+export const defaultViews: Views = {
+  Text: ({ value }) => value,
+  InlineCode: ({ value }) => h.code([], [value]),
+  HardBreak: () => h.br([]),
+  Emphasis: (_emphasis, content) => h.em([], content),
+  Strong: (_strong, content) => h.strong([], content),
+  Strikethrough: (_strikethrough, content) => h.del([], content),
+  Link: ({ url, maybeTitle }, content) =>
+    h.a([h.Href(url), ...titleAttribute(maybeTitle)], content),
+  Image: ({ url, alt, maybeTitle }) =>
+    h.img([h.Src(url), h.Alt(alt), ...titleAttribute(maybeTitle)]),
+  Heading: ({ level }, content) =>
+    M.value(level).pipe(
+      M.withReturnType<Html>(),
+      M.when(1, () => h.h1([], content)),
+      M.when(2, () => h.h2([], content)),
+      M.when(3, () => h.h3([], content)),
+      M.when(4, () => h.h4([], content)),
+      M.when(5, () => h.h5([], content)),
+      M.when(6, () => h.h6([], content)),
+      M.exhaustive,
+    ),
+  Paragraph: (_paragraph, content) => h.p([], content),
+  CodeBlock: ({ value }) => h.pre([], [h.code([], [value])]),
+  List: ({ isOrdered, maybeStartNumber }, items) => {
+    if (isOrdered) {
+      return h.ol(startAttribute(maybeStartNumber), items)
+    } else {
+      return h.ul([], items)
+    }
+  },
+  ListItem: (_listItem, blocks) => h.li([], blocks),
+  Blockquote: (_blockquote, blocks) => h.blockquote([], blocks),
+  ThematicBreak: () => h.hr([]),
+  Table: (_table, headerRow, bodyRows) =>
+    h.table([], [h.thead([], [headerRow]), h.tbody([], bodyRows)]),
+  TableRow: (_tableRow, cells) => h.tr([], cells),
+  TableCell: (_tableCell, content, alignment, isHeader) => {
+    if (isHeader) {
+      return h.th(alignmentAttribute(alignment), content)
+    } else {
+      return h.td(alignmentAttribute(alignment), content)
+    }
+  },
+}
+
+const inlineView = (views: Views, inline: Inline): Html | string =>
+  M.value(inline).pipe(
+    M.withReturnType<Html | string>(),
+    M.tagsExhaustive({
+      Text: views.Text,
+      InlineCode: views.InlineCode,
+      HardBreak: views.HardBreak,
+      Emphasis: emphasis =>
+        views.Emphasis(emphasis, inlineContent(views, emphasis.content)),
+      Strong: strong =>
+        views.Strong(strong, inlineContent(views, strong.content)),
+      Strikethrough: strikethrough =>
+        views.Strikethrough(
+          strikethrough,
+          inlineContent(views, strikethrough.content),
+        ),
+      Link: link => views.Link(link, inlineContent(views, link.content)),
+      Image: views.Image,
+    }),
+  )
+
+const inlineContent = (
+  views: Views,
+  content: ReadonlyArray<Inline>,
+): InlineContent => Array.map(content, inline => inlineView(views, inline))
+
+const alignmentAt = (
+  alignments: ReadonlyArray<Alignment>,
+  columnIndex: number,
+): Alignment =>
+  Option.getOrElse(Array.get(alignments, columnIndex), () => 'None')
+
+const tableRowView = (
+  views: Views,
+  table: Table,
+  row: TableRow,
+  isHeader: boolean,
+): Html =>
+  views.TableRow(
+    row,
+    Array.map(row.cells, (cell, columnIndex) =>
+      views.TableCell(
+        cell,
+        inlineContent(views, cell.content),
+        alignmentAt(table.alignments, columnIndex),
+        isHeader,
+      ),
+    ),
+  )
+
+// NOTE: Warns once per island name for the lifetime of the process, not per
+// document, so a missing island in one document suppresses the warning for the
+// same name in every later document. Per-render warnings would flood the
+// console, since the fold runs on every Message dispatch.
+const warnedInvalidAttributeIslandNames = new Set<string>()
+
+const warnInvalidAttributesOnce = (
+  islandName: string,
+  detail: string,
+): void => {
+  if (!warnedInvalidAttributeIslandNames.has(islandName)) {
+    warnedInvalidAttributeIslandNames.add(islandName)
+    console.warn(
+      `[@foldkit/markdown] Invalid attributes for island "${islandName}", so it renders nothing. ` +
+        `Compile with the markdown plugin's islands option to catch this at build time. ${detail}`,
+    )
+  }
+}
+
+/**
+ * Pairs island attribute schemas with typed views, producing the plain
+ * {@link Islands} record the fold consumes. Attributes decode through each
+ * island's schema before dispatch, and the views record must cover every
+ * declared island name. Pass the same definitions to the markdown Vite
+ * plugin's `islands` option so invalid directives fail the build instead of
+ * reaching this decode.
+ */
+export const islandsFor = <const Definitions extends IslandDefinitions>(
+  definitions: Definitions,
+  islandViews: IslandViewsFor<Definitions>,
+): Islands => {
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  const islandViewsByName = islandViews as Readonly<
+    Record<
+      string,
+      (
+        attributes: unknown,
+        content: ReadonlyArray<Html>,
+        occurrenceIndex: number,
+      ) => Html
+    >
+  >
+
+  return Record_.map(definitions, (attributesSchema, islandName) => {
+    const decodeAttributes = S.decodeUnknownSync(attributesSchema)
+
+    return (attributes, content, occurrenceIndex) =>
+      Option.match(Record_.get(islandViewsByName, islandName), {
+        onNone: () => {
+          warnMissingIslandOnce(islandName)
+          return null
+        },
+        onSome: renderIsland => {
+          try {
+            return renderIsland(
+              decodeAttributes(attributes),
+              content,
+              occurrenceIndex,
+            )
+          } catch (error) {
+            warnInvalidAttributesOnce(
+              islandName,
+              error instanceof Error ? error.message : String(error),
+            )
+            return null
+          }
+        },
+      })
+  })
+}
+
+const warnedIslandNames = new Set<string>()
+
+const warnMissingIslandOnce = (islandName: string): void => {
+  if (!warnedIslandNames.has(islandName)) {
+    warnedIslandNames.add(islandName)
+    console.warn(
+      `[@foldkit/markdown] No island view registered for "${islandName}", so it renders nothing. ` +
+        'Add it to the islands record passed to Markdown.view.',
+    )
+  }
+}
+
+type IslandOccurrenceCounts = Map<string, number>
+
+const islandView = (
+  views: Views,
+  islands: Islands,
+  islandOccurrenceCounts: IslandOccurrenceCounts,
+  island: Island,
+): Html => {
+  const occurrenceIndex = islandOccurrenceCounts.get(island.name) ?? 0
+  islandOccurrenceCounts.set(island.name, occurrenceIndex + 1)
+
+  return Option.match(Record_.get(islands, island.name), {
+    onNone: () => {
+      warnMissingIslandOnce(island.name)
+      return null
+    },
+    onSome: renderIsland =>
+      renderIsland(
+        island.attributes,
+        Array.map(island.blocks, block =>
+          blockView(views, islands, islandOccurrenceCounts, block),
+        ),
+        occurrenceIndex,
+      ),
+  })
+}
+
+const blockView = (
+  views: Views,
+  islands: Islands,
+  islandOccurrenceCounts: IslandOccurrenceCounts,
+  block: Block,
+): Html =>
+  M.value(block).pipe(
+    M.withReturnType<Html>(),
+    M.tagsExhaustive({
+      Heading: heading =>
+        views.Heading(heading, inlineContent(views, heading.content)),
+      Paragraph: paragraph =>
+        views.Paragraph(paragraph, inlineContent(views, paragraph.content)),
+      CodeBlock: views.CodeBlock,
+      List: list =>
+        views.List(
+          list,
+          Array.map(list.items, item =>
+            views.ListItem(
+              item,
+              Array.map(item.blocks, child =>
+                blockView(views, islands, islandOccurrenceCounts, child),
+              ),
+            ),
+          ),
+        ),
+      Blockquote: blockquote =>
+        views.Blockquote(
+          blockquote,
+          Array.map(blockquote.blocks, child =>
+            blockView(views, islands, islandOccurrenceCounts, child),
+          ),
+        ),
+      ThematicBreak: views.ThematicBreak,
+      Table: table =>
+        views.Table(
+          table,
+          tableRowView(views, table, table.headerRow, true),
+          Array.map(table.bodyRows, row =>
+            tableRowView(views, table, row, false),
+          ),
+        ),
+      Island: island =>
+        islandView(views, islands, islandOccurrenceCounts, island),
+    }),
+  )
+
+/**
+ * Folds a document into one Html node per top-level block. Use this when the
+ * blocks should land directly inside your own container element.
+ */
+export const viewBlocks = (
+  document: MarkdownDocument,
+  config: ViewConfig = {},
+): ReadonlyArray<Html> => {
+  const views: Views = { ...defaultViews, ...config.views }
+  const islands = config.islands ?? {}
+  const islandOccurrenceCounts: IslandOccurrenceCounts = new Map()
+  return Array.map(document.blocks, block =>
+    blockView(views, islands, islandOccurrenceCounts, block),
+  )
+}
+
+/**
+ * Folds a document into a single Html tree. Every node renders through
+ * {@link defaultViews} unless overridden in `config.views`, and every Island
+ * directive renders through the matching entry in `config.islands`.
+ */
+export const view = (
+  document: MarkdownDocument,
+  config: ViewConfig = {},
+): Html => h.div([], viewBlocks(document, config))

--- a/packages/markdown/src/vite/normalize.ts
+++ b/packages/markdown/src/vite/normalize.ts
@@ -1,0 +1,313 @@
+import {
+  Array,
+  Match as M,
+  Option,
+  Record as Record_,
+  Schema as S,
+} from 'effect'
+import type {
+  ListItem as MdastListItem,
+  Table as MdastTable,
+  TableRow as MdastTableRow,
+  PhrasingContent,
+  Root,
+  RootContent,
+} from 'mdast'
+import type {} from 'mdast-util-directive'
+import type { Position } from 'unist'
+
+import {
+  Alignment,
+  Block,
+  Blockquote,
+  CodeBlock,
+  Emphasis,
+  HardBreak,
+  Heading,
+  Image,
+  Inline,
+  InlineCode,
+  Island,
+  Link,
+  List,
+  ListItem,
+  MarkdownDocument,
+  Paragraph,
+  Strikethrough,
+  Strong,
+  Table,
+  TableCell,
+  TableRow,
+  Text,
+  ThematicBreak,
+} from '../ast/index.js'
+import type { IslandDefinition, IslandDefinitions } from '../island/index.js'
+
+/**
+ * Options for {@link normalizeRoot}. `islands`, when provided, maps each
+ * allowed directive name to the schema for its attributes; unknown names,
+ * unknown attributes, and attribute values outside the schema all fail with
+ * an error naming the offender.
+ */
+export type NormalizeOptions = Readonly<{
+  islands?: IslandDefinitions | undefined
+}>
+
+type PositionedNode = Readonly<{
+  type: string
+  position?: Position | undefined
+}>
+
+type DirectiveNode = Readonly<{
+  name: string
+  attributes?:
+    | Readonly<Record<string, string | null | undefined>>
+    | null
+    | undefined
+  position?: Position | undefined
+}>
+
+const UNSUPPORTED_GUIDANCE: Readonly<Record<string, string>> = {
+  html: 'Raw HTML is not part of the markdown vocabulary. Use an island directive to render custom views.',
+  textDirective:
+    'Inline directives are not supported. Use a leaf directive (`::Name`) on its own line, or a container directive (`:::Name`).',
+  linkReference:
+    'Reference-style links are not supported. Use an inline link (`[text](url)`).',
+  imageReference:
+    'Reference-style images are not supported. Use an inline image (`![alt](url)`).',
+  definition:
+    'Reference-style link definitions are not supported. Use inline links (`[text](url)`).',
+  footnoteReference: 'Footnotes are not supported.',
+  footnoteDefinition: 'Footnotes are not supported.',
+  yaml: 'Frontmatter is not supported. Keep document metadata in application code, for example a typed post registry.',
+  'leaf directive label':
+    'Leaf directive labels (`::Name[label]`) are not supported. Pass information through attributes (`::Name{label="..."}`) instead.',
+}
+
+const sourceLocation = (
+  node: Readonly<{ position?: Position | undefined }>,
+): string => {
+  const line = node.position?.start.line
+  if (line === undefined) {
+    return ''
+  } else {
+    return ` (line ${line})`
+  }
+}
+
+const unsupported = (node: PositionedNode): never => {
+  const guidance =
+    UNSUPPORTED_GUIDANCE[node.type] ??
+    'It is outside the @foldkit/markdown vocabulary.'
+  throw new Error(
+    `Unsupported markdown node "${node.type}"${sourceLocation(node)}. ${guidance}`,
+  )
+}
+
+const normalizeAttributes = (
+  attributes:
+    | Readonly<Record<string, string | null | undefined>>
+    | null
+    | undefined,
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(attributes ?? {}).map(([name, value]) => [
+      name,
+      value ?? '',
+    ]),
+  )
+
+const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:/
+const SAFE_URL_SCHEME_PATTERN = /^(?:https?|mailto|tel):/i
+
+// NOTE: The scheme check runs against the URL with ASCII control characters
+// and spaces stripped, because browsers strip them too, so `java\tscript:`
+// would otherwise smuggle an executable scheme past a plain prefix test.
+const toSafeUrl = (
+  node: Readonly<{ position?: Position | undefined }>,
+  url: string,
+): string => {
+  const compactUrl = url.replace(/[\u0000-\u0020]/g, '')
+  if (
+    URL_SCHEME_PATTERN.test(compactUrl) &&
+    !SAFE_URL_SCHEME_PATTERN.test(compactUrl)
+  ) {
+    throw new Error(
+      `Unsupported URL scheme in "${url}"${sourceLocation(node)}. ` +
+        'Link and image URLs may be relative, or use the http:, https:, mailto:, or tel: schemes.',
+    )
+  }
+  return url
+}
+
+const toInline = (node: PhrasingContent): Inline =>
+  M.value(node).pipe(
+    M.withReturnType<Inline>(),
+    M.discriminators('type')({
+      text: ({ value }) => Text({ value }),
+      inlineCode: ({ value }) => InlineCode({ value }),
+      break: () => HardBreak(),
+      emphasis: ({ children }) => Emphasis({ content: children.map(toInline) }),
+      strong: ({ children }) => Strong({ content: children.map(toInline) }),
+      delete: ({ children }) =>
+        Strikethrough({ content: children.map(toInline) }),
+      link: linkNode =>
+        Link({
+          url: toSafeUrl(linkNode, linkNode.url),
+          maybeTitle: Option.fromNullishOr(linkNode.title),
+          content: linkNode.children.map(toInline),
+        }),
+      image: imageNode =>
+        Image({
+          url: toSafeUrl(imageNode, imageNode.url),
+          alt: imageNode.alt ?? '',
+          maybeTitle: Option.fromNullishOr(imageNode.title),
+        }),
+    }),
+    M.orElse(unsupported),
+  )
+
+const toAlignment = (align: 'left' | 'right' | 'center' | null): Alignment =>
+  M.value(align).pipe(
+    M.withReturnType<Alignment>(),
+    M.when('left', () => 'Left'),
+    M.when('center', () => 'Center'),
+    M.when('right', () => 'Right'),
+    M.orElse(() => 'None'),
+  )
+
+const toTableRow = (row: MdastTableRow): TableRow =>
+  TableRow({
+    cells: row.children.map(cell =>
+      TableCell({ content: cell.children.map(toInline) }),
+    ),
+  })
+
+/**
+ * Converts a parsed mdast tree into a typed {@link MarkdownDocument}.
+ * Throws on any node outside the markdown vocabulary.
+ */
+export const normalizeRoot = (
+  root: Root,
+  options: NormalizeOptions = {},
+): MarkdownDocument => {
+  const validateIslandAttributes = (
+    directive: DirectiveNode,
+    attributesSchema: IslandDefinition,
+    attributes: Readonly<Record<string, string>>,
+  ): void => {
+    const allowedAttributeNames = Object.keys(attributesSchema.fields)
+    const unknownAttributeNames = Object.keys(attributes).filter(
+      attributeName => !allowedAttributeNames.includes(attributeName),
+    )
+    if (Array.isArrayNonEmpty(unknownAttributeNames)) {
+      const allowedDescription = Array.match(allowedAttributeNames, {
+        onEmpty: () => 'It takes no attributes.',
+        onNonEmpty: names => `Allowed attributes: ${names.join(', ')}.`,
+      })
+      throw new Error(
+        `Unknown attribute "${Array.headNonEmpty(unknownAttributeNames)}" for island "${directive.name}"${sourceLocation(directive)}. ` +
+          allowedDescription,
+      )
+    }
+
+    try {
+      S.decodeUnknownSync(attributesSchema)(attributes)
+    } catch (error) {
+      throw new Error(
+        `Invalid attributes for island "${directive.name}"${sourceLocation(directive)}. ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  const toIsland = (
+    directive: DirectiveNode,
+    blocks: ReadonlyArray<Block>,
+  ): Island => {
+    const attributes = normalizeAttributes(directive.attributes)
+    const { islands } = options
+
+    if (islands !== undefined) {
+      Option.match(Record_.get(islands, directive.name), {
+        onNone: () => {
+          throw new Error(
+            `Unknown island "${directive.name}"${sourceLocation(directive)}. ` +
+              `Allowed islands: ${Object.keys(islands).join(', ')}.`,
+          )
+        },
+        onSome: attributesSchema =>
+          validateIslandAttributes(directive, attributesSchema, attributes),
+      })
+    }
+
+    return Island({ name: directive.name, attributes, blocks })
+  }
+
+  const toListItem = (node: MdastListItem): ListItem => {
+    if (node.checked === null || node.checked === undefined) {
+      return ListItem({ blocks: node.children.map(toBlock) })
+    } else {
+      return unsupported({ type: 'task list item', position: node.position })
+    }
+  }
+
+  const toTable = (node: MdastTable): Table =>
+    Array.matchLeft(node.children.map(toTableRow), {
+      onEmpty: () => unsupported(node),
+      onNonEmpty: (headerRow, bodyRows) =>
+        Table({
+          alignments: (node.align ?? []).map(toAlignment),
+          headerRow,
+          bodyRows,
+        }),
+    })
+
+  const toBlock = (node: RootContent): Block =>
+    M.value(node).pipe(
+      M.withReturnType<Block>(),
+      M.discriminators('type')({
+        heading: ({ depth, children }) =>
+          Heading({ level: depth, content: children.map(toInline) }),
+        paragraph: ({ children }) =>
+          Paragraph({ content: children.map(toInline) }),
+        code: ({ lang, meta, value }) =>
+          CodeBlock({
+            maybeLanguage: Option.fromNullishOr(lang),
+            maybeMeta: Option.fromNullishOr(meta),
+            value,
+          }),
+        list: listNode => {
+          const items = listNode.children.map(toListItem)
+          // Array.match?
+          if (Array.isArrayNonEmpty(items)) {
+            return List({
+              isOrdered: listNode.ordered === true,
+              maybeStartNumber: Option.fromNullishOr(listNode.start),
+              items,
+            })
+          } else {
+            return unsupported(listNode)
+          }
+        },
+        blockquote: ({ children }) =>
+          Blockquote({ blocks: children.map(toBlock) }),
+        thematicBreak: () => ThematicBreak(),
+        table: toTable,
+        leafDirective: directive =>
+          Array.match(directive.children, {
+            onEmpty: () => toIsland(directive, []),
+            onNonEmpty: () =>
+              unsupported({
+                type: 'leaf directive label',
+                position: directive.position,
+              }),
+          }),
+        containerDirective: directive =>
+          toIsland(directive, directive.children.map(toBlock)),
+      }),
+      M.orElse(unsupported),
+    )
+
+  return { blocks: root.children.map(toBlock) }
+}

--- a/packages/markdown/src/vite/public.ts
+++ b/packages/markdown/src/vite/public.ts
@@ -1,0 +1,2 @@
+export { markdown, parseMarkdown } from './vite.js'
+export type { MarkdownPluginOptions } from './vite.js'

--- a/packages/markdown/src/vite/vite.test.ts
+++ b/packages/markdown/src/vite/vite.test.ts
@@ -1,0 +1,455 @@
+import { Option, Schema as S } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { decodeDocument, encodeDocument } from '../ast/index.js'
+import { markdown, parseMarkdown } from './vite.js'
+import type { MarkdownPluginOptions } from './vite.js'
+
+const lines = (...sourceLines: ReadonlyArray<string>): string =>
+  sourceLines.join('\n')
+
+describe('parseMarkdown', () => {
+  it('parses the core block vocabulary in document order', () => {
+    const document = parseMarkdown(
+      lines(
+        '# Title',
+        '',
+        'A paragraph.',
+        '',
+        '> Quoted.',
+        '',
+        '- one',
+        '- two',
+        '',
+        '---',
+        '',
+        '~~~ts twoslash',
+        'const count = 1',
+        '~~~',
+      ),
+    )
+
+    expect(document.blocks.map(block => block._tag)).toStrictEqual([
+      'Heading',
+      'Paragraph',
+      'Blockquote',
+      'List',
+      'ThematicBreak',
+      'CodeBlock',
+    ])
+  })
+
+  it('parses headings with their level and inline content', () => {
+    const document = parseMarkdown('## Two words')
+
+    expect(document.blocks).toStrictEqual([
+      {
+        _tag: 'Heading',
+        level: 2,
+        content: [{ _tag: 'Text', value: 'Two words' }],
+      },
+    ])
+  })
+
+  it('parses nested inline content', () => {
+    const document = parseMarkdown(
+      'Some *emphasis with `code`*, **strength**, ~~loss~~, and a [link](https://example.com "Example").',
+    )
+
+    expect(document.blocks).toStrictEqual([
+      {
+        _tag: 'Paragraph',
+        content: [
+          { _tag: 'Text', value: 'Some ' },
+          {
+            _tag: 'Emphasis',
+            content: [
+              { _tag: 'Text', value: 'emphasis with ' },
+              { _tag: 'InlineCode', value: 'code' },
+            ],
+          },
+          { _tag: 'Text', value: ', ' },
+          { _tag: 'Strong', content: [{ _tag: 'Text', value: 'strength' }] },
+          { _tag: 'Text', value: ', ' },
+          {
+            _tag: 'Strikethrough',
+            content: [{ _tag: 'Text', value: 'loss' }],
+          },
+          { _tag: 'Text', value: ', and a ' },
+          {
+            _tag: 'Link',
+            url: 'https://example.com',
+            maybeTitle: Option.some('Example'),
+            content: [{ _tag: 'Text', value: 'link' }],
+          },
+          { _tag: 'Text', value: '.' },
+        ],
+      },
+    ])
+  })
+
+  it('parses images with alt text', () => {
+    const document = parseMarkdown('![A film photograph](./photo.jpg)')
+
+    expect(document.blocks).toStrictEqual([
+      {
+        _tag: 'Paragraph',
+        content: [
+          {
+            _tag: 'Image',
+            url: './photo.jpg',
+            alt: 'A film photograph',
+            maybeTitle: Option.none(),
+          },
+        ],
+      },
+    ])
+  })
+
+  it('captures code block language and meta from the opening fence', () => {
+    const document = parseMarkdown(
+      lines('~~~ts filename=main.ts', 'const count = 1', '~~~'),
+    )
+
+    expect(document.blocks).toStrictEqual([
+      {
+        _tag: 'CodeBlock',
+        maybeLanguage: Option.some('ts'),
+        maybeMeta: Option.some('filename=main.ts'),
+        value: 'const count = 1',
+      },
+    ])
+  })
+
+  it('parses nested lists as block content of the parent item', () => {
+    const document = parseMarkdown(
+      lines('1. outer', '   - inner one', '   - inner two'),
+    )
+
+    expect(document.blocks).toStrictEqual([
+      {
+        _tag: 'List',
+        isOrdered: true,
+        maybeStartNumber: Option.some(1),
+        items: [
+          {
+            _tag: 'ListItem',
+            blocks: [
+              {
+                _tag: 'Paragraph',
+                content: [{ _tag: 'Text', value: 'outer' }],
+              },
+              {
+                _tag: 'List',
+                isOrdered: false,
+                maybeStartNumber: Option.none(),
+                items: [
+                  {
+                    _tag: 'ListItem',
+                    blocks: [
+                      {
+                        _tag: 'Paragraph',
+                        content: [{ _tag: 'Text', value: 'inner one' }],
+                      },
+                    ],
+                  },
+                  {
+                    _tag: 'ListItem',
+                    blocks: [
+                      {
+                        _tag: 'Paragraph',
+                        content: [{ _tag: 'Text', value: 'inner two' }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('parses tables with per-column alignments and a header row', () => {
+    const document = parseMarkdown(
+      lines(
+        '| Stock | Speed |',
+        '| :--- | ---: |',
+        '| Portra | 400 |',
+        '| Ektar | 100 |',
+      ),
+    )
+
+    expect(document.blocks).toStrictEqual([
+      {
+        _tag: 'Table',
+        alignments: ['Left', 'Right'],
+        headerRow: {
+          _tag: 'TableRow',
+          cells: [
+            { _tag: 'TableCell', content: [{ _tag: 'Text', value: 'Stock' }] },
+            { _tag: 'TableCell', content: [{ _tag: 'Text', value: 'Speed' }] },
+          ],
+        },
+        bodyRows: [
+          {
+            _tag: 'TableRow',
+            cells: [
+              {
+                _tag: 'TableCell',
+                content: [{ _tag: 'Text', value: 'Portra' }],
+              },
+              { _tag: 'TableCell', content: [{ _tag: 'Text', value: '400' }] },
+            ],
+          },
+          {
+            _tag: 'TableRow',
+            cells: [
+              {
+                _tag: 'TableCell',
+                content: [{ _tag: 'Text', value: 'Ektar' }],
+              },
+              { _tag: 'TableCell', content: [{ _tag: 'Text', value: '100' }] },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('parses a leaf directive into an island with attributes and no blocks', () => {
+    const document = parseMarkdown('::Counter{label="Clicks"}')
+
+    expect(document.blocks).toStrictEqual([
+      {
+        _tag: 'Island',
+        name: 'Counter',
+        attributes: { label: 'Clicks' },
+        blocks: [],
+      },
+    ])
+  })
+
+  it('parses a container directive into an island with nested blocks', () => {
+    const document = parseMarkdown(
+      lines(':::Note', 'Nested *prose* inside.', ':::'),
+    )
+
+    expect(document.blocks).toStrictEqual([
+      {
+        _tag: 'Island',
+        name: 'Note',
+        attributes: {},
+        blocks: [
+          {
+            _tag: 'Paragraph',
+            content: [
+              { _tag: 'Text', value: 'Nested ' },
+              { _tag: 'Emphasis', content: [{ _tag: 'Text', value: 'prose' }] },
+              { _tag: 'Text', value: ' inside.' },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('round-trips through the JSON wire form', () => {
+    const document = parseMarkdown(
+      lines(
+        '# Title',
+        '',
+        'Prose with a [link](https://example.com).',
+        '',
+        '3. starts at three',
+        '',
+        '::Counter{label="Clicks"}',
+      ),
+    )
+
+    const wire: unknown = JSON.parse(JSON.stringify(encodeDocument(document)))
+
+    expect(decodeDocument(wire)).toStrictEqual(document)
+  })
+
+  it('accepts declared islands and validates their attributes', () => {
+    const document = parseMarkdown('::Counter{label="Clicks"}', {
+      islands: { Counter: S.Struct({ label: S.optionalKey(S.String) }) },
+    })
+
+    expect(document.blocks.map(block => block._tag)).toStrictEqual(['Island'])
+  })
+
+  it('rejects non-schema island definitions from untyped callers', () => {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const malformedOptions = {
+      islands: { Counter: ['label'] },
+    } as unknown as MarkdownPluginOptions
+
+    expect(() => parseMarkdown('::Counter', malformedOptions)).toThrowError(
+      'Island "Counter" in markdown plugin options must map to a Schema struct describing its attributes.',
+    )
+  })
+
+  it('rejects island names missing from the declared islands', () => {
+    expect(() =>
+      parseMarkdown('::Conuter', {
+        islands: { Counter: S.Struct({}), Note: S.Struct({}) },
+      }),
+    ).toThrowError(
+      'Unknown island "Conuter" (line 1). Allowed islands: Counter, Note.',
+    )
+  })
+
+  it('rejects attributes missing from the island schema', () => {
+    expect(() =>
+      parseMarkdown('::Counter{labl="Clicks"}', {
+        islands: { Counter: S.Struct({ label: S.optionalKey(S.String) }) },
+      }),
+    ).toThrowError(
+      'Unknown attribute "labl" for island "Counter" (line 1). Allowed attributes: label.',
+    )
+  })
+
+  it('rejects attributes on islands that declare none', () => {
+    expect(() =>
+      parseMarkdown(lines(':::Note{tone="calm"}', 'Prose.', ':::'), {
+        islands: { Note: S.Struct({}) },
+      }),
+    ).toThrowError(
+      'Unknown attribute "tone" for island "Note" (line 1). It takes no attributes.',
+    )
+  })
+
+  it('rejects attribute values outside the island schema', () => {
+    expect(() =>
+      parseMarkdown('::Counter', {
+        islands: { Counter: S.Struct({ label: S.String }) },
+      }),
+    ).toThrowError(/Invalid attributes for island "Counter" \(line 1\)/)
+  })
+
+  it('rejects raw HTML blocks', () => {
+    expect(() => parseMarkdown('<div>raw</div>')).toThrowError(
+      /Unsupported markdown node "html" \(line 1\)/,
+    )
+  })
+
+  it('rejects raw inline HTML', () => {
+    expect(() => parseMarkdown('Some <em>raw</em> HTML.')).toThrowError(
+      /Unsupported markdown node "html"/,
+    )
+  })
+
+  it('rejects reference-style links', () => {
+    expect(() =>
+      parseMarkdown(
+        lines('See [the docs][docs].', '', '[docs]: https://example.com'),
+      ),
+    ).toThrowError(/Reference-style links are not supported/)
+  })
+
+  it('rejects task list items', () => {
+    expect(() => parseMarkdown('- [ ] pending')).toThrowError(
+      /Unsupported markdown node "task list item" \(line 1\)/,
+    )
+  })
+
+  it('rejects inline directives', () => {
+    expect(() => parseMarkdown('An inline :Counter directive.')).toThrowError(
+      /Inline directives are not supported/,
+    )
+  })
+
+  it('rejects leaf directive labels', () => {
+    expect(() => parseMarkdown('::Counter[Clicks while reading]')).toThrowError(
+      /Leaf directive labels \(`::Name\[label\]`\) are not supported/,
+    )
+  })
+
+  it('rejects executable URL schemes in links and images', () => {
+    expect(() => parseMarkdown('[click](javascript:alert(1))')).toThrowError(
+      /Unsupported URL scheme in "javascript:alert\(1\)" \(line 1\)/,
+    )
+    expect(() => parseMarkdown('[click](JaVaScRiPt:alert(1))')).toThrowError(
+      /Unsupported URL scheme/,
+    )
+    expect(() =>
+      parseMarkdown('[click](java&#9;script:alert(1))'),
+    ).toThrowError(/Unsupported URL scheme/)
+    expect(() =>
+      parseMarkdown('![x](data:image/svg+xml,payload)'),
+    ).toThrowError(/Unsupported URL scheme/)
+  })
+
+  it('accepts relative, fragment, and allowlisted absolute URLs', () => {
+    const document = parseMarkdown(
+      lines(
+        '[relative](./posts)',
+        '[fragment](#the-fold)',
+        '[absolute](https://example.com)',
+        '[email](mailto:devin@example.com)',
+      ),
+    )
+
+    expect(document.blocks).toHaveLength(1)
+  })
+
+  it('rejects non-Struct island schemas', () => {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const malformedOptions = {
+      islands: { Counter: S.String },
+    } as unknown as MarkdownPluginOptions
+
+    expect(() => parseMarkdown('::Counter', malformedOptions)).toThrowError(
+      'Island "Counter" in markdown plugin options must map to a Schema struct describing its attributes.',
+    )
+  })
+
+  it('rejects YAML frontmatter', () => {
+    expect(() =>
+      parseMarkdown(lines('---', 'title: My Post', '---', '', 'Prose.')),
+    ).toThrowError(/Frontmatter is not supported/)
+  })
+})
+
+describe('markdown', () => {
+  const runTransform = (source: string, id: string) => {
+    const plugin = markdown({
+      islands: { Counter: S.Struct({ label: S.optionalKey(S.String) }) },
+    })
+    if (typeof plugin.transform !== 'function') {
+      throw new Error('Expected the plugin transform hook to be a function')
+    }
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const transform = plugin.transform as unknown as (
+      source: string,
+      id: string,
+    ) => Readonly<{ code: string }> | undefined
+    return transform(source, id)
+  }
+
+  it('compiles .md modules into a decodable encoded default export', () => {
+    const result = runTransform('# Title', '/site/src/content/about.md')
+
+    if (result === undefined) {
+      throw new Error('Expected the transform to compile the .md module')
+    }
+    expect(result.code.startsWith('export default ')).toBe(true)
+
+    const wire: unknown = JSON.parse(
+      result.code.slice('export default '.length),
+    )
+    expect(decodeDocument(wire).blocks.map(block => block._tag)).toStrictEqual([
+      'Heading',
+    ])
+  })
+
+  it('leaves non-markdown modules untouched', () => {
+    expect(runTransform('# Title', '/site/src/main.ts')).toBeUndefined()
+    expect(
+      runTransform('# Title', '/site/src/content/about.md.bak'),
+    ).toBeUndefined()
+  })
+})

--- a/packages/markdown/src/vite/vite.ts
+++ b/packages/markdown/src/vite/vite.ts
@@ -1,0 +1,81 @@
+import { Schema as S } from 'effect'
+import remarkDirective from 'remark-directive'
+import remarkFrontmatter from 'remark-frontmatter'
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+import type { Plugin } from 'vite'
+
+import { MarkdownDocument, encodeDocument } from '../ast/index.js'
+import { normalizeRoot } from './normalize.js'
+import type { NormalizeOptions } from './normalize.js'
+
+// NOTE: remark-frontmatter is included so that YAML frontmatter parses as one
+// `yaml` node and fails the build with guidance. Without it, remark reads
+// `---` fences as a thematic break plus a setext heading and renders garbage.
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkFrontmatter)
+  .use(remarkGfm)
+  .use(remarkDirective)
+  .freeze()
+
+/** Options for {@link markdown} and {@link parseMarkdown}. */
+export type MarkdownPluginOptions = NormalizeOptions
+
+const validateMarkdownPluginOptions = (
+  options: MarkdownPluginOptions,
+): MarkdownPluginOptions => {
+  const islands = options.islands
+  if (islands === undefined) {
+    return options
+  }
+  for (const [islandName, attributesSchema] of Object.entries(islands)) {
+    if (!S.isSchema(attributesSchema) || !('fields' in attributesSchema)) {
+      throw new Error(
+        `Island "${islandName}" in markdown plugin options must map to a Schema struct describing its attributes.`,
+      )
+    }
+  }
+  return options
+}
+
+const parseWithValidatedOptions = (
+  source: string,
+  options: NormalizeOptions,
+): MarkdownDocument => normalizeRoot(processor.parse(source), options)
+
+/**
+ * Parses markdown source into a typed {@link MarkdownDocument}. Throws on any
+ * construct outside the markdown vocabulary, and on malformed options. The
+ * {@link markdown} plugin runs this per `.md` module; call it directly for
+ * one-off compilation in scripts.
+ */
+export const parseMarkdown = (
+  source: string,
+  options: MarkdownPluginOptions = {},
+): MarkdownDocument =>
+  parseWithValidatedOptions(source, validateMarkdownPluginOptions(options))
+
+/**
+ * Vite plugin that compiles imported `.md` files at build time into typed
+ * document modules. Decode the default export with `decodeDocument` and
+ * render it with `Markdown.view`.
+ */
+export const markdown = (options: MarkdownPluginOptions = {}): Plugin => {
+  const validatedOptions = validateMarkdownPluginOptions(options)
+
+  return {
+    name: 'foldkit-markdown',
+    transform(source, id) {
+      if (!id.endsWith('.md')) {
+        return undefined
+      }
+      const document = parseWithValidatedOptions(source, validatedOptions)
+      return {
+        code: `export default ${JSON.stringify(encodeDocument(document))}`,
+        map: null,
+      }
+    },
+  }
+}

--- a/packages/markdown/tsconfig.base.json
+++ b/packages/markdown/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/markdown/tsconfig.build.json
+++ b/packages/markdown/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/markdown/tsconfig.json
+++ b/packages/markdown/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.base.json"
+}

--- a/packages/markdown/vitest.config.ts
+++ b/packages/markdown/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+  },
+})

--- a/packages/website/scripts/playgroundFilesPlugin.ts
+++ b/packages/website/scripts/playgroundFilesPlugin.ts
@@ -1,6 +1,6 @@
-import { Array } from 'effect'
+import { Array, Option } from 'effect'
 import { readFile, readdir } from 'node:fs/promises'
-import { dirname, extname, join, relative, resolve } from 'node:path'
+import { dirname, extname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Plugin } from 'vite'
 
@@ -18,6 +18,7 @@ const WORKSPACE_PACKAGE_JSON_PATHS: Readonly<Record<string, string>> = {
   foldkit: resolve(WEBSITE_ROOT, '../foldkit/package.json'),
   '@foldkit/ui': resolve(WEBSITE_ROOT, '../ui/package.json'),
   '@foldkit/devtools': resolve(WEBSITE_ROOT, '../devtools/package.json'),
+  '@foldkit/markdown': resolve(WEBSITE_ROOT, '../markdown/package.json'),
   '@foldkit/vite-plugin': resolve(
     WEBSITE_ROOT,
     '../vite-plugin-foldkit/package.json',
@@ -28,7 +29,14 @@ const TS_CONFIG_BASE_PATH = resolve(WEBSITE_ROOT, '../../tsconfig.base.json')
 const VIRTUAL_MODULE_ID = 'virtual:playground-files'
 const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID
 
-const INCLUDED_EXTENSIONS = new Set(['.ts', '.tsx', '.css', '.html', '.json'])
+const INCLUDED_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.css',
+  '.html',
+  '.json',
+  '.md',
+])
 const EXPECTED_SKIP_EXTENSIONS = new Set([
   '.gif',
   '.ico',
@@ -36,7 +44,6 @@ const EXPECTED_SKIP_EXTENSIONS = new Set([
   '.jpg',
   '.log',
   '.map',
-  '.md',
   '.png',
   '.svg',
   '.tsbuildinfo',
@@ -62,6 +69,14 @@ export default defineConfig({
   plugins: [tailwindcss(), foldkit()],
 })
 `
+
+// NOTE: An example's vite.config.ts imports the monorepo alias helper, which
+// does not exist inside the WebContainer, so the playground replaces it with
+// STANDALONE_VITE_CONFIG. An example that needs extra plugins in the
+// playground (e.g. personal-blog's markdown compiler) ships a
+// vite.config.playground.ts written against published packages; when present,
+// its contents become the WebContainer's vite.config.ts instead.
+const PLAYGROUND_VITE_CONFIG_FILENAME = 'vite.config.playground.ts'
 
 const ROOT_LOADING_MARKUP = `<div id="root"><div style="display:flex;align-items:center;justify-content:center;min-height:100vh;font-family:system-ui,-apple-system,sans-serif;font-size:14px;color:#9ca3af">Loading\u2026</div></div>`
 
@@ -223,24 +238,44 @@ const buildExampleFileMap = async (
   const exampleDirectory = resolve(EXAMPLES_DIRECTORY, slug)
   const rawFiles = await collectFiles(exampleDirectory, exampleDirectory)
 
-  const transformedEntries = rawFiles.map(([path, contents]) => {
-    if (path === 'package.json') {
-      return [path, transformPackageJson(contents, versions)] as const
-    }
-    if (path === 'tsconfig.json') {
-      return [
-        path,
-        transformTsConfig(contents, baseCompilerOptions, baseExclude),
-      ] as const
-    }
-    if (path === 'vite.config.ts') {
-      return [path, STANDALONE_VITE_CONFIG] as const
-    }
-    if (path === 'index.html') {
-      return [path, injectLoadingPlaceholder(contents, slug)] as const
-    }
-    return [path, contents] as const
-  })
+  const standaloneViteConfig = Option.getOrElse(
+    Option.map(
+      Array.findFirst(
+        rawFiles,
+        ([path]) => path === PLAYGROUND_VITE_CONFIG_FILENAME,
+      ),
+      ([, contents]) => contents,
+    ),
+    () => STANDALONE_VITE_CONFIG,
+  )
+
+  // NOTE: Markdown is bundled only from src/, where it is app content compiled
+  // by @foldkit/markdown. Root-level markdown (README, CHANGELOG) is
+  // documentation and stays out of the WebContainer.
+  const transformedEntries = rawFiles
+    .filter(([path]) => path !== PLAYGROUND_VITE_CONFIG_FILENAME)
+    .filter(
+      ([path]) =>
+        extname(path) !== '.md' || path.split(sep).join('/').startsWith('src/'),
+    )
+    .map(([path, contents]) => {
+      if (path === 'package.json') {
+        return [path, transformPackageJson(contents, versions)] as const
+      }
+      if (path === 'tsconfig.json') {
+        return [
+          path,
+          transformTsConfig(contents, baseCompilerOptions, baseExclude),
+        ] as const
+      }
+      if (path === 'vite.config.ts') {
+        return [path, standaloneViteConfig] as const
+      }
+      if (path === 'index.html') {
+        return [path, injectLoadingPlaceholder(contents, slug)] as const
+      }
+      return [path, contents] as const
+    })
 
   return Object.fromEntries(transformedEntries)
 }

--- a/packages/website/src/page/example/meta.ts
+++ b/packages/website/src/page/example/meta.ts
@@ -31,6 +31,7 @@ export const ExampleSlug = S.Literals([
   'web-components',
   'embedding',
   'ui-showcase',
+  'personal-blog',
 ])
 export type ExampleSlug = typeof ExampleSlug.Type
 
@@ -294,6 +295,15 @@ export const examples: ReadonlyArray<ExampleMeta> = [
       'Interactive showcase of every Foldkit UI component with styled examples, routing, and component state management.',
     difficulty: 'Advanced',
     tags: ['UI Components', 'Routing'],
+    hasRouting: true,
+  },
+  {
+    slug: 'personal-blog',
+    title: 'Personal Blog',
+    description:
+      'Blog whose prose lives in markdown files. The @foldkit/markdown Vite plugin compiles each file into a typed document at build time, the app restyles the fold with per-node view overrides, and directive islands place a live Counter Submodel and a Note callout between paragraphs.',
+    difficulty: 'Advanced',
+    tags: ['Markdown', 'Islands', 'Submodels', 'Routing'],
     hasRouting: true,
   },
 ]

--- a/packages/website/src/page/example/sources.ts
+++ b/packages/website/src/page/example/sources.ts
@@ -45,6 +45,7 @@ const loadersBySlug: Readonly<Record<string, SourceLoader | undefined>> = {
   'web-components': () => import('virtual:example-sources/web-components'),
   embedding: () => import('virtual:example-sources/embedding'),
   'ui-showcase': () => import('virtual:example-sources/ui-showcase'),
+  'personal-blog': () => import('virtual:example-sources/personal-blog'),
 }
 
 export const loadSourcesForSlug = async (

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -766,7 +766,7 @@ const RESOLVED_EXAMPLE_SOURCES_PREFIX = '\0' + EXAMPLE_SOURCES_PREFIX
 
 const EXAMPLE_SLUG_SET: Set<string> = new Set(exampleSlugs)
 
-const EXAMPLE_FILE_EXTENSIONS = new Set(['.ts', '.tsx', '.css'])
+const EXAMPLE_FILE_EXTENSIONS = new Set(['.ts', '.tsx', '.css', '.md'])
 
 const langFromExtension = (filePath: string): string => {
   const extension = extname(filePath)
@@ -775,6 +775,9 @@ const langFromExtension = (filePath: string): string => {
   }
   if (extension === '.css') {
     return 'css'
+  }
+  if (extension === '.md') {
+    return 'markdown'
   }
   return 'typescript'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,6 +818,58 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.4)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  examples/personal-blog:
+    dependencies:
+      '@effect/platform-browser':
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97(effect@4.0.0-beta.97)
+      '@foldkit/devtools':
+        specifier: workspace:*
+        version: link:../../packages/devtools
+      '@foldkit/markdown':
+        specifier: workspace:*
+        version: link:../../packages/markdown
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@tailwindcss/vite':
+        specifier: ^4.3.1
+        version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      effect:
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97
+      foldkit:
+        specifier: workspace:*
+        version: link:../../packages/foldkit
+      tailwindcss:
+        specifier: ^4.3.1
+        version: 4.3.1
+    devDependencies:
+      '@foldkit/vite-plugin':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-foldkit
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^6.0.2
+        version: 6.0.2(@vue/compiler-sfc@3.5.38)(prettier@3.8.4)
+      happy-dom:
+        specifier: ^20.10.4
+        version: 20.10.4
+      prettier:
+        specifier: ^3.8.4
+        version: 3.8.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.4)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   examples/pixel-art:
     dependencies:
       '@effect/platform-browser':
@@ -1628,6 +1680,55 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.4)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/markdown:
+    dependencies:
+      remark-directive:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+    devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
+      effect:
+        specifier: 4.0.0-beta.97
+        version: 4.0.0-beta.97
+      foldkit:
+        specifier: workspace:*
+        version: link:../foldkit
+      happy-dom:
+        specifier: ^20.10.4
+        version: 20.10.4
+      mdast-util-directive:
+        specifier: ^3.1.0
+        version: 3.1.0
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.4)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -3339,6 +3440,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -3360,6 +3464,9 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -3376,6 +3483,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3654,6 +3764,9 @@ packages:
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3735,6 +3848,12 @@ packages:
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -3858,6 +3977,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -4033,6 +4155,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
@@ -4117,6 +4243,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -4142,6 +4271,9 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -4192,6 +4324,10 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
@@ -4373,9 +4509,18 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -4384,6 +4529,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -4396,6 +4544,10 @@ packages:
   is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -4633,6 +4785,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
@@ -4672,6 +4827,9 @@ packages:
     resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
@@ -4681,8 +4839,47 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-directive@3.1.0:
+    resolution: {integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -4702,20 +4899,95 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@4.0.0:
+    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
 
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
   micromark-util-sanitize-uri@2.0.1:
     resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
 
   micromark-util-symbol@2.0.1:
     resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
 
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -4913,6 +5185,9 @@ packages:
 
   parse-css-color@0.2.1:
     resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse-imports-exports@0.2.4:
     resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
@@ -5143,6 +5418,21 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  remark-directive@4.0.0:
+    resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -5443,6 +5733,9 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -5513,6 +5806,9 @@ packages:
 
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -6979,6 +7275,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
@@ -6997,6 +7297,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/ms@2.1.0': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@25.9.3':
@@ -7012,6 +7314,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -7315,6 +7619,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -7400,6 +7706,10 @@ snapshots:
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
 
@@ -7491,6 +7801,10 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   deep-extend@0.6.0: {}
 
@@ -7693,6 +8007,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -7823,6 +8139,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   extendable-error@0.1.7: {}
 
   fast-check@4.9.0:
@@ -7848,6 +8166,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
 
   fd-package-json@2.0.0:
     dependencies:
@@ -7910,6 +8232,8 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  format@0.2.2: {}
 
   formatly@0.3.0:
     dependencies:
@@ -8104,9 +8428,18 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.4
+
+  is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -8114,11 +8447,15 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@1.0.0: {}
 
   is-number@7.0.0: {}
 
   is-obj@1.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -8340,6 +8677,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  longest-streak@3.1.0: {}
+
   lru-cache@11.5.1: {}
 
   lunr@2.3.9: {}
@@ -8410,9 +8749,122 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  markdown-table@3.0.4: {}
+
   marked@14.0.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-directive@3.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
 
   mdast-util-to-hast@13.2.1:
     dependencies:
@@ -8426,6 +8878,22 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
@@ -8436,12 +8904,174 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-directive@4.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
   micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
 
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
@@ -8449,9 +9079,38 @@ snapshots:
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
 
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-util-symbol@2.0.1: {}
 
   micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -8702,6 +9361,16 @@ snapshots:
       color-name: 1.1.4
       hex-rgb: 4.3.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-imports-exports@0.2.4:
     dependencies:
       parse-statements: 1.0.11
@@ -8925,6 +9594,50 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  remark-directive@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-directive: 3.1.0
+      micromark-extension-directive: 4.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2: {}
 
@@ -9234,6 +9947,8 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trough@2.2.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -9302,6 +10017,16 @@ snapshots:
     dependencies:
       pako: 0.2.9
       tiny-inflate: 1.0.3
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
 
   unist-util-is@6.0.1:
     dependencies:

--- a/scripts/check-changeset-ignore.ts
+++ b/scripts/check-changeset-ignore.ts
@@ -9,6 +9,7 @@ const PUBLISHABLE_PACKAGES = [
   '@foldkit/vite-plugin',
   '@foldkit/devtools-mcp',
   '@foldkit/oxlint-plugin',
+  '@foldkit/markdown',
 ]
 
 interface PnpmListEntry {

--- a/scripts/cloud-session-setup.sh
+++ b/scripts/cloud-session-setup.sh
@@ -43,6 +43,7 @@ pnpm install --frozen-lockfile
 
 prerequisite_packages=(
   'foldkit:packages/foldkit'
+  '@foldkit/markdown:packages/markdown'
   '@foldkit/vite-plugin:packages/vite-plugin-foldkit'
   '@foldkit/oxlint-plugin:packages/oxlint-plugin-foldkit'
   '@typing-game/shared:packages/typing-game/shared'


### PR DESCRIPTION
## What

New published package `@foldkit/markdown`: markdown compiled at build time into typed Foldkit views, plus the `personal-blog` example as its showcase consumer.

- **`@foldkit/markdown`** (runtime entry): Effect Schema AST for CommonMark minus raw HTML, plus GFM tables, strikethrough, and directives; `decodeDocument`; a `view`/`viewBlocks` fold with unstyled semantic `defaultViews` and per-node overrides. Directive islands (`::Name`, `:::Name`) map to app-supplied views that receive attributes, rendered nested blocks, and a per-name occurrence index for instance-unique identifiers like `h.submodel` slotIds. State stays in the Model, so DevTools and time travel work through prose.
- **`@foldkit/markdown/vite`**: remark-based plugin that compiles imported `.md` files into typed document modules. No parser ships to the browser. Anything outside the vocabulary (raw HTML, footnotes, reference links, task lists, YAML frontmatter, directive labels) fails the build with the construct and line. `islandNames` extends that gate to unknown directive names.
- **`examples/personal-blog`**: markdown content with a live Counter Submodel island and a Note callout island, Tailwind restyling of the fold in `prose.ts`, routing, story/scene tests, and an e2e spec.
- **Playground infrastructure**: examples may now ship `vite.config.playground.ts` (written against published packages) that replaces the hard-coded standalone config in the WebContainer; `.md` files under `src/` are bundled; the source viewer highlights markdown.

## Why

Markdown content sites are a thing users should not have to reinvent, and the same pipeline is the candidate authoring path for the website docs ("markdown with little islands"). This reverses the earlier pure-Foldkit blog decision (FOL-233) deliberately.

## Review

A high-effort multi-agent review ran before this PR; all ten confirmed findings were fixed or consciously deferred, notably: island occurrence indexes (a fixed slotId crashed on a second `::Counter`), post content keyed by slug (presence-only keys let one post's DOM patch against another's), no vdom keys inside `defaultViews` (per-branch keys repeated across siblings, corrupting snabbdom's keyed diff), and fail-loudly handling for frontmatter and directive labels.

## Deliberately out of scope

- `create-foldkit-app` registration: the scaffolder's base template cannot carry the markdown plugin, and `@foldkit/markdown` resolves to a 404 until its first publish. Registration was reverted rather than shipping a broken scaffold.
- **Release ordering**: the deployed playground for personal-blog cannot npm-install `@foldkit/markdown` until the manual first publish and a website deploy after the version bump. Standard new-package bootstrap.
- Website docs page for the package and the docs-site markdown migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fZpdrj6R5pnRPPnwmnF2E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `@foldkit/markdown` package for build-time Markdown compilation into typed Foldkit views.
  * Added support for validated Markdown “islands” that embed interactive content in prose.
  * Added the Personal Blog example with routing, posts, Markdown rendering, interactive counters, and live demos.
  * Added website support for browsing and highlighting the new example and Markdown files.

* **Tests**
  * Added unit, rendering, story, and end-to-end coverage for Markdown, routing, islands, and the Personal Blog example.

* **Documentation**
  * Added package documentation and a README entry describing Markdown compilation and interactive islands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->