### PR TITLE
Enable manual trigger for typing game server deployment

### DIFF
--- a/.github/workflows/deploy-typing-game-server.yml
+++ b/.github/workflows/deploy-typing-game-server.yml
@@ -8,7 +8,9 @@ on:
       - 'packages/typing-game/server/**'
       - 'packages/typing-game/shared/**'
       - 'packages/typing-game/server/Dockerfile'
+      - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-typing-game-server.yml'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
Updated the typing game server deployment workflow to support manual triggering via `workflow_dispatch`, in addition to the existing automatic triggers on code changes.

## Changes
- Added `workflow_dispatch` event to the deployment workflow, allowing the workflow to be manually triggered from the GitHub Actions UI
- Added `pnpm-lock.yaml` to the trigger paths, ensuring deployments are triggered when dependency versions change

## Details
This change improves deployment flexibility by allowing developers to manually redeploy the typing game server without requiring code changes, while also ensuring that dependency updates automatically trigger a new deployment.

https://claude.ai/code/session_017My5tRGo7kFDQDoA5fw61k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation to run when dependency lockfile changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->