### PR TITLE
feat(foldkit): accept the name-keyed interruptible definition in resolve

### DIFF
--- a/.changeset/resolve-name-keyed-interruptible-definition.md
+++ b/.changeset/resolve-name-keyed-interruptible-definition.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+`Story.Command.resolve` and `Scene.Command.resolve` now accept a bare name-keyed interruptible Command definition, the with-args `Command.Interruptible.define` shape that omits `toKey`. The definition overload already accepted the no-args and keyed with-args shapes, but the name-keyed shape was missing from its union, so resolving one by its definition failed to typecheck and forced a resolve-by-instance workaround. Runtime matching was name-only all along, so this closes a type-level gap.

--- a/packages/foldkit/src/test/apps/drafts.ts
+++ b/packages/foldkit/src/test/apps/drafts.ts
@@ -1,0 +1,78 @@
+import { Effect, Match as M, Schema as S } from 'effect'
+
+import * as Command from '../../command/index.js'
+import * as Interruptible from '../../command/interruptible/index.js'
+import { type Document, html } from '../../html/index.js'
+import { m } from '../../message/index.js'
+import { evo } from '../../struct/index.js'
+
+// MODEL
+
+export const SaveStatus = S.Literals(['Editing', 'Saving', 'Saved'])
+export type SaveStatus = typeof SaveStatus.Type
+
+export const Model = S.Struct({
+  revision: S.Number,
+  status: SaveStatus,
+})
+export type Model = typeof Model.Type
+
+// MESSAGE
+
+export const ClickedSaveDraft = m('ClickedSaveDraft')
+export const SucceededSaveDraft = m('SucceededSaveDraft', {
+  revision: S.Number,
+})
+
+export const Message = S.Union([ClickedSaveDraft, SucceededSaveDraft])
+export type Message = typeof Message.Type
+
+// COMMAND
+
+export const SaveDraftArgs = S.Struct({ revision: S.Number })
+export type SaveDraftArgs = typeof SaveDraftArgs.Type
+
+export const SaveDraft = Interruptible.define(
+  'SaveDraft',
+  SaveDraftArgs.fields,
+  SucceededSaveDraft,
+)(({ revision }) => Effect.as(Effect.never, SucceededSaveDraft({ revision })))
+
+// INIT
+
+export const initialModel: Model = { revision: 0, status: 'Editing' }
+
+// UPDATE
+
+export const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<Command.Command<Message>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [Model, ReadonlyArray<Command.Command<Message>>]
+    >(),
+    M.tagsExhaustive({
+      ClickedSaveDraft: () => [
+        evo(model, { status: () => 'Saving' }),
+        [SaveDraft({ revision: model.revision })],
+      ],
+      SucceededSaveDraft: () => [evo(model, { status: () => 'Saved' }), []],
+    }),
+  )
+
+// VIEW
+
+export const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  const body = h.div(
+    [],
+    [
+      h.button([h.OnClick(ClickedSaveDraft())], ['Save draft']),
+      h.span([], [`draft: ${model.status}`]),
+    ],
+  )
+
+  return { title: 'Drafts', body }
+}

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -28,6 +28,13 @@ import {
   view as counterView,
 } from './apps/counter.js'
 import {
+  SaveDraft,
+  SucceededSaveDraft,
+  update as draftsUpdate,
+  view as draftsView,
+  initialModel as initialDraftsModel,
+} from './apps/drafts.js'
+import {
   initialModel as fileUploadInitialModel,
   update as fileUploadUpdate,
   view as fileUploadView,
@@ -1518,6 +1525,19 @@ describe('scene', () => {
       Scene.Command.expectNone(),
       Scene.tap(({ html }) => {
         expect(find(html, 'span')).toHaveText('upload 0: Done')
+      }),
+    )
+  })
+
+  test('resolves a name-keyed Command by its bare Definition, matching by name', () => {
+    Scene.scene(
+      { update: draftsUpdate, view: draftsView },
+      Scene.with(initialDraftsModel),
+      Scene.click(Scene.role('button', { name: 'Save draft' })),
+      Scene.Command.resolve(SaveDraft, SucceededSaveDraft({ revision: 0 })),
+      Scene.Command.expectNone(),
+      Scene.tap(({ html }) => {
+        expect(find(html, 'span')).toHaveText('draft: Saved')
       }),
     )
   })

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -244,6 +244,11 @@ type ResolvableCommandDefinition<Name extends string, ResultMessage> =
       any,
       Effect.Effect<ResultMessage, any, any>
     >
+  | Interruptible.DefinitionWithArgsNameKeyed<
+      Name,
+      any,
+      Effect.Effect<ResultMessage, any, any>
+    >
 
 const slotKey = ({ name, occurrence }: PendingMount): string =>
   `${name}#${occurrence}`

