### PR TITLE
fix(skills): correct drifted APIs and de-duplicate the review blind spots

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.10.30",
+  "version": "0.10.31",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/skills/audit-program/SKILL.md
+++ b/skills/audit-program/SKILL.md
@@ -45,6 +45,9 @@ Read these in order. Every audit, no shortcuts. They're the spec the audit grade
 1. [Architecture guide](../generate-program/architecture.md): TEA invariants, Submodel and OutMessage pattern, Flags, Subscriptions, Mount / Command / ManagedResource / CustomElement selection
 2. [Conventions guide](../generate-program/conventions.md): naming, Effect-TS idioms, Schema patterns, view conventions
 3. [Verification checklist](../generate-program/checklist.md): the canonical mechanical-check + quality-bar reference
+4. [Blind spots](../generate-program/blindSpots.md): the failure modes that survive typecheck, lint, and tests
+
+These four files are a snapshot. When the audited project vendors `repos/foldkit/`, the live source wins over anything here: read the `.d.ts` or the example rather than grading against a remembered signature.
 
 Do not skim. The audit's signal-to-noise depends on the auditor having internalized the bar before reading the audited code.
 
@@ -61,7 +64,7 @@ Before deep review, build a model of the audited code:
    - **Tier 5**: nested domain, CRUD
    - **Tier 6**: Submodels, OutMessage, multi-step flows
    - **Tier 7**: real-time, WebSocket, ManagedResources
-3. **Foldkit modules used**. Grep imports for `Calendar`, `File`, `FieldValidation`, `Ui.*`, `Subscription`, `Command`, `Mount`, `ManagedResource`, `CustomElement`, `Dom`, `HttpClient`, etc. Tells you which checklist sections apply.
+3. **Foldkit modules used**. Grep imports for `AsyncData`, `Calendar`, `File`, `Http`, `Update`, `Port`, `Subscription`, `Command`, `Mount`, `ManagedResource`, `CustomElement`, `Dom` from `foldkit`, plus `foldkit/fieldValidation` and any component imported from `@foldkit/ui`. HTTP usage shows up as `HttpClient` / `HttpClientRequest` imported from `effect/unstable/http`, not as a `foldkit` import, so grep for those separately; `Http` from `foldkit` is only the `layer` that provides the client. Tells you which checklist sections apply.
 4. **Tier-matching exemplar**. Pick at least one to read alongside the audited code:
    - Tier 1-2 → `${CLAUDE_SKILL_DIR}/../../examples/counter/src/main.ts`, `${CLAUDE_SKILL_DIR}/../../examples/stopwatch/src/main.ts`
    - Tier 3 → `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.ts`, `${CLAUDE_SKILL_DIR}/../../examples/form/src/main.ts`
@@ -69,7 +72,7 @@ Before deep review, build a model of the audited code:
    - Tier 5 → `${CLAUDE_SKILL_DIR}/../../examples/kanban/src/`
    - Tier 6 → `${CLAUDE_SKILL_DIR}/../../examples/auth/src/`, `${CLAUDE_SKILL_DIR}/../../examples/job-application/src/`
    - Tier 7 → `${CLAUDE_SKILL_DIR}/../../packages/typing-game/client/src/page/room/`
-5. **Foldkit UI integration**. If any `Ui.*` is imported, also read `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/main.ts` for the wiring pattern.
+5. **Foldkit UI integration**. If anything is imported from `@foldkit/ui`, also read `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/main.ts` and `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/ui/` for the wiring pattern.
 
 The exemplar is the comparison target. When you find a pattern that smells off, ask: **does the exemplar do this differently?** If yes, flag it.
 
