### PR TITLE
Show a real update function in the home page demos and keep highlights on screen

### DIFF
--- a/packages/website/scripts/demoCodePlugin.ts
+++ b/packages/website/scripts/demoCodePlugin.ts
@@ -8,14 +8,72 @@ const shikiThemes = {
   dark: shikiDarkTheme,
 }
 
+/** A run of snippet lines a demo phase highlights, addressed by exact line
+ *  text rather than line number. `to` is the first matching line at or after
+ *  `from`; omit it for a single-line region. */
+export type PhaseRegion = Readonly<{ from: string; to?: string }>
+
+/** The lines each phase highlights, keyed by the phase name the panel sets on
+ *  its `data-*-phase` attribute. */
+export type PhaseRegions = Readonly<Record<string, ReadonlyArray<PhaseRegion>>>
+
+const regionLineNumbers = (
+  bodyLines: ReadonlyArray<string>,
+  phase: string,
+  region: PhaseRegion,
+): ReadonlyArray<number> => {
+  const fromIndex = bodyLines.indexOf(region.from)
+  if (fromIndex === -1) {
+    throw new Error(
+      `Demo phase "${phase}" anchors on a line that is not in the snippet:\n  ${region.from}`,
+    )
+  }
+
+  if (region.to === undefined) {
+    return [fromIndex + 1]
+  }
+
+  const toOffset = bodyLines.slice(fromIndex).indexOf(region.to)
+  if (toOffset === -1) {
+    throw new Error(
+      `Demo phase "${phase}" never closes. No line after its start matches:\n  ${region.to}`,
+    )
+  }
+
+  const toIndex = fromIndex + toOffset
+  return Array.from(
+    { length: toIndex - fromIndex + 1 },
+    (_, i) => fromIndex + 1 + i,
+  )
+}
+
+const phaseTokensByLine = (
+  bodyLines: ReadonlyArray<string>,
+  phaseRegions: PhaseRegions,
+): ReadonlyArray<string> => {
+  const tokens: Array<Array<string>> = bodyLines.map(() => [])
+
+  Object.entries(phaseRegions).forEach(([phase, regions]) => {
+    regions.forEach(region => {
+      regionLineNumbers(bodyLines, phase, region).forEach(lineNumber => {
+        tokens[lineNumber - 1]!.push(phase)
+      })
+    })
+  })
+
+  return tokens.map(phases => phases.join(' '))
+}
+
 const demoCodeToHtml = async (
   importsCode: string,
   bodyCode: string,
+  phaseRegions: PhaseRegions,
 ): Promise<string> => {
   const importLines = importsCode.trimEnd().split('\n')
   const bodyLines = bodyCode.trimEnd().split('\n')
   const lines = [...importLines, '', ...bodyLines]
   const lineDigits = String(bodyLines.length).length
+  const tokens = phaseTokensByLine(bodyLines, phaseRegions)
 
   const html = await codeToHtml(lines.join('\n'), {
     lang: 'typescript',
@@ -23,7 +81,7 @@ const demoCodeToHtml = async (
     decorations: bodyLines.map((line, index) => ({
       start: { line: importLines.length + 1 + index, character: 0 },
       end: { line: importLines.length + 1 + index, character: line.length },
-      properties: { 'data-line': index + 1 },
+      properties: { 'data-line': index + 1, 'data-phases': tokens[index]! },
     })),
   })
 
@@ -35,6 +93,7 @@ const demoCodePlugin = (
   virtualId: string,
   importsCode: string,
   bodyCode: string,
+  phaseRegions: PhaseRegions,
 ): Plugin => {
   const resolvedVirtualId = '\0' + virtualId
 
@@ -52,7 +111,7 @@ const demoCodePlugin = (
         return undefined
       }
 
-      const html = await demoCodeToHtml(importsCode, bodyCode)
+      const html = await demoCodeToHtml(importsCode, bodyCode, phaseRegions)
 
       return `export default ${JSON.stringify(html)}`
     },
@@ -73,6 +132,7 @@ const Model = S.Struct({
   isResetting: S.Boolean,
   resetDuration: S.Number,
 })
+type Model = typeof Model.Type
 
 // MESSAGE
 
@@ -82,6 +142,14 @@ const ChangedResetDuration = m('ChangedResetDuration', {
 })
 const ClickedResetAfterDelay = m('ClickedResetAfterDelay')
 const CompletedDelayReset = m('CompletedDelayReset')
+
+const Message = S.Union([
+  ClickedIncrement,
+  ChangedResetDuration,
+  ClickedResetAfterDelay,
+  CompletedDelayReset,
+])
+type Message = typeof Message.Type
 
 // COMMAND
 
@@ -95,24 +163,71 @@ const DelayReset = Command.define(
 
 // UPDATE
 
-M.tagsExhaustive({
-  ClickedIncrement: () => [
-    evo(model, { count: count => count + 1 }),
-    [],
+type UpdateReturn = readonly [
+  Model,
+  ReadonlyArray<Command.Command<Message>>,
+]
+const withUpdateReturn = M.withReturnType<UpdateReturn>()
+
+const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tagsExhaustive({
+      ClickedIncrement: () => [
+        evo(model, { count: count => count + 1 }),
+        [],
+      ],
+      ChangedResetDuration: ({ seconds }) => [
+        evo(model, { resetDuration: () => seconds }),
+        [],
+      ],
+      ClickedResetAfterDelay: () => [
+        evo(model, { isResetting: () => true }),
+        [DelayReset({ seconds: model.resetDuration })],
+      ],
+      CompletedDelayReset: () => [
+        evo(model, { count: () => 0, isResetting: () => false }),
+        [],
+      ],
+    }),
+  )`
+
+const COUNTER_PHASE_REGIONS: PhaseRegions = {
+  IncrementMessage: [
+    { from: "const ClickedIncrement = m('ClickedIncrement')" },
   ],
-  ChangedResetDuration: ({ seconds }) => [
-    evo(model, { resetDuration: () => seconds }),
-    [],
+  IncrementUpdate: [
+    { from: '      ClickedIncrement: () => [', to: '      ],' },
   ],
-  ClickedResetAfterDelay: () => [
-    evo(model, { isResetting: () => true }),
-    [DelayReset({ seconds: model.resetDuration })],
+  IncrementModel: [{ from: 'const Model = S.Struct({', to: '})' }],
+  DurationMessage: [
+    {
+      from: "const ChangedResetDuration = m('ChangedResetDuration', {",
+      to: '})',
+    },
   ],
-  CompletedDelayReset: () => [
-    evo(model, { count: () => 0, isResetting: () => false }),
-    [],
+  DurationUpdate: [
+    { from: '      ChangedResetDuration: ({ seconds }) => [', to: '      ],' },
   ],
-})`
+  DurationModel: [{ from: '  resetDuration: S.Number,' }],
+  ResetMessage: [
+    { from: "const ClickedResetAfterDelay = m('ClickedResetAfterDelay')" },
+  ],
+  ResetUpdate: [
+    { from: '      ClickedResetAfterDelay: () => [', to: '      ],' },
+  ],
+  ResetCommand: [
+    { from: 'const DelayReset = Command.define(', to: ')' },
+    { from: '        [DelayReset({ seconds: model.resetDuration })],' },
+  ],
+  ResetCommandMessage: [
+    { from: "const CompletedDelayReset = m('CompletedDelayReset')" },
+  ],
+  ResetCommandUpdate: [
+    { from: '      CompletedDelayReset: () => [', to: '      ],' },
+  ],
+  ResetModel: [{ from: 'const Model = S.Struct({', to: '})' }],
+}
 
 /** Serves the async counter demo source as a virtual module of highlighted HTML. */
 export const counterDemoCodePlugin = (): Plugin =>
@@ -121,6 +236,7 @@ export const counterDemoCodePlugin = (): Plugin =>
     COUNTER_DEMO_CODE_ID,
     DEMO_IMPORTS,
     DEMO_CODE,
+    COUNTER_PHASE_REGIONS,
   )
 
 const NOTE_PLAYER_DEMO_CODE_ID = 'virtual:note-player-demo-code'
@@ -143,6 +259,7 @@ const Model = S.Struct({
   noteDuration: NoteDuration,
   playbackState: PlaybackState,
 })
+type Model = typeof Model.Type
 
 // MESSAGE
 
@@ -152,43 +269,56 @@ const CompletedPlayNote = m('CompletedPlayNote', {
   noteIndex: S.Number,
 })
 
+const Message = S.Union([ClickedPlay, ClickedPause, CompletedPlayNote])
+type Message = typeof Message.Type
+
 // UPDATE
 
-M.tagsExhaustive({
-  ClickedPlay: () => [
-    evo(model, {
-      playbackState: () =>
-        Playing({ noteSequence, currentNoteIndex: 0 }),
-    }),
-    [playNote(firstNote, model.noteDuration, 0)],
-  ],
-  ClickedPause: () => [
-    evo(model, {
-      playbackState: () =>
-        Paused({ noteSequence, currentNoteIndex }),
-    }),
-    [],
-  ],
-  CompletedPlayNote: ({ noteIndex }) => {
-    if (nextIndex >= noteSequence.length) {
-      return [
-        evo(model, { playbackState: () => Idle() }),
-        [],
-      ]
-    } else {
-      return [
+type UpdateReturn = readonly [
+  Model,
+  ReadonlyArray<Command.Command<Message, never, AudioContextService>>,
+]
+const withUpdateReturn = M.withReturnType<UpdateReturn>()
+
+const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tagsExhaustive({
+      ClickedPlay: () => [
         evo(model, {
           playbackState: () =>
-            Playing({
-              noteSequence,
-              currentNoteIndex: nextIndex,
-            }),
+            Playing({ noteSequence, currentNoteIndex: 0 }),
         }),
-        [playNote(nextNote, model.noteDuration, nextIndex)],
-      ]
-    }
-  },
-})
+        [playNote(firstNote, model.noteDuration, 0)],
+      ],
+      ClickedPause: () => [
+        evo(model, {
+          playbackState: () =>
+            Paused({ noteSequence, currentNoteIndex }),
+        }),
+        [],
+      ],
+      CompletedPlayNote: ({ noteIndex }) => {
+        if (nextIndex >= noteSequence.length) {
+          return [
+            evo(model, { playbackState: () => Idle() }),
+            [],
+          ]
+        } else {
+          return [
+            evo(model, {
+              playbackState: () =>
+                Playing({
+                  noteSequence,
+                  currentNoteIndex: nextIndex,
+                }),
+            }),
+            [playNote(nextNote, model.noteDuration, nextIndex)],
+          ]
+        }
+      },
+    }),
+  )
 
 // RESOURCE
 
@@ -224,6 +354,21 @@ const PlayNote = Command.define(
   }),
 )`
 
+const NOTE_PLAYER_PHASE_REGIONS: PhaseRegions = {
+  PlayMessage: [{ from: "const ClickedPlay = m('ClickedPlay')" }],
+  PauseMessage: [{ from: "const ClickedPause = m('ClickedPause')" }],
+  PlayUpdate: [{ from: '      ClickedPlay: () => [', to: '      ],' }],
+  PlayModel: [{ from: 'const Model = S.Struct({', to: '})' }],
+  NoteMessage: [
+    { from: "const CompletedPlayNote = m('CompletedPlayNote', {", to: '})' },
+  ],
+  NoteUpdate: [
+    { from: '      CompletedPlayNote: ({ noteIndex }) => {', to: '      },' },
+  ],
+  NoteModel: [{ from: 'const Model = S.Struct({', to: '})' }],
+  NoteCommand: [{ from: 'const PlayNote = Command.define(', to: ')' }],
+}
+
 /** Serves the note player demo source as a virtual module of highlighted HTML. */
 export const notePlayerDemoCodePlugin = (): Plugin =>
   demoCodePlugin(
@@ -231,4 +376,5 @@ export const notePlayerDemoCodePlugin = (): Plugin =>
     NOTE_PLAYER_DEMO_CODE_ID,
     NOTE_PLAYER_DEMO_IMPORTS,
     NOTE_PLAYER_DEMO_CODE,
+    NOTE_PLAYER_PHASE_REGIONS,
   )

--- a/packages/website/src/page/asyncCounterDemo.scene.test.ts
+++ b/packages/website/src/page/asyncCounterDemo.scene.test.ts
@@ -3,8 +3,10 @@ import { Scene } from 'foldkit'
 import { describe, test } from 'vitest'
 
 import {
+  CompletedScrollDemoHighlight,
   DelayAdvancePhase,
   ProgressedDemoPhase,
+  ScrollDemoHighlight,
   init,
   update,
   view,
@@ -12,13 +14,16 @@ import {
 
 const [initialModel] = init()
 
+// NOTE: every phase change also scrolls the highlighted lines into view, so
+// each step settles that Command alongside the one driving the animation.
 const advancePhases = (steps: number, generation: number) =>
-  Array.makeBy(steps, () =>
+  Array.makeBy(steps, () => [
+    Scene.Command.resolve(ScrollDemoHighlight, CompletedScrollDemoHighlight()),
     Scene.Command.resolve(
       DelayAdvancePhase,
       ProgressedDemoPhase({ generation }),
     ),
-  )
+  ]).flat()
 
 describe('async counter demo view', () => {
   test('Add 1 renders the new count', () => {

--- a/packages/website/src/page/asyncCounterDemo.test.ts
+++ b/packages/website/src/page/asyncCounterDemo.test.ts
@@ -41,7 +41,10 @@ describe('async counter demo', () => {
     expect(incremented.count).toBe(1)
     expect(incremented.phase).toBe('IncrementMessage')
     expect(incremented.generation).toBe(1)
-    expect(commands).toHaveLength(1)
+    expect(Array.map(commands, command => command.name)).toStrictEqual([
+      'DelayAdvancePhase',
+      'ScrollDemoHighlight',
+    ])
 
     const settled = advancePhases(incremented, INCREMENT_PHASE_STEPS)
     expect(settled.phase).toBe('Idle')

--- a/packages/website/src/page/asyncCounterDemo.ts
+++ b/packages/website/src/page/asyncCounterDemo.ts
@@ -8,7 +8,7 @@ import {
   Schema as S,
   pipe,
 } from 'effect'
-import { Command, Submodel } from 'foldkit'
+import { Command, Dom, Submodel } from 'foldkit'
 import { Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
@@ -72,12 +72,14 @@ export const ClickedDemoReset = m('ClickedDemoReset')
 export const ProgressedDemoPhase = m('ProgressedDemoPhase', {
   generation: S.Number,
 })
+export const CompletedScrollDemoHighlight = m('CompletedScrollDemoHighlight')
 
 export const Message = S.Union([
   ClickedDemoIncrement,
   ChangedDemoResetDuration,
   ClickedDemoReset,
   ProgressedDemoPhase,
+  CompletedScrollDemoHighlight,
 ])
 export type Message = typeof Message.Type
 
@@ -111,15 +113,27 @@ export const DelayAdvancePhase = Command.define(
   Effect.sleep(duration).pipe(Effect.as(ProgressedDemoPhase({ generation }))),
 )
 
+export const ScrollDemoHighlight = Command.define(
+  'ScrollDemoHighlight',
+  { phase: AnimationPhase },
+  CompletedScrollDemoHighlight,
+)(({ phase }) =>
+  Dom.scrollIntoViewIfNotVisible(`.demo-code-panel [data-phases~="${phase}"]`, {
+    block: 'nearest',
+  }).pipe(Effect.ignore, Effect.as(CompletedScrollDemoHighlight())),
+)
+
 const prependToLog =
   (entry: string) =>
   (messageLog: ReadonlyArray<string>): ReadonlyArray<string> =>
     pipe([entry, ...messageLog], Array.take(MAX_LOG_ENTRIES))
 
-export const update = (model: Model, message: Message): UpdateReturn =>
+const applyMessage = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
     withUpdateReturn,
     M.tagsExhaustive({
+      CompletedScrollDemoHighlight: () => [model, []],
+
       ClickedDemoIncrement: () => {
         const nextModel = evo(model, {
           count: N.increment,
@@ -291,6 +305,19 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       },
     }),
   )
+
+export const update = (model: Model, message: Message): UpdateReturn => {
+  const [nextModel, commands] = applyMessage(model, message)
+
+  if (nextModel.phase === model.phase || nextModel.phase === 'Idle') {
+    return [nextModel, commands]
+  } else {
+    return [
+      nextModel,
+      [...commands, ScrollDemoHighlight({ phase: nextModel.phase })],
+    ]
+  }
+}
 
 // VIEW
 

--- a/packages/website/src/page/notePlayerDemo.ts
+++ b/packages/website/src/page/notePlayerDemo.ts
@@ -11,7 +11,13 @@ import {
   String as Str,
   pipe,
 } from 'effect'
-import { Command, FieldValidation, ManagedResource, Submodel } from 'foldkit'
+import {
+  Command,
+  Dom,
+  FieldValidation,
+  ManagedResource,
+  Submodel,
+} from 'foldkit'
 import { Html, html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { ts } from 'foldkit/schema'
@@ -130,6 +136,7 @@ const ProgressedNotePhase = m('ProgressedNotePhase', {
 const SucceededAcquireAudioContext = m('SucceededAcquireAudioContext')
 const FailedAcquireAudioContext = m('FailedAcquireAudioContext')
 const ReleasedAudioContext = m('ReleasedAudioContext')
+const CompletedScrollNoteHighlight = m('CompletedScrollNoteHighlight')
 
 export const Message = S.Union([
   ChangedNoteInput,
@@ -142,6 +149,7 @@ export const Message = S.Union([
   SucceededAcquireAudioContext,
   FailedAcquireAudioContext,
   ReleasedAudioContext,
+  CompletedScrollNoteHighlight,
 ])
 export type Message = typeof Message.Type
 
@@ -226,10 +234,23 @@ const enterNoteCommandPhase = (
   ],
 ]
 
-export const update = (model: Model, message: Message): UpdateReturn =>
+const ScrollNoteHighlight = Command.define(
+  'ScrollNoteHighlight',
+  { phase: NoteHighlightPhase },
+  CompletedScrollNoteHighlight,
+)(({ phase }) =>
+  Dom.scrollIntoViewIfNotVisible(
+    `.note-demo-code-panel [data-phases~="${phase}"]`,
+    { block: 'nearest' },
+  ).pipe(Effect.ignore, Effect.as(CompletedScrollNoteHighlight())),
+)
+
+const applyMessage = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
     withUpdateReturn,
     M.tagsExhaustive({
+      CompletedScrollNoteHighlight: () => [model, []],
+
       ChangedNoteInput: ({ value }) => {
         const uppercased = Str.toUpperCase(value)
         const fieldState = Str.isEmpty(uppercased)
@@ -527,6 +548,22 @@ const PlayNote = Command.define(
     ),
   ),
 )
+
+export const update = (model: Model, message: Message): UpdateReturn => {
+  const [nextModel, commands] = applyMessage(model, message)
+
+  if (
+    nextModel.highlightPhase === model.highlightPhase ||
+    nextModel.highlightPhase === 'Idle'
+  ) {
+    return [nextModel, commands]
+  } else {
+    return [
+      nextModel,
+      [...commands, ScrollNoteHighlight({ phase: nextModel.highlightPhase })],
+    ]
+  }
+}
 
 // VIEW
 

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -270,11 +270,15 @@
     }
   }
 
+  /* NOTE: the base `pre` rule sets overflow-x, which computes overflow-y to
+     auto and makes `pre` look like a scroll container to scroll-into-view
+     lookups. The surrounding .demo-code-scroll owns both axes here. */
   .demo-code-panel pre,
   .note-demo-code-panel pre {
     background: transparent !important;
     border-radius: 0;
     border: none;
+    overflow: visible;
   }
 
   .demo-code-panel pre code .line[data-line]::before,
@@ -303,95 +307,73 @@
   }
 
   /* Demo line highlights: message (emerald), update (amber), model (blue), command (violet) */
-  /* NOTE: data-line counts from the first line after the import prologue, so these
-     numbers match DEMO_CODE and NOTE_PLAYER_DEMO_CODE in
-     scripts/demoCodePlugin.ts directly. */
-  .demo-code-panel[data-demo-phase='IncrementMessage'] [data-line='11'] {
+  .demo-code-panel[data-demo-phase='IncrementMessage']
+    [data-phases~='IncrementMessage'] {
     @apply bg-emerald-500/15;
     border-left-color: theme(--color-emerald-400);
   }
 
-  .demo-code-panel[data-demo-phase='IncrementUpdate'] [data-line='31'],
-  .demo-code-panel[data-demo-phase='IncrementUpdate'] [data-line='32'],
-  .demo-code-panel[data-demo-phase='IncrementUpdate'] [data-line='33'],
-  .demo-code-panel[data-demo-phase='IncrementUpdate'] [data-line='34'] {
+  .demo-code-panel[data-demo-phase='IncrementUpdate']
+    [data-phases~='IncrementUpdate'] {
     @apply bg-amber-500/15;
     border-left-color: theme(--color-amber-400);
   }
 
-  .demo-code-panel[data-demo-phase='IncrementModel'] [data-line='3'],
-  .demo-code-panel[data-demo-phase='IncrementModel'] [data-line='4'],
-  .demo-code-panel[data-demo-phase='IncrementModel'] [data-line='5'],
-  .demo-code-panel[data-demo-phase='IncrementModel'] [data-line='6'],
-  .demo-code-panel[data-demo-phase='IncrementModel'] [data-line='7'] {
+  .demo-code-panel[data-demo-phase='IncrementModel']
+    [data-phases~='IncrementModel'] {
     @apply bg-blue-500/15;
     border-left-color: theme(--color-blue-400);
   }
 
-  .demo-code-panel[data-demo-phase='DurationMessage'] [data-line='12'],
-  .demo-code-panel[data-demo-phase='DurationMessage'] [data-line='13'],
-  .demo-code-panel[data-demo-phase='DurationMessage'] [data-line='14'] {
+  .demo-code-panel[data-demo-phase='DurationMessage']
+    [data-phases~='DurationMessage'] {
     @apply bg-emerald-500/15;
     border-left-color: theme(--color-emerald-400);
   }
 
-  .demo-code-panel[data-demo-phase='DurationUpdate'] [data-line='35'],
-  .demo-code-panel[data-demo-phase='DurationUpdate'] [data-line='36'],
-  .demo-code-panel[data-demo-phase='DurationUpdate'] [data-line='37'],
-  .demo-code-panel[data-demo-phase='DurationUpdate'] [data-line='38'] {
+  .demo-code-panel[data-demo-phase='DurationUpdate']
+    [data-phases~='DurationUpdate'] {
     @apply bg-amber-500/15;
     border-left-color: theme(--color-amber-400);
   }
 
-  .demo-code-panel[data-demo-phase='DurationModel'] [data-line='6'] {
+  .demo-code-panel[data-demo-phase='DurationModel']
+    [data-phases~='DurationModel'] {
     @apply bg-blue-500/15;
     border-left-color: theme(--color-blue-400);
   }
 
-  .demo-code-panel[data-demo-phase='ResetMessage'] [data-line='15'] {
+  .demo-code-panel[data-demo-phase='ResetMessage']
+    [data-phases~='ResetMessage'] {
     @apply bg-emerald-500/15;
     border-left-color: theme(--color-emerald-400);
   }
 
-  .demo-code-panel[data-demo-phase='ResetUpdate'] [data-line='39'],
-  .demo-code-panel[data-demo-phase='ResetUpdate'] [data-line='40'],
-  .demo-code-panel[data-demo-phase='ResetUpdate'] [data-line='41'],
-  .demo-code-panel[data-demo-phase='ResetUpdate'] [data-line='42'] {
+  .demo-code-panel[data-demo-phase='ResetUpdate'] [data-phases~='ResetUpdate'] {
     @apply bg-amber-500/15;
     border-left-color: theme(--color-amber-400);
   }
 
-  .demo-code-panel[data-demo-phase='ResetCommand'] [data-line='20'],
-  .demo-code-panel[data-demo-phase='ResetCommand'] [data-line='21'],
-  .demo-code-panel[data-demo-phase='ResetCommand'] [data-line='22'],
-  .demo-code-panel[data-demo-phase='ResetCommand'] [data-line='23'],
-  .demo-code-panel[data-demo-phase='ResetCommand'] [data-line='24'],
-  .demo-code-panel[data-demo-phase='ResetCommand'] [data-line='25'],
-  .demo-code-panel[data-demo-phase='ResetCommand'] [data-line='26'],
-  .demo-code-panel[data-demo-phase='ResetCommand'] [data-line='41'] {
+  .demo-code-panel[data-demo-phase='ResetCommand']
+    [data-phases~='ResetCommand'] {
     @apply bg-violet-500/15;
     border-left-color: theme(--color-violet-400);
     animation: demo-pulse 1s ease-in-out infinite;
   }
 
-  .demo-code-panel[data-demo-phase='ResetCommandMessage'] [data-line='16'] {
+  .demo-code-panel[data-demo-phase='ResetCommandMessage']
+    [data-phases~='ResetCommandMessage'] {
     @apply bg-emerald-500/15;
     border-left-color: theme(--color-emerald-400);
   }
 
-  .demo-code-panel[data-demo-phase='ResetCommandUpdate'] [data-line='43'],
-  .demo-code-panel[data-demo-phase='ResetCommandUpdate'] [data-line='44'],
-  .demo-code-panel[data-demo-phase='ResetCommandUpdate'] [data-line='45'],
-  .demo-code-panel[data-demo-phase='ResetCommandUpdate'] [data-line='46'] {
+  .demo-code-panel[data-demo-phase='ResetCommandUpdate']
+    [data-phases~='ResetCommandUpdate'] {
     @apply bg-amber-500/15;
     border-left-color: theme(--color-amber-400);
   }
 
-  .demo-code-panel[data-demo-phase='ResetModel'] [data-line='3'],
-  .demo-code-panel[data-demo-phase='ResetModel'] [data-line='4'],
-  .demo-code-panel[data-demo-phase='ResetModel'] [data-line='5'],
-  .demo-code-panel[data-demo-phase='ResetModel'] [data-line='6'],
-  .demo-code-panel[data-demo-phase='ResetModel'] [data-line='7'] {
+  .demo-code-panel[data-demo-phase='ResetModel'] [data-phases~='ResetModel'] {
     @apply bg-blue-500/15;
     border-left-color: theme(--color-blue-400);
   }
@@ -408,98 +390,50 @@
   }
 
   /* Note player demo line highlights: message (emerald), update (amber), model (blue), command (violet) */
-  .note-demo-code-panel[data-note-demo-phase='PlayMessage'] [data-line='11'] {
+  .note-demo-code-panel[data-note-demo-phase='PlayMessage']
+    [data-phases~='PlayMessage'] {
     @apply bg-emerald-500/15;
     border-left-color: theme(--color-emerald-400);
   }
 
-  .note-demo-code-panel[data-note-demo-phase='PauseMessage'] [data-line='12'] {
+  .note-demo-code-panel[data-note-demo-phase='PauseMessage']
+    [data-phases~='PauseMessage'] {
     @apply bg-emerald-500/15;
     border-left-color: theme(--color-emerald-400);
   }
 
-  .note-demo-code-panel[data-note-demo-phase='PlayUpdate'] [data-line='20'],
-  .note-demo-code-panel[data-note-demo-phase='PlayUpdate'] [data-line='21'],
-  .note-demo-code-panel[data-note-demo-phase='PlayUpdate'] [data-line='22'],
-  .note-demo-code-panel[data-note-demo-phase='PlayUpdate'] [data-line='23'],
-  .note-demo-code-panel[data-note-demo-phase='PlayUpdate'] [data-line='24'],
-  .note-demo-code-panel[data-note-demo-phase='PlayUpdate'] [data-line='25'],
-  .note-demo-code-panel[data-note-demo-phase='PlayUpdate'] [data-line='26'] {
+  .note-demo-code-panel[data-note-demo-phase='PlayUpdate']
+    [data-phases~='PlayUpdate'] {
     @apply bg-amber-500/15;
     border-left-color: theme(--color-amber-400);
   }
 
-  .note-demo-code-panel[data-note-demo-phase='PlayModel'] [data-line='3'],
-  .note-demo-code-panel[data-note-demo-phase='PlayModel'] [data-line='4'],
-  .note-demo-code-panel[data-note-demo-phase='PlayModel'] [data-line='5'],
-  .note-demo-code-panel[data-note-demo-phase='PlayModel'] [data-line='6'],
-  .note-demo-code-panel[data-note-demo-phase='PlayModel'] [data-line='7'] {
+  .note-demo-code-panel[data-note-demo-phase='PlayModel']
+    [data-phases~='PlayModel'] {
     @apply bg-blue-500/15;
     border-left-color: theme(--color-blue-400);
   }
 
-  .note-demo-code-panel[data-note-demo-phase='NoteMessage'] [data-line='13'],
-  .note-demo-code-panel[data-note-demo-phase='NoteMessage'] [data-line='14'],
-  .note-demo-code-panel[data-note-demo-phase='NoteMessage'] [data-line='15'] {
+  .note-demo-code-panel[data-note-demo-phase='NoteMessage']
+    [data-phases~='NoteMessage'] {
     @apply bg-emerald-500/15;
     border-left-color: theme(--color-emerald-400);
   }
 
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='34'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='35'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='36'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='37'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='38'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='39'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='40'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='41'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='42'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='43'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='44'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='45'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='46'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='47'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='48'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='49'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='50'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='51'],
-  .note-demo-code-panel[data-note-demo-phase='NoteUpdate'] [data-line='52'] {
+  .note-demo-code-panel[data-note-demo-phase='NoteUpdate']
+    [data-phases~='NoteUpdate'] {
     @apply bg-amber-500/15;
     border-left-color: theme(--color-amber-400);
   }
 
-  .note-demo-code-panel[data-note-demo-phase='NoteModel'] [data-line='3'],
-  .note-demo-code-panel[data-note-demo-phase='NoteModel'] [data-line='4'],
-  .note-demo-code-panel[data-note-demo-phase='NoteModel'] [data-line='5'],
-  .note-demo-code-panel[data-note-demo-phase='NoteModel'] [data-line='6'],
-  .note-demo-code-panel[data-note-demo-phase='NoteModel'] [data-line='7'] {
+  .note-demo-code-panel[data-note-demo-phase='NoteModel']
+    [data-phases~='NoteModel'] {
     @apply bg-blue-500/15;
     border-left-color: theme(--color-blue-400);
   }
 
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='64'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='66'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='67'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='68'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='69'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='70'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='71'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='72'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='73'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='74'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='75'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='76'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='77'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='78'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='79'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='80'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='81'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='82'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='83'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='84'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='85'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='86'],
-  .note-demo-code-panel[data-note-demo-phase='NoteCommand'] [data-line='87'] {
+  .note-demo-code-panel[data-note-demo-phase='NoteCommand']
+    [data-phases~='NoteCommand'] {
     @apply bg-violet-500/15;
     border-left-color: theme(--color-violet-400);
   }


### PR DESCRIPTION
## Why

The demo section says *"Watch a message flow through **update** into the model."* There was no update function in it. Both snippets showed a bare `M.tagsExhaustive({ ... })` under an `// UPDATE` header, with `model` referenced from nowhere:

