### PR TITLE
Preserve PropertyKey identity in keyed rendering

### DIFF
--- a/.changeset/property-keys.md
+++ b/.changeset/property-keys.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+`h.keyed` and `createKeyedLazy` now accept any `PropertyKey`, so numeric and symbol Model identifiers no longer need conversion to strings before keyed rendering.

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -2326,7 +2326,7 @@ const keyed =
   <Message>() =>
   (tagName: TagName) =>
   (
-    key: string,
+    key: PropertyKey,
     attributes: ReadonlyArray<Attribute<Message> | ChildAttribute> = [],
     children: ReadonlyArray<Child> = [],
   ): Html => {

--- a/packages/foldkit/src/html/keyed.test.ts
+++ b/packages/foldkit/src/html/keyed.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { html } from './index.js'
+
+describe('keyed', () => {
+  it('preserves every PropertyKey without coercion', () => {
+    const h = html()
+    const keys: ReadonlyArray<PropertyKey> = [1, '1', Symbol('1')]
+
+    for (const key of keys) {
+      const vnode = h.keyed('div')(key)
+      expect(vnode?.key).toBe(key)
+    }
+  })
+})

--- a/packages/foldkit/src/html/lazy.test.ts
+++ b/packages/foldkit/src/html/lazy.test.ts
@@ -390,20 +390,26 @@ describe('createKeyedLazy', () => {
     expect(callCount).toBe(2)
   })
 
-  it('keeps numeric and string keys distinct', () => {
+  it('caches PropertyKeys by identity', () => {
     let callCount = 0
     const viewFn = (label: string) => {
       callCount++
       return h('div', {}, [label])
     }
 
+    const firstSymbol = Symbol('1')
+    const secondSymbol = Symbol('1')
     const lazy = createKeyedLazy()
     lazy(1, viewFn, ['number'])
     lazy('1', viewFn, ['string'])
+    lazy(firstSymbol, viewFn, ['first symbol'])
+    lazy(secondSymbol, viewFn, ['second symbol'])
     lazy(1, viewFn, ['number'])
     lazy('1', viewFn, ['string'])
+    lazy(firstSymbol, viewFn, ['first symbol'])
+    lazy(secondSymbol, viewFn, ['second symbol'])
 
-    expect(callCount).toBe(2)
+    expect(callCount).toBe(4)
   })
 
   it('recomputes only the key whose args changed', () => {

--- a/packages/foldkit/src/html/lazy.test.ts
+++ b/packages/foldkit/src/html/lazy.test.ts
@@ -390,6 +390,22 @@ describe('createKeyedLazy', () => {
     expect(callCount).toBe(2)
   })
 
+  it('keeps numeric and string keys distinct', () => {
+    let callCount = 0
+    const viewFn = (label: string) => {
+      callCount++
+      return h('div', {}, [label])
+    }
+
+    const lazy = createKeyedLazy()
+    lazy(1, viewFn, ['number'])
+    lazy('1', viewFn, ['string'])
+    lazy(1, viewFn, ['number'])
+    lazy('1', viewFn, ['string'])
+
+    expect(callCount).toBe(2)
+  })
+
   it('recomputes only the key whose args changed', () => {
     const calls: Array<string> = []
     const viewFn = (label: string) => {

--- a/packages/foldkit/src/html/lazy.ts
+++ b/packages/foldkit/src/html/lazy.ts
@@ -125,14 +125,14 @@ export const createLazy = (): (<Args extends ReadonlyArray<unknown>>(
  *  position in the tree. If the same item needs to appear in multiple
  *  positions, create one keyed lazy per position. */
 export const createKeyedLazy = (): (<Args extends ReadonlyArray<unknown>>(
-  key: string,
+  key: PropertyKey,
   fn: (...args: Args) => VNode | null,
   args: Args,
 ) => VNode | null) => {
-  const cache = new Map<string, CacheEntry>()
+  const cache = new Map<PropertyKey, CacheEntry>()
 
   return <Args extends ReadonlyArray<unknown>>(
-    key: string,
+    key: PropertyKey,
     fn: (...args: Args) => VNode | null,
     args: Args,
   ): VNode | null =>


### PR DESCRIPTION
Like React, Foldkit now accepts numeric keys directly, while additionally preserving full `PropertyKey` identity (`string | number | symbol`) across `h.keyed` and `createKeyedLazy`.

## Visualization

```mermaid
flowchart TB
  B1["Before: Model ID is a number"] --> B2["Convert with toString() every render"]
  B2 --> B3["h.keyed and createKeyedLazy receive string"]
  A1["After: Model ID stays a PropertyKey"]
  A1 --> A2["Pass the identifier directly"]
  A2 --> A3["h.keyed and createKeyedLazy receive PropertyKey"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Keyed rendering now supports any JavaScript `PropertyKey`, including numbers and symbols.
  - Lazy keyed views correctly cache and reuse results for supported key types without requiring conversion to strings.

- **Tests**
  - Added coverage confirming numeric, string, and symbol keys are preserved and cached correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->