### PR TITLE
fix: crash-handling gaps, plugin core-skip, and stale keying skills

### DIFF
--- a/.changeset/runtime-crash-handling-fixes.md
+++ b/.changeset/runtime-crash-handling-fixes.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Fix two crash-handling gaps in the runtime. A Command forked by a Message processed on the same synchronous stack just before a crash no longer runs its effect behind the crash view: the deferred fork now checks the crash flag as well as the disposal flag, so a side effect never executes once the crash view is shown. A defect in a ManagedResource's `modelToMaybeRequirements` or its equivalence now surfaces as the crash view instead of dying silently in a detached fiber, matching how Subscriptions already handle the same failure.

--- a/.changeset/vite-plugin-core-skip-anchor.md
+++ b/.changeset/vite-plugin-core-skip-anchor.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/vite-plugin': patch
+---
+
+The view-identity transform no longer un-brands a consumer module whose own path merely contains the `packages/foldkit/` segment (a workspace named `foldkit`, or a vendored fork holding application code). When the installed foldkit package resolves, the plugin's precise package-root gate is authoritative and the coarse path fragment is left to the resolution-failed fallback, so such a module keeps its branch identity instead of silently losing it.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.10.27",
+  "version": "0.10.28",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/packages/foldkit/src/runtime/messageProcessing.test.ts
+++ b/packages/foldkit/src/runtime/messageProcessing.test.ts
@@ -22,8 +22,9 @@ import { makeElement } from './runtime.js'
  *   render painted the init Model, and a Command returned by that result's
  *   update forks and completes correctly.
  * - A crash is terminal: Messages dispatched after update throws are
- *   dropped, so no update, Command fork, or side effect runs behind the
- *   crash view.
+ *   dropped, and a Command forked by a Message processed just before the
+ *   crash does not run its effect, so no update, Command fork, or side
+ *   effect runs behind the crash view.
  * - A Message dispatched while a render frame's patch is on the stack (an
  *   OnUnmount destroy hook) is buffered until the frame commits, so a
  *   defect in its update crashes cleanly and dispose still restores the