```ts
// UPDATE

M.tagsExhaustive({
  ClickedIncrement: () => [
    evo(model, { count: count => count + 1 }),
```

`update: (Model, Message) => [Model, Commands]` is the architecture the whole framework rests on, and it was the one thing the most-read Foldkit sample didn't show. `withReturnType` is a hard rule in this codebase and never appeared either, so anyone pattern-matching off the landing page started out unaware it exists.

## What changed

**Both snippets show the real update function** — the `Model` and `Message` type aliases, the Message union, the return type alias, `withReturnType`, and `update` built from `M.value(message).pipe(...)`.

**Highlight regions are resolved from anchor text, not line numbers.** The plugin finds each phase's region by the exact text of its first and last line, emits the matching phase names onto every line as a `data-phases` token list, and the stylesheet matches tokens. About a hundred line-number selectors became twenty token selectors.

An anchor that no longer matches now throws while the module builds:

```
Demo phase "ResetCommand" anchors on a line that is not in the snippet:
  const DelayReset = Command.define(
```

Previously a snippet edit silently misaligned the highlights. That happened twice while working on the previous PR and was caught only by eye.

**The panel now scrolls the highlighted lines into view.** It never did before, so on a 900px laptop the panel showed lines 1-32 of 47 and `scrollTop` stayed at `0` while the reset animation highlighted lines 43-46. The climax of the animation, the Model actually changing, happened entirely off screen. Each phase change dispatches a Command using `block: 'nearest'` so the panel scrolls and the page does not.

