### PR TITLE
docs(website): clarify zero side effects claim on the purity page

### DIFF
--- a/packages/website/src/page/bestPractices/sideEffectsAndPurity.ts
+++ b/packages/website/src/page/bestPractices/sideEffectsAndPurity.ts
@@ -102,10 +102,10 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       ),
       tableOfContentsEntryToHeader(overviewHeader),
       para(
-        'Correct Foldkit programs have zero side effects, period. Yes, zero (0).',
+        'A correct Foldkit program is a pure description with zero side effects, period. Yes, zero (0). Your program is the Foldkit application you define: your Model, update, view, the Command values returned by update, and more. Evaluating it does not perform side effects.',
       ),
       para(
-        'Every side effect is described as an Effect: a value that represents a computation without executing it. An Effect does nothing when you construct it. It produces side effects when the Foldkit runtime runs your program.',
+        'Every side effect is described as an Effect: a value that represents a computation without executing it. An Effect does nothing when you construct it. The side effects still happen, but only when the Foldkit runtime runs your program and executes the Effects it produces.',
       ),
       para(
         'Both ',


### PR DESCRIPTION
## What and why

The Side Effects & Purity best-practices page opens with two sentences that read as a contradiction. A reader flagged that:

> Correct Foldkit programs have zero side effects, period. Yes, zero (0).

appears to conflict with the next sentence, which says an Effect "produces side effects when the Foldkit runtime runs your program." Their own diagnosis was correct: the ambiguity is about what "program" refers to. This change scopes the claim so the two sentences no longer fight each other.

## What changed

Rewrote the two opening paragraphs of `packages/website/src/page/bestPractices/sideEffectsAndPurity.ts`:

- Paragraph 1 defines the program as the whole Foldkit application you define (your Model, update, view, the Command values returned by update, and more), states that the program itself is a pure description, and notes that evaluating it does not perform side effects.
- Paragraph 2 keeps the existing construct-versus-run framing (an Effect does nothing when you construct it) and clarifies that side effects still happen, but only when the Foldkit runtime runs your program and executes the Effects it produces.

Docs prose only. No behavior change, no versioned package touched (`website` is in the changeset `ignore` list), so no changeset.

## Design note

Framed the program as the application you define rather than a closed list of functions, since flags, Subscriptions, Mount, Resources, and Managed Resources are also part of a program. Avoided the word "layer" for the runtime because it collides with Effect's `Layer` type, which would be confusing on a page about purity.

## Verification

- Prettier check clean on the edited file.
- Full pre-push suite green: lint, dead-code, build, all-package typecheck, and tests all passed (website 146 tests). Website e2e is skipped locally (Playwright browsers absent) and runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the overview of side effects and purity.
  * Specified that side effects occur only when the Foldkit runtime executes `Effect` values produced by a correct Foldkit program, not during program evaluation or effect construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->