@@ -80,7 +83,7 @@ Run the canonical greps from the **Mechanical scans** block in [`../generate-pro
 For every hit, decide:
 
 - Is there a `// NOTE:` above it justifying the deviation?
-- If yes, evaluate the justification. Is it real, or defensive rationalization? Common false-justifications: "would require duplicate state" (most Ui components have small inline-constructable models), "the interaction is too custom" (the `toView` callback handles arbitrary HTML), "we don't want to wire toParentMessage" (that's the unavoidable cost of a11y-correct interactive widgets, paid once per use).
+- If yes, evaluate the justification. Is it real, or defensive rationalization? Common false-justifications: "would require duplicate state" (most `@foldkit/ui` components have small inline-constructable models, and the controlled render helpers have none at all), "the interaction is too custom" (the `toView` callback handles arbitrary HTML), "we don't want to wire toParentMessage" (that's the unavoidable cost of a11y-correct interactive widgets, paid once per use).
 - If no NOTE, it's a finding.
 
 Mechanical scans catch the cheap stuff. They're the floor of the audit, not the ceiling.
@@ -96,7 +99,7 @@ For non-trivial audits, parallelize. Spawn subagents in a single message so they
 Use `Agent` with `subagent_type: general-purpose`. Suggested fan-out:
 
 - **Subagent A (Structural correctness)**. Model schema completeness, Message union coverage, `M.tagsExhaustive` exhaustiveness, every `Succeeded*` paired with `Failed*`, every Command identity defined as a PascalCase constant via `Command.define`, every route variant rendered, no dead state variants. Native web components bound via `CustomElement.define`, not via `OnMount` + Subscription + tag-name registry. Flag any custom element wired through `OnMount` when its surface is just typed properties + observed attributes + dispatched `CustomEvent`s.
-- **Subagent B (Effect-TS idioms)**. `pipe` only for multi-step (no single-op pipes), `Option.match` over `Option.map(...).pipe(Option.getOrElse(...))`, `Array.match` for empty/non-empty branching, `Array.isArrayEmpty` over `.length === 0`, `evo` over spread, point-free `evo` setters when they only transform the current field, callable constructors over `as Type`, `Array.fromOption` for "zero or one Command", `Equal.equals` in predicates, no `Effect.ignore` on infallible Effects.
+- **Subagent B (Effect-TS idioms)**. `pipe` only for multi-step (no single-op pipes), `Option.match` over `Option.map(...).pipe(Option.getOrElse(...))`, `Array.match` for empty/non-empty branching, `Array.isArrayEmpty` / `Array.isArrayNonEmpty` over `.length === 0` / `.length > 0`, `evo` over spread, point-free `evo` setters when they only transform the current field, callable constructors over `as Type`, `Array.fromOption` for "zero or one Command", `Equal.equals` in predicates, no `Effect.ignore` on infallible Effects. Also: `AsyncData` over a hand-rolled remote-data union, and the update return type aliased once per file rather than repeated inline at the signature and again inside `M.withReturnType<...>()`. A named hand-written tuple alias is what most examples use and is not a finding; `Update.Return` is the preferred spelling for new code. See `repeated-scaffolding` in blindSpots.md.
 - **Subagent C (Naming and decomposition)**. `maybe*` reserved for `Option<T>`, `is*` for booleans, no opaque abbreviations or unexplained single-letter names, conventional domain shorthand allowed, `Updated*` not `Changed*`, `Completed*` mirrors Command name verb-first, named helpers use specific verbs not generic ones, handlers over ~15 lines extracted, view branches over ~30 lines extracted, no function exceeds ~40 lines.
 - **Subagent D (Foldkit UI and accessibility)**. Hand-rolled `input` / `textarea` / `button` / `dialog` flagged unless NOTE-justified, label/input pairing via `For(id)` + `Id(id)`, dynamic errors announce via `Role('alert')` or `AriaLive('polite')`, icon-only buttons have `AriaLabel`, external links carry `Rel('noopener noreferrer')`, exactly one `h1` per route, semantic landmarks (`main`, `nav`, `header`, `footer`) over `div` soup, focus visibility preserved (no `outline-none` without `focus-visible:` replacement).
 - **Subagent E (Testing, Tier 3+)**. `story.test.ts` exists with `Story.story` pipelines, every fallible Command tested for both `Succeeded*` and `Failed*` paths, at least one multi-step interaction test, Submodel tests assert `outMessage`, Commands resolved via `Story.Command.resolve(Definition, resultMessage)` not by running Effects directly. **`scene.test.ts` is REQUIRED at Tier 3+** and is a BLOCKER if absent. Each `Scene.scene` block must contain at least one `Scene.expect(...)` or interactive resolution. Locators must be accessible (`Scene.role`, `Scene.label`, `Scene.text`) over `Scene.placeholder` or CSS selectors.
@@ -107,59 +110,7 @@ For Tier 1-2 or focused audits, do the review inline. The surface is small enoug
 
 ### Walk these blind spots
 
-These are the failure modes that pass typecheck and tests but fall short of the bar. Hit each one explicitly. For each, output one line in your notes: `[#N] <dimension>: clean | flagged at <file:line>: <issue>`.
-
-1. **Off-by-one errors.** Logic with "after N", modulo, "every Nth", counter thresholds, or cycle boundaries. Trace for N=0, N=1, and the first transition. `count % 4 === 0` triggers on count=0. Intended or bug?
-
-2. **Skip / reset semantics.** Skip, reset, cancel, undo. Trace what each does to counters and derived state. Does skip increment the counter or bypass it? Does reset preserve it? Is the behavior consistent with what a user would expect?
-
-3. **State machine edges.** For every discriminated-union state, ask: can the code transition INTO every state? OUT of every state? Are there dead states (created, never entered)? Impossible-but-reachable states?
-
-4. **Redundant derived data in Model.** Fields that could be computed from others. `endTime` AND `remainingMs` on the same state. One can drift. Flag unless there's a documented reason (view needs pure data, etc.).
-
-5. **Repeated inline patterns.** Three or four handlers sharing the same 5-line scaffold (`M.tag` + `M.orElse`, `Option.match` + fallback) want a named helper. Genuinely duplicated decision logic, not coincidental similar shape. Specific case to check: `Match.withReturnType<readonly [Model, readonly Command<Message>[]]>()` written inline at every update site, especially when repeated across files. The convention is to extract once per file: `type UpdateReturn = readonly [Model, ReadonlyArray<Command<Message>>]; const withUpdateReturn = M.withReturnType<UpdateReturn>()`. Inline repetition is a tell that the author hasn't internalized the idiom.
-
-6. **Functions that do two things.** Orchestrators mixing "decide what to do" with "do it." Helpers with `if` branching into unrelated behaviors. Handlers that conflate state and command decisions.
-
-7. **Naming drift, and Messages that name the EFFECT instead of the EVENT.** Two related smells.
-
-   First: `Updated*` here, `Changed*` there for the same kind of event. `whenX` here, `handleX` there for analogous cases. Diverging naming is a quality regression.
-
-   Second: a Message named `Incremented` (the count was incremented) describes the resulting state change, not the user action. The Foldkit convention is verb-first past-tense for the EVENT that caused the update: `ClickedIncrement` (the user clicked the increment button). `Incremented` is past-tense in form but it names the consequence, not the cause. Same trap: `Saved`, `Deleted`, `Added` as Message names. The right names: `ClickedSave`, `ClickedDelete`, `ClickedAdd`, `SucceededSave`, `SucceededDelete`. Look for Messages that read like state mutations rather than user actions or external events.
-
-8. **Effect module inconsistency.** Mixing `items.map(f)` and `Array.map(items, f)` in the same file. Mixing `Option.match` and `Option.map(...).pipe(Option.getOrElse(...))` for similar code. One file should use one idiom throughout.
-
-9. **Stuttery `evo` setters.** If an `evo` setter only transforms that same field, it should be point-free: `entries: Array.map(revealErrors)`, `count: Number.increment`, `priceSlider: Slider.reflectRange({ min: minPrice, max: maxPrice })`. Flag `entries: () => Array.map(model.entries, revealErrors)`, `count: () => Number.increment(model.count)`, or `priceSlider: () => Slider.reflectRange(model.priceSlider, { min: minPrice, max: maxPrice })`. Replacement values from Messages, child updates, Commands, or other Model fields still use `() => value`.
-
-10. **Empty-object constructor calls.** No-field tagged structs called with `({})`: `Idle({})`, `Work({})`, `ClickedSubmit({})`. Should be `Idle()`, `Work()`, `ClickedSubmit()`. Both compile; exemplars uniformly use no-arg.
-
-11. **Dead state variants, unused fields, and no-op Commands.** Variants set but never observed by the view or other updates. Fields written but never read. Commands that resolve to Messages whose handlers are `[model, []]` (do nothing).
-
-    The **no-op startup Command** pattern shows up at app boot: `init` returns `[DEFAULT_MODEL, [triggerApplicationStarted]]`, the Command resolves to `ApplicationStarted()`, and the update handler is `ApplicationStarted: () => [model, []]`. The Command does nothing. It's bureaucratic ceremony. Either give the Command real work (load preferences, fetch initial data, focus first input, restore session) or delete the Command and the Message together. A Command whose Message handler is a pure no-op is dead code dressed up as architecture.
-
-    The **navigate-before-save** pattern is another instance: if `update` returns BOTH `saveState(...)` AND `navigateInternal(...)` in the same handler, the navigation races the save. A failure surfaced on the old page is unreachable. Idiomatic: emit save only, then navigate in the `Succeeded*` handler. Errors then surface on the page the user is still looking at.
-
-12. **Hard-coded route paths.** `Href('/')`, `navigateInternal('/new')`, ``Href(`/tag/${name}`)``. Routers are bidirectional. Call them as printers: `Href(homeRouter())`, `navigateInternal(newLinkRouter())`, `Href(tagFilterRouter({ tag: name }))`.
-
-13. **Hand-rolled accessible widgets.** Raw `input`, `textarea`, `button`, `dialog`, anything with `role="menu"` / `role="dialog"` / `role="tab"`. `Ui.Input`, `Ui.Textarea`, `Ui.Button`, `Ui.Dialog`, `Ui.Menu`, `Ui.Tabs` exist for a reason. A hand-rolled element without a NOTE explaining why is a BLOCKER, not a style preference. Hand-rolling skips accessibility work.
-
-14. **A11y gaps.** For anything outside `Ui.*` coverage: label/input pairing via `For(id)` + `Id(id)`, dynamic errors announced via `Role('alert')` or `AriaLive('polite')`, icon-only buttons with `AriaLabel`, external links with `Rel('noopener noreferrer')`, exactly one `h1` per route, semantic landmarks over `div` soup. Color is not the only carrier of meaning.
-
-15. **Missing scene test (Tier 3+).** `scene.test.ts` is REQUIRED at Tier 3+. Absent? BLOCKER. Present but no `Scene.expect(...)` or `Scene.Command.resolve(...)` in any block? Same. A Scene that only does `Scene.with(model)` only verifies the view doesn't throw; it doesn't test anything.
-
-16. **ARIA role confusion.** Checkboxes use `Role('checkbox')` + `AriaChecked(boolean)`. Toggle buttons (Play/Pause, Bold on/off, formatting toggles) use `AriaPressed(string)`. Mistaking one for the other is a semantic bug screen readers expose. Ask: does the label say "Mark as done" (checkbox) or "toggle bold" (pressed button)?
-
-17. **Unkeyed list rows.** Rows in `Array.map(items, ...)` carrying `OnClick` handlers bound to specific item ids, without `keyed('li')(item.id, ...)`, are a snabbdom patching bug. Delete from the middle, the OLD row's click handler patches onto a different row. User clicks "Delete B" and habit A is deleted. Subtle: invisible until a delete or reorder happens mid-list. Every row renderer that consumes a domain entity with an `id` should return `keyed('li')(item.id, ...)` or `keyed('div')(item.id, ...)`.
-
-18. **`T[]` syntax for array types.** `readonly Command<Message>[]` and `MyType[]` should be `ReadonlyArray<Command<Message>>` and `Array<MyType>`. Cosmetic but every exemplar is uniform on this. A common spot to find it: the inline `update` return type written as `readonly [Model, readonly Command<Message>[]]` should be `readonly [Model, ReadonlyArray<Command<Message>>]` (and ideally extracted to a `type UpdateReturn` alias, see blind spot #5).
-
-19. **`type Foo = typeof Foo.Type` declarations that earn nothing.** Writing `export const Model = S.Struct({...})` followed by `export type Model = typeof Model.Type` adds a line, and `typeof Model` already works in type positions since TypeScript merges value-and-type bindings under one name. But do not flag the alias by default. It is idiomatic, not noise, the moment the decoded type is referenced across modules in handler or parameter positions. `typeof Foo` is the constructor type Command consumes; any consumer that needs the decoded shape must otherwise write `typeof Foo.Type` at every call site, and the alias spares that repetition. The exemplars (typing-game, auth, kanban) export these aliases extensively for exactly this reason: `Model`, `Message`, `OutMessage`, and route types all cross module boundaries into handler and parameter signatures. Library exports where the type is part of a public API consumed externally (e.g. `ViewConfig` callback parameters) are the same case. Flag the alias only when the schema is used purely locally and no consumer references its type, or when consumers already reach for `typeof Foo.Type` directly and the alias sits unused. There the line is dead weight; otherwise leave it.
-
-20. **Flat parent Message Union absorbing a child's Messages instead of `Got*` wrapping.** When a parent's `Message = S.Union([ChildMessage, ParentLocalMessage])` directly includes the child's Message variants, every parent handler must know the child's tag names and the child can't grow its Message vocabulary without leaking into the parent. The canonical Submodel pattern wraps: `const GotChildMessage = m('GotChildMessage', { message: Child.Message })`, and the parent's `M.tagsExhaustive` has one `GotChildMessage` case that delegates: `Child.update(model.child, message)`. Flat unions work for trivial cases but don't scale and don't isolate child concerns. If you see a parent handling a child's tags directly, suggest the `Got*` wrapping for any Submodel that's likely to grow (or if the child needs to communicate to the parent via OutMessage).
-
-21. **View functions named after the namespace they're imported under.** A counter feature exporting `counter(model)` reads as `Counter.counter(model)` at call sites, which is awkward and asks the reader to parse "namespace.same-word". The convention from the typing-game and website exemplars: name the primary view function `view`, so call sites read `Counter.view(model)`, `Home.view(model)`, `Room.view(model)`. The namespace already disambiguates; the function name carries the role.
-
-22. **Data-derived keys.** A `keyed(...)` call whose key is built from displayed data (a key concatenating toggled booleans, a key set to a formatted summary string, a key that restates a field the subtree renders) is keying used as change detection. The key changes while the same conceptual thing stays on screen, so every content change tears the subtree down and rebuilds it, discarding focus, scroll position, and any open `details` element. Keys carry identity: a branch tag, a route tag, a stable id. If removing the key would leave the same structure rendering at that position, remove it and let patching handle the changed content.
+Walk every entry in [`../generate-program/blindSpots.md`](../generate-program/blindSpots.md). That file is the canonical list, shared with `generate-program`'s review loop, so the two skills grade against one bar. For each entry, output one line in your notes: `<slug>: clean | flagged at <file:line>: <issue>`. Silence is not a pass.
 
 ### Final exemplar comparison
 
@@ -219,7 +170,7 @@ When findings overlap (e.g. one helper has both a naming issue and a length issu
 Then, in a separate turn, ask whether to apply fixes. Group by reversibility and blast radius:
 
 - **Mechanical fixes** (single-line edits, name changes, import reorders, `({})` → `()`): offer to batch as one pass. Even the batch needs explicit consent. "Apply all 12 mechanical fixes?" is a real question with a real answer; don't proceed on assumed yes.
-- **Structural fixes** (handler extraction, Submodel introduction, view decomposition, replacing hand-rolled widgets with `Ui.*`): offer one at a time, confirm each, show the diff before applying.
+- **Structural fixes** (handler extraction, Submodel introduction, view decomposition, replacing hand-rolled widgets with `@foldkit/ui` components): offer one at a time, confirm each, show the diff before applying.
 - **Semantic fixes** (changing state shape, swapping booleans for discriminated unions, restructuring update logic): describe the change in prose, get explicit approval, then apply.
 
 Don't apply fixes silently. Don't apply fixes the user didn't approve. Don't bundle a structural change into a "mechanical" batch. If the user said "audit my app" without saying "and fix what you find", treat that as report-only and ask before doing anything else.
@@ -243,17 +194,19 @@ End with a summary diff: which findings were resolved, which were declined, whic
 
 When `$ARGUMENTS` narrows to a focus area, Phase 5 reduces to the relevant subagents and blind spots. The report still uses the BLOCKERS / QUALITY / NICE-TO-HAVE / VERDICT structure, just scoped.
 
-| Focus           | Subagents                                                                                                                                            | Blind spots     |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `a11y`          | D                                                                                                                                                    | #12, #13, #15   |
-| `effects`       | B                                                                                                                                                    | #5, #6, #8, #17 |
-| `naming`        | C                                                                                                                                                    | #7, #9, #20     |
-| `decomposition` | C                                                                                                                                                    | #5, #6          |
-| `forms`         | D + form-specific (Ui.Input adoption, fieldValidation usage, label/input pairing)                                                                    | #12, #13        |
-| `routing`       | A + routing-specific (bidirectional parser usage, route views as identity boundaries with no keyed route branches, `urlToString` in `Internal` case) | #11             |
-| `subscriptions` | A + subscription-specific (`Subscription.make` shape, `S.Struct({})` for always-active, message mapping inside `Stream.map`)                         | none            |
-| `testing`       | E                                                                                                                                                    | #14             |
-| `submodels`     | A + submodel-specific (Got\* wrapping, three-tuple update returns with OutMessage, parent ↔ child Message isolation)                                 | #19             |
-| `types`         | (inline) type-shape and aliasing                                                                                                                     | #17, #18        |
+Blind spots are named by their slug in [`../generate-program/blindSpots.md`](../generate-program/blindSpots.md). Cross-reference by slug, never by position.
+
+| Focus           | Subagents                                                                                                                                            | Blind spots                                                                                                                                                          |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a11y`          | D                                                                                                                                                    | `hand-rolled-widgets`, `a11y-gaps`, `aria-role-confusion`                                                                                                            |
+| `effects`       | B                                                                                                                                                    | `repeated-scaffolding`, `functions-doing-two-things`, `effect-module-inconsistency`, `stuttery-evo-setters`, `hand-rolled-async-state`, `manual-cache-orchestration` |
+| `naming`        | C                                                                                                                                                    | `naming-drift`, `messages-naming-the-effect`, `view-named-after-namespace`                                                                                           |
+| `decomposition` | C                                                                                                                                                    | `repeated-scaffolding`, `functions-doing-two-things`                                                                                                                 |
+| `forms`         | D + form-specific (`Input` / `Textarea` adoption, fieldValidation usage, label/input pairing)                                                        | `hand-rolled-widgets`, `a11y-gaps`                                                                                                                                   |
+| `routing`       | A + routing-specific (bidirectional parser usage, route views as identity boundaries with no keyed route branches, `urlToString` in `Internal` case) | `hard-coded-route-paths`, `data-derived-keys`                                                                                                                        |
+| `subscriptions` | A + subscription-specific (`Subscription.make` shape, `{}` fields for always-active, message mapping inside `Stream.map`)                            | `state-machine-edges`                                                                                                                                                |
+| `testing`       | E                                                                                                                                                    | `missing-scene-test`                                                                                                                                                 |
+| `submodels`     | A + submodel-specific (Got\* wrapping, three-tuple update returns with OutMessage, parent ↔ child Message isolation)                                 | `flat-parent-message-union`, `view-named-after-namespace`                                                                                                            |
+| `types`         | (inline) type-shape and aliasing                                                                                                                     | `array-type-syntax`, `unearned-type-aliases`, `hand-rolled-async-state`                                                                                              |
 
 For focused audits, skip Phase 4's full grep block and run only the greps relevant to the focus (e.g. for `a11y`, run `label without For`, `outline-none without focus-visible`, `_blank without Rel`).

--- a/skills/generate-program/SKILL.md
+++ b/skills/generate-program/SKILL.md
@@ -17,11 +17,13 @@ Before writing any code, analyze the description to identify:
 3. **Async operations**: external data that becomes Commands (e.g., "fetch weather", "save to localStorage")
 4. **Real-time needs**: streaming data that becomes Subscriptions (e.g., "live updates", "countdown", "WebSocket")
 5. **Pages/navigation**: URL structure that becomes routes (e.g., "home page", "detail page")
-6. **UI component needs**: interactive widgets that map to Foldkit UI components (e.g., "dropdown" → Menu, "modal" → Dialog, "tabs" → Tabs, "autocomplete" → Combobox, "date picker" → DatePicker, "file upload" → FileDrop, "reorderable list" → DragAndDrop, "toast/notification" → Toast, "hover tooltip" → Tooltip)
+6. **UI component needs**: interactive widgets that map to Foldkit UI components (e.g., "dropdown" → Menu, "modal" → Dialog, "tabs" → Tabs, "autocomplete" → Combobox, "date picker" → DatePicker, "file upload" → FileDrop, "reorderable list" → DragAndDrop, "toast/notification" → Toast, "hover tooltip" → Tooltip, "range/price filter" → Slider, "long scrolling list" → VirtualList)
 7. **Form validation needs**: required fields, format checks, async uniqueness → `foldkit/fieldValidation` module (see Phase 4)
-8. **Date handling**: birthdays, deadlines, scheduling → `Calendar` module + `Ui.DatePicker` or `Ui.Calendar`
-9. **File handling**: uploads, attachments, images → `File` module + `Ui.FileDrop`
-10. **Host embedding**: the program runs inside another app ("a widget in our React app", "embed this in an existing page", "the host needs to control it") → `Runtime.makeElement` plus the `Runtime.embed` lifecycle handle, with Flags for initial data and Ports for ongoing communication in both directions. `repos/foldkit/examples/embedding/` is the canonical reference: a plain TypeScript host driving a Foldkit widget end to end
+8. **Date handling**: birthdays, deadlines, scheduling → `Calendar` module + `DatePicker` or `Calendar` from `@foldkit/ui`
+9. **File handling**: uploads, attachments, images → `File` module + `FileDrop` from `@foldkit/ui`
+10. **Remote data**: anything fetched, cached, refreshed, or revalidated → the `AsyncData` module (see Phase 4). Don't hand-roll a loading/error union
+11. **Multi-state flows**: a described process that moves through several named steps with rules about which step follows which (checkout, onboarding, multi-step approval, a connection lifecycle) → consider the `Machine` module (`foldkit/experimental`). Writing the transitions as a table makes the edge set enumerable, so `unreachableStates()` and `deadTransitions()` catch a missing or unreachable step by computation instead of by review. Raise it as an option in the analysis you present, noting it is under `experimental/`, and let the user choose. Plain `ts()` unions with one `M.tagsExhaustive` are still right for a flow of two or three states. `repos/foldkit/examples/checkout-machine/` is the reference
+12. **Host embedding**: the program runs inside another app ("a widget in our React app", "embed this in an existing page", "the host needs to control it") → `Runtime.makeElement` plus the `Runtime.embed` lifecycle handle, with Flags for initial data and Ports for ongoing communication in both directions. `repos/foldkit/examples/embedding/` is the canonical reference: a plain TypeScript host driving a Foldkit widget end to end
 
 Present this analysis to the user before proceeding.
 
@@ -52,6 +54,9 @@ Read the architecture and conventions guides to internalize the rules:
 - [Architecture guide](architecture.md): TEA structure, file organization, type patterns
 - [Conventions guide](conventions.md): naming, Effect-TS patterns, anti-patterns
 - [Verification checklist](checklist.md): not just for Phase 5, also the generation bar. Skim the **Quality Bar** section now so you generate code that already meets it rather than code that will fail review.
+- [Blind spots](blindSpots.md): what the Phase 6 reviewer will grade you against. Reading it now is cheaper than fixing it later.
+
+These four files are a snapshot of a moving codebase. When they disagree with the live source (`repos/foldkit/`, or the `.d.ts` in `node_modules`), the live source is right. Treat the disagreement as a bug in this skill and say so in your final report.
 
 If you have access to a context7 MCP tool, use it to look up Effect-TS documentation when you're unsure about an API. Effect is a large library. Verify function signatures rather than guessing.
 
@@ -81,10 +86,10 @@ Read `${CLAUDE_SKILL_DIR}/../../examples/weather/src/main.ts` (HTTP with `HttpCl
 Read `${CLAUDE_SKILL_DIR}/../../examples/routing/src/main.ts` and `${CLAUDE_SKILL_DIR}/../../examples/query-sync/src/main.ts`
 
 **Tier 5: Complex state, nested domain models, CRUD, drag-and-drop:**
-Read `${CLAUDE_SKILL_DIR}/../../examples/shopping-cart/src/main.ts` (nested domain schemas, cart state) and `${CLAUDE_SKILL_DIR}/../../examples/kanban/src/main.ts` (CRUD with `Ui.DragAndDrop`, flags restoring from localStorage, subscriptions)
+Read `${CLAUDE_SKILL_DIR}/../../examples/shopping-cart/src/main.ts` (nested domain schemas, cart state) and `${CLAUDE_SKILL_DIR}/../../examples/kanban/src/main.ts` (CRUD with `DragAndDrop`, flags restoring from localStorage, subscriptions)
 
 **Tier 6: Submodels, OutMessage, multi-step forms, auth flows, multi-module apps:**
-Read `${CLAUDE_SKILL_DIR}/../../examples/auth/src/main.ts` (login/signup with Submodels, OutMessage, protected routes) and `${CLAUDE_SKILL_DIR}/../../examples/job-application/src/main.ts` (multi-step form with deeply nested Submodels in `step/`, `Ui.DatePicker`, `Ui.FileDrop`, `Ui.Menu`, `Calendar` module for date handling)
+Read `${CLAUDE_SKILL_DIR}/../../examples/auth/src/main.ts` (login/signup with Submodels, OutMessage, protected routes) and `${CLAUDE_SKILL_DIR}/../../examples/job-application/src/main.ts` (multi-step form with deeply nested Submodels in `step/`, `DatePicker`, `FileDrop`, `Listbox`, `Calendar` module for date handling)
 
 **Tier 7: Real-time, WebSocket, Managed Resources, production-grade:**
 Read `${CLAUDE_SKILL_DIR}/../../packages/typing-game/client/src/update.ts`, then explore its `page/home/` and `page/room/` directories for the full Submodel/OutMessage pattern.
@@ -93,53 +98,75 @@ Read examples from the target tier AND all lower tiers. A Tier 4 app should refl
 
 ## Phase 2.5: Identify Foldkit UI Component Opportunities
 
-Foldkit ships accessible UI components that handle keyboard navigation, ARIA attributes, and focus management automatically. Before generating, check if any part of the app maps to a built-in component:
+Foldkit ships accessible UI components that handle keyboard navigation, ARIA attributes, and focus management automatically. They live in a **separate package**, `@foldkit/ui`, and are imported by name:
 
-| User Need                       | Foldkit Component | What you get for free                                           |
-| ------------------------------- | ----------------- | --------------------------------------------------------------- |
-| Modal/dialog/confirmation       | `Dialog`          | Focus trapping, Escape to close, scroll locking, backdrop       |
-| Tabbed content                  | `Tabs`            | Arrow key navigation, aria-selected, roving tabindex            |
-| Dropdown menu                   | `Menu`            | Arrow keys, typeahead search, aria-expanded, click-outside      |
-| Autocomplete/tag input          | `Combobox`        | Filtering, arrow key selection, aria-activedescendant           |
-| Select dropdown                 | `Select`          | Keyboard selection, aria-selected, positioning                  |
-| Single selection from options   | `RadioGroup`      | Arrow key cycling, aria-checked                                 |
-| On/off toggle                   | `Switch`          | Spacebar toggle, aria-checked                                   |
-| Boolean option                  | `Checkbox`        | Spacebar toggle, aria-checked, indeterminate                    |
-| Expandable section              | `Disclosure`      | Enter/Space toggle, aria-expanded                               |
-| Floating content on hover/click | `Popover`         | Positioning, click-outside, focus management                    |
-| Hover tooltip                   | `Tooltip`         | Show-delay, keyboard dismiss, positioning, aria-describedby     |
-| Single-select list              | `Listbox`         | Arrow keys, typeahead, aria-selected                            |
-| Text input                      | `Input`           | Consistent styling/behavior wrapper                             |
-| Multi-line text                 | `Textarea`        | Auto-resize, consistent styling                                 |
-| Form group                      | `Fieldset`        | Disabled state propagation, grouping                            |
-| Styled button                   | `Button`          | Consistent click/keyboard handling                              |
-| Inline calendar grid            | `Calendar`        | Month navigation, keyboard nav, aria-selected, date constraints |
-| Date input + popover            | `DatePicker`      | Calendar popover, input masking, keyboard nav, constraints      |
-| File upload zone                | `FileDrop`        | Drag-and-drop, click-to-browse, accept filters, validation      |
-| Reorderable list                | `DragAndDrop`     | Pointer + keyboard drag, drop zones, announcement region        |
-| Transient notifications         | `Toast`           | Auto-dismiss, pause-on-hover, stacking, role=status/alert       |
+```ts
+import { Button, Dialog, Input } from '@foldkit/ui'
+```
 
-Each component is a Foldkit Submodel with its own Model, Message, init, update, and view. To use one:
+There is no `Ui` namespace on the `foldkit` package. Reach for `Dialog.view`, not `Ui.Dialog.view`. Deep imports (`@foldkit/ui/dialog`) work too when you want to keep the barrel out of the bundle.
 
-1. Add its Model to your Model: `confirmDialog: Ui.Dialog.Model`
-2. Add a `Got*` Message: `GotConfirmDialogMessage` with `{ message: Ui.Dialog.Message }`
-3. Initialize in init: `confirmDialog: Ui.Dialog.init({ id: 'confirm-dialog' })`
+Before generating, check if any part of the app maps to a built-in component:
+
+| User Need                       | Component     | What you get for free                                           |
+| ------------------------------- | ------------- | --------------------------------------------------------------- |
+| Modal/dialog/confirmation       | `Dialog`      | Focus trapping, Escape to close, scroll locking, backdrop       |
+| Tabbed content                  | `Tabs`        | Arrow key navigation, aria-selected, roving tabindex            |
+| Dropdown menu                   | `Menu`        | Arrow keys, typeahead search, aria-expanded, click-outside      |
+| Autocomplete/tag input          | `Combobox`    | Filtering, arrow key selection, aria-activedescendant           |
+| Select dropdown                 | `Select`      | Keyboard selection, aria-selected, positioning                  |
+| Single selection from options   | `RadioGroup`  | Arrow key cycling, aria-checked                                 |
+| On/off toggle                   | `Switch`      | Spacebar toggle, aria-checked                                   |
+| Boolean option                  | `Checkbox`    | Spacebar toggle, aria-checked, indeterminate                    |
+| Expandable section              | `Disclosure`  | Enter/Space toggle, aria-expanded                               |
+| Floating content on hover/click | `Popover`     | Positioning, click-outside, focus management                    |
+| Hover tooltip                   | `Tooltip`     | Show-delay, keyboard dismiss, positioning, aria-describedby     |
+| Single-select list              | `Listbox`     | Arrow keys, typeahead, aria-selected                            |
+| Text input                      | `Input`       | Consistent styling/behavior wrapper                             |
+| Multi-line text                 | `Textarea`    | Auto-resize, consistent styling                                 |
+| Form group                      | `Fieldset`    | Disabled state propagation, grouping                            |
+| Styled button                   | `Button`      | Consistent click/keyboard handling                              |
+| Inline calendar grid            | `Calendar`    | Month navigation, keyboard nav, aria-selected, date constraints |
+| Date input + popover            | `DatePicker`  | Calendar popover, input masking, keyboard nav, constraints      |
+| File upload zone                | `FileDrop`    | Drag-and-drop, click-to-browse, accept filters, validation      |
+| Reorderable list                | `DragAndDrop` | Pointer + keyboard drag, drop zones, announcement region        |
+| Transient notifications         | `Toast`       | Auto-dismiss, pause-on-hover, stacking, role=status/alert       |
+| Numeric range / price filter    | `Slider`      | Arrow/Home/End keys, aria-valuenow, multi-thumb ranges          |
+| Long scrolling list             | `VirtualList` | Windowed rendering, scroll anchoring, measured item heights     |
+| Site/section navigation         | `Nav`         | Current-page marking, keyboard traversal, landmark semantics    |
+
+The package is not one shape.
+
+**Stateful Submodels** carry their own Model, Message, update, and (mostly) OutMessage, and are embedded via `h.submodel`: `Menu`, `Listbox`, `Combobox`, `Calendar`, `DatePicker`, `Dialog`, `Popover`, `Tabs`, `Tooltip`, `FileDrop`, `DragAndDrop`, `Slider`, `VirtualList`, plus `Toast` once built through `Toast.make(PayloadSchema)`.
+
+**Stateless render helpers** have no Model at all. You call `view` directly and store the value in your own Model: `Button`, `Input`, `Textarea`, `Select`, `Fieldset`, `Checkbox`, `Switch`, `Disclosure`, `RadioGroup`, `Nav`.
+
+Don't take that split on faith, because components have moved across it (`Checkbox`, `Switch`, and `Disclosure` became controlled render helpers; `Tabs` and `Slider` moved their selection to the parent Model). Read the component's `public.d.ts`: exporting `Model` and `update` means Submodel, exporting only `view` and a `ViewConfig` / `ViewInputs` type means render helper. A render helper does not want a `Got*` Message.
+
+To use a stateful Submodel:
+
+1. Add its Model to your Model: `confirmDialog: Dialog.Model`
+2. Add a `Got*` Message: `GotConfirmDialogMessage` with `{ message: Dialog.Message }`
+3. Initialize in init: `confirmDialog: Dialog.init({ id: 'confirm-dialog' })`
 4. Delegate in update: `GotConfirmDialogMessage: ({ message }) => ...`
-5. Embed in view via `h.submodel`: `h.submodel({ slotId: 'confirm-dialog', view: Ui.Dialog.view, model: model.confirmDialog, toParentMessage: message => GotConfirmDialogMessage({ message }) })` (add `viewInputs` for components whose view takes them)
+5. Embed in view via `h.submodel`: `h.submodel({ slotId: 'confirm-dialog', view: Dialog.view, model: model.confirmDialog, toParentMessage: message => GotConfirmDialogMessage({ message }) })` (add `viewInputs` for components whose view takes them)
 
 **Always prefer Foldkit UI components over hand-rolling interactive widgets.** They make accessibility the default, not an afterthought.
 
-**For form inputs specifically:** every text input, textarea, and button in a form MUST use `Ui.Input`, `Ui.Textarea`, and `Ui.Button` respectively. This is not optional, even though raw `input`/`textarea` HTML elements are available from `html<Message>()`. The form example (`examples/form/src/main.ts:347-403`) defines `inputFieldView` and `textareaFieldView` helpers that wrap `Ui.Input.view` and `Ui.Textarea.view` with label + validation feedback. Copy that helper pattern. Raw `input`/`textarea` are for non-form cases (search fields, inline editors) where you're intentionally working below the Ui component layer, and even then, reach for the Ui component first.
+**For form inputs specifically:** every text input, textarea, and button in a form MUST go through `Input`, `Textarea`, and `Button`. This is not optional, even though raw `input`/`textarea` HTML elements are available from `html<Message>()`. The form example (`examples/form/src/main.ts`) defines `inputFieldView` and `textareaFieldView` helpers that wrap `Input.view` and `Textarea.view` with label + validation feedback. Copy that helper pattern. Raw `input`/`textarea` are for non-form cases (search fields, inline editors) where you're intentionally working below the component layer, and even then, reach for the component first.
 
 If the app uses UI components, **always read the ui-showcase example first** to understand how components are wired. This is the canonical reference for Foldkit UI integration patterns:
 
 - `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/main.ts`: root wiring, `Got*` delegation, `toParentMessage` helpers
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/message.ts`: how UI component Messages are structured
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/model.ts`: how UI component Models are composed
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/update.ts`: how UI component updates are delegated
-- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/toast.ts`: read when using `Ui.Toast`: Toast is unique in that it's parameterized on a payload schema via `Ui.Toast.make(PayloadSchema)`, returning a typed module you import from
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/ui/message.ts`: how component Messages are structured
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/ui/model.ts`: how component Models are composed
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/ui/update.ts`: how component updates are delegated
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/ui/subscriptions.ts`: which components need Subscriptions lifted into the parent (`DragAndDrop`, `Slider`, `VirtualList`)
+- `${CLAUDE_SKILL_DIR}/../../examples/ui-showcase/src/ui/toast.ts`: read when using `Toast`. It's unique in that it's parameterized on a payload schema via `Toast.make(PayloadSchema)`, returning a typed module you import from
 
-For apps using `Ui.DatePicker`, `Ui.FileDrop`, or other recently-added components, also read the `job-application` example (see Tier 6 below). It's the most complete real-world integration of these components together.
+Directory names under `examples/ui-showcase/src/` have moved before. List the directory rather than trusting these paths blind.
+
+For apps using `DatePicker`, `FileDrop`, or other recently-added components, also read the `job-application` example (see Tier 6 below). It's the most complete real-world integration of these components together.
 
 ## Phase 3: Determine File Organization
 
@@ -299,13 +326,14 @@ Before writing any code, READ the type signatures of every Foldkit module you wi
 
 For each Foldkit module you plan to use, read the `.d.ts` at the paths below. Read the public surface; you don't need the internals. Write a short signature crib in your working notes so you don't have to re-check while generating.
 
-```
+```text
 # Every app
-<project>/node_modules/foldkit/dist/index.d.ts          # top-level re-exports
-<project>/node_modules/foldkit/dist/html/index.d.ts     # html<Message>(), element signatures, Attribute<Message>, empty, keyed
+<project>/node_modules/foldkit/dist/index.d.ts          # top-level re-exports: the authoritative list of what `foldkit` exposes
+<project>/node_modules/foldkit/dist/html/index.d.ts     # html<Message>(), element signatures, Attribute<Message>
 <project>/node_modules/foldkit/dist/message/index.d.ts  # m()
 <project>/node_modules/foldkit/dist/schema/index.d.ts   # ts(), r()
 <project>/node_modules/foldkit/dist/struct/index.d.ts   # evo(): check nested-update signature
+<project>/node_modules/foldkit/dist/update/public.d.ts  # Update.Return, Update.ReturnWithOutMessage, Update.combine, Update.refresh
 <project>/node_modules/foldkit/dist/runtime/runtime.d.ts # ApplicationInit, RoutingApplicationInit, makeApplication, makeElement
 
 # If using routing
@@ -314,40 +342,51 @@ For each Foldkit module you plan to use, read the `.d.ts` at the paths below. Re
 <project>/node_modules/foldkit/dist/navigation/index.d.ts # pushUrl, load: all return Effect<void> (no Effect.ignore needed)
 
 # If using async / side effects
-<project>/node_modules/foldkit/dist/command/index.d.ts  # Command.define: result schemas are required
+<project>/node_modules/foldkit/dist/command/index.d.ts  # Command.define: result schemas are required. Command.mapMessages for parent<-child mapping
+<project>/node_modules/foldkit/dist/asyncData/public.d.ts # AsyncData: Idle/Loading/Refreshing/Failure/Stale/Success + Schema, match, isPending, hasData, revalidate
+<project>/node_modules/foldkit/dist/http/public.d.ts     # Http.layer: provide it to Commands that use HttpClient
 <project>/node_modules/foldkit/dist/dom/index.d.ts      # focus, advanceFocus, scrollIntoView, showDialog, closeDialog, clickElement, lockScroll, unlockScroll, inertOthers, restoreInert, detectElementMovement, waitForAnimationSettled. For time/random/uuid/delay use Effect's Clock, Random, Effect.uuid, Effect.sleep + Duration directly.
 
 # If using subscriptions
 <project>/node_modules/foldkit/dist/subscription/index.d.ts # Subscription.make<Model, Message>, Subscription.lift, Subscription.aggregate
 
 # If using mount / managed-resource / custom-element
-<project>/node_modules/foldkit/dist/mount/index.d.ts             # Mount.define: for per-instance VNode lifecycle
+<project>/node_modules/foldkit/dist/mount/public.d.ts            # Mount.define (one-shot) / Mount.defineStream (continuous): per-instance VNode lifecycle
 <project>/node_modules/foldkit/dist/managedResource/public.d.ts  # ManagedResource.make / lift / aggregate + tag: for stateful runtime objects keyed on Model condition
 <project>/node_modules/foldkit/dist/customElement/index.d.ts     # CustomElement.define: for typed bindings to native web components
+
+# If the host application drives the program
+<project>/node_modules/foldkit/dist/port/public.d.ts    # Port.inbound / outbound / emit / stream / subscription
 
 # If using forms
 <project>/node_modules/foldkit/dist/fieldValidation/public.d.ts # Field (tagged union), makeRules({required?, rules}), validate, allValid; rule constructors on the Rule namespace (Rule.url(options), Rule.email, Rule.minLength, Rule.pattern, Rule.fromSchema, ...)
 # Rule.Rule is [Predicate, Rule.RuleMessage], NOT {test, message}. Field.Invalid has `errors: NonEmptyArray<string>`, not `error: string`.
 
-# If using any UI component
-<project>/node_modules/foldkit/dist/ui/<component>/public.d.ts  # Model, Message, init, update, view (Submodel-shaped) or ViewConfig (render-helper-shaped), OutMessage when applicable
-# Check: is it a Submodel (Menu/Listbox/Combobox/Calendar/Disclosure/Dialog/Popover/etc.) embedded via h.submodel, or a stateless render helper (Button/Input/Textarea/Select/Fieldset) called directly with a ViewConfig? Submodels carry their own Model/Message/update/OutMessage; render helpers don't. Check ViewInputs (for Submodels) or ViewConfig (for helpers) for the slot callbacks (toView, itemToConfig, etc.).
+# If using any UI component (SEPARATE PACKAGE)
+<project>/node_modules/@foldkit/ui/dist/<component>/public.d.ts  # Model, Message, init, update, view (Submodel-shaped) or ViewConfig (render-helper-shaped), OutMessage when applicable
+# Check: is it a Submodel (Menu/Listbox/Combobox/Calendar/DatePicker/Dialog/Popover/Tabs/Tooltip/FileDrop/DragAndDrop/Slider/VirtualList/Toast) embedded via h.submodel, or a stateless render helper (Button/Input/Textarea/Select/Fieldset/Checkbox/Switch/Disclosure/RadioGroup/Nav) called directly? Submodels carry their own Model/Message/update/OutMessage; render helpers don't. Check ViewInputs (for Submodels) or ViewConfig (for helpers) for the slot callbacks (toView, itemToConfig, etc.).
 
 # If using dates
 <project>/node_modules/foldkit/dist/calendar/index.d.ts # CalendarDate, today.local (returns Effect<CalendarDate>); for raw millis use Clock.currentTimeMillis
 ```
 
+If a path above doesn't resolve, list the package's `dist/` and find the module. **The `.d.ts` is authoritative and this file is not.** Where the two disagree, the `.d.ts` is right and the disagreement is a bug in this skill worth reporting.
+
 ### What to record in the crib
 
 For each symbol you'll call, write one line:
 
-```
-html<Message>(): { div, input (VOID), textarea, button, Class, Href, For, Id, Role, OnClick(Message), OnInput(value=>Message), OnBlur(Message), OnSubmit(Message), keyed, empty, ... }
+```text
+html<Message>(): { div, input (VOID), textarea, button, Class, Href, For, Id, Role, OnClick(Message), OnInput(value=>Message), OnBlur(Message), OnSubmit(Message), keyed, empty, submodel, ... }
 Route.mapTo(schema)(parser): curried
 pushUrl(path): Effect<void>  // NOT fallible, no Effect.ignore needed
 urlToString(url: Url): string
-Ui.Input.view({ id, value, onInput, isInvalid?, type?, placeholder?, toView: (attrs) => Html })
-  // attrs: { label: Attribute<M>[], input: Attribute<M>[], description: Attribute<M>[] }
+Update.Return<Model, Message>: readonly [Model, ReadonlyArray<Command<Message>>]
+Command.mapMessages(commands, toParentMessage): re-tag a child's Commands
+AsyncData.Schema(DataSchema, ErrorSchema): { schema, Idle(), Loading(), Success({data}), Failure({error}), ... }
+Input.view({ id, value, onInput, isInvalid?, type?, placeholder?, toView: (attrs) => Html })
+  // from '@foldkit/ui', NOT Ui.Input
+  // attrs: { label: ReadonlyArray<Attribute<M>>, input: ..., description: ... }
 Field (schema): NotValidated | Validating | Valid | Invalid(errors: NonEmpty<Rule Message>)
 ```
 
@@ -368,6 +407,12 @@ Record these in the crib and keep them visible while generating:
 - **`Field.Invalid` has `errors: NonEmptyArray<string>`, not `error: string`.** Use `Array.headNonEmpty(errors)` to get the first message; use `Rule.resolveMessage(message, value)` to resolve a rule message to its final string.
 - **Route variants are `HomeRoute`, `NewLinkRoute`, etc., with the `Route` suffix.** Every exemplar uses this convention.
 - **Routers are callable for printing**: `homeRouter()` returns `'/'`, `tagFilterRouter({ tag: 'foo' })` returns `'/tag/foo'`. Never hand-construct URLs.
+- **UI components come from `@foldkit/ui`, not from a `Ui` namespace on `foldkit`.** `import { Dialog, Input } from '@foldkit/ui'`, then `Dialog.view(...)`. There is no `Ui` export on the `foldkit` package.
+- **`HttpClient` and `HttpClientRequest` come from `effect/unstable/http`**, not `@effect/platform`. Provide the client to the Command's Effect with `Effect.provide(effect, Http.layer)`, where `Http` is imported from `foldkit`. `@effect/platform-browser` is a different thing, used for `BrowserKeyValueStore` and `BrowserCrypto`.
+- **Map a child Submodel's Commands with `Command.mapMessages(childCommands, message => GotChildMessage({ message }))`.** Not `Command.mapEffect`.
+- **Name the update return type once per file**, and prefer `Update.Return<Model, Message>` from `foldkit/update` for the alias. Spelling the tuple out by hand is what most examples still do and is fine; what to avoid is skipping the alias and repeating `readonly [Model, ReadonlyArray<Command.Command<Message>>]` at the signature and again inside `M.withReturnType<...>()`.
+- **Effect's array predicates are `Array.isArrayEmpty` / `Array.isArrayNonEmpty`**, not `isEmptyArray` / `isNonEmptyArray`.
+- **`empty` and `keyed` are properties on `h`**, so they are never in the `foldkit/html` import list. Import `{ Document, Html, html }` and reach for `h.empty` / `h.keyed`.
 
 ## Phase 4: Generate the App
 
@@ -379,7 +424,8 @@ Generate files following the architecture and conventions guides exactly. Write 
 - Use discriminated unions for state: `Idle | Loading | Error | Ok`, never booleans for multi-valued state
 - Use `Option` for fields that may be absent. Never empty strings or null
 - Prefix Option-typed fields with `maybe`: `maybeCurrentUser`, `maybeError`
-- For async data, define `Idle`, `Loading`, `Error`, `Ok` variants with `ts()` and compose into an `S.Union`. See Discriminated Unions for State in [conventions.md](conventions.md)
+- For remote data, use the `AsyncData` module rather than hand-rolling a union. `AsyncData.Schema(WeatherData, S.String)` returns `{ schema, Idle, Loading, Refreshing, Failure, Stale, Success }`; put `schema` in the Model and build values with the constructors. The `Refreshing` and `Stale` states are the point: they let a reload keep the current data on screen, and a failed reload keep it rather than discarding it. `examples/weather/src/main.ts` is the canonical use
+- For non-remote multi-valued state (form steps, editor modes, connection phases), define variants with `ts()` and compose into an `S.Union`. See Discriminated Unions for State in [conventions.md](conventions.md)
 - For apps with multiple domain entities referenced across modules, extract shared schemas into `src/domain/` (e.g., `domain/product.ts`, `domain/session.ts`). See the shopping-cart and auth examples for this pattern, and read `${CLAUDE_SKILL_DIR}/../../packages/website/src/page/projectOrganization.ts` for guidance on when and how to structure domain modules
 
 ### Messages
@@ -437,9 +483,18 @@ Every message must carry meaning. No `NoOp`.
 
 ### Update
 
+- Name the return type once per file from the framework's alias, then bind the matcher to it:
+
+  ```ts
+  type UpdateReturn = Update.Return<Model, Message>
+  const withUpdateReturn = M.withReturnType<UpdateReturn>()
+  ```
+
+  `Update.ReturnWithOutMessage<Model, Message, OutMessage>` is the Submodel counterpart. `Update.Return` is the preferred spelling; a hand-written tuple alias is what most examples still use and is fine. What to avoid is skipping the alias and repeating the tuple at the signature and again inside `M.withReturnType<...>()`
+
 - Use `M.value(message).pipe(withUpdateReturn, M.tagsExhaustive({...}))`. Never switch
-- Every case returns `[Model, ReadonlyArray<Command<Message>>]`
 - Use `evo(model, { field: () => newValue })` for immutable updates
+- When a `Succeeded*` handler has to write several caches and kick off refetches, sequence them with `Update.combine(model, [step, step, ...])` and build the refetch steps with `Update.refresh({ read, revalidate, write, load })`, which reloads a cache only when it actually holds data. `examples/route-transitions/src/main.ts` shows both
 - In `evo`, use point-free field transformers when the update only depends on that field's current value: `items: Array.map(updateItem)`, `count: Number.increment`, `priceSlider: Slider.reflectRange({ min: minPrice, max: maxPrice })`. Use `() => value` for replacement values from Messages, child updates, Commands, or other Model fields.
 - Extract complex handlers to separate functions when a case exceeds ~15 lines
 - For Submodels: return `[Model, ReadonlyArray<Command<Message>>, Option.Option<OutMessage>]`
@@ -457,7 +512,8 @@ Every message must carry meaning. No `NoOp`.
 - Factory functions named by action: `fetchWeather`, not `fetchWeatherCommand`
 - Fire-and-forget Commands return `Completed*` Messages
 - Use Foldkit's `Dom` module for DOM operations (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showDialog`, `Dom.lockScroll`, etc.) and Effect built-ins for everything else (`Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep(Duration.millis(...))`). See DOM and Effect Helpers in [architecture.md](architecture.md)
-- For HTTP requests, use `HttpClient` from `@effect/platform`. See the weather example for the pattern
+- For HTTP requests, use `HttpClient` and `HttpClientRequest` from `effect/unstable/http`, and provide the client with `Effect.provide(effect, Http.layer)` where `Http` comes from `foldkit`. See `examples/weather/src/main.ts` for the pattern
+- To re-tag a child Submodel's Commands for the parent, use `Command.mapMessages(childCommands, message => GotChildMessage({ message }))`
 
 ### Form Validation
 
@@ -501,14 +557,14 @@ Canonical reference: `${CLAUDE_SKILL_DIR}/../../examples/form/src/main.ts` (asyn
 For date handling (birthday, deadlines, scheduling):
 
 - Use the `Calendar` module: `Calendar.CalendarDate`, `Calendar.today.local` (Effect returning today's date in the user's timezone), `Calendar.make(year, month, day)`, `Calendar.addDays`, etc.
-- Use `Ui.DatePicker` (input + popover calendar) or `Ui.Calendar` (inline grid) for the UI
+- Use `DatePicker` (input + popover calendar) or `Calendar` (inline grid) from `@foldkit/ui` for the UI
 - Seed the initial date via flags when needed. See `job-application` example, which uses `Calendar.today.local` in its flags Effect
 
 For file uploads (resumes, images, attachments):
 
 - Use the `File` module for file primitives
-- Use `Ui.FileDrop` for a drag-and-drop + click-to-browse zone with validation
-- `Ui.FileDrop.ReceivedFiles` is a `NonEmptyArray<File>` OutMessage. Empty selections never fire
+- Use `FileDrop` from `@foldkit/ui` for a drag-and-drop + click-to-browse zone with validation
+- `FileDrop.ReceivedFiles` carries `files: NonEmptyArray<File>`, so the happy path never has to handle an empty list. A drop that produced no files arrives as the separate `RejectedNonFiles` OutMessage; handle it to surface a message like "Only files are accepted"
 - Canonical reference: `${CLAUDE_SKILL_DIR}/../../examples/job-application/src/step/attachments.ts`
 
 ### View
@@ -583,11 +639,13 @@ This is ~2 minutes of reading per file. It saves ~15 minutes of review loop per 
 Before moving to Phase 6, run ALL FOUR of these and fix everything they surface. Not one, not three. All four:
 
 ```bash
-npm run format      # or: npx prettier -w .   (run FIRST: rewrites files)
-npm run lint        # or: npx eslint .
-npm run typecheck   # or: npx tsc --noEmit
-npm run test        # or: npx vitest run
+npm run format      # run FIRST: rewrites files
+npm run lint
+npm run typecheck
+npm run test
 ```
+
+Use whichever package manager the project was scaffolded with: `npm run`, `pnpm run`, `yarn`, or `bun run`. If a script is missing, run the project-local binary through that manager's exec (`pnpm exec prettier -w .`, `npm exec --no-install prettier -w .`, `yarn exec prettier -w .`, `bun x --no-install prettier -w .`). Avoid bare `npx`, which fetches and runs a package from the registry when the binary isn't installed locally.
 
 Run **format first** because it rewrites files; running it last would leave tsc/test passing against unformatted code that a pre-commit hook would then reformat, creating a diff the user has to clean up. Running it first means lint/typecheck/test verify the exact code that will be committed.
 
@@ -598,7 +656,7 @@ Each catches different classes of issue:
 - **Typecheck** catches API misuse, wrong parameter shapes, missing required props, and structural type errors. Doesn't catch unused imports.
 - **Tests** catch behavioral regressions. Don't catch either of the above.
 
-If the project doesn't have a format/lint script, check `package.json` and run `npx prettier -w .` / `npx eslint .` directly. Don't skip either because "there's no script". The scaffolded `create-foldkit-app` project always ships both configured.
+If the project doesn't have a format/lint script, check `package.json` and run the binaries through your package manager's exec (`pnpm exec prettier -w .` / `pnpm exec oxlint src`, or the npm / yarn / bun equivalent) directly. Don't skip either because "there's no script". The scaffolded `create-foldkit-app` project always ships both configured.
 
 Fix ALL output from all four before declaring Phase 5 done. "Typecheck clean and tests pass" is insufficient. Unformatted code with unused imports is not at the bar.
 
@@ -634,7 +692,7 @@ Write `Scene.scene` pipelines covering:
 - **Scoped queries**: use `Scene.within(parent, child)` to compose a single scoped Locator (good for one-off scoped assertions or reusable named locators). Use `Scene.inside(parent, ...steps)` to scope a whole block of steps to the same parent. Every Locator referenced by the nested steps resolves within the parent's subtree. Reach for `inside` when two or more steps share a scope; reach for `within` for single-use scoping.
 - Prefer accessible locators: `Scene.label(...)`, `Scene.role(...)`, `Scene.text(...)` over `Scene.placeholder(...)` or CSS selectors
 
-Run `npx vitest run` to verify tests pass.
+Run the project's test script (`npm run test`, or your package manager's equivalent) to verify tests pass.
 
 Then run through the [verification checklist](checklist.md) to catch structural gaps. Fix any remaining issues before moving on.
 
@@ -646,13 +704,13 @@ Code review and automated tests don't catch rendering bugs or accessibility gaps
 
 Start the dev server (`npm run dev`) and open the app in a browser. Click through every route. Interact with every form. Watch for:
 
-- Inputs with missing backgrounds (Tailwind preflight strips the browser-default white; `bg-white` must be explicit on every `input`/`textarea` you don't route through `Ui.Input`)
+- Inputs with missing backgrounds (Tailwind preflight strips the browser-default white; `bg-white` must be explicit on every raw `input` or `textarea`, meaning every one you don't route through `Input` or `Textarea` from `@foldkit/ui`)
 - Text that's too dim or too small to read
 - Overlapping elements, broken spacing, layout shifts
 - Cursor/hover states that don't feel right
 - Focus rings that are invisible or missing on interactive elements
 
-Many visual bugs are invisible to typecheck, tests, and code review. The only tools that catch them are (1) looking at the rendered output and (2) using `Ui.*` components that already bake sensible defaults in.
+Many visual bugs are invisible to typecheck, tests, and code review. The only tools that catch them are (1) looking at the rendered output and (2) using `@foldkit/ui` components that already bake sensible defaults in.
 
 If the app has UI, **don't claim Phase 5 complete until you've loaded the app and clicked through it.** If you can't run a browser in your environment, say so explicitly in the final report rather than skipping the check silently.
 
@@ -682,174 +740,40 @@ After round 3, if issues remain, exit the loop and carry the unresolved items in
 
 Use a prompt of roughly this shape. Tailor only the file list and project path. Keep the rubric, output format, blind-spots checklist, and bar-setting instructions intact.
 
-```
+```text
 You are reviewing a freshly generated Foldkit program. The bar is:
 this code should be indistinguishable in quality from hand-written
 code in `packages/typing-game/client/src/` or `packages/website/src/`.
 Not "works." Not "structurally valid." Typing-game quality.
 
 Read FIRST, in this order:
-1. <absolute path to generated src/ files: list every file>
-2. /Users/devinjameson/Repos/foldkit/skills/generate-program/architecture.md
-3. /Users/devinjameson/Repos/foldkit/skills/generate-program/conventions.md
-4. /Users/devinjameson/Repos/foldkit/skills/generate-program/checklist.md
-5. At least one exemplar file matching the generated app's complexity:
-   - Tier 1-2: packages/foldkit/src/runtime/runtime.ts (for quality calibration)
+1. The generated source files, project-relative: list every one
+   (src/main.ts, src/update.ts, ...).
+2. ${CLAUDE_SKILL_DIR}/architecture.md
+3. ${CLAUDE_SKILL_DIR}/conventions.md
+4. ${CLAUDE_SKILL_DIR}/checklist.md
+5. ${CLAUDE_SKILL_DIR}/blindSpots.md
+6. At least one exemplar file matching the generated app's complexity,
+   from the foldkit repo (vendored at repos/foldkit/ when the project
+   has the subtree):
+   - Tier 1-2: packages/foldkit/src/runtime/runtime.ts (quality calibration)
    - Tier 3-4: examples/weather/src/main.ts OR examples/form/src/main.ts
    - Tier 5: examples/kanban/src/update.ts AND examples/kanban/src/domain/
    - Tier 6: examples/job-application/src/update.ts AND examples/auth/src/page/
    - Tier 7: packages/typing-game/client/src/page/room/
 
+Every path above is either project-relative or resolved through
+${CLAUDE_SKILL_DIR}, the same way the rest of this skill refers to its
+own files. Do not rewrite them as absolute paths. An absolute path is
+machine-specific, and hand-pasting one is what made an earlier version
+of this prompt unusable anywhere but the machine it was written on.
+
 Then walk the entire checklist.md against the generated code. Every item.
+Then walk every entry in blindSpots.md and report one line per entry:
+`<slug>: clean | flagged at <file:line>: <issue>`. Silence is not a pass.
 Also read at least one of the generated files side-by-side with the
 exemplar you chose. Ask: does this look like it was written by the
 same hand?
-
-COMMON BLIND SPOTS. Check each explicitly; these are frequently missed:
-
-1. OFF-BY-ONE ERRORS. Any logic with "after N", modulo, "every Nth",
-   counter thresholds, or cycle boundaries. Trace the logic for N=0,
-   N=1, and the first transition. Does the boundary go where it should?
-   Example to look for: `count % 4 === 0` triggers on count=0 too.
-   Is that intended or a bug?
-
-2. SKIP / RESET SEMANTICS. If the app has skip, reset, cancel, or
-   undo actions, trace what happens to counters and derived state.
-   Does skip increment or bypass the counter? Does reset clear the
-   counter or preserve it? Is the behavior consistent with what a
-   user would expect?
-
-3. STATE MACHINE EDGES. Every discriminated-union state. Can the
-   current code transition *into* every state? Out of every state?
-   Are there dead states (created, never entered)? Impossible
-   transitions (states that should be reachable but aren't)?
-
-4. REDUNDANT DERIVED DATA IN MODEL. Fields that could be computed
-   from other fields. Example: `endTime` AND `remainingMs` on the
-   same state, where one can drift. Flag these unless there's a
-   concrete reason (view needs pure data, etc.), and if there IS a
-   reason, the code should document it.
-
-5. REPEATED INLINE PATTERNS. If three or four handlers share the
-   same 5-line scaffold (M.tag + M.orElse, Option.match + fallback,
-   etc.), that scaffold wants a named helper. Don't flag every
-   repetition, but flag genuinely duplicated decision logic.
-
-6. FUNCTIONS THAT DO TWO THINGS. Orchestrators that mix "decide
-   what to do" with "do it." Helpers with an `if` that branches
-   into two unrelated behaviors. Handlers that both mutate state
-   AND emit a command in a way that conflates the decisions.
-
-7. NAMING DRIFT. One Message uses `Updated*`, another uses
-   `Changed*` for the same kind of event. One helper is `whenX`,
-   another is `handleX` for analogous cases. Consistency matters;
-   diverging naming is a quality regression.
-
-8. EFFECT MODULE INCONSISTENCY. Mixing `items.map(f)` and
-   `Array.map(items, f)` in the same file. Mixing `Option.match`
-   with `maybe.pipe(Option.map(...), Option.getOrElse(...))` for
-   similar code. One file should use one idiom throughout.
-
-9. EMPTY-OBJECT CONSTRUCTOR CALLS. No-field tagged structs and
-   messages should be called with NO argument: `Idle()`, `Work()`,
-   `ClickedSubmit()`. Never `Idle({})`, `Work({})`. Both compile,
-   but exemplars consistently use the no-arg form. The `({})` form
-   reads as "a value with some empty object in it" and makes a
-   reader wonder what's supposed to be there. Grep for `({})` as a
-   quick scan; should be zero matches in generated code.
-
-10. DEAD STATE VARIANTS. State variants (or fields on state
-    variants) that are assigned but never observed downstream.
-    Examples:
-    - `Saving` state set on submit, but the update also navigates
-      away before the view renders, so the user never sees "Saving."
-    - `SaveError` set on failure, but the form is no longer
-      visible because the user already navigated to the home route
-      on the optimistic submit. Error is unreachable to the user.
-    - `Running.remainingMs` stored alongside `endTime`, where
-      `remainingMs = endTime - now`. One can drift from the other.
-    - A field in Model that's written by updates but never read by
-      the view or other updates.
-
-    **The "navigate-before-save" pattern is a specific instance to
-    look for**: if an update handler emits BOTH `saveState(...)`
-    AND `navigateInternal(...)` in the same return, the navigation
-    races the save. A failure surfaced on the old page is
-    unreachable. The idiomatic pattern is: emit save only, then
-    navigate in the `Succeeded*` handler. Errors then surface on
-    the page the user is still looking at.
-
-    For every discriminated-union variant, trace whether the view
-    branches on it and whether the branch is actually reachable.
-    For every Model field, trace whether it's read anywhere except
-    its own writes. If not, flag it: either the code is missing
-    something, or the variant/field should be deleted.
-
-11. HARD-CODED ROUTE PATHS. Template strings for internal navigation
-    (`Href('/')`, `navigateInternal('/new')`, `/tag/${name}`). Route
-    parsers are bidirectional; each router is callable as a printer:
-    `Href(homeRouter())`, `navigateInternal(newLinkRouter())`,
-    `Href(tagFilterRouter({ tag: name }))`. Grep for `Href('/` and
-    `navigateInternal('/`; should be zero matches in generated code.
-
-12. HAND-ROLLED ACCESSIBLE WIDGETS. Raw `input`, `textarea`, `button`,
-    `dialog`, or any element with `role="menu"` / `role="dialog"` /
-    `role="tab"`. Foldkit ships `Ui.Input`, `Ui.Textarea`, `Ui.Button`,
-    `Ui.Dialog`, `Ui.Menu`, `Ui.Tabs` etc., the whole component table
-    in Phase 2.5. If a form renders `input(...)` directly, that's a
-    BLOCKER unless there's a `// NOTE:` comment explaining why the
-    component can't be used. Hand-rolling isn't a style preference;
-    it's skipping accessibility work. Grep `src/` for the bare
-    elements and flag every match that isn't in a NOTE-justified
-    escape hatch.
-
-13. A11Y GAPS. For anything NOT covered by a Ui.* component (static
-    content, custom layouts, any residual hand-rolled input), verify:
-    label/input association via `For(id)` + `Id(id)`, dynamic errors
-    announced via `Role('alert')` or `AriaLive('polite')`, icon-only
-    buttons have `AriaLabel(...)`, external links have
-    `Rel('noopener noreferrer')`, exactly one `h1` per route, semantic
-    landmarks (`main`, `nav`, `header`) instead of `div` soup. The
-    checklist.md "Accessibility" section lists concrete grep commands;
-    run the ones relevant to what the generator built.
-
-14. MISSING SCENE TEST. For Tier 3+ apps (routing, async Commands,
-    forms), `scene.test.ts` must exist. Check the file tree:
-    if it's absent and the app is Tier 3+, that's a BLOCKER, not a
-    QUALITY item. Story tests alone test the update function in
-    isolation; Scene tests test the rendered view through accessible
-    locators, which is what a real user interacts with. An app
-    without a scene test hasn't been tested at all from the user's
-    perspective.
-
-    Also: **Scene tests must contain assertions.** A `Scene.scene(...)`
-    call with only `Scene.with(model)` and no `Scene.expect(...)` or
-    `Scene.click(...).resolve(...)` only verifies the view doesn't
-    throw. Each test needs at least one `Scene.expect(locator).toX()`
-    or an interaction that asserts on the resulting state.
-
-15. ARIA ROLE CONFUSION.
-    - **Checkboxes**: `Role('checkbox')` + `AriaChecked(boolean)`.
-      Screen readers announce "checkbox, checked/unchecked."
-    - **Toggle buttons** (Play/Pause, Bold on/off, formatting
-      toggles): `AriaPressed(string)` on a `button`. Screen readers
-      announce "toggle button, pressed/not pressed."
-    Using `AriaPressed` on something the user thinks of as a
-    checkbox is wrong semantically. Ask: "does the label say 'Mark
-    X as done' (checkbox) or 'toggle bold' (pressed button)?" The
-    former is a checkbox role; the latter is a toggle button.
-
-16. UNKEYED LIST ROWS. Rows in a list (li or div returned inside
-    `Array.map`) that carry `OnClick` handlers bound to a specific
-    item id, without a `keyed('li')(item.id, ...)` wrapper, are a
-    snabbdom patching bug. Deleting a row from the middle causes
-    the OLD row's click handler to be patched onto what should have
-    been a DIFFERENT row. User clicks "Delete B" and habit A is
-    deleted. This is the exact failure mode `keyed` exists to prevent,
-    and it's subtle because the bug is invisible until a delete or
-    reorder happens mid-list. Every row renderer that consumes a
-    domain entity with an `id` field should return `keyed('li')(item.id, ...)`
-    or `keyed('div')(item.id, ...)`, not bare `li(...)`.
 
 Output format. Exactly this structure:
 
@@ -883,10 +807,12 @@ Do NOT write code. Review only. Be specific, be brutal, don't grade on
 a curve. If you're unsure whether something is at the bar, compare it
 to the exemplar. If the exemplar wouldn't write it that way, flag it.
 
-Before finishing, confirm the generator ran all three gates. If the
-generator claims Phase 5 complete but lint output wasn't shown, flag
-it as a BLOCKER: "Run `npm run lint`: unverified." Lint catches unused
-imports that tsc does not, and those leak into review as noise.
+Before finishing, confirm the generator ran all four gates (format,
+lint, typecheck, test) and showed the output of each. If it claims
+Phase 5 complete but a gate's output wasn't shown, flag it as a
+BLOCKER naming the gate: "Run `npm run lint`: unverified." Lint
+catches unused imports that tsc does not, and those leak into review
+as noise.
 ```
 
 ### After the loop

--- a/skills/generate-program/architecture.md
+++ b/skills/generate-program/architecture.md
@@ -106,6 +106,22 @@ const Model = S.Struct({
 
 With booleans, you can have `isLoading: true` AND `isError: true`, an impossible state. With unions, you're always in exactly one state.
 
+For **remote data specifically**, don't hand-roll the union. The `AsyncData` module ships it:
+
+```ts
+import { AsyncData } from 'foldkit'
+
+const WeatherAsyncData = AsyncData.Schema(WeatherData, S.String)
+
+const Model = S.Struct({
+  weather: WeatherAsyncData.schema,
+})
+```
+
+That gives six states, not four: `Idle`, `Loading`, `Refreshing`, `Failure`, `Stale`, `Success`. The two extra ones are the reason to use it. `Refreshing` carries the previous data while a reload runs, so a refetch doesn't blank the screen. `Stale` carries both the previous data and the new error, so a failed reload doesn't discard what the user was reading. A hand-rolled `Idle | Loading | Error | Ok` forces both of those regressions.
+
+The module also supplies the operations: `AsyncData.match`, `matchData`, `isPending`, `hasData`, `getData`, `map`, `revalidate`, `revalidateOrLoad`, `loadIfMissing`, `zipWith`, `all`. Read `foldkit/asyncData`'s `public.d.ts` for the full surface. `repos/foldkit/examples/weather/src/main.ts` is the canonical use.
+
 ### 5. Messages Are Facts, Not Commands
 
 Messages describe what happened, not what should happen. The update function decides what to do. Messages don't dictate the response:
@@ -121,6 +137,38 @@ const ClickedRefresh = m('ClickedRefresh')
 const SelectedFilter = m('SelectedFilter', { filter: S.String })
 const ClickedOpenModal = m('ClickedOpenModal')
 ```
+
+## The update Return Type
+
+`foldkit/update` names the shape so you don't have to:
+
+```ts
+import { Update } from 'foldkit'
+
+type UpdateReturn = Update.Return<Model, Message>
+const withUpdateReturn = M.withReturnType<UpdateReturn>()
+```
+
+`Update.ReturnWithOutMessage<Model, Message, OutMessage>` is the Submodel counterpart, adding the `Option<OutMessage>` third element.
+
+The rule that matters is **name the alias once per file**. Several examples still spell the tuple out by hand (`type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>]`) and that reads fine; `Update.Return` is the tidier spelling and the right default for new code. What to avoid is skipping the alias and repeating the full tuple at the signature and again inside `M.withReturnType<...>()`.
+
+The module also carries two combinators for handlers that fan out after a mutation succeeds:
+
+- `Update.combine(model, [step, step, ...])` sequences update steps over one Model, threading the Model through and collecting the Commands.
+- `Update.refresh({ read, revalidate, write, load })` builds a step that reloads a cache **only when it already holds data**. A cache sitting at `Idle` returns `[model, []]`. That one rule is what makes blanket revalidation safe: a `Succeeded*` handler can list every cache that might be affected without refetching ones nobody has looked at.
+
+```ts
+SucceededUpdateNote: ({ note }) =>
+  Update.combine(model, [
+    replaceNoteInCaches(note),
+    refreshNote(note.id),
+    refreshAllNotes,
+    showToast('Success', `Updated ${note.title}`),
+  ])
+```
+
+`repos/foldkit/examples/route-transitions/src/main.ts` uses both.
 
 ## Flags: Side Effects That Seed the Initial Model
 
@@ -178,11 +226,7 @@ Child → Parent: the child returns an `Option<OutMessage>` as a third tuple ele
 
 ```ts
 // Child update return type
-type UpdateReturn = [
-  Model,
-  ReadonlyArray<Command<Message>>,
-  Option.Option<OutMessage>,
-]
+type UpdateReturn = Update.ReturnWithOutMessage<Model, Message, OutMessage>
 
 // Child signals to parent
 CreatedRoom: ({ roomId, player }) => [
@@ -198,8 +242,8 @@ GotChildMessage: ({ message }) => {
     message,
   )
 
-  const mappedCommands = childCommands.map(
-    Command.mapEffect(Effect.map(message => GotChildMessage({ message }))),
+  const mappedCommands = Command.mapMessages(childCommands, message =>
+    GotChildMessage({ message }),
   )
 
   return Option.match(maybeOutMessage, {

--- a/skills/generate-program/blindSpots.md
+++ b/skills/generate-program/blindSpots.md
@@ -1,0 +1,156 @@
+# Review Blind Spots
+
+The failure modes that pass typecheck, pass lint, pass tests, and still fall short of the bar. `generate-program` walks this list in its Phase 6 review; `audit-program` walks it in Phase 5. This file is the single canonical copy. Update it here and both skills inherit the change.
+
+Each entry has a stable slug in its heading. Cross-reference by slug, never by position, so inserting an entry can't silently repoint every reference.
+
+For each item, output one line: `<slug>: clean | flagged at <file:line>: <issue>`. Silence is not a pass.
+
+> Example paths are written for a consumer project with the Foldkit subtree vendored at `repos/foldkit/`. Working inside the Foldkit repo itself, drop that prefix; the same paths exist at the project root.
+
+## Logic
+
+### `off-by-one`
+
+Logic with "after N", modulo, "every Nth", counter thresholds, or cycle boundaries. Trace for N=0, N=1, and the first transition. `count % 4 === 0` triggers on count=0. Intended or bug?
+
+### `skip-reset-semantics`
+
+Skip, reset, cancel, undo. Trace what each does to counters and derived state. Does skip increment the counter or bypass it? Does reset preserve it? Is the behavior what a user would expect?
+
+### `state-machine-edges`
+
+For every discriminated-union state: can the code transition INTO every state? OUT of every state? Are there dead states (created, never entered)? States that should be reachable but aren't?
+
+When the answer takes real tracing, that is the signal to reach for `Machine` (`foldkit/experimental`, with `to` / `when` / `otherwise` from `foldkit/experimental/machine`). Writing the transitions as a table makes the edge set enumerable data instead of control flow spread across update handlers, and the Machine then answers this blind spot by computation rather than by reading:
+
+- `unreachableStates()` returns the states nothing transitions into.
+- `deadTransitions()` returns edges that can never fire, tagged `UnreachableSource` or `ShadowedByOtherwise`.
+- `reachableFrom(tag)` gives the closure from any state, and `toMermaid()` renders the diagram for review.
+
+Recommend it when a flow has several states, guarded transitions, or edges that are easy to get wrong (checkout, onboarding, multi-step approval, connection lifecycles). `repos/foldkit/examples/checkout-machine/` is the reference. Don't push it on a three-state union that one `M.tagsExhaustive` already handles legibly; the table costs more than it saves there. The module is under `experimental/`, so say so when recommending it.
+
+### `derived-data-in-model`
+
+Fields computable from other fields. `endTime` AND `remainingMs` on the same state, where one can drift from the other. Flag unless there's a documented reason (view needs pure data, etc.).
+
+### `dead-variants-and-noop-commands`
+
+Variants set but never observed by the view or other updates. Fields written but never read. Commands whose result Message handler is `[model, []]`.
+
+The **no-op startup Command**: `init` returns `[DEFAULT_MODEL, [triggerApplicationStarted]]`, the Command resolves to `ApplicationStarted()`, and the handler is `ApplicationStarted: () => [model, []]`. Give the Command real work (load preferences, fetch initial data, focus first input, restore session) or delete the Command and the Message together.
+
+The **navigate-before-save**: a handler returning BOTH `saveState(...)` AND `navigateInternal(...)` races the save against the navigation. A failure surfaced on the old page is unreachable. Idiomatic: emit the save only, then navigate in the `Succeeded*` handler, so errors surface on the page the user is still looking at.
+
+For every union variant, trace whether the view branches on it and whether that branch is reachable. For every Model field, trace whether anything reads it besides its own writes.
+
+## Structure and decomposition
+
+### `repeated-scaffolding`
+
+Three or four handlers sharing the same 5-line scaffold (`M.tag` + `M.orElse`, `Option.match` + fallback) want a named helper. Genuinely duplicated decision logic, not coincidentally similar shape.
+
+Specific case: the update return type written inline at every update site. The convention is to name it once per file:
+
+```ts
+type UpdateReturn = Update.Return<Model, Message>
+const withUpdateReturn = M.withReturnType<UpdateReturn>()
+```
+
+`Update.ReturnWithOutMessage<Model, Message, OutMessage>` is the Submodel counterpart.
+
+**Flag the repetition, not the spelling.** Writing the tuple out as `type UpdateReturn = readonly [Model, ReadonlyArray<Command.Command<Message>>]` is what most examples still do (kanban, auth, job-application); `Update.Return` is the tidier spelling and the right default for new code, but a hand-written alias is not a finding. What is a finding: no alias at all, with the full tuple repeated at the signature and again inside `M.withReturnType<...>()`.
+
+### `functions-doing-two-things`
+
+Orchestrators mixing "decide what to do" with "do it." Helpers whose `if` branches into unrelated behaviors. Handlers that conflate the state decision with the command decision.
+
+### `manual-cache-orchestration`
+
+Handlers that hand-thread several cache writes and refetches after a mutation succeeds. `Update.combine(model, [step, step, ...])` sequences update steps over one Model, and `Update.refresh({ read, revalidate, write, load })` builds a step that reloads a cache only when it actually holds data. A `Succeeded*` handler doing this by hand with nested `evo` calls and conditional Command arrays should use them.
+
+## Naming
+
+### `naming-drift`
+
+`Updated*` here, `Changed*` there for the same kind of event. `whenX` here, `handleX` there for analogous cases. One file, one idiom.
+
+### `messages-naming-the-effect`
+
+A Message named `Incremented` describes the resulting state change, not the user action. The convention is verb-first past-tense for the EVENT that caused the update: `ClickedIncrement`. Same trap with `Saved`, `Deleted`, `Added`. The right names: `ClickedSave`, `ClickedDelete`, `ClickedAdd`, `SucceededSave`. Look for Messages that read like state mutations rather than user actions or external events.
+
+### `view-named-after-namespace`
+
+A counter feature exporting `counter(model)` reads as `Counter.counter(model)` at call sites. Name the primary view function `view`, so call sites read `Counter.view(model)`, `Home.view(model)`, `Room.view(model)`. The namespace disambiguates; the function name carries the role.
+
+### `unearned-type-aliases`
+
+`export const Model = S.Struct({...})` followed by `export type Model = typeof Model.Type`.
+
+**Do not flag this by default.** It is idiomatic the moment the decoded type is referenced across modules in handler or parameter positions: `typeof Foo` is the constructor type Command consumes, so any consumer needing the decoded shape must otherwise write `typeof Foo.Type` at every call site. The exemplars export these aliases extensively for exactly that reason. Library exports whose type is part of a public API (e.g. `ViewConfig` callback parameters) are the same case.
+
+Flag only when the schema is used purely locally with no consumer referencing its type, or when consumers already write `typeof Foo.Type` directly and the alias sits unused.
+
+## Effect and Foldkit idiom
+
+### `effect-module-inconsistency`
+
+Mixing `items.map(f)` and `Array.map(items, f)` in the same file. Mixing `Option.match` and `Option.map(...).pipe(Option.getOrElse(...))` for similar code. One file, one idiom.
+
+### `stuttery-evo-setters`
+
+An `evo` setter that only transforms that same field should be point-free: `entries: Array.map(revealErrors)`, `count: Number.increment`, `priceSlider: Slider.reflectRange({ min: minPrice, max: maxPrice })`. Flag `entries: () => Array.map(model.entries, revealErrors)` and friends. Replacement values from Messages, child updates, Commands, or other Model fields still use `() => value`.
+
+### `empty-object-constructors`
+
+No-field tagged structs called with `({})`: `Idle({})`, `Work({})`, `ClickedSubmit({})`. Should be `Idle()`, `Work()`, `ClickedSubmit()`. Both compile; exemplars are uniform on the no-arg form.
+
+### `hand-rolled-async-state`
+
+A hand-written `Idle | Loading | Error | Ok` union for remote data, when `AsyncData` ships it: `AsyncData.Schema(DataSchema, ErrorSchema)` yields the schema plus constructors for `Idle`, `Loading`, `Refreshing`, `Failure`, `Stale`, and `Success`, with `isPending`, `hasData`, `match`, `revalidate`, and the rest of the module's operations. `repos/foldkit/examples/weather/src/main.ts` is the canonical use.
+
+The two states a hand-rolled union usually lacks are the ones that matter: `Refreshing` (data on screen while a reload runs) and `Stale` (data on screen after a reload failed). A union without them forces a refetch to blank the screen or an error to discard good data. Flag a hand-rolled union unless the states genuinely aren't remote-data states.
+
+### `array-type-syntax`
+
+`readonly Command<Message>[]` and `MyType[]` should be `ReadonlyArray<Command<Message>>` and `Array<MyType>`. Cosmetic, but every exemplar is uniform.
+
+## Routing and views
+
+### `hard-coded-route-paths`
+
+`Href('/')`, `navigateInternal('/new')`, ``Href(`/tag/${name}`)``. Routers are bidirectional; call them as printers: `Href(homeRouter())`, `navigateInternal(newLinkRouter())`, `Href(tagFilterRouter({ tag: name }))`.
+
+### `unkeyed-list-rows`
+
+Rows in `Array.map(items, ...)` carrying `OnClick` handlers bound to specific item ids, without `keyed('li')(item.id, ...)`, are a snabbdom patching bug. Delete from the middle and the OLD row's click handler patches onto a different row: the user clicks "Delete B" and A is deleted. Invisible until a delete or reorder happens mid-list.
+
+### `data-derived-keys`
+
+A `keyed(...)` whose key is built from displayed data (concatenated booleans, a formatted summary string, a restated field the subtree renders) is keying used as change detection. The key changes while the same conceptual thing stays on screen, so every content change tears the subtree down, discarding focus, scroll position, and open `details` elements. Keys carry identity: a branch tag, a route tag, a stable id. If removing the key leaves the same structure rendering at that position, remove it.
+
+### `flat-parent-message-union`
+
+`Message = S.Union([ChildMessage, ParentLocalMessage])` makes every parent handler know the child's tag names, and the child can't grow its vocabulary without leaking into the parent. The canonical Submodel pattern wraps: `const GotChildMessage = m('GotChildMessage', { message: Child.Message })`, and the parent's `M.tagsExhaustive` has one `GotChildMessage` case delegating to `Child.update(model.child, message)`. Flat unions work for trivial cases but don't isolate child concerns. Suggest `Got*` wrapping for any Submodel likely to grow, or any child that needs an OutMessage.
+
+## Accessibility
+
+### `hand-rolled-widgets`
+
+Raw `input`, `textarea`, `button`, `dialog`, anything with `role="menu"` / `role="dialog"` / `role="tab"`. `@foldkit/ui` ships `Input`, `Textarea`, `Button`, `Dialog`, `Menu`, `Tabs` and the rest. A hand-rolled element without a `// NOTE:` explaining why is a BLOCKER, not a style preference: hand-rolling skips accessibility work.
+
+### `a11y-gaps`
+
+For anything outside `@foldkit/ui` coverage: label/input pairing via `For(id)` + `Id(id)`, dynamic errors announced via `Role('alert')` or `AriaLive('polite')`, icon-only buttons with `AriaLabel`, external links with `Rel('noopener noreferrer')`, exactly one `h1` per route, semantic landmarks over `div` soup. Color is never the only carrier of meaning.
+
+### `aria-role-confusion`
+
+Checkboxes use `Role('checkbox')` + `AriaChecked(boolean)`; screen readers announce "checkbox, checked." Toggle buttons (Play/Pause, Bold on/off) use `AriaPressed(string)`; screen readers announce "toggle button, pressed." Ask: does the label say "Mark as done" (checkbox) or "toggle bold" (pressed button)?
+
+## Testing
+
+### `missing-scene-test`
+
+`scene.test.ts` is REQUIRED at Tier 3+. Absent is a BLOCKER, not a QUALITY item.
+
+Present but with no `Scene.expect(...)` and no interactive resolution in a block is the same finding. A `Scene.scene(...)` that only does `Scene.with(model)` verifies that the view doesn't throw and nothing else.

--- a/skills/generate-program/checklist.md
+++ b/skills/generate-program/checklist.md
@@ -3,13 +3,20 @@
 Run through each category after generating an app. Fix any issues before presenting the result.
 
 > **This is the canonical reference for mechanical checks.** `SKILL.md` phases 4.5, 5, and 5.5 point here rather than duplicating the grep commands inline, to prevent drift. If you update a grep or add a new one, update it here. The phases will inherit the change.
+> Example paths assume a consumer project with the Foldkit subtree vendored at `repos/foldkit/`. Working inside the Foldkit repo itself, drop that prefix; the same paths exist at the project root.
 
 ## Gate commands (run ALL FOUR; fix everything they surface)
 
-- [ ] `npm run format` (or `npx prettier -w .`): run FIRST; rewrites files so subsequent gates see the committed shape.
-- [ ] `npm run lint` (or `npx eslint .`): output clean. Catches unused imports, unused vars, style-rule violations that `tsc` does not.
-- [ ] `npm run typecheck` (or `npx tsc --noEmit`): no errors.
-- [ ] `npm run test` (or `npx vitest run`): all tests pass.
+- [ ] `format`: run FIRST; rewrites files so subsequent gates see the committed shape. The scaffold wires prettier.
+- [ ] `lint`: output clean. Catches unused imports, unused vars, style-rule violations that `tsc` does not. The scaffold wires oxlint.
+- [ ] `typecheck`: no errors. The scaffold wires `tsc --noEmit`.
+- [ ] `test`: all tests pass. The scaffold wires vitest.
+
+The project's configured script is the contract for each gate; the tools named
+are what `create-foldkit-app` happens to wire up. If a project swapped one out,
+run its script, not the tool named here.
+
+Invoke each through the package manager the project was scaffolded with (`npm run lint`, `pnpm run lint`, `yarn lint`, `bun run lint`). If a script is missing, run the project-local binary through that manager's exec (`pnpm exec oxlint src`, `npm exec --no-install oxlint src`, `yarn exec oxlint src`, `bun x --no-install oxlint src`). Avoid bare `npx`, which fetches from the registry when the binary isn't installed locally.
 
 "Typecheck clean and tests pass" is NOT sufficient. Generated code is rarely Prettier-exact out of the box, and frequently has unused imports (`Invalid`, `NotValidated`, `Valid` imported as values when only used as string-literal tag keys in `M.tag(...)`) that only the linter catches. Skipping either means the user's first `git commit` produces a cascade of formatting/lint fixes they have to clean up.
 
@@ -21,18 +28,46 @@ These are the fast greps that catch the common write-time violations. Run them a
 # Empty-object constructor calls: no-field tagged structs should call with no arg
 grep -rn "({})" src/
 
+# Wrong package for UI components: they come from '@foldkit/ui', and there is
+# no Ui namespace on foldkit. Any Ui.Something is a stale import.
+grep -rn "\bUi\.[A-Z]" src/
+
+# Wrong package for HTTP: HttpClient lives in effect/unstable/http.
+# (@effect/platform-browser is fine; that's KeyValueStore and Crypto.)
+grep -rn "from '@effect/platform'" src/
+
+# Update return type written inline at a match site instead of aliased once
+# per file. The alias itself is fine (most examples spell it by hand);
+# repeating the tuple inline is the finding. Two alternatives on purpose:
+# `withReturnType<$` catches the wrapped form where the tuple sits on the next
+# line, and `withReturnType<readonly [` catches the single-line form. Keep both.
+grep -rn "withReturnType<\s*$\|withReturnType<readonly \[" src/
+
+# T[] syntax in the return type: use ReadonlyArray<Command<Message>>
+grep -rn "readonly Command<.*>\[\]" src/
+
+# Hand-rolled remote-data union: use AsyncData.Schema(Data, Error).
+# Eyeball each hit; a non-remote state machine with these names is fine.
+grep -rn "ts('Loading')" src/
+
+# Effect array predicates are isArrayEmpty / isArrayNonEmpty
+grep -rn "isEmptyArray\|isNonEmptyArray" src/
+
 # Hard-coded route paths: use router() / router({params}) instead of template strings
 grep -rn "Href('/" src/
 grep -rn "navigateInternal('/" src/
 
-# Hand-rolled form inputs: should use Ui.Input.view / Ui.Textarea.view
-grep -rn "^\s*input(\[" src/
-grep -rn "^\s*textarea(\[" src/
-
-# Hand-rolled buttons: should use Ui.Button.view (except inside a Ui.Button toView callback,
-# where ...attributes.button is present). A `button(` line without `...attributes.button` is
-# almost always a hand-rolled button that should go through Ui.Button.
-grep -rn "^\s*button(" src/
+# Hand-rolled form controls: should use Input.view / Textarea.view / Button.view
+# from '@foldkit/ui'. Views bind `const h = html<Message>()`, so the call shape is
+# `h.input(...)`, not a bare `input(...)`; match both, and don't assume the element
+# starts the line or that OnClick precedes it.
+#
+# Legitimate exception: inside the component's own `toView` callback you DO render
+# the element, spreading the component's attribute group into it. Those calls
+# contain `...attributes.input` / `...attributes.textarea` / `...attributes.button`,
+# usually on a different line, so the exclusion has to be eyeballed per hit rather
+# than grepped. A hit whose enclosing call has no such spread is hand-rolled.
+grep -rnE "(^|[^.[:alnum:]_])(h\.)?(input|textarea|button)\(" src/
 
 # Option ceremony: Array.findFirst(...)._tag === 'Some' should be Array.some(...)
 grep -rn "Array\.findFirst.*_tag" src/
@@ -70,8 +105,11 @@ grep -rn "evo(.*, {" src/ -A 3 | grep "\.\.\."
 # as casts on constructor returns: constructors already return the right type
 grep -rn " as [A-Z][a-zA-Z]*State\b\| as [A-Z][a-zA-Z]*Message\b" src/
 
-# Labels without For: should pair with Id on input, or use Ui.Input
-grep -rn "label(\[" src/ | grep -v "For("
+# Labels without For: should pair with Id on the input, or use Input from
+# '@foldkit/ui'. The attribute array often starts on the next line, so match the
+# call and read its attribute block rather than filtering the matched line: a
+# `grep -v "For("` on one line silently passes every multiline label.
+grep -rnE "(^|[^.[:alnum:]_])(h\.)?label\(" src/
 
 # maybe* on non-Option: should be Option<T>
 grep -rn "maybe[A-Z][a-zA-Z]*: [A-Z][a-zA-Z]* | undefined" src/
@@ -83,14 +121,18 @@ grep -rn "\.span(\[\], \[\])\|^span(\[\], \[\])" src/
 # Effect.ignore on infallible Effects (pushUrl, load, back, forward)
 grep -rn "pushUrl.*Effect\.ignore\|load(.*)\.pipe.*Effect\.ignore" src/
 
-# _blank links missing Rel (fast scan; multi-line matches need eyeballing)
-grep -rn "Target('_blank')" src/ -A 2 | grep -B 1 "Rel(" || echo "(all _blank have Rel, or none are used)"
+# _blank links missing Rel. Match the bare literal, not `Target('_blank')`: the
+# argument may be wrapped onto its own line, quoted either way, and the Rel may
+# sit any distance from Target or precede it. Anything narrower silently passes
+# an unformatted anchor. List every _blank and read each one's whole attribute
+# block for Rel.
+grep -rn "_blank" src/
 
 # outline-none without focus-visible replacement
 grep -rn "outline-none" src/ | grep -v "focus-visible:"
 ```
 
-Alongside the greps, eyeball each file's imports. Every symbol you imported should be called. ESLint flags this, but so do you, at write-time.
+Alongside the greps, eyeball each file's imports. Every symbol you imported should be called. The linter flags this, but so do you, at write-time.
 
 ## Structural completeness
 
@@ -164,6 +206,17 @@ Alongside the greps, eyeball each file's imports. Every symbol you imported shou
 - [ ] Impossible states are unrepresentable
 - [ ] `ts()` for non-Message tagged structs (Model states, route variants)
 - [ ] `m()` only for Message variants
+- [ ] **Remote data uses `AsyncData`, not a hand-rolled union.** `AsyncData.Schema(DataSchema, ErrorSchema)` supplies `Idle`, `Loading`, `Refreshing`, `Failure`, `Stale`, and `Success` plus `match`, `isPending`, `hasData`, `revalidate`, and the rest. A hand-rolled `Idle | Loading | Error | Ok` is missing `Refreshing` and `Stale`, which is what forces a refetch to blank the screen and a failed refetch to discard good data. Reference: `repos/foldkit/examples/weather/src/main.ts`
+
+## Framework modules over hand-rolled equivalents
+
+Foldkit ships these; reaching past them is a finding, not a style choice.
+
+- [ ] Update return type is aliased once per file, not repeated inline at the signature and again at each `M.withReturnType` site. `Update.Return<Model, Message>` (or `Update.ReturnWithOutMessage<Model, Message, OutMessage>`) is the preferred spelling for new code; a hand-written tuple alias is what most examples still use and is not itself a finding
+- [ ] Multi-step post-mutation handlers use `Update.combine(model, [...])` and `Update.refresh({ read, revalidate, write, load })` rather than hand-threaded `evo` chains and conditional Command arrays
+- [ ] Child Submodel Commands are re-tagged with `Command.mapMessages(commands, toParentMessage)`
+- [ ] HTTP uses `HttpClient` / `HttpClientRequest` from `effect/unstable/http`, with `Effect.provide(effect, Http.layer)` to supply the client. Not `@effect/platform` (`@effect/platform-browser` is separate and is for `BrowserKeyValueStore` / `BrowserCrypto`)
+- [ ] UI components are imported from `@foldkit/ui` by name (`import { Dialog, Input } from '@foldkit/ui'`). There is no `Ui` namespace on `foldkit`
 
 ## Effect-TS patterns
 
@@ -184,27 +237,42 @@ Alongside the greps, eyeball each file's imports. Every symbol you imported shou
 ## Foldkit UI
 
 - [ ] Foldkit UI components used where interaction matches (Dialog, Tabs, Menu, Combobox, DatePicker, FileDrop, Toast, Tooltip, DragAndDrop, etc.). Never hand-roll accessible widgets
-- [ ] **Form inputs use `Ui.Input.view`, `Ui.Textarea.view`, `Ui.Button`.** Hand-rolled `input`/`textarea`/`button` elements in a form are a fail unless the file has a NOTE comment explaining why the component couldn't be used.
-- [ ] Each stateful UI component has its Model in the app Model, a `Got*` Message, init in init, and delegation in update. Stateless render helpers (`Ui.Button`, `Ui.Input`, `Ui.Textarea`, `Ui.RadioGroup`, `Ui.Checkbox`, `Ui.Switch`, `Ui.Disclosure`) are called directly in view and dispatch parent Messages; the controlled ones (`Ui.RadioGroup`, `Ui.Checkbox`, `Ui.Switch`, `Ui.Disclosure`) take the current value in from the parent Model, which stores the new value on toggle
-- [ ] `Ui.Toast` uses `Ui.Toast.make(PayloadSchema)` to bind to a consumer-defined payload type
+- [ ] **Form inputs use `Input.view`, `Textarea.view`, `Button.view` from `@foldkit/ui`.** Hand-rolled `input`/`textarea`/`button` elements in a form are a fail unless the file has a NOTE comment explaining why the component couldn't be used.
+- [ ] Each stateful UI component has its Model in the app Model, a `Got*` Message, init in init, and delegation in update. Stateless render helpers (`Button`, `Input`, `Textarea`, `Select`, `Fieldset`, `RadioGroup`, `Checkbox`, `Switch`, `Disclosure`, `Nav`) are called directly in view and dispatch parent Messages; the controlled ones (`RadioGroup`, `Checkbox`, `Switch`, `Disclosure`) take the current value in from the parent Model, which stores the new value on toggle
+- [ ] `Toast` uses `Toast.make(PayloadSchema)` to bind to a consumer-defined payload type
 - [ ] No custom keyboard navigation or ARIA attributes for patterns covered by Foldkit UI components
 
 ### Mechanical check: no hand-rolling
 
-Run these greps against `src/`. Each should return zero matches (or only matches inside a `NOTE:` justification):
+Run these greps against `src/`. Every hit needs an explanation: a sanctioned `toView` spread, a `NOTE:` justification, or a fix.
 
 ```bash
-grep -rn "^\s*input(\[" src/            # raw <input>: should use Ui.Input
-grep -rn "^\s*textarea(\[" src/         # raw <textarea>: should use Ui.Textarea
-grep -rn "OnClick(.*) .*button(" src/   # raw <button> with click handler: should use Ui.Button
-grep -rn "role.*dialog\|role.*menu" src/  # hand-rolled ARIA: should use Ui.Dialog / Ui.Menu
+# Raw input / textarea / button: should use Input, Textarea, Button.
+# Matches both `input(...)` and the usual `h.input(...)`, anywhere on the line.
+grep -rnE "(^|[^.[:alnum:]_])(h\.)?(input|textarea|button)\(" src/
+
+# Hand-rolled ARIA: should use Dialog / Menu / Tabs. Capital-R `Role(` is the
+# view attribute; lowercase `Scene.role(` is a test locator and is not a finding.
+grep -rnE "(^|[^.[:alnum:]_])(h\.)?Role\(['\"](dialog|menu|tab)" src/
 ```
 
-The rule: **if the interaction pattern appears in the Ui.\* component table (Phase 2.5 of SKILL.md), use the component.** Hand-rolling is permitted only when: (a) the component doesn't exist yet, AND (b) you add a `// NOTE: hand-rolling because <specific reason>` comment above the element. Without the NOTE, the reviewer treats hand-rolling as a BLOCKER, not a style preference.
+Eyeball every hit from the first grep. A call that spreads the component's own
+attribute group (`...attributes.input`, `...attributes.textarea`,
+`...attributes.button`) is the sanctioned `toView` case, not a finding. The spread
+usually sits on a later line than the element call, which is why this exclusion is
+a read rather than a `grep -v`.
+
+The rule: **if the interaction pattern appears in the `@foldkit/ui` component table (Phase 2.5 of SKILL.md), use the component.** The gate is about the interaction, not the tag, so a hit is only a finding once you know which of these it is:
+
+- **Inside the component's own `toView`** (the call spreads `...attributes.input` / `.textarea` / `.button` / `.label`): sanctioned, not a finding.
+- **A form control** (a text input, textarea, or button in a form): must go through `Input`, `Textarea`, or `Button`. Raw here is a BLOCKER unless a `// NOTE: hand-rolling because <specific reason>` comment sits above it.
+- **A deliberate non-form control** (a search field, an inline editor, anything intentionally below the component layer, per the form-inputs rule in Phase 2.5): allowed. Still check it directly against the Accessibility section below, since nothing is supplying the label wiring, focus ring, or ARIA for you.
+
+Hand-rolling a control the table covers is permitted only when the component genuinely doesn't fit, and only with the NOTE. Without the NOTE, the reviewer treats it as a BLOCKER, not a style preference.
 
 **A NOTE is not a free pass.** Before writing one, read the component's `.d.ts` and confirm the concern is real. Common false-justifications to avoid:
 
-- _"Using the Ui component would require a per-row Model instance and duplicate state"_: first check whether the component is stateful. Stateless controlled helpers like `Ui.Checkbox`, `Ui.Switch`, `Ui.Disclosure`, and `Ui.RadioGroup` do not add a child Model. Store the value in the parent Model and pass it to `view` with an `onToggle` or `onSelect` Message. For stateful components, the component Model holds UI state (focus, open/closed, typeahead key buffer), not your domain value, so holding it is not duplication.
+- _"Using the component would require a per-row Model instance and duplicate state"_: first check whether the component is stateful. Stateless controlled helpers like `Checkbox`, `Switch`, `Disclosure`, and `RadioGroup` do not add a child Model. Store the value in the parent Model and pass it to `view` with an `onToggle` or `onSelect` Message. For stateful components, the component Model holds UI state (focus, open/closed, typeahead key buffer), not your domain value, so holding it is not duplication.
 - _"The component needs a toParentMessage and I don't want to wire one"_: that's always the wiring cost. The whole point of Ui components is that you pay it once per use and get a11y for free.
 - _"The interaction is too custom for the component"_: check the `toView` callback signature. It lets you render whatever HTML you want inside the component's attribute-scaffolding. Custom visual = fine, custom a11y = never needed.
 
@@ -212,29 +280,29 @@ Reviewers should challenge every NOTE: "Is this justification actually true, or 
 
 ## Accessibility
 
-Foldkit UI components ARE the a11y pass for their covered patterns. These checks apply to anything NOT covered by a Ui.\* component (raw inputs in a custom context, static content, custom layouts) and to the overall document structure.
+Foldkit UI components ARE the a11y pass for their covered patterns. These checks apply to anything NOT covered by a `@foldkit/ui` component (raw inputs in a custom context, static content, custom layouts) and to the overall document structure.
 
 - [ ] Exactly one `h1` per route. Headings descend without skipping levels (no `h3` without an `h2` above it).
 - [ ] Semantic landmarks used: `main`, `nav`, `header`, `footer`, `aside`, `section`. Not `div` soup.
-- [ ] Every `label` is associated with its input: `label([For('email-input')], ['Email'])` paired with `input([Id('email-input'), ...])`. Or use `Ui.Input.view` which handles the association. Grep for `label([` followed by no `For(` → should be zero.
+- [ ] Every `label` is associated with its input: `label([For('email-input')], ['Email'])` paired with `input([Id('email-input'), ...])`. Or use `Input.view` which handles the association. Grep the `label(` calls and read each one's attribute block for `For(`; a single-line `grep -v` misses labels whose attributes wrap. A `...attributes.label` spread is the component's own `toView` and is not a finding.
 - [ ] Every `input`, `textarea`, and `select` has either an associated `label` OR an explicit `AriaLabel(...)`. Unlabeled form fields are a fail.
 - [ ] Icon-only buttons have `AriaLabel(...)` describing the action. `button([OnClick(...)], ['★'])` without an aria label is unreadable to screen readers.
 - [ ] Dynamic error messages wrap in `role="alert"` (for immediate errors) or `aria-live="polite"` (for non-urgent updates). Validation errors that appear after blur should be announced. Example: `p([Role('alert'), ...], [errorMessage])`. Grep for error-class CSS (e.g. `text-red`) and verify each error container has `Role('alert')` or a parent with `AriaLive('polite')`.
 - [ ] External links (`Target('_blank')`) also have `Rel('noopener noreferrer')`.
 - [ ] Images have `Alt(...)`. Decorative images use `Alt('')` explicitly. Never omitted.
 - [ ] Interactive lists (navigable items, selectable rows) use `ul`/`ol` + `li`, not `div` stacks. Screen readers announce "list with N items" for real lists.
-- [ ] Required form fields are marked `AriaRequired(true)` OR the `Ui.Input` `required: true` is set. The `required` HTML attribute alone is not enough for every screen reader.
+- [ ] Required form fields are marked `AriaRequired(true)` on the rendered input. `Input.view` has no `required` option, so pass it through the `toView` callback's `input` attribute group. The `required` HTML attribute alone is not enough for every screen reader.
 - [ ] Focus is visible, either via Tailwind's `focus-visible:` classes or the browser default. If you've reset outline, you must replace it. Grep for `outline-none` without a paired `focus-visible:` class.
 - [ ] Color is not the only carrier of meaning. A red border on an invalid input needs an accompanying error message or icon. Don't ship "invalid = red only."
 - [ ] Page `<title>` is set via the `title` field of the `Document` returned by `view` (with `Runtime.makeApplication`). For routed apps, each route returns a distinct title.
 
 ### Mechanical check: a11y
 
-The greps below are **fast starting scans**, not authoritative. Attributes often span multiple lines (`Target('_blank')` on line N, `Rel('noopener noreferrer')` on line N+1), so line-only matches can false-positive. Every hit should be eyeballed in context before flagging it as a bug, but every hit DOES need to be eyeballed.
+The greps below are **fast starting scans**, not authoritative. Attributes often span multiple lines (`Target('_blank')` on line N, `Rel('noopener noreferrer')` several lines later, or ordered the other way), so a fixed `-A` window silently passes anchors whose `Rel` falls outside it. Each scan lists candidates; you confirm by reading the whole attribute block. Every hit should be eyeballed in context before flagging it as a bug, but every hit DOES need to be eyeballed.
 
 ```bash
-grep -rn "label(\[" src/ | grep -v "For("                # labels without For
-grep -rn "Target('_blank')" src/ -A 2 | grep -B 1 "Rel("  # _blank paired with rel
+grep -rnE "(^|[^.[:alnum:]_])(h\.)?label\(" src/       # labels: read each block for For(
+grep -rn "_blank" src/                                  # then read each anchor's block for Rel(
 grep -rn "outline-none" src/ | grep -v "focus-visible:"  # killed focus outline without replacement
 ```
 
@@ -246,7 +314,7 @@ Each confirmed miss is a concrete a11y bug a screen reader user would hit.
 
 - [ ] Form validation uses `foldkit/fieldValidation` (`Field`, `makeRules`, `validate`, `allValid`). No hand-rolled `Valid | Invalid` unions when validation is the concern
 - [ ] Date handling uses the `Calendar` module (`Calendar.CalendarDate`, `Calendar.today.local`). No raw `Date` objects in Model
-- [ ] File handling uses the `File` module with `Ui.FileDrop`. No direct `File` API usage in update/view
+- [ ] File handling uses the `File` module with `FileDrop` from `@foldkit/ui`. No direct `File` API usage in update/view
 
 ## File organization
 
@@ -264,7 +332,7 @@ Each confirmed miss is a concrete a11y bug a screen reader user would hit.
 - [ ] At least one multi-step test that chains Messages and Command resolutions
 - [ ] Submodel tests assert `outMessage` when the child signals to parent
 - [ ] Tests use `Story.Command.resolve(Definition, resultMessage)`. Never run Command Effects directly in story tests
-- [ ] All tests pass with `npx vitest run`
+- [ ] All tests pass with the project's test script
 
 **Scene tests** (REQUIRED at Tier 3+; strongly encouraged at Tier 2):
 
@@ -318,7 +386,7 @@ Items without a tier marker apply universally (even to a 50-line counter). When 
 - [ ] **Pure domain logic lives in `domain/*.ts`**, not in update handlers. Examples: `Column.reorder(columns, from, to)`, `Cart.totalPrice(items)`. If the update is doing array surgery on domain entities, that surgery belongs in the domain module.
 - [ ] Domain files export schemas AND pure operations on those schemas. Update calls the operations; it doesn't reimplement them.
 - [ ] Domain modules never import from `model.ts`, `update.ts`, `view.ts`, or `message.ts`. Domain is the leaf layer.
-- [ ] References: `examples/kanban/src/domain/`, `examples/job-application/src/domain/`, `examples/shopping-cart/src/domain/`.
+- [ ] References: `repos/foldkit/examples/kanban/src/domain/`, `repos/foldkit/examples/job-application/src/domain/`, `repos/foldkit/examples/shopping-cart/src/domain/`.
 
 ## Naming precision
 

--- a/skills/generate-program/conventions.md
+++ b/skills/generate-program/conventions.md
@@ -99,10 +99,10 @@ pipe(
 // Model fields
 maybeError: S.Option(S.String) // not error: S.String with '' as none
 
-// Conditional rendering
+// Conditional rendering (inside a view function that bound `const h = html<Message>()`)
 Option.match(model.maybeError, {
-  onNone: () => empty,
-  onSome: error => div([Class('text-red-500')], [error]),
+  onNone: () => h.empty,
+  onSome: error => h.div([h.Class('text-red-500')], [error]),
 })
 
 // Conditional values
@@ -339,6 +339,18 @@ const Model = S.Struct({
 })
 ```
 
+For **remote data**, don't write that union at all. `AsyncData` ships it, with two states hand-rolled versions always miss:
+
+```ts
+const DataAsyncData = AsyncData.Schema(Data, S.String)
+
+const Model = S.Struct({
+  data: DataAsyncData.schema,
+})
+```
+
+`Idle | Loading | Refreshing | Failure | Stale | Success`. `Refreshing` holds the previous data during a reload so a refetch doesn't blank the screen; `Stale` holds previous data alongside the new error so a failed reload doesn't throw away what the user was reading. Hand-rolling the four-state version bakes both regressions in. Keep `ts()` unions for state that isn't remote data: form steps, editor modes, connection phases.
+
 For form field validation:
 
 ```ts
@@ -420,22 +432,41 @@ import {
   String as String_,
   pipe,
 } from 'effect'
+import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import {
+  AsyncData,
   Calendar,
   Command,
   Dom,
   File,
+  Http,
   Runtime,
   Subscription,
-  Ui,
+  Update,
   Url,
 } from 'foldkit'
-import { Html, empty, html, keyed } from 'foldkit/html'
+import { Document, Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { r } from 'foldkit/route'
 import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
+
+import { Button, Dialog, Input } from '@foldkit/ui'
 ```
+
+Two component names collide with `foldkit` module names: `Calendar` (the date
+module) and `Toast`. Alias the component with a `Ui` prefix, which is what the
+exemplars do:
+
+```ts
+import { Calendar } from 'foldkit'
+
+import { Calendar as UiCalendar, Toast as UiToast } from '@foldkit/ui'
+```
+
+`Calendar.CalendarDate` is then the date type and `UiCalendar.view` the
+component. Alias the `foldkit` side instead (`Calendar as FoldkitCalendar`) when
+the component is the one used throughout the file.
 
 For form validation, also:
 
@@ -456,9 +487,11 @@ import {
 Notes:
 
 - Only import what you actually use in the file. The lint pass catches unused imports.
-- Module-by-module reminders, for example: `Calendar` for `Calendar.CalendarDate`, `Calendar.today.local`, `Calendar.make`, `Calendar.addDays` etc., paired with `Ui.Calendar` or `Ui.DatePicker`. `Dom` for DOM-side-effect helpers (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showDialog`, `Dom.closeDialog`, `Dom.lockScroll`, `Dom.unlockScroll`, `Dom.waitForAnimationSettled`, etc.). `File` for file upload primitives paired with `Ui.FileDrop`. `foldkit/fieldValidation` for form validation.
+- Module-by-module reminders, for example: `Calendar` for `Calendar.CalendarDate`, `Calendar.today.local`, `Calendar.make`, `Calendar.addDays` etc., paired with the `Calendar` or `DatePicker` component from `@foldkit/ui` (the component and the `foldkit` date module share the name `Calendar`; they are different things). `Dom` for DOM-side-effect helpers (`Dom.focus`, `Dom.scrollIntoView`, `Dom.showDialog`, `Dom.closeDialog`, `Dom.lockScroll`, `Dom.unlockScroll`, `Dom.waitForAnimationSettled`, etc.). `File` for file upload primitives paired with `FileDrop` from `@foldkit/ui`. `foldkit/fieldValidation` for form validation.
 - For time, randomness, UUIDs, or delays, use Effect's built-ins directly rather than reaching for a Foldkit module: `Clock.currentTimeMillis`, `Random.nextIntBetween`, `Effect.uuid`, `Effect.sleep(Duration.millis(...))`.
 - When an Effect module name collides with a global, alias the Effect import with a trailing underscore: `String as String_`, `Array as Array_`, `Number as Number_`.
-- `Match as M` is Effect's Match module. Foldkit re-exports `M.value`, `M.tagsExhaustive`, `M.withReturnType` etc. through Effect's `Match`.
-- `Ui` from `foldkit` gives access to all UI components: `Ui.Dialog`, `Ui.Tabs`, `Ui.Menu`, `Ui.DatePicker`, `Ui.FileDrop`, `Ui.Toast`, `Ui.Tooltip`, etc.
-- `empty` and `keyed` are properties on `h` after binding `const h = html<Message>()` inside the view function. They are not top-level exports of `foldkit/html`.
+- `Match as M` is Effect's Match module, imported from `effect`. `M.value`, `M.tagsExhaustive`, and `M.withReturnType` are Effect APIs; Foldkit does not wrap or re-export them.
+- **UI components live in a separate package.** Import them by name from `@foldkit/ui`: `import { Dialog, DatePicker, FileDrop, Toast, Tooltip } from '@foldkit/ui'`. Deep imports (`@foldkit/ui/dialog`) work too. There is no `Ui` export on the `foldkit` package, so `Ui.Dialog.view` does not resolve.
+- **`empty` and `keyed` are properties on `h`**, reached as `h.empty` / `h.keyed` after binding `const h = html<Message>()` inside the view function. They are not top-level exports of `foldkit/html`, so they never belong in that import list. Same for `h.submodel`.
+- `AsyncData` for remote data state, `Update` for the update return type and the `combine` / `refresh` combinators, `Http` for the `layer` that provides `HttpClient` to a Command.
+- HTTP types come from `effect/unstable/http`, not `@effect/platform`. `@effect/platform-browser` is a separate package used for `BrowserKeyValueStore` and `BrowserCrypto`.


### PR DESCRIPTION
The generate-program and audit-program skills encoded a lot of API detail
as prose, and that prose had drifted far enough to produce broken code.
The skills' own cited exemplars contradicted them.

Correct what moved. UI components live in `@foldkit/ui` and are imported
by name, so every `Ui.Dialog.view` and the `node_modules/foldkit/dist/ui/`
grounding path was wrong. `HttpClient` comes from `effect/unstable/http`,
not `@effect/platform`. Parent-child Command mapping is
`Command.mapMessages`, not `Command.mapEffect`. The scaffold lints with
oxlint. The ui-showcase files moved under `src/ui/`. `Input` has no
`required` option. The conventions import block imported `empty` and
`keyed` from `foldkit/html` while the same file's closing note said they
aren't exports. Drop the absolute `/Users/...` paths baked into the review
subagent prompt.

Cover what shipped since the last pass. `AsyncData` supplies the
remote-data union the skills told generators to hand-roll, including the
`Refreshing` and `Stale` states a hand-rolled version always misses.
`Update.Return` names the update return type, and `Update.combine` /
`Update.refresh` replace hand-threaded cache fan-out. Add `Http.layer`,
`Port`, and the `Slider`, `VirtualList`, and `Nav` components. Correct the
Submodel / render-helper split, which had moved under both feet:
`Tooltip` and `FileDrop` are Submodels, `Nav` is a render helper.

Move the review blind spots into one `blindSpots.md` that both skills
read. The list had been copy-pasted into both and diverged to 16 items
against 22, and audit-program's focus-area table still indexed the other
copy's numbering, so every row pointed at the wrong item: `testing`
resolved to "A11y gaps" and `types` to "Unkeyed list rows". Entries now
carry named slugs and the table cites those, so inserting an entry can't
silently repoint a reference. `state-machine-edges` now points at the
experimental `Machine` module, whose `unreachableStates` and
`deadTransitions` answer that blind spot by computation, and Phase 1's
analysis list raises it as an option for flows that move through several
named steps so the choice surfaces before the code is written.

Fix the hand-rolling scans, which caught nothing. Views bind
`const h = html<Message>()`, so the call shape is `h.button(...)`, but the
greps looked for a bare `button(` at the start of a line and for `OnClick`
preceding the element. Against the five raw `h.button(` calls in the
api-cache example all three returned zero. The label scan had the same
defect, missing every call whose attribute array starts on the next line,
and the `Target('_blank')` scan filtered on a fixed two-line window. Match
the receiver-qualified form, drop the ordering assumption, and note that
the sanctioned `toView` spread has to be eyeballed because it sits on a
later line. Scope the ARIA scan to the capital-R `Role(` view attribute so
`Scene.role(` locators in tests stop reading as findings.

Add mechanical greps for each drift class, including one for the stale
`isEmptyArray` / `isNonEmptyArray` spellings corrected on main, so a stale
import surfaces in the audit rather than in generated code. Invoke the
gate commands through whichever package manager the project was
scaffolded with rather than a bare `npx`, which resolves from the registry
when the binary is missing locally. Say plainly in both skills that the
`.d.ts` wins over these files when they disagree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated program generation and audit guidance with current Foldkit, Effect-TS, and `@foldkit/ui` conventions, including remote state modeling with `AsyncData`, standardized `Update.Return` patterns, HTTP typing/layer guidance, and improved form/date/file guidance.
  * Added standardized, slug-based “Review Blind Spots” reporting (including explicit handling of “silence”), and expanded Phase 5–7 guidance plus the post-generation verification checklist and conventions.
* **Chores**
  * Bumped the plugin version to **0.10.31**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->