### PR TITLE
feat(foldkit): make toKey optional on the interruptible with-args define

### DIFF
--- a/.changeset/interruptible-optional-to-key.md
+++ b/.changeset/interruptible-optional-to-key.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+`Command.Interruptible.define` now accepts an optional `toKey` on the with-args form. Omit it when at most one invocation is meaningfully in flight, and the key is the Command name, exactly like the no-args form, with `Interrupt` taking only `toMessage`. This drops the empty `{}` key args a single-instance submit flow was forced to pass. Provide `toKey`, derived from the owning Model identity, when invocations run concurrently and must be interrupted independently.

--- a/packages/foldkit/src/command/interruptible/interruptible.test.ts
+++ b/packages/foldkit/src/command/interruptible/interruptible.test.ts
@@ -54,6 +54,110 @@ describe('Interruptible.define', () => {
     expect(interrupt.interruptsKey).toBe('SyncLibrary')
   })
 
+  it('uses the Command name as the key on the with-args form when toKey is omitted', () => {
+    const SaveDraft = define(
+      'SaveDraft',
+      { taskId: S.Number },
+      SucceededTask,
+    )(({ taskId }) => Effect.succeed(SucceededTask({ taskId })))
+
+    const instance = SaveDraft({ taskId: 7 })
+    expect(instance.name).toBe('SaveDraft')
+    expect(instance.args).toEqual({ taskId: 7 })
+    expect(instance.key).toBe('SaveDraft')
+
+    const interrupt = SaveDraft.Interrupt(outcome => outcome)
+    expect(interrupt.name).toBe('SaveDraft.Interrupt')
+    expect(interrupt.interruptsKey).toBe('SaveDraft')
+  })
+
+  it.effect(
+    'interrupts the in-flight holder on the with-args form when toKey is omitted',
+    () =>
+      Effect.gen(function* () {
+        const registry = __makeRegistry()
+
+        const SaveDraft = define(
+          'SaveDraft',
+          { taskId: S.Number },
+          SucceededTask,
+        )(({ taskId }) => Effect.as(Effect.never, SucceededTask({ taskId })))
+
+        const fiber = yield* Effect.forkChild(
+          SaveDraft({ taskId: 7 }).effect.pipe(provideRegistry(registry)),
+        )
+        yield* Effect.yieldNow
+
+        expect(
+          Array.isReadonlyArrayNonEmpty(registry.lookup('SaveDraft')),
+        ).toBe(true)
+
+        const outcome = yield* SaveDraft.Interrupt(
+          outcome => outcome,
+        ).effect.pipe(provideRegistry(registry))
+
+        expect(outcome._tag).toBe('Interrupted')
+        expect(Array.isReadonlyArrayEmpty(registry.lookup('SaveDraft'))).toBe(
+          true,
+        )
+
+        const exit = yield* Fiber.await(fiber)
+        expect(exit._tag).toBe('Failure')
+      }),
+  )
+
+  it.effect(
+    'reports NotFound after the holder completed on the with-args form when toKey is omitted',
+    () =>
+      Effect.gen(function* () {
+        const registry = __makeRegistry()
+
+        const SaveDraft = define(
+          'SaveDraft',
+          { taskId: S.Number },
+          SucceededTask,
+        )(({ taskId }) => Effect.succeed(SucceededTask({ taskId })))
+
+        const message = yield* SaveDraft({ taskId: 7 }).effect.pipe(
+          provideRegistry(registry),
+        )
+        expect(message).toEqual(SucceededTask({ taskId: 7 }))
+
+        const outcome = yield* SaveDraft.Interrupt(
+          outcome => outcome,
+        ).effect.pipe(provideRegistry(registry))
+
+        expect(outcome._tag).toBe('NotFound')
+      }),
+  )
+
+  it.effect(
+    'releases the key when the Effect fails on the with-args form when toKey is omitted',
+    () =>
+      Effect.gen(function* () {
+        const registry = __makeRegistry()
+
+        const SaveDraft = define(
+          'SaveDraft',
+          { taskId: S.Number },
+          SucceededTask,
+        )(({ taskId }) =>
+          Effect.flatMap(Effect.fail('boom'), () =>
+            Effect.succeed(SucceededTask({ taskId })),
+          ),
+        )
+
+        const exit = yield* Effect.exit(
+          SaveDraft({ taskId: 7 }).effect.pipe(provideRegistry(registry)),
+        )
+
+        expect(exit._tag).toBe('Failure')
+        expect(Array.isReadonlyArrayEmpty(registry.lookup('SaveDraft'))).toBe(
+          true,
+        )
+      }),
+  )
+
   it.effect('interrupts the in-flight holder and reports Interrupted', () =>
     Effect.gen(function* () {
       const registry = __makeRegistry()

--- a/packages/foldkit/src/command/interruptible/interruptible.ts
+++ b/packages/foldkit/src/command/interruptible/interruptible.ts
@@ -216,6 +216,28 @@ export interface DefinitionWithArgs<
   }>
 }
 
+/** An interruptible Command definition with declared args but no `toKey`, so
+ *  its key is the Command name, exactly like the no-args form. Call as
+ *  `Definition(args)` to produce a Command instance; use `Definition.Interrupt`
+ *  to build the Command that stops it. Reach for this when a Command takes args
+ *  yet at most one invocation is meaningfully in flight, so its invocations need
+ *  nothing to distinguish them. */
+export interface DefinitionWithArgsNameKeyed<
+  Name extends string,
+  Fields extends Schema.Struct.Fields,
+  Eff extends Effect.Effect<any, any, any>,
+> {
+  readonly [CommandDefinitionTypeId]: CommandDefinitionTypeId
+  readonly name: Name
+  readonly Interrupt: InterruptDefinitionNoArgs<Name>;
+  (args: Schema.Schema.Type<Schema.Struct<Fields>>): Readonly<{
+    name: Name
+    args: Schema.Schema.Type<Schema.Struct<Fields>>
+    key: string
+    effect: Eff
+  }>
+}
+
 const brandAsDefinition = (definition: unknown, name: string): void => {
   Object.defineProperty(definition, 'name', {
     value: name,
@@ -275,6 +297,13 @@ const makeInterruptDefinitionWithArgs = (
  * from a generated value: the update function is pure, and any invocation you
  * can meaningfully target is already distinguished by data in the Model.
  *
+ * `toKey` is optional on the with-args form. Omit it when at most one
+ * invocation is meaningfully in flight (a single-instance submit flow), and the
+ * key is the Command name, exactly like the no-args form, with `Interrupt`
+ * taking only `toMessage`. Provide it, deriving the key from the owning Model
+ * identity, when invocations run concurrently and must be interrupted
+ * independently.
+ *
  * Semantics:
  *
  * - A key is an address, not a lock. Any number of invocations may run under
@@ -326,6 +355,21 @@ const makeInterruptDefinitionWithArgs = (
  *   CompletedCancelUploadFile({ uploadId: 1, outcome }),
  * )
  * ```
+ *
+ * @example With args, keyed by name (one invocation in flight)
+ * ```ts
+ * const SaveDraft = Command.Interruptible.define(
+ *   'SaveDraft',
+ *   { draftId: S.String, body: S.String },
+ *   SucceededSaveDraft,
+ *   FailedSaveDraft,
+ * )(({ draftId, body }) =>
+ *   Effect.gen(function* () { ... }),
+ * )
+ * // Call sites:
+ * SaveDraft({ draftId: 'abc', body })
+ * SaveDraft.Interrupt(outcome => CompletedCancelSaveDraft({ outcome }))
+ * ```
  */
 export function define<
   const Name extends string,
@@ -351,6 +395,18 @@ export function define<
   effectBuilder: (args: Schema.Schema.Type<Schema.Struct<Fields>>) => Eff,
 ) => DefinitionWithArgs<Name, Fields, KeyArgs, Eff>
 
+export function define<
+  const Name extends string,
+  Fields extends Schema.Struct.Fields,
+  Results extends ReadonlyArray<Schema.Top>,
+>(
+  name: Name,
+  args: Fields,
+  ...results: Results
+): <Eff extends Effect.Effect<Schema.Schema.Type<Results[number]>, any, any>>(
+  effectBuilder: (args: Schema.Schema.Type<Schema.Struct<Fields>>) => Eff,
+) => DefinitionWithArgsNameKeyed<Name, Fields, Eff>
+
 export function define(name: string, ...rest: ReadonlyArray<unknown>): unknown {
   const [maybeArgs, maybeToKey] = rest
 
@@ -373,6 +429,32 @@ export function define(name: string, ...rest: ReadonlyArray<unknown>): unknown {
       /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
       return definition as unknown as DefinitionNoArgs<
         string,
+        Effect.Effect<any, any, any>
+      >
+    }
+  }
+
+  const isToKeyFunction =
+    Predicate.isFunction(maybeToKey) && !Schema.isSchema(maybeToKey)
+
+  if (!isToKeyFunction) {
+    const key = name
+    return (effectBuilder: (args: any) => Effect.Effect<any, any, any>) => {
+      const definition = (args: any) => ({
+        name,
+        args,
+        key,
+        effect: registerKeyWhileRunning(key, effectBuilder(args)),
+        messageMappers: [],
+      })
+      brandAsDefinition(definition, name)
+      Object.defineProperty(definition, 'Interrupt', {
+        value: makeInterruptDefinitionNoArgs(name, key),
+      })
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      return definition as unknown as DefinitionWithArgsNameKeyed<
+        string,
+        any,
         Effect.Effect<any, any, any>
       >
     }

--- a/packages/foldkit/src/command/interruptible/public.ts
+++ b/packages/foldkit/src/command/interruptible/public.ts
@@ -1,6 +1,7 @@
 export type {
   DefinitionNoArgs,
   DefinitionWithArgs,
+  DefinitionWithArgsNameKeyed,
   InterruptDefinitionNoArgs,
   InterruptDefinitionWithArgs,
 } from './index.js'

--- a/packages/website/src/page/core/commands.ts
+++ b/packages/website/src/page/core/commands.ts
@@ -262,7 +262,11 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('Command.Interruptible.define'),
         ' declares a Command that can be stopped mid-flight. It works like ',
         inlineCode('Command.define'),
-        ' with one addition: a key that identifies the invocation. The key function is stated once at the definition and maps the args to whatever distinguishes invocations; Foldkit prefixes it with the Command name automatically, so keys never collide across definitions. A Command with no declared args needs no key function at all: its key is the Command name.',
+        ' with one addition: a key that identifies the invocation. The key function is stated once at the definition and maps the args to whatever distinguishes invocations; Foldkit prefixes it with the Command name automatically, so keys never collide across definitions. A Command with no declared args needs no key function at all: its key is the Command name. The key function is optional even with declared args: omit it when at most one invocation is meaningfully in flight, and the key falls back to the Command name, so ',
+        inlineCode('Interrupt'),
+        ' takes only ',
+        inlineCode('toMessage'),
+        '; provide it, derived from the owning Model identity, when invocations run concurrently and must be interrupted independently.',
       ),
       highlightedCodeBlock(
         h.div(
@@ -291,7 +295,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       para(
         'The definition carries an ',
         inlineCode('Interrupt'),
-        ' constructor. It takes the key args and a function from the interrupt outcome to a Message, and returns an ordinary Command: update stays pure, DevTools shows the dispatch, and tests resolve it like any other Command. The outcome is ',
+        ' constructor. It takes a function from the interrupt outcome to a Message, preceded by the key args for a definition whose key is derived from its args, and returns an ordinary Command: update stays pure, DevTools shows the dispatch, and tests resolve it like any other Command. The outcome is ',
         inlineCode('Interrupted'),
         ' when an in-flight Command was stopped, or ',
         inlineCode('NotFound'),


### PR DESCRIPTION
## What and why

`Command.Interruptible.define` coupled two orthogonal properties: whether a Command takes args, and whether its invocations need distinguishing. The no-args form keys invocations by the Command name and its `Interrupt(toMessage)` takes no key args. The with-args form required a `toKey`, so a single-instance submit flow (one form, one chain, at most one invocation in flight) had args but nothing to distinguish and was forced into ceremony: a constant `toKey` and an empty `{}` at every interrupt site. The `{}` is the worst part, since a reader cannot tell "empty key args, deliberate constant key" from "forgot to pass the key args."

This makes `toKey` optional on the with-args form. When omitted, the key is the Command name (exactly the no-args behavior) and the definition's `Interrupt` takes the `InterruptDefinitionNoArgs` shape, `Interrupt(toMessage)`, with no key args parameter.

```ts
const SaveDraft = Command.Interruptible.define(
  'SaveDraft',
  { draftId: S.String, body: S.String },
  SucceededSaveDraft,
  FailedSaveDraft,
)(({ draftId, body }) => ...)

// Before: SaveDraft.Interrupt({}, outcome => CompletedCancelSaveDraft({ outcome }))
// Now:    SaveDraft.Interrupt(outcome => CompletedCancelSaveDraft({ outcome }))
```

Fixes #773.

## What changed

- `packages/foldkit/src/command/interruptible/interruptible.ts`: new `DefinitionWithArgsNameKeyed` type, a third `define` overload for the with-args form with `toKey` omitted, and a runtime branch that keys by the Command name and attaches the no-args `Interrupt`.
- `packages/foldkit/src/command/interruptible/public.ts`: exports `DefinitionWithArgsNameKeyed`.
- `packages/foldkit/src/command/interruptible/interruptible.test.ts`: two tests covering the new form's key/`Interrupt` shape and actual interruption of the in-flight holder.
- `packages/website/src/page/core/commands.ts`: one sentence carrying the omit-vs-provide guidance.
- Changeset (`minor`): a backward-compatible addition to the `foldkit` package.

## Design decision

The runtime distinguishes an omitted `toKey` from a result Schema with `Predicate.isFunction(maybeToKey) && !Schema.isSchema(maybeToKey)`. A callable Message constructor is both a function and a Schema, so `isFunction` alone cannot separate a real key function from a result; the `!isSchema` guard is what does. The overloads are ordered no-args, with-args + `toKey`, with-args without `toKey`, so a `toKey` call still binds the third overload (a `string`-returning function is not a `Schema.Top`) and a no-`toKey` call falls through to the new one (a Message constructor's callable signature returns a Message, not a `string`, so it does not satisfy the `toKey` overload).

The alternative, a single overload with an optional `toKey` parameter, was rejected because it cannot make `Interrupt` drop its key args parameter based on whether `toKey` was supplied. Separate return types are what let the definition expose `Interrupt(toMessage)` in the omitted case and `Interrupt(keyArgs, toMessage)` otherwise.

## Verification

- `foldkit` typecheck and full test suite pass; the two new tests exercise both key derivation and real interruption, and `interruptible.ts` is at 100% statement coverage.
- A throwaway `@ts-expect-error` file confirmed the type-level precision: the new form's `Interrupt` rejects key args, the with-`toKey` form still requires them, and the name-keyed instance still requires its declared args. All positive forms compile. (Removed after checking.)
- `lint`, `format:check`, and `check:dead-code` are green. The website page typechecks against a fresh `pnpm build`.
- The pre-push suite ran on push; the website e2e step was skipped only because Playwright browsers are not installed in this container, which CI installs and runs on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNWutniyyS4ULNNBzQ5Q6z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional key-mapping for `Command.Interruptible.define` in the “with-args” form: when `toKey` is omitted and only one invocation matters, Foldkit uses the command name as the interruption key.
* **Documentation**
  * Updated “Interrupting Commands” to reflect the new optional-key behavior, including the `Interrupt` call shape when no key function is provided.
* **Tests**
  * Expanded coverage for the “args without key function” constructor form, verifying correct interruption outcomes and registry-key cleanup on completion/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->