### PR TITLE
fix(vite-plugin): close and restart the MCP relay with the dev server

### DIFF
--- a/.changeset/mcp-relay-middleware-shutdown.md
+++ b/.changeset/mcp-relay-middleware-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/vite-plugin': patch
+---
+
+Shut the DevTools MCP relay down when the Vite dev server closes in middleware mode, and keep it alive across a dev server restart. The plugin hung its shutdown off `server.httpServer`, which is null when Vite runs as middleware, so with `devToolsMcpPort` set the relay's WebSocket server stayed bound and held the process open. Under Vitest that showed up as a `close timed out after 10000ms` delay on every run. Restarting a dev server also used to kill the relay for the rest of the session, because Vite binds the replacement server's relay while the server it replaces still owns the port, and the resulting `EADDRINUSE` was reported as a conflict with another project. The relay now retries the bind for a few seconds so the port hands over, and a genuine conflict reports the same message once the retries are spent. Binding runs alongside the HMR bridge rather than ahead of it, so a contended port never delays model preservation. Connected MCP clients are terminated as part of shutdown, so no socket the relay opened outlives the server. The MCP server already reconnects on a dropped connection.

--- a/packages/vite-plugin-foldkit/src/index.ts
+++ b/packages/vite-plugin-foldkit/src/index.ts
@@ -2,6 +2,7 @@ import {
   Array,
   Console,
   Data,
+  Duration,
   Effect,
   Exit,
   Fiber,
@@ -9,9 +10,11 @@ import {
   HashSet,
   Match as M,
   Option,
+  Predicate,
   Queue,
   Ref,
   Schema as S,
+  Schedule,
   Stream,
   pipe,
 } from 'effect'
@@ -31,7 +34,12 @@ import {
 } from 'foldkit/hmr-protocol'
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
-import type { Plugin, ViteDevServer, WebSocketClient } from 'vite'
+import type {
+  Plugin,
+  ResolvedConfig,
+  ViteDevServer,
+  WebSocketClient,
+} from 'vite'
 import { type WebSocket, WebSocketServer } from 'ws'
 
 import { foldkitViewIdentity } from './viewIdentity.js'
@@ -130,7 +138,7 @@ const resolveInstalledFoldkitPackages = (root: string): Array<string> => {
     } catch (error) {
       return !(
         error instanceof Error &&
-        'code' in error &&
+        Predicate.hasProperty(error, 'code') &&
         error.code === 'MODULE_NOT_FOUND'
       )
     }
@@ -524,50 +532,92 @@ const registerViteWsHandlers = (
 
 // MCP RELAY
 
-const startMcpRelay = (port: number, enqueue: (event: Event) => void) =>
-  Effect.acquireRelease(
-    Effect.sync(() => {
-      const wss = new WebSocketServer({ port })
+// NOTE: Restarting a dev server briefly leaves two of them alive. Vite builds
+// the replacement, which binds its relay, before closing the server it
+// replaces, which still owns the port. The bind loses that race and has to
+// wait for the outgoing server to release the port, so it retries for four
+// seconds before reporting the port as taken.
+const RELAY_BIND_RETRY_DELAY = Duration.millis(100)
+const RELAY_BIND_RETRY_COUNT = 40
+
+class RelayBindFailed extends Data.TaggedError('RelayBindFailed')<{
+  readonly cause: Error
+}> {}
+
+const isPortInUse = (error: Error) =>
+  Predicate.hasProperty(error, 'code') && error.code === 'EADDRINUSE'
+
+const bindMcpRelay = (port: number, enqueue: (event: Event) => void) =>
+  Effect.callback<WebSocketServer, RelayBindFailed>(resume => {
+    const wss = new WebSocketServer({ port })
+
+    wss.on('connection', client => {
+      enqueue(Event.McpClientConnected({ client }))
+      client.on('message', raw =>
+        enqueue(Event.McpRequestReceived({ client, raw: raw.toString() })),
+      )
+      client.on('close', () => enqueue(Event.McpClientDisconnected({ client })))
+      client.on('error', error => {
+        console.error('[foldkit:devTools] MCP client error', error)
+      })
+    })
+
+    const onListening = () => {
+      wss.off('error', onBindFailed)
       wss.on('error', error => {
-        if ('code' in error && error.code === 'EADDRINUSE') {
-          console.error(
-            `\n[foldkit:devTools] Port ${port} is already in use, so the DevTools MCP relay could not start.\n` +
-              `[foldkit:devTools] This usually means another Foldkit project is already running and bound to this port.\n` +
-              `[foldkit:devTools] Until the port is freed, agents will not be able to connect to this app via the Foldkit DevTools MCP server.\n` +
-              `[foldkit:devTools] Stop the other project, or set a different \`devToolsMcpPort\` in this project's vite config.\n` +
-              `[foldkit:devTools] If you change \`devToolsMcpPort\`, also set \`FOLDKIT_DEVTOOLS_MCP_PORT\` to the same value for your MCP server.\n`,
-          )
-        } else {
-          console.error(
-            `[foldkit:devTools] MCP relay failed to start on port ${port}; continuing without the relay`,
-            error,
-          )
-        }
+        console.error('[foldkit:devTools] MCP relay error', error)
       })
-      wss.on('connection', client => {
-        enqueue(Event.McpClientConnected({ client }))
-        client.on('message', raw =>
-          enqueue(Event.McpRequestReceived({ client, raw: raw.toString() })),
-        )
-        client.on('close', () =>
-          enqueue(Event.McpClientDisconnected({ client })),
-        )
-        client.on('error', error => {
-          console.error('[foldkit:devTools] MCP client error', error)
-        })
-      })
-      wss.on('listening', () => {
-        console.log(
-          `[foldkit:devTools] MCP relay listening on ws://localhost:${port}`,
-        )
-      })
-      return wss
+      console.log(
+        `[foldkit:devTools] MCP relay listening on ws://localhost:${port}`,
+      )
+      resume(Effect.succeed(wss))
+    }
+
+    const onBindFailed = (cause: Error) => {
+      wss.off('listening', onListening)
+      wss.close()
+      resume(Effect.fail(new RelayBindFailed({ cause })))
+    }
+
+    wss.once('listening', onListening)
+    wss.once('error', onBindFailed)
+  })
+
+const reportRelayBindFailed = (port: number, cause: Error) => {
+  if (isPortInUse(cause)) {
+    return Console.error(
+      `\n[foldkit:devTools] Port ${port} is already in use, so the DevTools MCP relay could not start.\n` +
+        `[foldkit:devTools] This usually means another Foldkit project is already running and bound to this port.\n` +
+        `[foldkit:devTools] Until the port is freed, agents will not be able to connect to this app via the Foldkit DevTools MCP server.\n` +
+        `[foldkit:devTools] Stop the other project, or set a different \`devToolsMcpPort\` in this project's vite config.\n` +
+        `[foldkit:devTools] If you change \`devToolsMcpPort\`, also set \`FOLDKIT_DEVTOOLS_MCP_PORT\` to the same value for your MCP server.\n`,
+    )
+  } else {
+    return Console.error(
+      `[foldkit:devTools] MCP relay failed to start on port ${port}; continuing without the relay`,
+      cause,
+    )
+  }
+}
+
+const startMcpRelay = (port: number, enqueue: (event: Event) => void) =>
+  Effect.acquireRelease(bindMcpRelay(port, enqueue), wss =>
+    Effect.gen(function* () {
+      for (const client of wss.clients) {
+        client.terminate()
+      }
+      wss.close()
+      yield* Console.log('[foldkit:devTools] MCP relay stopped')
     }),
-    wss =>
-      Effect.sync(() => {
-        wss.close()
-        console.log('[foldkit:devTools] MCP relay stopped')
-      }),
+  ).pipe(
+    Effect.retry({
+      while: ({ cause }) => isPortInUse(cause),
+      times: RELAY_BIND_RETRY_COUNT,
+      schedule: Schedule.spaced(RELAY_BIND_RETRY_DELAY),
+    }),
+    Effect.catchTag('RelayBindFailed', ({ cause }) =>
+      reportRelayBindFailed(port, cause),
+    ),
   )
 
 // PROGRAM
@@ -585,8 +635,13 @@ const main = (
 
     yield* registerViteWsHandlers(server, state, enqueue)
 
+    // NOTE: Forked rather than awaited because binding the relay can retry for
+    // seconds. The HMR bridge is independent of the relay, and the runtime
+    // gives up on its boot-time model request in well under a second, so
+    // sequencing the dispatch loop behind the bind would cost model
+    // preservation whenever the port is contended.
     if (options.devToolsMcpPort !== undefined) {
-      yield* startMcpRelay(options.devToolsMcpPort, enqueue)
+      yield* Effect.forkScoped(startMcpRelay(options.devToolsMcpPort, enqueue))
     }
 
     yield* Stream.fromQueue(events).pipe(
@@ -605,6 +660,23 @@ const main = (
 export const foldkit = (options: FoldkitPluginOptions = {}): Array<Plugin> => {
   const events = Effect.runSync(Queue.unbounded<Event>())
 
+  // NOTE: One plugin instance can serve more than one dev server, and on
+  // restart Vite builds the replacement, running `configureServer` again,
+  // before closing the server being replaced. Keying by resolved config keeps
+  // each server's shutdown pointed at its own fiber.
+  const mainFibers = new WeakMap<ResolvedConfig, Fiber.Fiber<void, never>>()
+
+  const stopMain = (config: ResolvedConfig) =>
+    Effect.suspend(() => {
+      const fiber = mainFibers.get(config)
+      mainFibers.delete(config)
+      if (fiber === undefined) {
+        return Effect.void
+      } else {
+        return Fiber.interrupt(fiber)
+      }
+    })
+
   const hmrPlugin: Plugin = {
     name: 'foldkit-hmr',
     apply: 'serve',
@@ -620,9 +692,14 @@ export const foldkit = (options: FoldkitPluginOptions = {}): Array<Plugin> => {
     }),
     configureServer: server => {
       const fiber = Effect.runFork(Effect.scoped(main(server, events, options)))
-      server.httpServer?.on('close', () => {
-        Effect.runFork(Fiber.interrupt(fiber))
-      })
+      mainFibers.set(server.config, fiber)
+    },
+    // NOTE: Vite awaits `closeBundle` when the dev server closes, once per
+    // environment plugin container. Hanging shutdown off `server.httpServer`
+    // instead would never run in middleware mode, which is how Vitest and
+    // other embedders run Vite, and the relay would outlive the server.
+    closeBundle() {
+      return Effect.runPromise(stopMain(this.environment.getTopLevelConfig()))
     },
     handleHotUpdate: ({
       server,

--- a/packages/vite-plugin-foldkit/test/mcpRelay.test.ts
+++ b/packages/vite-plugin-foldkit/test/mcpRelay.test.ts
@@ -1,0 +1,231 @@
+import { connect, createServer as createNetServer } from 'node:net'
+import { resolve } from 'node:path'
+import { createServer } from 'vite'
+import { describe, expect, it, onTestFinished } from 'vitest'
+import { WebSocket } from 'ws'
+
+import { foldkit } from '../src/index.ts'
+
+const PACKAGE_ROOT = resolve(import.meta.dirname, '..')
+const TEST_TIMEOUT = 20_000
+const POLL_TIMEOUT = 10_000
+// The runtime gives up on its boot-time model request after 500ms, and the
+// relay retries a contended bind for four seconds.
+const HMR_RESPONSE_BUDGET = 500
+
+const findFreePort = () =>
+  new Promise<number>((resolvePort, reject) => {
+    const probe = createNetServer()
+    probe.on('error', error => {
+      probe.close()
+      reject(error)
+    })
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      if (address === null || typeof address === 'string') {
+        probe.close()
+        reject(new Error('Could not determine a free port'))
+        return
+      }
+      const { port } = address
+      probe.close(() => resolvePort(port))
+    })
+  })
+
+const isPortAccepting = (port: number) =>
+  new Promise<boolean>(resolveAccepting => {
+    const socket = connect({ port, host: '127.0.0.1' })
+    socket.on('connect', () => {
+      socket.destroy()
+      resolveAccepting(true)
+    })
+    socket.on('error', () => {
+      socket.destroy()
+      resolveAccepting(false)
+    })
+  })
+
+const startMiddlewareModeServer = async (devToolsMcpPort: number) => {
+  const server = await createServer({
+    root: PACKAGE_ROOT,
+    configFile: false,
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+    plugins: [foldkit({ devToolsMcpPort })],
+  })
+  onTestFinished(() => server.close().catch(() => undefined))
+  return server
+}
+
+const startStandaloneServer = async (
+  devToolsMcpPort: number,
+  serverPort: number,
+) => {
+  const server = await createServer({
+    root: PACKAGE_ROOT,
+    configFile: false,
+    logLevel: 'silent',
+    server: { port: serverPort, strictPort: true, host: '127.0.0.1' },
+    plugins: [foldkit({ devToolsMcpPort })],
+  })
+  onTestFinished(() => server.close().catch(() => undefined))
+  await server.listen()
+  return server
+}
+
+const waitUntilRelayListening = (port: number) =>
+  expect.poll(() => isPortAccepting(port), { timeout: POLL_TIMEOUT }).toBe(true)
+
+const connectClient = async (port: number) => {
+  const client = new WebSocket(`ws://127.0.0.1:${port}`)
+  onTestFinished(() => client.terminate())
+  await new Promise<void>((resolveOpen, reject) => {
+    client.on('open', () => resolveOpen())
+    client.on('error', reject)
+  })
+  return client
+}
+
+// NOTE: Binds every interface, the way `ws` does. Holding only 127.0.0.1
+// leaves the relay free to bind `::` and the contention never happens.
+const holdPort = async (port: number) => {
+  const squatter = createNetServer()
+  onTestFinished(() => new Promise<void>(done => squatter.close(() => done())))
+  await new Promise<void>((resolveListening, reject) => {
+    squatter.on('error', reject)
+    squatter.listen(port, () => resolveListening())
+  })
+}
+
+const requestPreservedModel = async (port: number) => {
+  const client = new WebSocket(`ws://127.0.0.1:${port}`, 'vite-hmr')
+  onTestFinished(() => client.terminate())
+  await new Promise<void>((resolveOpen, reject) => {
+    client.on('open', () => resolveOpen())
+    client.on('error', reject)
+  })
+
+  const restored = new Promise<void>(resolveRestored => {
+    client.on('message', raw => {
+      const message = JSON.parse(raw.toString())
+      if (message.event === 'foldkit:restore-model') {
+        resolveRestored()
+      }
+    })
+  })
+
+  client.send(
+    JSON.stringify({
+      type: 'custom',
+      event: 'foldkit:request-model',
+      data: { id: 'test-runtime' },
+    }),
+  )
+
+  return restored
+}
+
+describe('DevTools MCP relay', () => {
+  it(
+    'releases its port when a middleware-mode dev server closes',
+    async () => {
+      const port = await findFreePort()
+      const server = await startMiddlewareModeServer(port)
+      await waitUntilRelayListening(port)
+
+      await server.close()
+
+      expect(await isPortAccepting(port)).toBe(false)
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
+    'closes connected MCP clients when the dev server closes',
+    async () => {
+      const port = await findFreePort()
+      const server = await startMiddlewareModeServer(port)
+      await waitUntilRelayListening(port)
+      const client = await connectClient(port)
+
+      await server.close()
+
+      await expect.poll(() => client.readyState === client.CLOSED).toBe(true)
+      expect(await isPortAccepting(port)).toBe(false)
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
+    'releases its port when a standalone dev server closes',
+    async () => {
+      const port = await findFreePort()
+      const serverPort = await findFreePort()
+      const server = await startStandaloneServer(port, serverPort)
+      await waitUntilRelayListening(port)
+
+      await server.close()
+
+      expect(await isPortAccepting(port)).toBe(false)
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
+    'hands the relay over to the replacement when a dev server restarts',
+    async () => {
+      const port = await findFreePort()
+      const server = await startMiddlewareModeServer(port)
+      await waitUntilRelayListening(port)
+
+      await server.restart()
+
+      await waitUntilRelayListening(port)
+      const client = await connectClient(port)
+      expect(client.readyState).toBe(client.OPEN)
+
+      await server.close()
+
+      expect(await isPortAccepting(port)).toBe(false)
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
+    'serves HMR model requests while a contended bind is still retrying',
+    async () => {
+      const port = await findFreePort()
+      const serverPort = await findFreePort()
+      await holdPort(port)
+      await startStandaloneServer(port, serverPort)
+
+      await expect(
+        Promise.race([
+          requestPreservedModel(serverPort),
+          new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error('HMR bridge did not answer in time')),
+              HMR_RESPONSE_BUDGET,
+            ),
+          ),
+        ]),
+      ).resolves.toBeUndefined()
+    },
+    TEST_TIMEOUT,
+  )
+
+  it(
+    'closes promptly while a contended bind is still retrying',
+    async () => {
+      const port = await findFreePort()
+      await holdPort(port)
+      const server = await startMiddlewareModeServer(port)
+
+      const startedAt = Date.now()
+      await server.close()
+
+      expect(Date.now() - startedAt).toBeLessThan(HMR_RESPONSE_BUDGET)
+    },
+    TEST_TIMEOUT,
+  )
+})


### PR DESCRIPTION
Fixes #823.

Two bugs, both in how the DevTools MCP relay tracks the dev server's lifecycle. The second was found while reviewing the fix for the first.

## 1. The relay was never shut down in middleware mode

`configureServer` attached shutdown to `server.httpServer?.on('close')`. Vite leaves `server.httpServer` null in middleware mode, which is how Vitest and other embedders run it, so the listener was never attached. The relay's `WebSocketServer` stayed bound after the tests finished and held the process open until Vitest gave up on it.

Reproduced against the reporter's MRE shape, one trivial test, built plugin:

| | before | after |
| --- | --- | --- |
| `vitest run` | 10.49s, `close timed out after 10000ms` | 0.53s, `MCP relay stopped` |

**Shutdown now runs from `closeBundle`.** `EnvironmentPluginContainer.close()` calls it with no environment filter, `DevEnvironment.close()` awaits it, and `closeServer` awaits every environment with no `middlewareMode` branch. Verified in the installed vite@8.0.16 and in vite@7.3.6, so it covers the whole `^7.0.0 || ^8.0.0` peer range in both modes. The old `httpServer` listener is gone: unreachable in middleware mode, and redundant in standalone mode where `closeBundle` deterministically wins the race anyway (microtask chain versus a libuv close callback). Keeping it would have left an unawaited second path that quietly stops guaranteeing the relay is down if that ordering ever flips.

**The fiber is keyed to the resolved config of the server that started it**, in a `WeakMap`, rather than held in a single slot on the plugin closure. One plugin instance can serve more than one dev server, and on restart Vite builds the replacement (running `configureServer` again) *before* it closes the server being replaced. A single slot lets the outgoing server interrupt the incoming server's fiber and leak its own, which also crashes the process with an uncaught `EADDRINUSE`, because `wss.close()` strips the internal server's error listener before the pending bind error is delivered.

**Connected MCP clients are terminated** as part of shutdown, so no socket the relay opened outlives the server. `@foldkit/devtools-mcp` already reconnects on a dropped connection.

## 2. A restarted dev server lost its relay for the rest of the session

The same overlap has a second consequence. The replacement server binds its relay while the outgoing server still owns the port, so the bind always failed with `EADDRINUSE`, and the plugin reported it as a conflict with another Foldkit project. In practice: edit `vite.config.ts`, Vite restarts, agents can no longer reach the app, and the error message points at the wrong cause.

**The bind now retries on `EADDRINUSE`**, 40 attempts spaced 100ms, so the port hands over. A genuine conflict still reports the same message once the retries are spent, four seconds later than it used to. Measured on a restart: relay stopped, replacement bound, client connected, total restart 428ms.

**Binding is forked rather than awaited**, so those retries never sit in front of the HMR bridge. The runtime gives up on its boot-time model request after 500ms, well inside the four second budget, so sequencing the dispatch loop behind the bind cost model preservation whenever the port was contended, and printed a second warning telling the user to install a plugin they already had. Caught by review after I first wrote this fix; there is now a test that drives a real `foldkit:request-model` round trip over Vite's HMR socket with the relay port held.

Retry delays are interruptible. `acquireRelease` runs its acquire uninterruptibly, so the retry sits *outside* it, one bind attempt per acquire. A dev server that closes mid-retry closes in ~1ms, which matters because that is exactly the issue-823 scenario when a real dev server already holds port 9988.

## Alternative rejected

Awaiting the `wss.close()` callback before finishing the release, so Vite's close would not resolve until the relay had fully drained.

It buys nothing. Node closes the listening fd synchronously inside `close()`, so the port is already free when the release returns. Rebinding it immediately after `close()` returns, with no await, succeeds 50 out of 50 times, 0 `EADDRINUSE`. Since `closeBundle` awaits the fiber and `Fiber.interrupt` awaits the scope finalizer, `await server.close()` already implies a released port.

What the callback actually waits for is connected *clients*. With an upgraded client left connected it is still pending after 4s, which is why the release terminates `wss.clients` first. Awaiting on top of that would couple teardown to client disconnection for no gain. The release stays synchronous.

## Verification

New `packages/vite-plugin-foldkit/test/mcpRelay.test.ts`. Each test was checked to fail for the reason it exists:

| test | on `main` | single-slot fiber | no bind retry | awaited bind |
| --- | --- | --- | --- | --- |
| port released, middleware mode | fails | passes | passes | passes |
| connected MCP clients closed | fails | passes | passes | passes |
| port released, standalone mode | passes (guards the path this PR reroutes) | passes | passes | passes |
| relay handed over on restart | fails | fails | fails | passes |
| HMR served while the bind retries | passes | passes | passes | **fails** |
| closes promptly while the bind retries | passes | passes | passes | passes |

The last two hold the relay port with a listener on every interface, the way `ws` binds. An earlier version held only `127.0.0.1`, which let the relay bind `::` unopposed and made both tests pass vacuously.

### End to end through the real MCP path

Driven manually with `@foldkit/devtools-mcp` and a browser, since the tests only drive raw `ws` clients. `examples/counter` on `devToolsMcpPort: 9988`, editing `vite.config.ts` to force a restart.

On `main`:

```
[vite] vite.config.ts changed, restarting server...
[foldkit:devTools] Port 9988 is already in use, so the DevTools MCP relay could not start.
[foldkit:devTools] This usually means another Foldkit project is already running...
[foldkit:devTools] MCP relay stopped
[vite] server restarted.
```

`foldkit_list_runtimes` then returns `TimeoutError`. The agent is cut off for the rest of the session, blamed on a project that does not exist.

On this branch:

```
[vite] vite.config.ts changed, restarting server...
[foldkit:devTools] MCP relay stopped
[foldkit:devTools] MCP relay listening on ws://localhost:9988
[foldkit:devTools] MCP client connected (1 total)
[vite] server restarted.
```

`foldkit_list_runtimes` lists the runtime, `foldkit_get_model` reads `count: 0`, `foldkit_dispatch_message ClickedIncrement` is accepted, and the Model reads back `count: 1`. Same again after the restart, with a fresh connection id.

Repeated against `packages/website`, the largest project in the repo, to check the four second budget on a slower `server.close()`: clean handover, no port-in-use banner.

Also measured directly against the built plugin: the end-to-end Vitest run above, restart handover with a real client connecting to the replacement relay, prompt close during a retry, the port-conflict message still appearing once retries are spent, and no handle accumulation across failed bind attempts. Suite run five times with no flake. Plus the pre-push suite (format, changeset status, lint, dead-code, build, all-package typecheck, all tests, website e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DevTools MCP relay shutdown so development servers close cleanly without lingering connections or processes.
  * Preserved relay availability across middleware-mode development server restarts.
  * Added retry handling for temporary port handoffs while continuing to report genuine port conflicts.
  * Enabled MCP clients to reconnect after dropped connections.

* **Tests**
  * Added coverage for relay shutdown, reconnection, restart behavior, port contention, and HMR model preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->