@@ -387,6 +388,69 @@ describe('message processing', () => {
       // Give any wrongly-forked Command time to run before asserting.
       await new Promise(resolve => setTimeout(resolve, 20))
       expect(processedLog).toEqual(['ThrewInUpdate'])
+      expect(commandEffectSpy).not.toHaveBeenCalled()
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('does not run a Command forked by a Message processed just before a crash', async () => {
+    let capturedDispatch: ((message: Message) => void) | null = null
+    const commandEffectSpy = vi.fn()
+
+    const spiedCommand: Command<Message> = {
+      name: 'ProduceSpiedResult',
+      effect: Effect.sync(() => {
+        commandEffectSpy()
+        return AppendedCommandResult()
+      }),
+    }
+
+    const update = (
+      model: Model,
+      message: Message,
+    ): readonly [Model, ReadonlyArray<Command<Message>>] => {
+      if (message._tag === 'ThrewInUpdate') {
+        throw new Error('boom in update')
+      }
+      const nextModel = { log: [...model.log, message._tag] }
+      if (message._tag === 'AppendedFirst') {
+        return [nextModel, [spiedCommand]]
+      }
+      return [nextModel, []]
+    }
+
+    const element = makeElement({
+      Model,
+      init: () => [{ log: [] }, []],
+      update,
+      view: model => {
+        capturedDispatch = __requireDispatch()
+        return view(model)
+      },
+      crash: {
+        view: () => h.div([], ['crash-view-marker']),
+      },
+      container,
+    })
+
+    const fiber = Effect.runFork(element.start())
+    await vi.waitFor(() => {
+      expect(capturedDispatch).not.toBeNull()
+    })
+
+    try {
+      const dispatch = capturedDispatch!
+      // AppendedFirst forks a Command whose fork is deferred to a microtask;
+      // ThrewInUpdate crashes on the same synchronous stack before that
+      // microtask runs. The Command's side effect must not run behind the
+      // crash view.
+      dispatch(AppendedFirst())
+      dispatch(ThrewInUpdate())
+      expect(document.body.textContent).toContain('crash-view-marker')
+
+      // Give the deferred Command fork a chance to run before asserting.
+      await new Promise(resolve => setTimeout(resolve, 20))
       expect(commandEffectSpy).not.toHaveBeenCalled()
     } finally {
       await Effect.runPromise(Fiber.interrupt(fiber))

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -1852,7 +1852,14 @@ const makeRuntime = <
           message: Option.Option<Message>,
         ): void => {
           queueMicrotask(() => {
-            if (isRuntimeDisposed) {
+            // NOTE: `isCrashed` as well as `isRuntimeDisposed`. A crash is
+            // terminal but does not dispose the runtime, and a Command forked
+            // by a Message processed just before the crashing Message sits in
+            // this microtask when the crash view paints. Without the crash
+            // check its effect would run behind the crash view, contradicting
+            // the crash-terminality contract. `crashWith` sets `isCrashed`
+            // synchronously, so it is already set by the time this runs.
+            if (isRuntimeDisposed || isCrashed) {
               return
             }
             Effect.runForkWith(runtimeContextForCommands)(
@@ -2555,7 +2562,7 @@ const makeRuntime = <
           ) =>
           (
             maybeRequirements: unknown,
-          ): Stream.Stream<Effect.Effect<Message, unknown>> => {
+          ): Stream.Stream<Effect.Effect<Message>> => {
             if (
               Option.isOption(maybeRequirements) &&
               Option.isNone(maybeRequirements)
@@ -2619,6 +2626,13 @@ const makeRuntime = <
                   maybeRequirementsToLifecycle(config, resourceRef),
                 ),
                 Stream.runForEach(Effect.flatMap(enqueueMessageEffect)),
+                // NOTE: mirrors the Subscription fork so a defect in
+                // `modelToMaybeRequirements` or the equivalence surfaces as
+                // the crash view instead of dying silently in this detached
+                // fiber. `provideAllResources` is not needed: `acquire` only
+                // requires `Scope`, which `Stream.scoped` supplies, and
+                // `release` requires nothing.
+                Effect.catchCause(cause => crashWith(cause, Option.none())),
               ),
             )
           })

--- a/packages/vite-plugin-foldkit/src/viewIdentity.ts
+++ b/packages/vite-plugin-foldkit/src/viewIdentity.ts
@@ -194,7 +194,10 @@ const isAlreadyBranded = (program: AstNode): boolean => {
   )
 }
 
-const isEligibleModuleId = (id: string): boolean => {
+const isEligibleModuleId = (
+  id: string,
+  isFoldkitCoreResolved: boolean,
+): boolean => {
   if (id.startsWith(VIRTUAL_MODULE_PREFIX)) {
     return false
   }
@@ -205,6 +208,15 @@ const isEligibleModuleId = (id: string): boolean => {
   }
   if (!SCRIPT_FILE_PATTERN.test(strippedId)) {
     return false
+  }
+  // NOTE: the unanchored `packages/foldkit/` fragment is a best-effort
+  // fallback, applied only when the installed foldkit package could not be
+  // resolved. When it was resolved, the plugin's precise `foldkitPackageRoot`
+  // gate already excluded core, so re-applying the fragment here would wrongly
+  // un-brand a consumer whose own app path merely contains the segment (a
+  // workspace named `foldkit`, a vendored fork holding app code).
+  if (isFoldkitCoreResolved) {
+    return true
   }
   return !normalizedId.includes(FOLDKIT_CORE_PATH_FRAGMENT)
 }
@@ -424,10 +436,14 @@ export type ViewIdentityTransformResult = Readonly<{
  * every function, including async and generator functions and functions that
  * never produce a vnode, is inert outside view results.
  *
- * Skips foldkit core modules (both under `node_modules` and when aliased into
- * `packages/foldkit/`): if the element factory's own returns were branded,
- * every vnode would carry an identity at construction and set-if-absent would
- * neutralize the feature.
+ * Skips foldkit core modules: if the element factory's own returns were
+ * branded, every vnode would carry an identity at construction and
+ * set-if-absent would neutralize the feature. Core under `node_modules` is
+ * always skipped. The plugin resolves the installed foldkit package and passes
+ * `isFoldkitCoreResolved`; when it resolved, the plugin's precise package-root
+ * gate is authoritative and the coarse `packages/foldkit/` path fragment is
+ * left to the resolution-failed fallback, so a consumer whose own path merely
+ * contains that segment is still branded.
  *
  * Skips modules whose parsed program imports or re-exports the
  * `foldkit/brand` specifier: packages such as `@foldkit/ui` and
@@ -443,8 +459,9 @@ export const transformViewIdentity = (
   code: string,
   id: string,
   root: string,
+  options?: Readonly<{ isFoldkitCoreResolved?: boolean }>,
 ): ViewIdentityTransformResult | null => {
-  if (!isEligibleModuleId(id)) {
+  if (!isEligibleModuleId(id, options?.isFoldkitCoreResolved ?? false)) {
     return null
   }
   const program = parseProgram(code)
@@ -595,7 +612,9 @@ export const foldkitViewIdentity = (): Plugin => {
       ) {
         return null
       }
-      return transformViewIdentity(code, id, resolvedRoot)
+      return transformViewIdentity(code, id, resolvedRoot, {
+        isFoldkitCoreResolved: foldkitPackageRoot !== undefined,
+      })
     },
   }
 }

--- a/packages/vite-plugin-foldkit/test/viewIdentity.test.ts
+++ b/packages/vite-plugin-foldkit/test/viewIdentity.test.ts
@@ -210,7 +210,7 @@ const view = () => 2
 describe('eligibility', () => {
   const FUNCTION_SOURCE = 'const view = () => 1\n'
 
-  it('skips foldkit core aliased into packages/foldkit', () => {
+  it('skips a packages/foldkit path via the fallback when foldkit is unresolved', () => {
     expect(
       transformViewIdentity(
         FUNCTION_SOURCE,
@@ -218,6 +218,21 @@ describe('eligibility', () => {
         ROOT,
       ),
     ).toBeNull()
+  })
+
+  it('brands a consumer module under packages/foldkit once foldkit resolves', () => {
+    // Regression: with the installed foldkit package resolved, the plugin's
+    // precise package-root gate is authoritative, so the coarse
+    // `packages/foldkit/` fragment must not un-brand a consumer whose own app
+    // path merely contains the segment.
+    const result = transformViewIdentity(
+      FUNCTION_SOURCE,
+      '/work/app/packages/foldkit/View.ts',
+      '/work/app',
+      { isFoldkitCoreResolved: true },
+    )
+    expect(result).not.toBeNull()
+    expect(result?.code).toContain('"packages/foldkit/View.ts#view"')
   })
 
   it('skips foldkit core under node_modules', () => {

--- a/skills/audit-program/SKILL.md
+++ b/skills/audit-program/SKILL.md
@@ -185,8 +185,8 @@ If none: write `None.`
 ## QUALITY
 Items that work but fall short of the bar: generic naming, inline
 handlers that should be extracted, native methods instead of Effect
-modules in pipes, views that should be decomposed, missing branch
-keys or wrappers introduced only to carry a key, etc. Should fix.
+modules in pipes, views that should be decomposed, branch keys or
+key-only wrapper elements that view identity makes redundant, etc. Should fix.
 Each item: `path/to/file.ts:line: <the gap>. Idiomatic version: <what to write>`.
 Cite the exemplar when relevant: "typing-game does this as X at
 page/home/update/handleKeyPressed.ts:33-40".
@@ -243,17 +243,17 @@ End with a summary diff: which findings were resolved, which were declined, whic
 
 When `$ARGUMENTS` narrows to a focus area, Phase 5 reduces to the relevant subagents and blind spots. The report still uses the BLOCKERS / QUALITY / NICE-TO-HAVE / VERDICT structure, just scoped.
 
-| Focus           | Subagents                                                                                                                    | Blind spots     |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `a11y`          | D                                                                                                                            | #12, #13, #15   |
-| `effects`       | B                                                                                                                            | #5, #6, #8, #17 |
-| `naming`        | C                                                                                                                            | #7, #9, #20     |
-| `decomposition` | C                                                                                                                            | #5, #6          |
-| `forms`         | D + form-specific (Ui.Input adoption, fieldValidation usage, label/input pairing)                                            | #12, #13        |
-| `routing`       | A + routing-specific (bidirectional parser usage, keyed branches on `route._tag`, `urlToString` in `Internal` case)          | #11             |
-| `subscriptions` | A + subscription-specific (`Subscription.make` shape, `S.Struct({})` for always-active, message mapping inside `Stream.map`) | none            |
-| `testing`       | E                                                                                                                            | #14             |
-| `submodels`     | A + submodel-specific (Got\* wrapping, three-tuple update returns with OutMessage, parent ↔ child Message isolation)         | #19             |
-| `types`         | (inline) type-shape and aliasing                                                                                             | #17, #18        |
+| Focus           | Subagents                                                                                                                                            | Blind spots     |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `a11y`          | D                                                                                                                                                    | #12, #13, #15   |
+| `effects`       | B                                                                                                                                                    | #5, #6, #8, #17 |
+| `naming`        | C                                                                                                                                                    | #7, #9, #20     |
+| `decomposition` | C                                                                                                                                                    | #5, #6          |
+| `forms`         | D + form-specific (Ui.Input adoption, fieldValidation usage, label/input pairing)                                                                    | #12, #13        |
+| `routing`       | A + routing-specific (bidirectional parser usage, route views as identity boundaries with no keyed route branches, `urlToString` in `Internal` case) | #11             |
+| `subscriptions` | A + subscription-specific (`Subscription.make` shape, `S.Struct({})` for always-active, message mapping inside `Stream.map`)                         | none            |
+| `testing`       | E                                                                                                                                                    | #14             |
+| `submodels`     | A + submodel-specific (Got\* wrapping, three-tuple update returns with OutMessage, parent ↔ child Message isolation)                                 | #19             |
+| `types`         | (inline) type-shape and aliasing                                                                                                                     | #17, #18        |
 
 For focused audits, skip Phase 4's full grep block and run only the greps relevant to the focus (e.g. for `a11y`, run `label without For`, `outline-none without focus-visible`, `_blank without Rel`).

--- a/skills/generate-program/SKILL.md
+++ b/skills/generate-program/SKILL.md
@@ -518,7 +518,7 @@ For file uploads (resumes, images, attachments):
 - Use `clsx` from the `clsx` package for conditional class composition: `h.Class(clsx('base-classes', { 'active-class': isActive, 'bg-blue-500': variant === 'Primary' }))`. Use `clsx` whenever classes depend on model state, boolean flags, or discriminated union tags. Never string concatenation, template literals, or `&&` expressions.
 - Pattern match on model state: `M.value(model.state).pipe(M.tagsExhaustive({...}))`
 - Use `Option.match` for conditional rendering based on Option fields
-- Key every layout branch: inline branch roots directly, delegating branches via `h.keyed('div')(routeOrStateTag, attrs, children)` at the branch site
+- Never key branches. View functions are the differ's identity boundaries; the vite plugin brands each function's return, so switching branches that render through different view functions replaces the subtree. Extract a same-tag inline ternary into named view functions when switching must reset DOM state
 - Delegate complex sections to extracted view functions
 - Wire events to messages: `h.OnClick(ClickedSubmit())` (Message directly, not a callback), `h.OnInput(value => UpdatedEmail({ value }))` (callback that maps the value to a Message)
 - Use Foldkit UI components when the interaction matches (Dialog for modals, Tabs for tabbed content, etc.)
@@ -539,7 +539,7 @@ For file uploads (resumes, images, attachments):
 - **Suffix route variant constants with `Route`**: `HomeRoute`, `NewLinkRoute`, `NotFoundRoute`. Every exemplar (auth, shopping-cart, routing) does this. Disambiguates the route schema from views, models, or UI components with matching tag names.
 - Build each route as a Router: `const homeRouter = pipe(Route.root, Route.mapTo(HomeRoute))`. **Routers are callable**: `homeRouter()` returns `'/'`, `tagFilterRouter({ tag: 'foo' })` returns `'/tag/foo'`. This is the print side of the bidirectional parser.
 - **Never hand-construct paths with template strings.** `Href(homeRouter())` not `Href('/')`. `navigateInternal(newLinkRouter())` not `navigateInternal('/new')`. `Href(tagFilterRouter({ tag: tagName }))` not ``Href(`/tag/${encodeURIComponent(tagName)}`)``. The router handles encoding and keeps the URL shape in one place so a refactor changes one file, not every call site.
-- Key view content on `model.route._tag`
+- Render each route through its own view function; identity handles the switch, so route branches are never keyed. Key by entity id only when one shared view function renders different entities across route params (a detail page across slugs)
 - Use `pushUrl` from `foldkit/navigation` in Commands for programmatic navigation. In the `ClickedLink` handler's `Internal` case, use `urlToString(url)` from `foldkit/url`. Never reconstruct the URL from `url.pathname + search + hash` manually; that path drops the `?` prefix and hash silently.
 - In the `ClickedLink` handler, **don't pre-update `model.route`**. The runtime fires `ChangedUrl` after `pushUrl` resolves, which updates the route. Pre-updating creates a double-write.
 

--- a/skills/generate-program/architecture.md
+++ b/skills/generate-program/architecture.md
@@ -259,25 +259,26 @@ Canonical live examples:
 - **Conditional WebSocket connection** (active only when a session exists): `repos/foldkit/examples/websocket-chat/src/main.ts`
 - **Production multi-stream pattern**: `repos/foldkit/packages/typing-game/client/src/subscription.ts`
 
-## Keyed Views
+## View Identity and Keys
 
-Key every branch of a view that renders different content at one DOM position, even when the branch root tags differ. Tag-based replacement is an implementation detail of the differ, and it silently stops protecting a branch the moment someone changes its root tag.
+View functions are the differ's identity boundaries. `@foldkit/vite-plugin` brands every view function's return with that function's identity, so switching between branches that render through different view functions replaces the old subtree instead of patching it, even when both branch roots share a tag. Branches are never keyed. `if`/`else`, ternaries, Effect `Match`, and `switch` all behave the same way: each arm's view function carries its own identity, and continuity is structural.
 
-Keys live at the branch site. Key inline branch roots directly, never a wrapper introduced only to carry a key. Ternaries and `if`/`else` chains always key each branch node: they have no ready discriminator, and synthesizing one for a wrapper key restates the branch logic in a string that nothing keeps in sync. When the arms of a tag match delegate to other view functions, key a single wrapper at the branch site instead of pushing keys into those functions:
+Extract the arms into named view functions when a same-tag inline ternary must reset DOM state on switch. An inline `cond ? div(...) : div(...)` renders both arms through the enclosing function, so they share one identity and patch in place; two named functions give each arm its own identity.
+
+Write keys in exactly two places:
+
+- **Mapped list items**, keyed by a stable Model id, never by array position. Rows rendered by one row view function all share that function's identity, so the key is what distinguishes them.
+- **A shared view function rendering different entities at one position** (a detail page across slugs or ids), keyed by the entity id, so switching entities resets DOM state instead of bleeding it across.
 
 ```ts
-// Inline branches: key each branch's root element directly
-keyed('div')('landing', [...], [...])
-keyed('div')('docs', [...], [...])
+// Mapped list: key each row by its stable Model id
+Array.map(model.items, item => keyed('li')(item.id, [...], [...]))
 
-// Delegating branches: key a wrapper on the discriminator at the
-// branch site, keeping the branching visible where it happens
-keyed('div')(model.route._tag, [], [routeContent])
+// Shared view function across entities: key by the entity id
+keyed('article')(model.selectedProduct.id, [...], [...])
 ```
 
-Without keying, the virtual DOM tries to patch one layout into another, causing stale DOM, mismatched event handlers, and rendering bugs.
-
-Keys carry identity, never data. A key answers which branch or item occupies a position, not what it currently shows. Never derive a key from displayed data to force a refresh when content changes:
+Keys carry identity, never data. A key answers which item or entity occupies a position, not what it currently shows. Never derive a key from displayed data to force a refresh when content changes:
 
 ```ts
 // Wrong: the key restates displayed data, so every toggle tears the
@@ -288,7 +289,7 @@ keyed('div')(`${model.isCardSelected}:${model.isTermsAccepted}`, [...], [...])
 div([...], [...])
 ```
 
-If a key can change while the same conceptual thing stays on screen, the key is doing change detection, and patching already does that.
+If a key can change while the same conceptual thing stays on screen, the key is doing change detection, and patching already does that. Always build with `@foldkit/vite-plugin`; without it, branch identity falls back to positional-plus-key semantics and every branch point needs a hand-written key.
 
 ## DOM and Effect Helpers
 

--- a/skills/generate-program/checklist.md
+++ b/skills/generate-program/checklist.md
@@ -177,7 +177,7 @@ Alongside the greps, eyeball each file's imports. Every symbol you imported shou
 
 ## View
 
-- [ ] Every layout branch keyed (route-based or state-based); inline branch roots keyed directly, delegating branches behind a single keyed wrapper at the branch site, no wrapper introduced only to carry a key
+- [ ] Branches are never keyed; each branch renders through a view function (identity boundary), with a same-tag inline ternary extracted into named view functions when switching must reset DOM state
 - [ ] Events dispatch Messages, never perform actions directly
 - [ ] Semantic HTML elements (`main`, `nav`, `section`, `article`, `header`, `footer`)
 


### PR DESCRIPTION
## Summary

Four fixes surfaced by a pre-release review of the owned-differ (`36ae509`) and
plain-hot-path (`2b788f2`) commits. Two are runtime crash-handling bugs, one is a
`@foldkit/vite-plugin` resolution edge case, and one aligns the shipped skills
with the new view-identity keying model.

## Changes

**1. A Command's side effect no longer runs behind the crash view** (`packages/foldkit/src/runtime/runtime.ts`)

`forkCommand`'s deferred `queueMicrotask` guarded only on `isRuntimeDisposed`. A
crash is terminal but does not dispose the runtime, so a Command forked by a
Message processed on the same synchronous stack just before a crashing Message
would still fork and run its effect (a network write, a `localStorage` write, a
scroll lock) after the crash view painted. The guard now also checks `isCrashed`,
which `crashWith` sets synchronously. Pinned by a new `messageProcessing.test.ts`
case, verified failing without the fix.

**2. ManagedResource lifecycle defects surface the crash view** (`packages/foldkit/src/runtime/runtime.ts`)

The ManagedResource lifecycle stream was forked with no `catchCause`, so a defect
in `modelToMaybeRequirements` or the equivalence died silently in a detached
fiber (no crash view, resource never re-acquired) while the equivalent defect in
a Subscription rendered the crash view. Added
`Effect.catchCause(cause => crashWith(cause, Option.none()))`, mirroring the
Subscription fork. `provideAllResources` is not needed: `acquire` requires only
`Scope` (supplied by `Stream.scoped`) and `release` requires nothing. The
lifecycle stream's element annotation is tightened from `Effect<Message, unknown>`
to `Effect<Message>` so the fork's error channel is genuinely `never`, matching
the Subscription path.

**3. Plugin core-skip no longer over-matches consumer paths** (`packages/vite-plugin-foldkit/src/viewIdentity.ts`)

`isEligibleModuleId` skipped any module whose path contained the unanchored
substring `packages/foldkit/`, so a consumer whose own app code lives under a
path with that segment (a workspace named `foldkit`, a vendored fork) was
silently un-branded and lost branch identity. The plugin already resolves the
installed foldkit package; that precise package-root gate is now authoritative,
and the coarse substring is applied only as a fallback when resolution fails.
Regression test added.

**4. Shipped skills teach the identity keying model** (`skills/generate-program/`, `skills/audit-program/`)

The owned-differ commit migrated `CLAUDE.md`, `AGENTS.md`, the starter template,
and the website keying docs to "never key branches; view functions are identity
boundaries," but the two plugin-shipped skills still taught "key every layout
branch." They now teach the identity model: branches are never keyed, and keys
remain only for mapped list items and for a shared view function rendering
different entities at one position. Plugin version bumped 0.10.27 to 0.10.28. The
still-valid list-row and data-derived-key guidance is unchanged.

## Design note

Finding 3's originally suggested fix (anchor the substring to the config root) is
insufficient: a consumer's own `<root>/packages/foldkit/` is still under their
config root, so a config-root anchor still skips it. The two cases are
path-identical, so only the precise package resolution can disambiguate. Hence
the resolution-authoritative approach here.

## Verification

- The new `messageProcessing.test.ts` case fails without fix 1 and passes with it.
- A new `viewIdentity.test.ts` regression case covers fix 3.
- `foldkit` and `@foldkit/vite-plugin` typecheck clean; the ManagedResource and
  message-processing suites are green; lint, dead-code, format, changeset, and
  skill-version gates pass.
- Two patch changesets (`foldkit`, `@foldkit/vite-plugin`); the skills are carried
  by the plugin version bump and need no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsmNBvGCPdew443zv8ujoD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deferred command effects from running after the crash view is shown.
  * Routed managed resource failures to the crash view instead of failing silently.
  * Improved view-identity handling for vendored/workspace setups with `packages/foldkit/`, using resolution-aware core gating.
* **Tests**
  * Added regression coverage to confirm crashes are terminal and deferred commands are discarded.
* **Documentation**
  * Updated generation and audit guidance around view identity and keys, including routing/view rendering best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->