### PR TITLE
Add lang and dir to Document for runtime language switching

### DIFF
--- a/.changeset/document-lang-dir.md
+++ b/.changeset/document-lang-dir.md
@@ -1,0 +1,9 @@
+---
+'foldkit': minor
+---
+
+Add `lang` and `dir` to the view's `Document`, so an app that switches language at runtime can drive the `<html>` attributes from its Model. `Document` already carried `title`, `canonical`, and `ogUrl`, but the root element was the one piece of document state a view could not reach, because `<html>` sits outside the application container. Getting at it meant a Mount or a Command poking `document.documentElement`, the imperative escape hatch that `title` exists to avoid.
+
+`dir` is typed by a new `TextDirection` Schema exported from `foldkit/html`, covering `'Ltr' | 'Rtl' | 'Auto'`, which the runtime writes as the lowercase attribute values. It is a Schema rather than a bare type union so a Model that stores the direction can use it directly in an `S.Struct`, the same way `Canvas.LineCap` and `Canvas.TextAlign` already work.
+
+Both fields are optional and have no default: when a view omits one, the runtime does not touch that attribute, leaving whatever value it currently holds, so a view that never sets it leaves the served HTML in place and existing apps are unaffected. `makeElement` writes neither, matching how it already leaves the `<head>` alone. Note that the runtime can only sync after the first render, so the served HTML still decides what a crawler sees on first paint.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.10.33",
+  "version": "0.10.34",
   "description": "Skills for building Foldkit apps — app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -7,6 +7,7 @@ import {
   Function,
   Option,
   Record,
+  Schema as S,
   Stream,
 } from 'effect'
 
@@ -125,20 +126,36 @@ const keyboardModifiers = (event: KeyboardEvent): KeyboardModifiers => ({
 export type Html = VNode | null
 export type Child = Html | string
 
+/** Text direction for the document root, applied to `dir` on the `<html>`
+ *  element. `Auto` defers to the browser's first-strong-character heuristic. */
+export const TextDirection = S.Literals(['Ltr', 'Rtl', 'Auto'])
+/** Text direction for the document root, applied to `dir` on the `<html>`
+ *  element. `Auto` defers to the browser's first-strong-character heuristic. */
+export type TextDirection = typeof TextDirection.Type
+
 /** A view's complete output for the runtime: title, body, and optional document
- *  metadata. The runtime applies `title` to `document.title`, syncs `canonical`
- *  to `<link rel="canonical">` (creating it if absent), syncs `ogUrl` to
- *  `<meta property="og:url">` (creating it if absent), and patches `body` into
- *  the application container.
+ *  metadata. The runtime applies `title` to `document.title`, syncs `lang` and
+ *  `dir` to the `<html>` element, syncs `canonical` to `<link rel="canonical">`
+ *  (creating it if absent), syncs `ogUrl` to `<meta property="og:url">`
+ *  (creating it if absent), and patches `body` into the application container.
  *
  *  When `canonical` is omitted, it defaults to the current URL (origin +
  *  pathname + search). When `ogUrl` is omitted, it falls back to `canonical`.
  *
+ *  `lang` and `dir` have no default. When either is omitted the runtime does not
+ *  touch that attribute, leaving whatever value it currently holds, so a view
+ *  that never sets it leaves the served HTML in place. Drive them from the Model
+ *  when the app switches language at runtime. The served HTML still decides what
+ *  a crawler sees on first paint, because the runtime can only sync after the
+ *  first render.
+ *
  *  This is the return type of a `makeApplication` view, which owns the document. An
  *  app embedded at a node should use `makeElement` instead, whose view returns
- *  `Html` and never touches the `<head>`. */
+ *  `Html` and never touches the `<head>` or the `<html>` element. */
 export type Document = Readonly<{
   title: string
+  lang?: string
+  dir?: TextDirection
   canonical?: string
   ogUrl?: string
   body: Html

--- a/packages/foldkit/src/html/public.ts
+++ b/packages/foldkit/src/html/public.ts
@@ -4,6 +4,7 @@ export {
   createLazy,
   html,
   submodel,
+  TextDirection,
 } from './index.js'
 
 export type {

--- a/packages/foldkit/src/runtime/makeElement.test.ts
+++ b/packages/foldkit/src/runtime/makeElement.test.ts
@@ -1,9 +1,10 @@
-import { Effect, Fiber, Match as M, Schema as S } from 'effect'
+import { Effect, Fiber, Match as M, Number, Schema as S } from 'effect'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Command } from '../command/index.js'
-import { html } from '../html/index.js'
+import { TextDirection, html } from '../html/index.js'
 import { m } from '../message/index.js'
+import { evo } from '../struct/index.js'
 import { makeApplication, makeElement } from './runtime.js'
 
 const Rendered = m('Rendered')
@@ -28,7 +29,46 @@ const update = (
     }),
   )
 
+const LocaleModel = S.Struct({
+  lang: S.String,
+  dir: TextDirection,
+  revision: S.Number,
+})
+type LocaleModel = typeof LocaleModel.Type
+
+const ENGLISH_LTR = LocaleModel.make({ lang: 'en', dir: 'Ltr', revision: 0 })
+const FRENCH_AUTO = LocaleModel.make({
+  lang: 'fr-CA',
+  dir: 'Auto',
+  revision: 0,
+})
+
+const ClickedArabic = m('ClickedArabic')
+const ClickedRerender = m('ClickedRerender')
+const LocaleMessage = S.Union([ClickedArabic, ClickedRerender])
+type LocaleMessage = typeof LocaleMessage.Type
+
+const localeH = html<LocaleMessage>()
+
+const localeUpdate = (
+  model: LocaleModel,
+  message: LocaleMessage,
+): readonly [LocaleModel, ReadonlyArray<Command<LocaleMessage>>] =>
+  M.value(message).pipe(
+    M.withReturnType<
+      readonly [LocaleModel, ReadonlyArray<Command<LocaleMessage>>]
+    >(),
+    M.tagsExhaustive({
+      ClickedArabic: () => [
+        evo(model, { lang: () => 'ar', dir: () => 'Rtl' }),
+        [],
+      ],
+      ClickedRerender: () => [evo(model, { revision: Number.increment }), []],
+    }),
+  )
+
 const HOST_TITLE = 'Host Page Title'
+const HOST_LANG = 'en'
 
 let container: HTMLElement
 
@@ -41,9 +81,15 @@ const removeHeadMetadata = (): void => {
   })
 }
 