**Demo `pre` elements set `overflow: visible`.** The shared `pre` rule sets `overflow-x`, which computes `overflow-y` to `auto` per spec, so `findScrollParent` stopped at the `pre` (which does not scroll) and never reached `.demo-code-scroll`.

## Verification

Every phase in both demos was checked against the built page, asserting on the highlighted **text** rather than line numbers:

| | |
|---|---|
| Counter phases correct | 12 / 12 |
| Note player phases correct | 8 / 8 |
| Reset animation highlights on screen | 6 / 6 (was 4 / 6) |
| Page scroll during animation | settles once, then static |
| Horizontal scrolling of long lines | still works |

160 website tests pass.

## Notes for the reviewer

`Dom.scrollIntoViewIfNotVisible` uses `findScrollParent` only to decide *whether* to scroll, then calls `element.scrollIntoView`, which cascades to every scrollable ancestor including the window. `block: 'nearest'` keeps that to a single 42px settle here, but a container-only scroll primitive would be the cleaner fix. Worth considering separately in `packages/foldkit`.

The note player's `NoteCommand` phase still does not reliably land in view. Its phases advance faster than the scroll settles, and the next phase supersedes it. This is not a regression: that region was off screen on `main` too, since nothing scrolled at all. The other seven note player phases are fixed.

No changeset: `website` is in the changeset ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSa5LNbiAsBvumafYPs5dC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSa5LNbiAsBvumafYPs5dC)_