### PR TITLE
feat(skills): add Codex and ChatGPT descriptors to the shipped skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/packages/website/src/link.ts
+++ b/packages/website/src/link.ts
@@ -54,4 +54,6 @@ export const Link = {
     'https://github.com/foldkit/foldkit/blob/main/packages/foldkit/CHANGELOG.md',
   dragAndDropDocumentStyles:
     'https://github.com/foldkit/foldkit/blob/main/packages/ui/src/dragAndDrop/index.ts#L663-L689',
+  chatgptSkills: 'https://learn.chatgpt.com/docs/build-skills',
+  opencodeSkills: 'https://opencode.ai/docs/skills/',
 }

--- a/packages/website/src/page/aiSkills.ts
+++ b/packages/website/src/page/aiSkills.ts
@@ -1,19 +1,46 @@
 import { Html, html } from 'foldkit/html'
 
+import { Link } from '../link'
 import type { TableOfContentsEntry } from '../main'
 import type { Message } from '../message'
 import {
   inlineCode,
+  link,
   pageTitle,
   para,
   tableOfContentsEntryToHeader,
 } from '../prose'
+import { aiOverviewRouter } from '../route'
 import { type CopiedSnippets, codeBlock } from '../view/codeBlock'
 
 const overviewHeader: TableOfContentsEntry = {
   level: 'h2',
   id: 'overview',
   text: 'Overview',
+}
+
+const installationHeader: TableOfContentsEntry = {
+  level: 'h2',
+  id: 'installation',
+  text: 'Installation',
+}
+
+const claudeCodeHeader: TableOfContentsEntry = {
+  level: 'h3',
+  id: 'claude-code',
+  text: 'Claude Code',
+}
+
+const codexHeader: TableOfContentsEntry = {
+  level: 'h3',
+  id: 'codex-and-chatgpt',
+  text: 'Codex and ChatGPT',
+}
+
+const opencodeHeader: TableOfContentsEntry = {
+  level: 'h3',
+  id: 'opencode',
+  text: 'OpenCode',
 }
 
 const availableSkillsHeader: TableOfContentsEntry = {
@@ -42,6 +69,10 @@ const auditProgramHeader: TableOfContentsEntry = {
 
 export const tableOfContents: ReadonlyArray<TableOfContentsEntry> = [
   overviewHeader,
+  installationHeader,
+  claudeCodeHeader,
+  codexHeader,
+  opencodeHeader,
   availableSkillsHeader,
   foldkitHeader,
   generateProgramHeader,
@@ -65,13 +96,22 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       para(
         'Foldkit ships a ',
         inlineCode('foldkit-skills'),
-        ' plugin for ',
-        inlineCode('Claude Code'),
-        ' that provides agent skills tailored to the Foldkit architecture. These skills encode the conventions, patterns, and quality standards that make Foldkit apps well-factored and maintainable.',
+        ' plugin that provides agent skills tailored to the Foldkit architecture. These skills encode the conventions, patterns, and quality standards that make Foldkit apps well-factored and maintainable.',
       ),
       para(
-        'To install, first add the Foldkit marketplace, then install the plugin:',
+        'The skills work with ',
+        inlineCode('Claude Code'),
+        ', ',
+        inlineCode('Codex'),
+        ', the ChatGPT desktop app, and ',
+        inlineCode('OpenCode'),
+        '. Each skill is a directory with a ',
+        inlineCode('SKILL.md'),
+        ' file, the format they all read.',
       ),
+      tableOfContentsEntryToHeader(installationHeader),
+      tableOfContentsEntryToHeader(claudeCodeHeader),
+      para('Add the Foldkit marketplace, then install the plugin:'),
       codeBlock(
         ADD_MARKETPLACE_COMMAND,
         'Copy marketplace command',
@@ -83,6 +123,51 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         'Copy install command',
         copiedSnippets,
         'mb-4',
+      ),
+      tableOfContentsEntryToHeader(codexHeader),
+      para(
+        'Codex discovers repo-local skills from ',
+        inlineCode('.agents/skills/'),
+        '. Vendor the Foldkit repository as a git subtree (see the ',
+        link(aiOverviewRouter(), 'AI overview'),
+        ') so the sources are on disk, then copy or symlink the skill directories from ',
+        inlineCode('repos/foldkit/skills/'),
+        ' into ',
+        inlineCode('.agents/skills/'),
+        ' in your project. Invoke a skill by name, for example ',
+        inlineCode('$generate-program'),
+        '.',
+      ),
+      para(
+        'The ChatGPT desktop app surfaces the skills in its picker from the ',
+        inlineCode('agents/openai.yaml'),
+        ' descriptor shipped alongside each ',
+        inlineCode('SKILL.md'),
+        ' (display name, short description, and default prompt). Follow the ',
+        link(Link.chatgptSkills, 'ChatGPT skills guide'),
+        ' to register them.',
+      ),
+      tableOfContentsEntryToHeader(opencodeHeader),
+      para(
+        link(Link.opencodeSkills, 'OpenCode'),
+        ' discovers skills from ',
+        inlineCode('.opencode/skills/'),
+        ', ',
+        inlineCode('.claude/skills/'),
+        ', and ',
+        inlineCode('.agents/skills/'),
+        ', walking up from the working directory to the git root. It reads the ',
+        inlineCode('SKILL.md'),
+        ' frontmatter directly and ignores the ChatGPT ',
+        inlineCode('agents/openai.yaml'),
+        ' descriptor.',
+      ),
+      para(
+        'Copy or symlink the skills from the vendored subtree (',
+        inlineCode('repos/foldkit/skills/'),
+        ') into one of those directories. OpenCode also reads ',
+        inlineCode('AGENTS.md'),
+        ', so the conventions the starter template ships already apply.',
       ),
       tableOfContentsEntryToHeader(availableSkillsHeader),
       tableOfContentsEntryToHeader(foldkitHeader),

--- a/skills/audit-program/agents/openai.yaml
+++ b/skills/audit-program/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Audit Program'
+  short_description: 'Audit a Foldkit app against the architecture and conventions'
+  default_prompt: 'Use $audit-program to review a Foldkit app against the architecture and conventions.'

--- a/skills/foldkit/agents/openai.yaml
+++ b/skills/foldkit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Foldkit'
+  short_description: 'Load Foldkit architecture framing and conventions'
+  default_prompt: 'Use $foldkit to load Foldkit framing before working on a Foldkit app.'

--- a/skills/generate-program/agents/openai.yaml
+++ b/skills/generate-program/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Generate Program'
+  short_description: 'Generate an idiomatic Foldkit app from a description'
+  default_prompt: 'Use $generate-program to build a complete Foldkit app from a description.'


### PR DESCRIPTION
## What and why

The `foldkit-skills` plugin shipped only as a Claude Code plugin, and the `ai/skills` docs page presented the skills as Claude Code only. This adds Codex and ChatGPT support. Codex and the ChatGPT desktop app read the same `SKILL.md` format the skills already use, so the only gaps were the ChatGPT skill-picker metadata (`agents/openai.yaml`) and documentation.

## What changed

- Added an `agents/openai.yaml` descriptor (display name, short description, default prompt) to each shipped skill: `foldkit`, `generate-program`, and `audit-program`. This mirrors the format the repo already uses for its own `.agents/skills/commit-changes` maintenance skill.
- Bumped `.claude-plugin/plugin.json` to `0.10.29` so installs pick up the new files (required by the skill-version check).
- Reworked the `ai/skills` website page into an Installation section with a Claude Code subsection (the existing marketplace and install commands) and a new Codex and ChatGPT subsection, plus an overview line noting both tools.

## Design decision

The descriptors live alongside each skill's existing `SKILL.md` inside `skills/<name>/`, keeping a single source of truth. The Claude Code plugin lists skill directories, so the extra `agents/openai.yaml` is inert for Claude Code users (confirmed by a clean build). The alternative, copying all three skill bodies into a separate `.agents/skills/` tree for Codex, would duplicate roughly 2,400 lines that then have to stay in sync, so I avoided it.

I did not invent a Codex install command. The docs point users at the vendored subtree (where the skill sources live) and to the ChatGPT skills guide for the tool-specific registration steps.

## Verification

- `pnpm format:check`, `pnpm lint`, website `typecheck`, and the full website build pass.
- `pnpm check:skill-version` confirms the plugin version bump.
- `pnpm changeset status --since=origin/main` is clean. The change touches no changeset-versioned package (`website` is changeset-ignored and `skills/` is not a workspace package).
- The full pre-push suite ran on push.

Fixes #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWbj42Sv2spw4kiMYBby13)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new OpenAI skill agent interfaces for Audit Program, Foldkit, and Generate Program.
  * Expanded the AI Skills page with new TOC-backed sections, including Installation, Claude Code, and Codex/ChatGPT plus OpenCode guidance.
  * Introduced a new ChatGPT Skills documentation link for easier navigation.

* **Documentation**
  * Refreshed AI Skills page intro and added more detailed, link-rich instructions for registering and viewing skills.

* **Chores**
  * Bumped the plugin manifest version to 0.10.29.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->