### PR TITLE
fix(website): make note player demo snippet self-contained

### DIFF
--- a/packages/website/scripts/demoCodePlugin.ts
+++ b/packages/website/scripts/demoCodePlugin.ts
@@ -242,6 +242,7 @@ export const counterDemoCodePlugin = (): Plugin =>
 const NOTE_PLAYER_DEMO_CODE_ID = 'virtual:note-player-demo-code'
 
 const NOTE_PLAYER_DEMO_IMPORTS = `import {
+  Array,
   Context,
   Effect,
   Layer,
@@ -250,13 +251,22 @@ const NOTE_PLAYER_DEMO_IMPORTS = `import {
 } from 'effect'
 import { Command } from 'foldkit'
 import { m } from 'foldkit/message'
+import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'`
 
 const NOTE_PLAYER_DEMO_CODE = `// MODEL
 
+const Note = S.Literals(['A', 'B', 'C', 'D', 'E', 'F', 'G'])
+type Note = typeof Note.Type
+
+const Idle = ts('Idle')
+const Playing = ts('Playing', { currentNoteIndex: S.Number })
+const Paused = ts('Paused', { currentNoteIndex: S.Number })
+const PlaybackState = S.Union([Idle, Playing, Paused])
+
 const Model = S.Struct({
-  noteInput: NoteInputField.Union,
-  noteDuration: NoteDuration,
+  noteSequence: S.Array(Note),
+  noteDuration: S.Number,
   playbackState: PlaybackState,
 })
 type Model = typeof Model.Type
@@ -269,52 +279,77 @@ const CompletedPlayNote = m('CompletedPlayNote', {
   noteIndex: S.Number,
 })
 
-const Message = S.Union([ClickedPlay, ClickedPause, CompletedPlayNote])
+const Message = S.Union([
+  ClickedPlay,
+  ClickedPause,
+  CompletedPlayNote,
+])
 type Message = typeof Message.Type
 
 // UPDATE
 
 type UpdateReturn = readonly [
   Model,
-  ReadonlyArray<Command.Command<Message, never, AudioContextService>>,
+  ReadonlyArray<
+    Command.Command<Message, never, AudioContextService>
+  >,
 ]
 const withUpdateReturn = M.withReturnType<UpdateReturn>()
+
+const playNoteAt = (
+  model: Model,
+  noteIndex: number,
+): UpdateReturn => [
+  evo(model, {
+    playbackState: () => Playing({ currentNoteIndex: noteIndex }),
+  }),
+  [
+    PlayNote({
+      note: Array.getUnsafe(model.noteSequence, noteIndex),
+      duration: model.noteDuration,
+      noteIndex,
+    }),
+  ],
+]
 
 const update = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
     withUpdateReturn,
     M.tagsExhaustive({
-      ClickedPlay: () => [
-        evo(model, {
-          playbackState: () =>
-            Playing({ noteSequence, currentNoteIndex: 0 }),
-        }),
-        [playNote(firstNote, model.noteDuration, 0)],
-      ],
-      ClickedPause: () => [
-        evo(model, {
-          playbackState: () =>
-            Paused({ noteSequence, currentNoteIndex }),
-        }),
-        [],
-      ],
+      ClickedPlay: () =>
+        M.value(model.playbackState).pipe(
+          withUpdateReturn,
+          M.tagsExhaustive({
+            Idle: () => playNoteAt(model, 0),
+            Paused: ({ currentNoteIndex }) =>
+              playNoteAt(model, currentNoteIndex),
+            Playing: () => [model, []],
+          }),
+        ),
+      ClickedPause: () =>
+        M.value(model.playbackState).pipe(
+          withUpdateReturn,
+          M.tagsExhaustive({
+            Playing: ({ currentNoteIndex }) => [
+              evo(model, {
+                playbackState: () => Paused({ currentNoteIndex }),
+              }),
+              [],
+            ],
+            Idle: () => [model, []],
+            Paused: () => [model, []],
+          }),
+        ),
       CompletedPlayNote: ({ noteIndex }) => {
-        if (nextIndex >= noteSequence.length) {
-          return [
-            evo(model, { playbackState: () => Idle() }),
-            [],
-          ]
+        const { playbackState, noteSequence } = model
+        const nextCurrentNoteIndex = noteIndex + 1
+
+        if (playbackState._tag !== 'Playing') {
+          return [model, []]
+        } else if (nextCurrentNoteIndex >= noteSequence.length) {
+          return [evo(model, { playbackState: () => Idle() }), []]
         } else {
-          return [
-            evo(model, {
-              playbackState: () =>
-                Playing({
-                  noteSequence,
-                  currentNoteIndex: nextIndex,
-                }),
-            }),
-            [playNote(nextNote, model.noteDuration, nextIndex)],
-          ]
+          return playNoteAt(model, nextCurrentNoteIndex)
         }
       },
     }),
@@ -326,7 +361,10 @@ class AudioContextService extends Context.Service<
   AudioContextService,
   AudioContext
 >()('AudioContextService') {
-  static readonly Default = Layer.sync(this, () => new AudioContext())
+  static readonly Default = Layer.sync(
+    this,
+    () => new AudioContext(),
+  )
 }
 
 // COMMAND
@@ -357,13 +395,17 @@ const PlayNote = Command.define(
 const NOTE_PLAYER_PHASE_REGIONS: PhaseRegions = {
   PlayMessage: [{ from: "const ClickedPlay = m('ClickedPlay')" }],
   PauseMessage: [{ from: "const ClickedPause = m('ClickedPause')" }],
-  PlayUpdate: [{ from: '      ClickedPlay: () => [', to: '      ],' }],
+  PlayUpdate: [
+    { from: '      ClickedPlay: () =>', to: '        ),' },
+    { from: 'const playNoteAt = (', to: ']' },
+  ],
   PlayModel: [{ from: 'const Model = S.Struct({', to: '})' }],
   NoteMessage: [
     { from: "const CompletedPlayNote = m('CompletedPlayNote', {", to: '})' },
   ],
   NoteUpdate: [
     { from: '      CompletedPlayNote: ({ noteIndex }) => {', to: '      },' },
+    { from: 'const playNoteAt = (', to: ']' },
   ],
   NoteModel: [{ from: 'const Model = S.Struct({', to: '})' }],
   NoteCommand: [{ from: 'const PlayNote = Command.define(', to: ')' }],


### PR DESCRIPTION
## What

The note player snippet on the home page referenced values it never defined. A reader following the code saw `noteSequence`, `currentNoteIndex`, `firstNote`, `nextIndex`, and `nextNote` appear out of nowhere, plus a `playNote(note, duration, index)` helper that does not exist. The snippet also called that lowercase helper with three positional arguments while defining a `PlayNote` Command forty lines below it, whose `Command.define` constructor takes a single object. The two halves of the same snippet contradicted each other on screen.

The `Model` referenced `NoteInputField.Union` and `NoteDuration`, neither of which appeared anywhere either.

## Changes

Every identifier the snippet uses is now declared in the snippet:

- `Note` literal schema.
- `Idle`, `Playing`, and `Paused` playback states, which is what gives `currentNoteIndex` an origin.
- `noteSequence` moved onto the Model, so playback state carries only `currentNoteIndex` instead of duplicating the sequence.

The update function reads as real code:

- A `playNoteAt` helper builds the Model update and the Command together, mirroring `enterNoteCommandPhase` in the actual demo source. `ClickedPlay` and `CompletedPlayNote` both delegate to it, so the `PlayNote({ note, duration, noteIndex })` call site appears once and matches the Command defined in the same snippet.
- `ClickedPause` matches on `model.playbackState` to read `currentNoteIndex`.
- `CompletedPlayNote` derives `nextIndex` and compares against `model.noteSequence.length`.

## Size

The snippet sits next to the running app and has to stay skimmable, so this keeps the growth small:

| | body lines |
|---|---|
| `main` | 101 |
| this branch | 122 |

Of the 21 added lines, 8 are the playback state and `Note` declarations (the substance), 6 are the update changes, and 7 are line rewrapping described below.

## Panel width

Five snippet lines exceeded the code panel's usable width. Three came from the new code, two predate it (`const Message = S.Union([...])` at 71 characters and the `Layer.sync` line at 70). All are rewrapped, so the widest line is now 68 and the panel no longer scrolls sideways.

Measured on the built site at 1440x900, `.demo-code-scroll` horizontal overflow on the note panel:

| | overflow |
|---|---|
| `main` | 12px |
| this branch | 0px |

## Phase highlighting

`PlayUpdate` and `NoteUpdate` now cover their branch plus the `playNoteAt` helper both branches call. The other six regions anchor on text that did not move.

All eight phases resolve against the rendered HTML:

```
PlayModel      11-15          PlayMessage    20
NoteModel      11-15          PauseMessage   21
NoteMessage    22-24          PlayUpdate     43-57, 63
NoteUpdate     43-57, 75-83   NoteCommand    101-122
```

An anchor that stops matching throws at build time, so a future snippet edit that breaks one fails the build rather than silently misaligning the highlight.

## Verification

`pnpm format:check`, `pnpm lint`, `pnpm build`, `pnpm -r typecheck`, and the 160 website tests all pass. Panel measurements and the phase table above come from the built site in a headless browser.

No changeset: `website` is in the changeset ignore list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the embedded note-player demo’s playback flow, making play, pause, and note-completion transitions more reliable.
  * Enhanced behavior when note sequences are empty or cannot be played.
* **Style**
  * Updated the demo’s displayed source formatting and the highlighted code regions to match the latest demo layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->