--- a/packages/foldkit/src/test/story.test.ts
+++ b/packages/foldkit/src/test/story.test.ts
@@ -16,6 +16,13 @@ import {
   update,
 } from './apps/counter.js'
 import {
+  ClickedSaveDraft,
+  SaveDraft,
+  SucceededSaveDraft,
+  update as draftsUpdate,
+  initialModel as initialDraftsModel,
+} from './apps/drafts.js'
+import {
   CancelledForm,
   CompletedReset,
   GotChildMessage,
@@ -536,6 +543,19 @@ describe('interruptible Commands', () => {
     )
   })
 
+  test('resolves a name-keyed Command by its bare Definition, matching by name', () => {
+    Story.story(
+      draftsUpdate,
+      Story.with(initialDraftsModel),
+      Story.message(ClickedSaveDraft()),
+      Story.Command.resolve(SaveDraft, SucceededSaveDraft({ revision: 0 })),
+      Story.model(model => {
+        expect(model.status).toBe('Saved')
+      }),
+      Story.Command.expectNone(),
+    )
+  })
+
   test('resolveAll resolves keyed Commands by their bare Definition', () => {
     Story.story(
       uploadsUpdate,
@@ -742,6 +762,14 @@ describe('type safety', () => {
     const resolver = Story.Command.resolve(
       UploadFile,
       SucceededUploadFile({ uploadId: 0 }),
+    )
+    expectTypeOf(resolver).toBeFunction()
+  })
+
+  test('resolve accepts a bare name-keyed interruptible Command definition', () => {
+    const resolver = Story.Command.resolve(
+      SaveDraft,
+      SucceededSaveDraft({ revision: 0 }),
     )
     expectTypeOf(resolver).toBeFunction()
   })

--- a/packages/foldkit/src/test/story.ts
+++ b/packages/foldkit/src/test/story.ts
@@ -47,6 +47,11 @@ type ResolvableCommandDefinition<Name extends string, ResultMessage> =
       any,
       Effect.Effect<ResultMessage, any, any>
     >
+  | Interruptible.DefinitionWithArgsNameKeyed<
+      Name,
+      any,
+      Effect.Effect<ResultMessage, any, any>
+    >
 
 /** An immutable test simulation of a Foldkit program. */
 export type StorySimulation<Model, Message, OutMessage = undefined> = Readonly<{


### PR DESCRIPTION
## What and why

Follow-up to the 0.131.0 pair of changes that widened `Story.Command.resolve` and `Scene.Command.resolve` to accept bare interruptible Command definitions. That widening added `Interruptible.DefinitionNoArgs` and `Interruptible.DefinitionWithArgs` to the `ResolvableCommandDefinition` union, but a later change made `toKey` optional on the with-args `Interruptible.define`, introducing a third definition shape, `DefinitionWithArgsNameKeyed`, that the union never picked up.

So a with-args interruptible Command that omits `toKey` (the newly blessed single-instance form) still could not be resolved by its bare definition:

```
Argument of type 'DefinitionWithArgsNameKeyed<"SaveDraft", ...>' is not assignable
to parameter of type 'ResolvableCommandDefinition<"SaveDraft", ...>'.
```

Runtime matching is name-only through the shared `CommandDefinitionTypeId` brand, exactly as before, so this was purely type-level. Resolve-by-instance was the workaround.

## What changed

- Added `Interruptible.DefinitionWithArgsNameKeyed` to the `ResolvableCommandDefinition` union in both `test/story.ts` and `test/scene.ts`, closing the loop with the other two interruptible shapes.
- Added a `drafts` test fixture: a draft-autosave app whose `SaveDraft` is a name-keyed interruptible Command (with args, no `toKey`).
- Added Story and Scene tests that resolve the Command by its bare definition, plus a Story type-safety test guarding the union against regression.

## Verification

- Removed the new union member and confirmed the exact error from the issue reproduces, with both the runtime and the type-safety test catching it. Restored the member and confirmed the suite is green.
- `pnpm typecheck`, `pnpm lint`, `pnpm check:dead-code`, `prettier --check`, and the foldkit build all pass. The Story and Scene suites pass (593 tests). The full pre-push suite ran on push.

Fixes #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvqNNU7bkKE2hKsjGtDStY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command resolution now supports bare name-keyed interruptible command definitions in stories and scenes.
  * Added a Drafts example flow with save-status tracking and success handling.

* **Bug Fixes**
  * Fixed type-checking failures when resolving name-keyed interruptible commands by definition.
  * Added coverage confirming commands resolve correctly and update the saved draft state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->