### PR TITLE
docs: point the README example list at interrupting-commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ This is what makes Foldkit unusually AI-friendly. The same property that makes t
 - **[Charting](https://foldkit.dev/example-apps/charting)**: Live public GitHub and npm telemetry rendered through an ECharts Mount adapter
 - **[Routing](https://foldkit.dev/example-apps/routing)**: URL routing with parser combinators
 - **[Route Transitions](https://foldkit.dev/example-apps/route-transitions)**: Live transition log with entry, exit, and stayed navigation policies
-- **[Upload](https://foldkit.dev/example-apps/upload)**: Simulated file uploads with cancellable, restartable interruptible Commands
+- **[Interrupting Commands](https://foldkit.dev/example-apps/interrupting-commands)**: Simulated file uploads with cancellable, restartable interruptible Commands
 - **[Query Sync](https://foldkit.dev/example-apps/query-sync)**: URL query parameter sync with filtering and sorting
 - **[Snake](https://foldkit.dev/example-apps/snake)**: Classic game built with Subscriptions
 - **[Map](https://foldkit.dev/example-apps/map)**: Interactive MapLibre GL map demonstrating Mount with a third-party DOM library


### PR DESCRIPTION
PR #752 renamed the upload example but missed the example list in the root README, which still linked the old slug under the old name. This updates that one entry to `[Interrupting Commands](https://foldkit.dev/example-apps/interrupting-commands)`; the description is unchanged.

A repo-wide sweep for other spellings (`[Upload]`, "upload example", `example-apps/upload`, `playground/upload`) confirms this was the last stale reference. The two old paths remaining in the deploy workflow are the 308 redirects themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkVkVTcXCofrt4GfVkcPxM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkVkVTcXCofrt4GfVkcPxM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Examples list to link to the interrupting-commands example instead of the upload example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->