### PR TITLE
fix(foldkit): accept interruptible Command definitions in resolve

### DIFF
--- a/.changeset/story-resolve-interruptible-definitions.md
+++ b/.changeset/story-resolve-interruptible-definitions.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+`Story.Command.resolve` and `Scene.Command.resolve` now accept a bare interruptible Command definition (from `Command.Interruptible.define`), matching it by name the way their `expectHas` and `expectExact` counterparts already do. Previously the definition overload only accepted plain `Command.define` definitions, so resolving an interruptible Command by its definition failed to typecheck and forced a resolve-by-instance workaround.

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -91,6 +91,13 @@ import {
   view as resumeView,
 } from './apps/resumeUpload.js'
 import type { Model as ResumeModel } from './apps/resumeUpload.js'
+import {
+  SucceededUploadFile,
+  UploadFile,
+  initialModel as initialUploadsModel,
+  update as uploadsUpdate,
+  view as uploadsView,
+} from './apps/uploads.js'
 import { parseSelector } from './query.js'
 import {
   attr,
@@ -1497,6 +1504,20 @@ describe('scene', () => {
       Scene.tap(({ html }) => {
         expect(find(html, '[role="alert"]')).toHaveText('Invalid credentials')
         expect(find(html, '.retry')).toExist()
+      }),
+    )
+  })
+
+  test('resolves a keyed Command by its bare Definition, matching by name', () => {
+    Scene.scene(
+      { update: uploadsUpdate, view: uploadsView },
+      Scene.with(initialUploadsModel),
+      Scene.click(Scene.role('button', { name: 'Start upload' })),
+      Scene.Command.expectExact(UploadFile),
+      Scene.Command.resolve(UploadFile, SucceededUploadFile({ uploadId: 0 })),
+      Scene.Command.expectNone(),
+      Scene.tap(({ html }) => {
+        expect(find(html, 'span')).toHaveText('upload 0: Done')
       }),
     )
   })

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -11,6 +11,7 @@ import {
 import { dual } from 'effect/Function'
 
 import type { CommandDefinition } from '../command/index.js'
+import type * as Interruptible from '../command/interruptible/index.js'
 import type { File } from '../file/index.js'
 import type { FoldkitMountMarker } from '../html/index.js'
 import {
@@ -228,6 +229,21 @@ type SceneCommandInstance<ResultMessage = unknown> = Readonly<{
   args?: Record<string, unknown>
   effect: Effect.Effect<ResultMessage, any, any>
 }>
+
+/** A Command Definition accepted by `Scene.Command.resolve` as a name matcher:
+ *  a plain `Command.define` Definition or an interruptible
+ *  `Command.Interruptible.define` Definition. Both carry the
+ *  `CommandDefinitionTypeId` brand and match by name at runtime, so `resolve`
+ *  accepts either, the way `expectHas`/`expectExact` already do. */
+type ResolvableCommandDefinition<Name extends string, ResultMessage> =
+  | CommandDefinition<Name, ResultMessage>
+  | Interruptible.DefinitionNoArgs<Name, Effect.Effect<ResultMessage, any, any>>
+  | Interruptible.DefinitionWithArgs<
+      Name,
+      any,
+      any,
+      Effect.Effect<ResultMessage, any, any>
+    >
 
 const slotKey = ({ name, occurrence }: PendingMount): string =>
   `${name}#${occurrence}`
@@ -637,7 +653,7 @@ const with_ = <Model>(model: Model): WithStep<Model> => {
  *  or a Command instance (matches by name AND args; strict). */
 const resolveCommand: {
   <Name extends string, ResultMessage>(
-    definition: CommandDefinition<Name, ResultMessage>,
+    definition: ResolvableCommandDefinition<Name, ResultMessage>,
     resultMessage: ResultMessage,
   ): <Model, Message, OutMessage = undefined>(
     simulation: SceneSimulation<Model, Message, OutMessage>,

--- a/packages/foldkit/src/test/story.test.ts
+++ b/packages/foldkit/src/test/story.test.ts
@@ -523,6 +523,39 @@ describe('interruptible Commands', () => {
     )
   })
 
+  test('resolves a keyed Command by its bare Definition, matching by name', () => {
+    Story.story(
+      uploadsUpdate,
+      Story.with(initialUploadsModel),
+      Story.message(ClickedStartUpload()),
+      Story.Command.resolve(UploadFile, SucceededUploadFile({ uploadId: 0 })),
+      Story.model(model => {
+        expect(model.uploads).toEqual([{ id: 0, status: 'Done' }])
+      }),
+      Story.Command.expectNone(),
+    )
+  })
+
+  test('resolveAll resolves keyed Commands by their bare Definition', () => {
+    Story.story(
+      uploadsUpdate,
+      Story.with(initialUploadsModel),
+      Story.message(ClickedStartUpload()),
+      Story.message(ClickedStartUpload()),
+      Story.Command.resolveAll(
+        [UploadFile, SucceededUploadFile({ uploadId: 0 })],
+        [UploadFile, SucceededUploadFile({ uploadId: 1 })],
+      ),
+      Story.model(model => {
+        expect(model.uploads).toEqual([
+          { id: 0, status: 'Done' },
+          { id: 1, status: 'Done' },
+        ])
+      }),
+      Story.Command.expectNone(),
+    )
+  })
+
   test('resolving an Interrupt with NotFound keeps nothing pending and skips the status change', () => {
     Story.story(
       uploadsUpdate,
@@ -701,6 +734,14 @@ describe('type safety', () => {
     const resolver = Story.Command.resolve(
       FetchCount,
       SucceededFetchCount({ count: 0 }),
+    )
+    expectTypeOf(resolver).toBeFunction()
+  })
+
+  test('resolve accepts a bare interruptible Command definition', () => {
+    const resolver = Story.Command.resolve(
+      UploadFile,
+      SucceededUploadFile({ uploadId: 0 }),
     )
     expectTypeOf(resolver).toBeFunction()
   })

--- a/packages/foldkit/src/test/story.ts
+++ b/packages/foldkit/src/test/story.ts
@@ -1,6 +1,7 @@
 import { Array, Effect, Equal, Option, Predicate, pipe } from 'effect'
 
 import type { CommandDefinition } from '../command/index.js'
+import type * as Interruptible from '../command/interruptible/index.js'
 import type {
   AnyCommand,
   BaseInternal,
@@ -31,6 +32,21 @@ type AnyCommandInstance<ResultMessage = unknown> = Readonly<{
   args?: Record<string, unknown>
   effect: Effect.Effect<ResultMessage, any, any>
 }>
+
+/** A Command Definition accepted by `Story.Command.resolve` as a name matcher:
+ *  a plain `Command.define` Definition or an interruptible
+ *  `Command.Interruptible.define` Definition. Both carry the
+ *  `CommandDefinitionTypeId` brand and match by name at runtime, so `resolve`
+ *  accepts either, the way `expectHas`/`expectExact` already do. */
+type ResolvableCommandDefinition<Name extends string, ResultMessage> =
+  | CommandDefinition<Name, ResultMessage>
+  | Interruptible.DefinitionNoArgs<Name, Effect.Effect<ResultMessage, any, any>>
+  | Interruptible.DefinitionWithArgs<
+      Name,
+      any,
+      any,
+      Effect.Effect<ResultMessage, any, any>
+    >
 
 /** An immutable test simulation of a Foldkit program. */
 export type StorySimulation<Model, Message, OutMessage = undefined> = Readonly<{
@@ -142,7 +158,7 @@ export const message =
  *  or a Command instance (matches by name AND args; strict). */
 const resolveCommand: {
   <Name extends string, ResultMessage>(
-    definition: CommandDefinition<Name, ResultMessage>,
+    definition: ResolvableCommandDefinition<Name, ResultMessage>,
     resultMessage: ResultMessage,
   ): <Model, Message, OutMessage = undefined>(
     simulation: StorySimulation<Model, Message, OutMessage>,


### PR DESCRIPTION
Fixes #770.

## What and why

`Story.Command.resolve` and `Scene.Command.resolve` typed their definition overload as `CommandDefinition`, which excludes the `Command.Interruptible.DefinitionNoArgs` and `DefinitionWithArgs` shapes. Passing a bare interruptible definition failed to typecheck, even though the runtime matcher only compares by name via the shared `CommandDefinitionTypeId` brand, and `expectHas`/`expectExact` already accept interruptible definitions. The gap forced a resolve-by-instance workaround, and instance matching compares args with `Equal.equals`, so tests with non-structural args (a `File`) had to share the exact reference between dispatch and resolution.

## What changed

- Widened the `resolve` definition overload in `Story` and `Scene` to a `ResolvableCommandDefinition` union that also accepts the interruptible definition shapes, preserving the result Message inference so the second argument stays checked against the Command's declared results.
- No runtime change. The matcher already handles interruptible definitions via the brand, which is why `expectHas`/`expectExact` worked all along.
- Added Story and Scene tests that resolve keyed Commands by their bare definition, plus a type-level assertion that `resolve` accepts a bare interruptible definition.

## Scope note

The issue names only `Story.Command.resolve`. `Scene.Command.resolve` had the byte-for-byte identical gap and the same resolve-by-instance workaround in its interruptible tests, so both were fixed to keep the parallel test APIs symmetric.

## Verification

- Reproduced the original type error with a probe, confirmed the fix resolves it, and confirmed a result Message outside the Command's declared results is still rejected (inference preserved).
- `pnpm typecheck` (per-package and recursive), `pnpm lint`, `pnpm check:dead-code`, and the pre-push suite pass. The Story and Scene test suites pass. Website e2e is exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkZDggGNepRLXC8b8CZjrX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed resolution of interruptible commands when resolving by using the bare (non-instantiated) command definition, including single and multiple keyed pending commands.
  - Resolution now consistently matches pending commands by command name.

- **Type Safety**
  - Updated `Story.Command.resolve` and `Scene.Command.resolve` typings to accept interruptible command definitions while preserving the expected result type.

- **Tests**
  - Added/expanded runtime and type-checking coverage for interruptible command resolution and verified the resulting rendered UI.

- **Documentation**
  - Refreshed the published API/typing contract for interruptible command resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->