### PR TITLE
docs: acknowledge React Compiler and remove the render-phase ref write

### DIFF
--- a/comparisons/pixel-art-react/src/App.tsx
+++ b/comparisons/pixel-art-react/src/App.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useReducer, useRef } from 'react'
+import { useMemo, useReducer } from 'react'
 
 import { Canvas } from './components/Canvas'
 import { ConfirmDialog } from './components/ConfirmDialog'
@@ -103,9 +103,6 @@ export const App = () => {
 
   const paletteColors = theme.colors
 
-  const stateRef = useRef(state)
-  stateRef.current = state
-
   useKeyboardShortcuts(dispatch)
   useMouseRelease(state.isDrawing, dispatch)
   useLocalStorage(
@@ -116,9 +113,7 @@ export const App = () => {
     state.isDrawing,
   )
 
-  const handleExport = useCallback(() => {
-    exportPng(stateRef.current, dispatch)
-  }, [dispatch])
+  const handleExport = () => exportPng(state, dispatch)
 
   const currentGrid = useMemo(
     () =>
@@ -194,9 +189,7 @@ const DownloadIcon = () => (
   </svg>
 )
 
-const Header = memo(function Header({
-  onExport,
-}: Readonly<{ onExport: () => void }>) {
+const Header = ({ onExport }: Readonly<{ onExport: () => void }>) => {
   return (
     <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800">
       <div className="flex flex-col">
@@ -225,4 +218,4 @@ const Header = memo(function Header({
       </div>
     </div>
   )
-})
+}

--- a/packages/website/src/page/comingFromReact/faq.ts
+++ b/packages/website/src/page/comingFromReact/faq.ts
@@ -4,6 +4,7 @@ export const FAQ_IDS = [
   'faq-routing',
   'faq-forms',
   'faq-ui-components',
+  'faq-react-compiler',
   'faq-data-fetching',
   'faq-testing',
   'faq-where-to-start',

--- a/packages/website/src/page/comingFromReact/view.ts
+++ b/packages/website/src/page/comingFromReact/view.ts
@@ -18,9 +18,11 @@ import {
 import {
   coreCounterExampleRouter,
   coreSubmodelRouter,
+  coreViewMemoizationRouter,
   exampleDetailRouter,
   fieldValidationRouter,
   gettingStartedRouter,
+  reactComparisonRouter,
   routingAndNavigationRouter,
   testingSceneRouter,
   testingStoryRouter,
@@ -39,6 +41,7 @@ const [
   faqRouting,
   faqForms,
   faqUiComponents,
+  faqReactCompiler,
   faqDataFetching,
   faqTesting,
   faqWhereToStart,
@@ -101,7 +104,12 @@ const patternMappingTable: Html = comparisonTable(
     ],
     [
       [inlineCode('useMemo'), ' / ', inlineCode('useCallback')],
-      ['Not needed (no stale closures)'],
+      [
+        inlineCode('createLazy'),
+        ' / ',
+        inlineCode('createKeyedLazy'),
+        ' (memoize on data, not closure identity)',
+      ],
     ],
     [['Custom hooks'], ['Domain modules with pure functions']],
     [['JSX'], ['Plain functions from Model to HTML']],
@@ -284,11 +292,13 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           'One more feature: an input that controls how much each tick and manual click increments by.',
         ),
         para(
-          'This is where the React version hits a wall. The ',
+          'This is where the React version gets subtle. The ',
           inlineCode('setInterval'),
           ' callback captures ',
           inlineCode('step'),
-          ' at creation time. If you change the step while playing, the interval keeps using the old value: a stale closure. The fix is a ref and a sync effect to keep it current:',
+          ' at creation time. If you change the step while playing, the interval keeps using the old value: a stale closure. Nothing flags it at build time; the counter just increments by the wrong amount. React’s current fix is ',
+          inlineCode('useEffectEvent'),
+          ', stable since 19.2: declare the tick as an Effect Event and every call reads current state:',
         ),
         highlightedCodeBlock(
           h.div(
@@ -304,7 +314,13 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           'mb-4',
         ),
         para(
-          'Two refs, two effects, and a subtle bug that only manifests at runtime. The interval silently uses a stale value until you add the ref workaround. Most React developers have been burned by this.',
+          'This is React’s best answer, and look at what it asks of you. First you meet the bug at runtime, because nothing flags a stale closure. Then you classify the read: ',
+          inlineCode('step'),
+          ' must be non-reactive here, so it belongs in an Effect Event. The nearest wrong answer is silent: for the naive version, ',
+          inlineCode('react-hooks/exhaustive-deps'),
+          ' suggests adding ',
+          inlineCode('step'),
+          ' to the dependency array instead, which restarts the interval on every keystroke and quietly resets its rhythm. And codebases older than React 19.2 solve this with a ref plus a sync effect to carry the current value past the closure, a pattern you will still meet everywhere. Most React developers have been burned by this.',
         ),
         para('In Foldkit, there is no stale closure:'),
         highlightedCodeBlock(
@@ -328,14 +344,14 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
           inlineCode('Ticked'),
           ' use ',
           inlineCode('model.step'),
-          ' and it just works. No refs, no sync effects, no runtime surprises.',
+          ' and it just works. No refs, no Effect Events, and no deciding which reads are reactive.',
         ),
         para(
           'Read the update function top to bottom. Every behavior in the app is right there. Each case is independent. They don’t interact through shared mutable state or overlapping effect dependencies. Adding a feature meant adding cases, not restructuring existing ones.',
         ),
         infoCallout(
           'The pattern',
-          'In React, complexity compounds. Each feature interacts with existing effects, refs, and closures. In Foldkit, complexity scales linearly. Each feature adds Messages, update cases, and possibly Commands or Subscriptions, but they don’t interact with each other through shared mutable state.',
+          'In React, each new feature interacts with the effects, refs, and closures already there. In Foldkit, each new feature adds Messages, update cases, and possibly Commands or Subscriptions to structures that already exist, and the cases don’t interact through shared mutable state.',
         ),
         para(
           'This structure also makes testing trivial. Your update function is pure. Pass a Model and a Message, assert on the returned Model. No rendering, no mocking ',
@@ -444,6 +460,34 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
             para(
               link(uiOverviewRouter(), 'Foldkit UI'),
               ' is a first-party set of headless, accessible components: Dialog, Combobox, Listbox, Menu, Popover, and more. Each one follows The Elm Architecture with its own Model, Message, and update, and integrates into your app via the Submodels pattern. You provide the markup and styling; Foldkit UI provides the accessibility attributes, keyboard navigation, and state management.',
+            ),
+          ],
+          model,
+        ),
+        faqItem(
+          faqReactCompiler,
+          'What about React Compiler?',
+          [
+            para(
+              'React Compiler, stable since October 2025, automatically memoizes components that follow the Rules of React, replacing most hand-written ',
+              inlineCode('memo'),
+              ', ',
+              inlineCode('useMemo'),
+              ', and ',
+              inlineCode('useCallback'),
+              '. If you stay in React, evaluate it; it addresses a real cost. What it does not change is the architecture this page is about: state still lives across hooks and libraries rather than in one Model, side effects still live in ',
+              inlineCode('useEffect'),
+              ' bodies with dependency arrays, and none of it is visible to the reducer, the type system, or a unit test.',
+            ),
+            para(
+              'Foldkit’s equivalent of memoization is ',
+              link(
+                coreViewMemoizationRouter(),
+                'createLazy and createKeyedLazy',
+              ),
+              ', keyed on Model data instead of closure identity. See the ',
+              link(reactComparisonRouter(), 'Foldkit vs React comparison'),
+              ' for the full side by side.',
             ),
           ],
           model,

--- a/packages/website/src/page/effectAtomComparison.ts
+++ b/packages/website/src/page/effectAtomComparison.ts
@@ -497,7 +497,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       para(
         'Atom-level subscriptions mean Effect Atom often needs less memoization than a ',
         inlineCode('useReducer'),
-        ' app. But the React machinery is still present: the rules of hooks, the memoization you maintain by hand, and the dependency arrays. The ',
+        ' app. But the React machinery is still present: the rules of hooks, the dependency arrays, and the memoization you maintain by hand or delegate to React Compiler, which in turn requires every component to follow the Rules of React. The ',
         inlineCode('react-hooks/exhaustive-deps'),
         ' lint rule catches the common mistakes, but it is a lint rule you have to run and heed, not a property of the type system.',
       ),

--- a/packages/website/src/page/reactComparison.ts
+++ b/packages/website/src/page/reactComparison.ts
@@ -15,6 +15,7 @@ import {
   coreDevToolsRouter,
   coreMessagesRouter,
   coreModelRouter,
+  coreMountRouter,
   coreSubmodelRouter,
   coreSubscriptionsRouter,
   exampleDetailRouter,
@@ -257,7 +258,7 @@ const oneFunctionHeader: TableOfContentsEntry = {
 const noStaleClosuresHeader: TableOfContentsEntry = {
   level: 'h3',
   id: 'no-stale-closures',
-  text: 'No stale closures, ever',
+  text: 'No stale closures in view, update, or Subscriptions',
 }
 
 const scalabilityHeader: TableOfContentsEntry = {
@@ -455,9 +456,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       ),
       para(
         inlineCode('ClickedExport'),
-        ' is missing: export fires through a ',
-        inlineCode('useCallback'),
-        ' in the App component, not through the reducer. ',
+        ' is missing: export fires through an inline handler in the App component, not through the reducer. ',
         inlineCode('SucceededExportPng'),
         ' and ',
         inlineCode('CompletedSaveCanvas'),
@@ -472,9 +471,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         ' bundle, so dismissal never becomes an app Message.',
       ),
       para(
-        'Stating the difference plainly: Foldkit pulls side effect results and UI component state changes into the Message union as first-class facts. React leaves them distributed: effect outcomes inside ',
-        inlineCode('useCallback'),
-        ' closures and ',
+        'Stating the difference plainly: Foldkit pulls side effect results and UI component state changes into the Message union as first-class facts. React leaves them distributed: effect outcomes inside handler closures and ',
         inlineCode('useEffect'),
         ' bodies, component-internal events inside library hooks. Both are valid design choices. But only one gives you a single answer when a teammate asks “how can state change in this app?”. The Message union catalogs every event, and the update function implements every transition.',
       ),
@@ -485,7 +482,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       ),
       tableOfContentsEntryToHeader(reactAppHeader),
       para(
-        'The React App component initializes the reducer, computes derived values, delegates global event listeners to custom hooks, works around stale closures with a ref, memoizes a callback, and manually threads state into 6 child components:',
+        'The React App component initializes the reducer, computes derived values, delegates global event listeners to custom hooks, and manually threads state into 6 child components:',
       ),
       highlightedCodeBlock(
         h.div(
@@ -505,20 +502,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('useReducer'),
         ', two ',
         inlineCode('useMemo'),
-        ', one ',
-        inlineCode('useRef'),
-        ', one ',
-        inlineCode('useCallback'),
-        ', plus three custom hooks. That’s 8 hooks in a single component. Remove any of them and something breaks.',
-      ),
-      para(
-        'The ',
-        inlineCode('stateRef'),
-        ' pattern is worth a closer look. It exists because ',
-        inlineCode('handleExport'),
-        ' is wrapped in ',
-        inlineCode('useCallback'),
-        ' for memoization, which closes over stale state. So you need a ref to read the current state. This is not a mistake. It’s the standard pattern. React’s closure-based model requires you to manually escape closures when you need current state in a memoized callback.',
+        ', plus three custom hooks. That’s 6 hooks in a single component. Remove any of them and something breaks.',
       ),
       para(
         'Then look at the JSX. Each child receives ',
@@ -762,9 +746,7 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         'Now try to answer one question: what side effects does this app have? In Foldkit, you open two files. In React, there is no list. There is no file you can open.',
       ),
       para(
-        'Here’s where the React side effects actually live. The PNG export fires from a ',
-        inlineCode('useCallback'),
-        ' in ',
+        'Here’s where the React side effects actually live. The PNG export fires from an inline handler in ',
         inlineCode('App.tsx'),
         '. The localStorage save lives in a ',
         inlineCode('useEffect'),
@@ -1227,9 +1209,25 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('useCallback'),
         ' wrapping every handler and ',
         inlineCode('useMemo'),
-        ' wrapping every derived value, the memoized child re-renders anyway because its props look new. Forget one ',
+        ' wrapping every derived value, the memoized child re-renders anyway because its props look new. Maintained by hand, this is optimization you must not forget: miss one wrapper and the grid slows down with no test failure or type error to flag it.',
+      ),
+      para(
+        'React Compiler, stable since October 2025, exists to write these wrappers for you. Enable it and the ',
+        inlineCode('memo'),
+        ', ',
         inlineCode('useCallback'),
-        ' and the optimization silently breaks: your grid rendering slows down, no test catches it, no type error flags it, and you only notice when someone profiles the app.',
+        ', and ',
+        inlineCode('useMemo'),
+        ' in this section are generated at build time; forgetting one stops being a failure mode. We ran the compiler over this React app and every component compiles, so for this codebase the ceremony gap mostly closes. Three things scope that. The compiler is opt-in, in Next.js 16 as everywhere else. It requires components to follow the Rules of React, and code that breaks them is common: an earlier revision of this app wrapped its export handler in ',
+        inlineCode('useCallback'),
+        ' and escaped the resulting stale closure by writing a ref during render, and the compiler rejected the whole root component for it. And when the compiler cannot prove a component safe, it skips it, and that component silently ships unmemoized: the failure mode above at a different layer, with ',
+        inlineCode('eslint-plugin-react-hooks'),
+        ' as the way to find out.',
+      ),
+      para(
+        'What the compiler does not change is everything else on this page. It memoizes. It does not move side effects out of ',
+        inlineCode('useEffect'),
+        ', give the reducer a way to return them, connect an effect to the action that caused it, or make any of them visible to a test.',
       ),
 
       tableOfContentsEntryToHeader(cellLevelMemoizationHeader),
@@ -1288,9 +1286,9 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
         inlineCode('dispatch'),
         ' in its dependency array so it doesn’t capture stale coordinates. Miss any and the cell misbehaves silently. Write them but forget ',
         inlineCode('memo'),
-        ' on the component and every cell re-renders on every stroke. The pattern works. But it’s a lot of ceremony for what Foldkit expresses as two event attributes on a plain ',
-        inlineCode('div'),
-        '.',
+        ' on the component and every cell re-renders on every stroke. The pattern works, and with React Compiler enabled these wrappers are generated instead of written by hand. What no compiler changes is what sits at the boundary: the React cell hands its child closures that must be proven stable, by you or by a build tool. The Foldkit cell hands the runtime two Message values. There is nothing to stabilize because there is nothing that can go stale: ',
+        inlineCode('PressedCell({ x, y })'),
+        ' is data, compared by value, the same on every render.',
       ),
 
       tableOfContentsEntryToHeader(guaranteesHeader),
@@ -1368,7 +1366,9 @@ export const view = (copiedSnippets: CopiedSnippets): Html => {
       para(
         'No dependency arrays. No ',
         inlineCode('useCallback'),
-        ' wrappers. No refs to escape closures. The view and Subscriptions always receive the current Model because the runtime calls them with it on every update. There is no closure captured at render time waiting to go stale. The entire class of bugs that comes from React’s closure-based model does not exist in Foldkit.',
+        ' wrappers. No refs to escape closures. The view, Subscriptions, and update always receive the current Model because the runtime calls them with it on every update. There is no closure captured at render time waiting to go stale. One boundary works differently: ',
+        link(coreMountRouter(), 'Mount'),
+        ' args are captured when the element enters the DOM and are not refreshed by later renders, with a documented escape hatch for post-mount Model changes. That is the whole list. React’s largest bug class, narrowed to a single boundary you can name.',
       ),
 
       tableOfContentsEntryToHeader(scalabilityHeader),

--- a/packages/website/src/snippet/comparisonReactApp.tsx
+++ b/packages/website/src/snippet/comparisonReactApp.tsx
@@ -6,9 +6,6 @@ export const App = () => {
     [state.paletteThemeIndex],
   )
 
-  const stateRef = useRef(state)
-  stateRef.current = state
-
   useKeyboardShortcuts(dispatch)
   useMouseRelease(state.isDrawing, dispatch)
   useLocalStorage(
@@ -19,9 +16,7 @@ export const App = () => {
     state.isDrawing,
   )
 
-  const handleExport = useCallback(() => {
-    exportPng(stateRef.current, dispatch)
-  }, [dispatch])
+  const handleExport = () => exportPng(state, dispatch)
 
   const currentGrid = useMemo(
     () =>

--- a/packages/website/src/snippet/comparisonReactMemoization.tsx
+++ b/packages/website/src/snippet/comparisonReactMemoization.tsx
@@ -6,9 +6,7 @@ export const App = () => {
     [state.paletteThemeIndex],
   )
 
-  const handleExport = useCallback(() => {
-    exportPng(stateRef.current, dispatch)
-  }, [dispatch])
+  const handleExport = () => exportPng(state, dispatch)
 
   const currentGrid = useMemo(
     () =>
@@ -33,10 +31,7 @@ export const App = () => {
   )
 }
 
-// Every component must be wrapped in memo() to avoid re-rendering
-const Header = memo(function Header({ onExport }: { onExport: () => void }) {
-  // ...
-})
+// Every component receiving state slices is wrapped in memo()
 const Toolbar = memo(function Toolbar({
   tool,
   mirrorMode,

--- a/packages/website/src/snippet/reactCounterAutoPlay.tsx
+++ b/packages/website/src/snippet/reactCounterAutoPlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useEffectEvent, useRef, useState } from 'react'
 
 const TICK_INTERVAL_MS = 1000
 
@@ -8,7 +8,6 @@ function Counter() {
   const [count, setCount] = useState(0)
   const [isAutoCounting, setIsPlaying] = useState(false)
   const [step, setStep] = useState(1)
-  const stepRef = useRef(step)
 
   const handleClickIncrement = () => {
     setCount(count => count + step)
@@ -18,15 +17,13 @@ function Counter() {
     setIsPlaying(isAutoCounting => !isAutoCounting)
   }
 
-  useEffect(() => {
-    stepRef.current = step
-  }, [step])
+  const onTick = useEffectEvent(() => {
+    setCount(count => count + step)
+  })
 
   useEffect(() => {
     if (isAutoCounting) {
-      intervalRef.current = setInterval(() => {
-        setCount(count => count + stepRef.current)
-      }, TICK_INTERVAL_MS)
+      intervalRef.current = setInterval(() => onTick(), TICK_INTERVAL_MS)
     }
 
     return () => clearInterval(intervalRef.current)


### PR DESCRIPTION
The React comparison pages argued against manual memoization ceremony
without ever mentioning React Compiler, and presented a stateRef written
during render as the standard pattern. react.dev forbids reading or
writing a ref during render, and React Compiler rejects the root
component for it.

- Drop the useCallback plus stateRef export handler from the React
  pixel art app and its snippet copies; an inline handler needs no ref.
- Add a React Compiler passage to the Rendering Performance section:
  concede that it generates the memoization wrappers, scope it as
  opt-in, Rules of React gated, and silent on bailout, and state what
  it does not change.
- Retitle and scope the no-stale-closures guarantee to view, update,
  and Subscriptions, naming Mount's captured-args boundary.
- Map useMemo and useCallback to createLazy and createKeyedLazy in the
  Coming from React table, name useEffectEvent in the step-size
  section, drop the scales-linearly phrasing, and add a React Compiler
  FAQ item.
- Align the Effect Atom comparison's memoization paragraph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated React comparison guides with clearer memoization and stale-closure explanations, including event-handling and boundaries behavior.
  - Added and linked a new FAQ entry about React Compiler, including updated page routing and table guidance.
  - Refreshed examples for export handlers, memoization wrapping guidance, and auto-updating counters using stable event handlers.
- **Refactor**
  - Simplified example implementations to avoid ref-based state forwarding while keeping the same visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->