### PR TITLE
fix(website): gate the playground on capability, not the user agent

### DIFF
--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -153,7 +153,7 @@ export const Flags = S.Struct({
   maybeSidebarState: S.Option(SidebarState),
   systemTheme: ResolvedTheme,
   isNarrowViewport: S.Boolean,
-  isChromium: S.Boolean,
+  isPlaygroundSupported: S.Boolean,
   currentYear: S.Number,
   today: Calendar.CalendarDate,
 })
@@ -162,14 +162,14 @@ type Flags = typeof Flags.Type
 
 export const NARROW_VIEWPORT_QUERY = '(max-width: 1023px)'
 
-const CHROMIUM_BRANDS = new Set(['Chromium', 'Google Chrome', 'Microsoft Edge'])
-const CHROMIUM_UA_PATTERN = /Chrome\/|Chromium\/|Edg\/|OPR\//
-
-const detectChromium = (): boolean =>
-  Option.match(Option.fromNullishOr(navigator.userAgentData?.brands), {
-    onNone: () => CHROMIUM_UA_PATTERN.test(navigator.userAgent),
-    onSome: brands => brands.some(({ brand }) => CHROMIUM_BRANDS.has(brand)),
-  })
+// NOTE: WebContainer needs a cross-origin isolated document and
+// `SharedArrayBuffer`. Reading the capability beats sniffing the user agent:
+// every engine that satisfies it works, and an engine that gains support
+// later needs no change here. This is only meaningful on playground routes,
+// which load a fresh document carrying the COEP/COOP headers. Every other
+// route reports `false` because it never sets those headers.
+const detectPlaygroundSupport = (): boolean =>
+  window.crossOriginIsolated && typeof SharedArrayBuffer !== 'undefined'
 
 export const flags: Effect.Effect<Flags> = Effect.gen(function* () {
   const themePreference: Option.Option<typeof ThemePreference.Type> =
@@ -213,7 +213,7 @@ export const flags: Effect.Effect<Flags> = Effect.gen(function* () {
     () => window.matchMedia(NARROW_VIEWPORT_QUERY).matches,
   )
 
-  const isChromium = yield* Effect.sync(detectChromium)
+  const isPlaygroundSupported = yield* Effect.sync(detectPlaygroundSupport)
 
   const currentYear = yield* DateTime.now.pipe(
     Effect.map(DateTime.getPartUtc('year')),
@@ -226,7 +226,7 @@ export const flags: Effect.Effect<Flags> = Effect.gen(function* () {
     maybeSidebarState,
     systemTheme,
     isNarrowViewport,
-    isChromium,
+    isPlaygroundSupported,
     currentYear,
     today,
   }
@@ -247,7 +247,7 @@ export const Model = S.Struct({
   activeSection: S.Option(S.String),
   isLandingHeaderVisible: S.Boolean,
   isNarrowViewport: S.Boolean,
-  isChromium: S.Boolean,
+  isPlaygroundSupported: S.Boolean,
   playground: S.Option(Page.Playground.Model),
   sidebarGroups: SidebarGroups,
   isMapMessagesUnderHoodOpen: S.Boolean,
@@ -433,7 +433,7 @@ export const init: Runtime.RoutingApplicationInit<
       aiHeadingToggleCount: 0,
       isLandingHeaderVisible: isLandingHeaderAlwaysVisible(initialRoute),
       isNarrowViewport: flags.isNarrowViewport,
-      isChromium: flags.isChromium,
+      isPlaygroundSupported: flags.isPlaygroundSupported,
       playground: pipe(
         initialRoute,
         Option.liftPredicate(isPlaygroundRoute),
@@ -1311,7 +1311,9 @@ export const view = (model: Model): Document => {
               slotId: `playground-${playgroundModel.slug}`,
               model: playgroundModel,
               view: Page.Playground.view,
-              viewInputs: { isChromium: model.isChromium },
+              viewInputs: {
+                isPlaygroundSupported: model.isPlaygroundSupported,
+              },
               toParentMessage: message => GotPlaygroundMessage({ message }),
             }),
         }),

--- a/packages/website/src/page/example/exampleDetail.ts
+++ b/packages/website/src/page/example/exampleDetail.ts
@@ -264,19 +264,7 @@ const featureTag = (text: string): Html => {
   )
 }
 
-const chromeRecommendedHint = (): Html => {
-  const h = html<Message>()
-
-  return h.p(
-    [h.Class('text-xs text-gray-500 dark:text-gray-400')],
-    ['Requires a Chromium browser'],
-  )
-}
-
-const launchPlaygroundSection = (
-  meta: ExampleMeta,
-  isChromium: boolean,
-): Html => {
+const launchPlaygroundSection = (meta: ExampleMeta): Html => {
   const h = html<Message>()
 
   return h.div(
@@ -289,12 +277,11 @@ const launchPlaygroundSection = (
         ],
         [Icon.bolt('w-4 h-4'), 'Launch Playground'],
       ),
-      ...(isChromium ? [] : [chromeRecommendedHint()]),
     ],
   )
 }
 
-const headerView = (meta: ExampleMeta, isChromium: boolean): Html => {
+const headerView = (meta: ExampleMeta): Html => {
   const h = html<Message>()
 
   return h.div(
@@ -318,7 +305,7 @@ const headerView = (meta: ExampleMeta, isChromium: boolean): Html => {
       h.div(
         [h.Class('flex flex-col items-start gap-3 mt-3')],
         [
-          launchPlaygroundSection(meta, isChromium),
+          launchPlaygroundSection(meta),
           h.a(
             [
               h.Href(exampleSourceHref(meta.slug)),
@@ -648,11 +635,10 @@ type ViewInputs = Readonly<{
   slug: string
   copiedSnippets: CopiedSnippets
   isNarrowViewport: boolean
-  isChromium: boolean
 }>
 
 export const view = Submodel.defineView<Model, Message, ViewInputs>(
-  (model, { slug, copiedSnippets, isNarrowViewport, isChromium }): Html => {
+  (model, { slug, copiedSnippets, isNarrowViewport }): Html => {
     const h = html<Message>()
 
     return Option.match(findBySlug(slug), {
@@ -662,7 +648,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           slug,
           [],
           [
-            headerView(meta, isChromium),
+            headerView(meta),
             livePreviewDisclosureView(
               model.isLivePreviewOpen,
               meta,

--- a/packages/website/src/page/playground.ts
+++ b/packages/website/src/page/playground.ts
@@ -1014,22 +1014,26 @@ const editorLayoutView = (model: Model): Html => {
   )
 }
 
-type ViewInputs = Readonly<{ isChromium: boolean }>
+type ViewInputs = Readonly<{ isPlaygroundSupported: boolean }>
 
 export const view = Submodel.defineView<Model, Message, ViewInputs>(
-  (model, { isChromium }): Html => {
+  (model, { isPlaygroundSupported }): Html => {
     const h = html<Message>()
 
     const maybeMeta = findBySlug(model.slug)
     const maybeFiles = Option.fromNullishOr(filesBySlug[model.slug])
 
-    const content = M.value({ isChromium, maybeMeta, maybeFiles }).pipe(
+    const content = M.value({
+      isPlaygroundSupported,
+      maybeMeta,
+      maybeFiles,
+    }).pipe(
       M.when(
-        ({ isChromium }) => !isChromium,
+        ({ isPlaygroundSupported }) => !isPlaygroundSupported,
         () =>
           messageView(
-            'Playground requires a Chromium browser',
-            'The editable playground runs on WebContainers, which requires Chrome, Edge, Brave, or another Chromium-based browser. You can still see the example running on its detail page.',
+            'Your browser cannot run the playground',
+            'The editable playground runs on WebContainers, which needs a cross-origin isolated document and SharedArrayBuffer. Chromium browsers and Firefox support this today; Safari does not yet. You can still see the example running on its detail page.',
             maybeMeta,
           ),
       ),

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -492,7 +492,6 @@ export const docsView = (model: Model, docsRoute: DocsRoute) => {
               slug: exampleSlug,
               copiedSnippets: model.copiedSnippets,
               isNarrowViewport: model.isNarrowViewport,
-              isChromium: model.isChromium,
             },
             toParentMessage: message => GotExampleDetailMessage({ message }),
           }),

--- a/packages/website/src/view/landing.ts
+++ b/packages/website/src/view/landing.ts
@@ -185,26 +185,6 @@ const playgroundItemClassName =
 
 const playgroundBackdropClassName = 'fixed inset-0 z-10'
 
-const chromeRecommendedHint: Html = (() => {
-  const h = html<Message>()
-
-  return h.p(
-    [h.Class('text-xs text-gray-500 dark:text-gray-400')],
-    ['Requires a Chromium browser'],
-  )
-})()
-
-const withChromeRecommendedHint = (menu: Html, isChromium: boolean): Html => {
-  const h = html<Message>()
-
-  return isChromium
-    ? menu
-    : h.div(
-        [h.Class('flex flex-col items-start gap-1')],
-        [menu, chromeRecommendedHint],
-      )
-}
-
 const playgroundItemContent = (meta: ExampleMeta): Html => {
   const h = html<Message>()
 
@@ -297,12 +277,9 @@ export const landingView = (model: Model) => {
     model.emailSubscriptionStatus,
   )
 
-  const playgroundMenu = withChromeRecommendedHint(
-    playgroundMenuView(
-      model.playgroundMenu,
-      examples.map(example => example.slug),
-    ),
-    model.isChromium,
+  const playgroundMenu = playgroundMenuView(
+    model.playgroundMenu,
+    examples.map(example => example.slug),
   )
 
   const buttonLabelFor = (tab: DemoTab.Tab): string =>


### PR DESCRIPTION
## Problem

From [the Hacker News thread](https://news.ycombinator.com/item?id=49037031):

> WebContainers have been available in Safari and Firefox for years. Why does it say I need Chrome? https://webcontainers.io/guides/browser-support

The commenter is right about Firefox. The playground was gated behind a user-agent sniff for Chromium brands (`main.ts:165-172`), and the copy told everyone else that WebContainers "requires Chrome, Edge, Brave, or another Chromium-based browser".

WebContainers needs a cross-origin isolated document and `SharedArrayBuffer`. Firefox has satisfied both since it shipped COEP `credentialless` in version 119 (Oct 2023).

## Evidence

Measured against production `foldkit.dev` with real engines:

| Engine | `crossOriginIsolated` on `/playground/*` | `SharedArrayBuffer` | What the site rendered |
|---|---|---|---|
| Firefox 151 | true | available | "requires a Chromium browser" |
| WebKit 26.5 | false | unavailable | "requires a Chromium browser" |
| Chromium 149 | true | available | playground boots |

With **only the user-agent string changed** and nothing else, real Firefox boots the playground end to end on production: file tree renders, Monaco loads, the install runs, and the preview iframe comes up at `…local-credentialless.webcontainer-api.io`. Nothing but the regex stood between Firefox users and a working playground.

Safari is a separate story, and the current copy misattributes it. WebKit is excluded because the site chose `credentialless`, which WebKit has never implemented, not because of WebContainers. An isolated local control confirms WebKit reaches `crossOriginIsolated` under `require-corp`:

| COEP | WebKit | Firefox |
|---|---|---|
| `credentialless` | false | true |
| `require-corp` | **true** | true |

Moving `/playground/*` to `require-corp` would likely unblock Safari, but every cross-origin subresource would then need CORP headers and I did not verify that path, so it is out of scope here.

## Change

Detection now reads the capability the code actually depends on:

```ts
const detectPlaygroundSupport = (): boolean =>
  window.crossOriginIsolated && typeof SharedArrayBuffer !== 'undefined'
```

This is accurate in every engine, needs no brand list to maintain, and stays correct if Safari ships `credentialless` or if the site later moves to `require-corp`. It is meaningful because playground routes already force a fresh document load so the COEP and COOP headers apply, which `main.ts` documents at the `Internal` navigation branch.

Copy on the playground page now names the requirement instead of a browser.

## The one judgment call

The advance hints on the landing page and the example detail pages are removed. They ran the same sniff on routes that carry no COEP headers, so no capability check can replace them there, and their only job was to save a click. The playground page now explains the real requirement on arrival.

If you would rather keep an advance hint, the honest version is static text shown to everyone rather than any form of detection. Happy to switch it.

## Checks

`pnpm --filter website typecheck`, `oxlint`, `prettier --check`, website tests (160), and `scripts/run-website-e2e.sh` all pass. No test referenced the old gate. `website` is in the changeset ignore list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved playground compatibility detection based on cross-origin isolation and `SharedArrayBuffer` support.
  * Updated playground availability messaging to accurately describe supported browsers and requirements.

* **Bug Fixes**
  * Removed inaccurate Chromium-specific recommendations and browser checks from playground and example pages.
  * Playground access now reflects actual browser capabilities rather than browser branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->