+const resetRootAttributes = (): void => {
+  document.documentElement.lang = HOST_LANG
+  document.documentElement.removeAttribute('dir')
+}
+
 beforeEach(() => {
   document.title = HOST_TITLE
   removeHeadMetadata()
+  resetRootAttributes()
   container = document.createElement('div')
   container.id = 'app'
   document.body.appendChild(container)
@@ -53,6 +99,7 @@ afterEach(() => {
   document.body.innerHTML = ''
   document.title = HOST_TITLE
   removeHeadMetadata()
+  resetRootAttributes()
 })
 
 const awaitBodyText = (text: string): Promise<void> =>
@@ -60,10 +107,12 @@ const awaitBodyText = (text: string): Promise<void> =>
     expect(document.body.textContent).toContain(text)
   })
 
-const expectHeadUntouched = (): void => {
+const expectDocumentUntouched = (): void => {
   expect(document.title).toBe(HOST_TITLE)
   expect(document.head.querySelector('link[rel="canonical"]')).toBeNull()
   expect(document.head.querySelector('meta[property="og:url"]')).toBeNull()
+  expect(document.documentElement.lang).toBe(HOST_LANG)
+  expect(document.documentElement.hasAttribute('dir')).toBe(false)
 }
 
 describe('makeElement', () => {
@@ -80,7 +129,7 @@ describe('makeElement', () => {
 
     try {
       await awaitBodyText('hello')
-      expectHeadUntouched()
+      expectDocumentUntouched()
     } finally {
       await Effect.runPromise(Fiber.interrupt(fiber))
     }
@@ -109,7 +158,7 @@ describe('makeElement', () => {
       button?.click()
 
       await awaitBodyText('world')
-      expectHeadUntouched()
+      expectDocumentUntouched()
     } finally {
       await Effect.runPromise(Fiber.interrupt(fiber))
     }
@@ -132,7 +181,7 @@ describe('makeElement', () => {
 
     try {
       await awaitBodyText('from-flags')
-      expectHeadUntouched()
+      expectDocumentUntouched()
     } finally {
       await Effect.runPromise(Fiber.interrupt(fiber))
     }
@@ -156,7 +205,7 @@ describe('makeElement', () => {
 
     try {
       await awaitBodyText('Crashed Widget')
-      expectHeadUntouched()
+      expectDocumentUntouched()
     } finally {
       await Effect.runPromise(Fiber.interrupt(fiber))
     }
@@ -262,6 +311,130 @@ describe('makeApplication', () => {
         canonicalSetAttributeSpy.mockRestore()
         ogUrlSetAttributeSpy.mockRestore()
       }
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('applies lang and dir to the html element', async () => {
+    const application = makeApplication({
+      Model: LocaleModel,
+      init: () => [FRENCH_AUTO, []],
+      update: localeUpdate,
+      view: model => ({
+        title: 'Localized',
+        lang: model.lang,
+        dir: model.dir,
+        body: localeH.div([], ['bonjour']),
+      }),
+      container,
+    })
+
+    const fiber = Effect.runFork(application.start())
+
+    try {
+      await awaitBodyText('bonjour')
+
+      expect(document.documentElement.lang).toBe('fr-CA')
+      expect(document.documentElement.dir).toBe('auto')
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('leaves lang and dir alone when the view omits them', async () => {
+    const application = makeApplication({
+      Model,
+      init: () => [{ label: 'hello' }, []],
+      update,
+      view: model => ({ title: model.label, body: h.div([], [model.label]) }),
+      container,
+    })
+
+    const fiber = Effect.runFork(application.start())
+
+    try {
+      await awaitBodyText('hello')
+
+      expect(document.documentElement.lang).toBe(HOST_LANG)
+      expect(document.documentElement.hasAttribute('dir')).toBe(false)
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('applies lang without touching dir when the view sets only one', async () => {
+    const application = makeApplication({
+      Model,
+      init: () => [{ label: 'hello' }, []],
+      update,
+      view: model => ({
+        title: model.label,
+        lang: 'ja',
+        body: h.div([], [model.label]),
+      }),
+      container,
+    })
+
+    const fiber = Effect.runFork(application.start())
+
+    try {
+      await awaitBodyText('hello')
+
+      expect(document.documentElement.lang).toBe('ja')
+      expect(document.documentElement.hasAttribute('dir')).toBe(false)
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('tracks lang and dir across renders, and reasserts them on a later render that leaves both unchanged', async () => {
+    const application = makeApplication({
+      Model: LocaleModel,
+      init: () => [ENGLISH_LTR, []],
+      update: localeUpdate,
+      view: model => ({
+        title: 'Localized',
+        lang: model.lang,
+        dir: model.dir,
+        body: localeH.div(
+          [],
+          [
+            localeH.button([localeH.OnClick(ClickedArabic())], ['arabic']),
+            localeH.button([localeH.OnClick(ClickedRerender())], ['rerender']),
+            `${model.lang}-${model.revision}`,
+          ],
+        ),
+      }),
+      container,
+    })
+
+    const fiber = Effect.runFork(application.start())
+
+    try {
+      await awaitBodyText('en-0')
+      expect(document.documentElement.lang).toBe('en')
+      expect(document.documentElement.dir).toBe('ltr')
+
+      const buttons = document.body.querySelectorAll('button')
+      const arabicButton = buttons.item(0)
+      const rerenderButton = buttons.item(1)
+      if (arabicButton === null || rerenderButton === null) {
+        throw new Error('expected the arabic and rerender buttons')
+      }
+
+      arabicButton.click()
+      await awaitBodyText('ar-0')
+      expect(document.documentElement.lang).toBe('ar')
+      expect(document.documentElement.dir).toBe('rtl')
+
+      document.documentElement.lang = 'de'
+      document.documentElement.dir = 'ltr'
+
+      rerenderButton.click()
+      await awaitBodyText('ar-1')
+      expect(document.documentElement.lang).toBe('ar')
+      expect(document.documentElement.dir).toBe('rtl')
     } finally {
       await Effect.runPromise(Fiber.interrupt(fiber))
     }

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -40,6 +40,7 @@ import {
   type BoundaryRegistry,
   Document,
   Html,
+  TextDirection,
   __beginRender as beginHtmlRender,
   __beginReplayRender as beginReplayHtmlRender,
   __clearRuntime as clearHtmlRuntime,
@@ -2722,6 +2723,14 @@ const currentLocationUrl = (): string => {
   return `${origin}${pathname}${search}`
 }
 
+const textDirectionForHtmlElement: Readonly<
+  Record<TextDirection, 'ltr' | 'rtl' | 'auto'>
+> = {
+  Ltr: 'ltr',
+  Rtl: 'rtl',
+  Auto: 'auto',
+}
+
 type DocumentMetadataElements = {
   canonical?: HTMLLinkElement
   ogUrl?: HTMLMetaElement
@@ -2771,6 +2780,22 @@ const applyDocumentMetadata = (
 
   if (document.title !== nextDocument.title) {
     document.title = nextDocument.title
+  }
+
+  const { documentElement } = document
+
+  if (
+    nextDocument.lang !== undefined &&
+    documentElement.lang !== nextDocument.lang
+  ) {
+    documentElement.lang = nextDocument.lang
+  }
+
+  if (nextDocument.dir !== undefined) {
+    const dir = textDirectionForHtmlElement[nextDocument.dir]
+    if (documentElement.dir !== dir) {
+      documentElement.dir = dir
+    }
   }
 
   const canonical = nextDocument.canonical ?? currentLocationUrl()

--- a/packages/website/src/page/core/runtime.md
+++ b/packages/website/src/page/core/runtime.md
@@ -22,13 +22,13 @@ With a `routing` config, the program manages the URL bar. The init function rece
 
 The `routing` config has two handlers: `onUrlRequest` is called when a link is clicked (giving you a chance to handle internal vs external links), and `onUrlChange` is called when the URL changes (so you can update your Model with the new route). See the [Routing & Navigation](/core/routing-and-navigation) guide for a full walkthrough.
 
-Your `view` function returns a `Document`: an object with `title`, `body`, and optional `canonical` / `ogUrl` fields. The runtime sets `document.title` from your `title` on every render, and syncs the canonical and og\:url meta tags so platform share menus copy the right link as you navigate. Both meta fields default to the current URL when omitted.
+Your `view` function returns a `Document` rather than bare HTML: the body to render, plus the document-level state the runtime keeps in sync. `makeApplication` owns that state and reapplies it on every render, so the tab title, the `<html>` language and direction, and the canonical and og\:url tags all track your Model. The [View](/core/view#the-document) page lists every field and what to put in it.
 
 ## makeElement {#make-element}
 
-`makeApplication` assumes it owns the page. It writes `document.title` and manages the canonical and og\:url tags on every render. That is what you want for an app that owns its tab, but not for a widget embedded on a page you do not control, where it would clobber the host page metadata.
+`makeApplication` assumes it owns the page, reapplying on every render whatever document state the view declares. That is what you want for an app that owns its tab, but not for a widget embedded on a page you do not control, where it would clobber the host page metadata.
 
-Use `makeElement` to mount a Foldkit app scoped to its container. Its `view` returns `Html` directly rather than a `Document`, so there is no title to discard, and the runtime never touches the document `<head>`. Everything else (Model, `init`, `update`, Commands, Subscriptions, flags, crash handling) works exactly as it does with `makeApplication`. Embedded apps do not own the URL bar, so `makeElement` has no `routing` config.
+Use `makeElement` to mount a Foldkit app scoped to its container. Its `view` returns `Html` directly rather than a `Document`, so there is no title to discard, and the runtime never touches the document `<head>` or the `<html>` element. Everything else (Model, `init`, `update`, Commands, Subscriptions, flags, crash handling) works exactly as it does with `makeApplication`. Embedded apps do not own the URL bar, so `makeElement` has no `routing` config.
 
 ::Snippet{name="runMakeElement" label="makeElement example"}
 

--- a/packages/website/src/page/core/view.md
+++ b/packages/website/src/page/core/view.md
@@ -14,6 +14,43 @@ Given the same Model, view always produces the same HTML. It never modifies stat
 In React, functional components can hold local state and run effects via hooks, which come with ordering rules you have to follow. In Foldkit, view is guaranteed pure: no hooks, no effects, no local state. It’s a function from Model to Html.
 :::
 
+## The Document
+
+A `makeApplication` view returns a `Document` rather than bare HTML. A Document is everything the runtime needs to render one frame: the body to patch into the container, plus the document-level state that should track the Model.
+
+| Field       | Type                       | Required | What the runtime does with it                                                                  |
+| ----------- | -------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `title`     | `string`                   | Yes      | Writes it to `document.title`, so the browser tab tracks the current page.                     |
+| `body`      | `Html`                     | Yes      | Patches it into the application container.                                                     |
+| `lang`      | `string`                   | No       | Syncs it to `lang` on `<html>`. Omit it and the current value stands.                          |
+| `dir`       | `'Ltr' \| 'Rtl' \| 'Auto'` | No       | Syncs it to `dir` on `<html>`, lowercased. Omit it and the current value stands.               |
+| `canonical` | `string`                   | No       | Syncs it to `<link rel="canonical">`, creating the tag if absent. Defaults to the current URL. |
+| `ogUrl`     | `string`                   | No       | Syncs it to `<meta property="og:url">`, creating the tag if absent. Defaults to `canonical`.   |
+
+Every field is a function of the Model, exactly like `body`. There is no imperative `setTitle` and no separate head-management API: you return the values you want and the runtime makes the document match on each render.
+
+A `makeElement` view returns `Html` directly instead of a `Document`. An embedded app does not own the page, so it has no title or document metadata to declare, and the rest of this section does not apply to it. Everything on this page outside this section applies to both. See [Runtime](/core/runtime#make-element) for which of the two to reach for.
+
+### Language and direction
+
+`lang` and `dir` sync to the `<html>` element. Drive them from the Model when the app switches language at runtime, the same way `title` tracks the current page.
+
+::Snippet{name="documentLanguage" label="Localized document example"}
+
+`dir` takes `'Ltr'`, `'Rtl'`, or `'Auto'`, which the runtime writes as the lowercase `dir` attribute values. `Auto` hands the decision to the browser's first-strong-character heuristic. `foldkit/html` exports `TextDirection` as a Schema, so a Model that stores the direction rather than deriving it can drop the field straight into an `S.Struct`.
+
+Neither field has a default. When a view omits one, the runtime does not touch that attribute, leaving whatever value it currently holds, so a view that never sets it leaves the `lang` from your `index.html` in place. That is the right behavior for an app that ships in one language, and it means adding these fields never changes an existing app.
+
+The runtime can only sync after the first render, so the served HTML still decides what a crawler sees on first paint. When the language is known per request, stamp `<html lang>` in the HTML shell and let the runtime keep it in sync from there. The runtime sync is what a screen reader picks up when a user flips the language switcher, which is the part a static shell cannot do.
+
+To mark up a passage in a different language from the page, use the `Lang` attribute on that element instead. `Document.lang` is only the root.
+
+### Canonical and share URLs
+
+`canonical` and `ogUrl` keep `<link rel="canonical">` and `<meta property="og:url">` current as you navigate, so a platform share menu copies the link for the route the user is actually on rather than the one the page was first served as.
+
+Set neither and both fall back to the current URL, which is what a routed app usually wants. The two are chained rather than independent: `canonical` falls back to the current URL, and `ogUrl` falls back to the resolved `canonical`, so setting `canonical` alone moves both. Set them explicitly when the canonical URL differs from the address bar, such as a paginated list whose later pages should point back at the first.
+
 ## Typed HTML Helpers
 
 Foldkit’s HTML functions are typed to your Message type. This ensures event handlers only accept valid Messages from your application. Bind the factory once per module by calling `html<Message>()`, then reach for `h.div`, `h.OnClick`, and the rest off the returned record:

--- a/packages/website/src/snippet/documentLanguage.ts
+++ b/packages/website/src/snippet/documentLanguage.ts
@@ -1,0 +1,39 @@
+import { type Document, type TextDirection, html } from 'foldkit/html'
+
+// TRANSLATION
+
+const translate = (locale: Locale, key: string): string => {
+  // Your catalog lookup. Foldkit does not ship translation.
+  return catalog[locale][key]
+}
+
+// VIEW
+
+const languageTag: Readonly<Record<Locale, string>> = {
+  English: 'en',
+  Arabic: 'ar',
+  Japanese: 'ja',
+}
+
+const textDirection: Readonly<Record<Locale, TextDirection>> = {
+  English: 'Ltr',
+  Arabic: 'Rtl',
+  Japanese: 'Ltr',
+}
+
+const view = (model: Model): Document => {
+  const h = html<Message>()
+
+  return {
+    title: translate(model.locale, 'PageTitle'),
+    lang: languageTag[model.locale],
+    dir: textDirection[model.locale],
+    body: h.div(
+      [h.Class('mx-auto max-w-prose p-6')],
+      [
+        h.h1([], [translate(model.locale, 'PageTitle')]),
+        localePicker(model.locale),
+      ],
+    ),
+  }
+}

--- a/skills/generate-program/SKILL.md
+++ b/skills/generate-program/SKILL.md
@@ -592,8 +592,8 @@ For file uploads (resumes, images, attachments):
 
 ### Runtime Wiring
 
-- Use `Runtime.makeApplication` for apps that own the page. Add `routing: { onUrlRequest, onUrlChange }` for apps with URL routing. The `view` returns a `Document` (`{ title, canonical?, ogUrl?, body }`); the runtime applies `title` and the canonical / og:url tags after every render
-- Use `Runtime.makeElement` for a widget embedded on a page it does not own. The `view` returns `Html` and the runtime never touches the document `<head>`. No `routing` config
+- Use `Runtime.makeApplication` for apps that own the page. Add `routing: { onUrlRequest, onUrlChange }` for apps with URL routing. The `view` returns a `Document` (`{ title, lang?, dir?, canonical?, ogUrl?, body }`); the runtime applies `title`, the `lang` / `dir` attributes on `<html>`, and the canonical / og:url tags after every render
+- Use `Runtime.makeElement` for a widget embedded on a page it does not own. The `view` returns `Html` and the runtime never touches the document `<head>` or the `<html>` element. No `routing` config
 - See the With and Without URL Routing section in [architecture.md](architecture.md) for the full pattern
 - Include `ClickedLink` and `ChangedUrl` Messages for programs with routing, with proper `InternalUrl`/`ExternalUrl` handling in update
 - Always end with `Runtime.run(application)` for a page-owning app. When a host application controls the program's lifecycle, end with `Runtime.embed(element)` instead and hand the returned handle to the host; mirror `repos/foldkit/examples/embedding/src/host.ts` for the host side and its `main.ts` for the widget side

--- a/skills/generate-program/architecture.md
+++ b/skills/generate-program/architecture.md
@@ -428,9 +428,9 @@ Runtime.run(application)
 
 ### Scoped to a Node (Embedded Widgets)
 
-`makeApplication` assumes it owns the page: its `view` returns a `Document` (`{ title, canonical?, ogUrl?, body }`) and the runtime writes `document.title` and manages the canonical / og:url tags on every render. For a widget embedded on a page you do not control, that clobbers the host page's metadata.
+`makeApplication` assumes it owns the page: its `view` returns a `Document` (`{ title, lang?, dir?, canonical?, ogUrl?, body }`) and the runtime writes `document.title`, the `lang` / `dir` attributes on `<html>`, and the canonical / og:url tags on every render. For a widget embedded on a page you do not control, that clobbers the host page's metadata.
 
-Use `Runtime.makeElement` instead. Its `view` returns `Html` directly (no title to discard) and the runtime never touches the document `<head>`. Everything else (Model, init, update, Commands, Subscriptions, flags, crash handling) is identical. Embedded apps don't own the URL bar, so `makeElement` has no `routing` config.
+Use `Runtime.makeElement` instead. Its `view` returns `Html` directly (no title to discard) and the runtime never touches the document `<head>` or the `<html>` element. Everything else (Model, init, update, Commands, Subscriptions, flags, crash handling) is identical. Embedded apps don't own the URL bar, so `makeElement` has no `routing` config.
 
 ```ts
 const element = Runtime.makeElement({
@@ -446,9 +446,11 @@ Runtime.run(element)
 
 When the host application needs to control the embedded app (mount and unmount it, push data in, receive values out), start it with `Runtime.embed(program)` instead of `Runtime.run`. `embed` returns a handle with `dispose` plus one entry per Port declared on the config: the host sends on inbound Ports, subscribes to outbound Ports, and disposes on unmount, never touching the Model. Inbound Ports are consumed by the app as Subscription sources and outbound Ports are written from Commands, so the app itself stays inside the standard architecture. `repos/foldkit/examples/embedding/` shows the full pattern: the widget in `src/main.ts`, the host in `src/host.ts`.
 
-### Document Title
+### Document Metadata
 
-With `makeApplication`, the `view` returns a `Document`. The runtime sets `document.title` from its `title` field after every render and syncs the canonical / og:url tags (both default to the current URL when omitted). With `makeElement`, there is no title or head management at all.
+With `makeApplication`, the `view` returns a `Document`. The runtime sets `document.title` from its `title` field after every render and syncs the canonical / og:url tags (`canonical` defaults to the current URL, and `ogUrl` defaults to `canonical`, so setting `canonical` alone moves both). With `makeElement`, there is no title or metadata management at all.
+
+`lang` and `dir` sync to the `<html>` element, so an app that switches language at runtime drives them from the Model. `dir` is `TextDirection` from `foldkit/html`, a Schema over `'Ltr' | 'Rtl' | 'Auto'` that you can drop straight into a Model `S.Struct`, and the runtime writes it as the lowercase attribute value. Both fields are optional and have no default: when a view omits one, the runtime does not touch that attribute, leaving whatever value it currently holds, so a view that never sets it leaves the served HTML in place.
 
 `onUrlRequest` fires when the user clicks a link. The Message receives a `UrlRequest` (a tagged union from the `Navigation` namespace) which you handle in update by matching on its `_tag`. `onUrlChange` fires when the browser URL changes (back/forward buttons); the handler updates the route from the new URL.
 


### PR DESCRIPTION
Add `lang` and `dir` fields to the `Document` type so applications can drive the `<html>` element's language and text direction from their Model, enabling runtime language switching without imperative DOM manipulation.

## Summary

The `<html>` element was the one piece of document state that views could not reach, since it sits outside the application container. This change exposes `lang` and `dir` as optional fields on `Document`, allowing views to declare the desired language and direction just as they declare `title`, `canonical`, and `ogUrl`.

## Key Changes

- **Document type**: Added optional `lang: string` and `dir: TextDirection` fields to `Document` in `packages/foldkit/src/html/index.ts`
- **TextDirection type**: New exported type `'Ltr' | 'Rtl' | 'Auto'` for the `dir` field, with `Auto` deferring to the browser's first-strong-character heuristic
- **Runtime sync**: Updated `applyDocumentMetadata` in `packages/foldkit/src/runtime/runtime.ts` to sync `lang` and `dir` to the `<html>` element on each render, with a mapping table to convert `TextDirection` values to lowercase attribute strings
- **makeElement isolation**: `makeElement` continues to leave the `<html>` element alone, matching its existing behavior of not touching the `<head>`
- **Documentation**: Updated runtime and view guides to explain the new fields, their defaults (none—omit them and the served value stands), and the timing guarantee (runtime can only sync after first render, so the served HTML decides what crawlers see on first paint)
- **Example**: Added `documentLanguage.ts` snippet showing a localized app that drives `lang` and `dir` from a locale Model
- **Tests**: Comprehensive test coverage for applying, omitting, and tracking `lang` and `dir` across renders, including reassertion when external code modifies the attributes

## Implementation Details

Both fields are optional with no defaults. When omitted, the runtime leaves those attributes alone, so existing apps are unaffected and the served HTML's values stand. The runtime can only sync after the first render, so the static shell still controls what crawlers see on first paint—when language is known per request, stamp `<html lang>` in the HTML and let the runtime keep it in sync from there.

The `dir` field uses the semantic `TextDirection` union rather than raw strings, ensuring type safety and making the valid values explicit at the call site.

https://claude.ai/code/session_01Azv1JwSUWYNjmyC3cYfnSP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Applications can now provide optional `lang` and `dir` on the `Document` to synchronize the root `<html>` element after render.
  * `dir` supports `Ltr`, `Rtl`, and `Auto` (written as lowercase HTML `dir` attribute values).
* **Bug Fixes / Reliability**
  * If `lang`/`dir` are omitted, existing `<html>` attributes are left unchanged and remain correct across re-renders, even after external DOM mutations.
* **Documentation**
  * Updated runtime and `Document`/`makeElement`/`makeApplication` guidance around document metadata ownership and `<html>` language/direction handling.
* **Tests**
  * Expanded coverage for locale syncing, omission behavior, and locale/state invariants for both initial render and subsequent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->