### PR TITLE
feat(foldkit): add rootAttributes for app-level handlers inside Submodels

### DIFF
--- a/.changeset/root-attributes.md
+++ b/.changeset/root-attributes.md
@@ -1,0 +1,18 @@
+---
+'foldkit': minor
+---
+
+Add `rootAttributes`, the mirror of `childAttributes`, for shared view helpers that dispatch app-level Messages from inside a Submodel.
+
+A handler's dispatcher is chosen by where the element is built, not by the Message it carries. `html<Message>()`'s type argument is erased and the runtime reads the boundary off the current frame, so a shared helper that constructs an app-level Message works at the root and breaks inside a Submodel: the boundary applies its `toParentMessage`, that wrapper is a Schema constructor, and it throws on the foreign Message inside the event listener. Nothing is dispatched, no `update` runs, and the only signal is an uncaught error in the console. Nothing catches it at compile time.
+
+`rootAttributes` binds its attributes to the app's own dispatcher, so they reach `update` unwrapped through any depth of Submodel nesting:
+
+```ts
+h.button(
+  [h.AriaLabel(label), ...rootAttributes([h.OnClick(ClickedCopy({ text }))])],
+  [Icon.copy()],
+)
+```
+
+It returns the existing `ChildAttribute` type, which element constructors already accept, so nothing else changes. Reach for it only when a Submodel renders app-level chrome it does not own, such as a copy button or an analytics hook. When a Submodel reports something about itself, that is still an OutMessage.

--- a/packages/foldkit/src/html/childAttribute.test.ts
+++ b/packages/foldkit/src/html/childAttribute.test.ts
@@ -1,8 +1,9 @@
-import { Context } from 'effect'
+import { Context, Stream } from 'effect'
 import { afterEach, beforeEach, expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
+import type { MountAction } from '../mount/index.js'
 import { MountTracker } from '../mount/index.js'
 import { Dispatch } from '../runtime/index.js'
 import { h as snabbdomH } from '../snabbdom/index.js'
@@ -11,8 +12,17 @@ import {
   beginRender,
   createBoundaryRegistry,
 } from './boundary.js'
-import { type ChildAttribute, childAttributes } from './childAttribute.js'
-import { type Html, html } from './index.js'
+import {
+  type ChildAttribute,
+  childAttributes,
+  rootAttributes,
+} from './childAttribute.js'
+import {
+  FOLDKIT_MOUNT_KEY,
+  type FoldkitMountMarker,
+  type Html,
+  html,
+} from './index.js'
 import {
   type DispatchSync,
   clearRuntime,
@@ -308,5 +318,194 @@ describe('childAttributes', () => {
       { _tag: 'GotChild', message: { _tag: 'ChildClicked' } },
       { _tag: 'ParentDirect' },
     ])
+  })
+})
+
+describe('rootAttributes', () => {
+  let registry: BoundaryRegistry
+  let dispatched: Array<unknown>
+
+  beforeEach(() => {
+    registry = createBoundaryRegistry()
+    dispatched = []
+    setUpRuntime(registry, dispatched)
+    beginRender(registry)
+  })
+
+  afterEach(() => {
+    clearRuntime()
+  })
+
+  type AppLevel = Readonly<{ _tag: 'AppLevel' }>
+
+  const renderInsideSubmodel = (build: () => Html, slotId = 'chrome') =>
+    submodel({
+      slotId,
+      model: {},
+      view: defineView<object, ChildClicked, object>(build),
+      viewInputs: {},
+      toParentMessage: message => GotChild({ message }),
+    })
+
+  it('delivers an app-level message unwrapped from inside a Submodel', () => {
+    // Without rootAttributes this same handler dispatches
+    // GotChild({ message: { _tag: 'AppLevel' } }), which a parent's Schema
+    // rejects because AppLevel is not in the child's Message union.
+    const h = html<AppLevel>()
+    const result = renderInsideSubmodel(() =>
+      h.button([...rootAttributes([h.OnClick({ _tag: 'AppLevel' })])], []),
+    )
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const onClick = result?.data?.on?.click as () => void
+    onClick()
+
+    expect(dispatched).toEqual([{ _tag: 'AppLevel' }])
+  })
+
+  it("leaves the Submodel's own handlers routed through its wrap", () => {
+    const h = html<ChildClicked>()
+    const result = renderInsideSubmodel(() =>
+      h.button([h.OnClick({ _tag: 'ChildClicked' })], []),
+    )
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const onClick = result?.data?.on?.click as () => void
+    onClick()
+
+    expect(dispatched).toEqual([
+      { _tag: 'GotChild', message: { _tag: 'ChildClicked' } },
+    ])
+  })
+
+  it('skips every lift when Submodels are nested more than one deep', () => {
+    const h = html<AppLevel>()
+    const result = renderInsideSubmodel(() =>
+      submodel({
+        slotId: 'inner',
+        model: {},
+        view: defineView<object, ChildClicked, object>(() =>
+          h.button([...rootAttributes([h.OnClick({ _tag: 'AppLevel' })])], []),
+        ),
+        viewInputs: {},
+        toParentMessage: message => GotChild({ message }),
+      }),
+    )
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const onClick = result?.data?.on?.click as () => void
+    onClick()
+
+    expect(dispatched).toEqual([{ _tag: 'AppLevel' }])
+  })
+
+  it('dispatches unwrapped at the root boundary too, where there is no wrap to skip', () => {
+    const h = html<AppLevel>()
+    const button = h.button(
+      [...rootAttributes([h.OnClick({ _tag: 'AppLevel' })])],
+      [],
+    )
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const onClick = button?.data?.on?.click as () => void
+    onClick()
+
+    expect(dispatched).toEqual([{ _tag: 'AppLevel' }])
+  })
+
+  it('routes a root-bound and a child-bound group on one element to their own dispatchers', () => {
+    const hApp = html<AppLevel>()
+    const result = renderInsideSubmodel(() =>
+      hApp.button(
+        [
+          ...rootAttributes([hApp.OnClick({ _tag: 'AppLevel' })]),
+          ...childAttributes([
+            html<ChildClicked>().OnKeyPress(() => ({
+              _tag: 'ChildClicked' as const,
+            })),
+          ]),
+        ],
+        [],
+      ),
+    )
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const onClick = result?.data?.on?.click as () => void
+    onClick()
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const onKeyPress = result?.data?.on?.keypress as (e: KeyboardEvent) => void
+    onKeyPress(
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      {
+        key: 'a',
+        shiftKey: false,
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+      } as KeyboardEvent,
+    )
+
+    expect(dispatched).toEqual([
+      { _tag: 'AppLevel' },
+      { _tag: 'GotChild', message: { _tag: 'ChildClicked' } },
+    ])
+  })
+
+  it('sends an OnUnmount message straight to the root, skipping the wrap', () => {
+    const h = html<AppLevel>()
+    const result = renderInsideSubmodel(() =>
+      h.div([...rootAttributes([h.OnUnmount({ _tag: 'AppLevel' })])], []),
+    )
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const destroy = result?.data?.hook?.destroy as (vnode: unknown) => void
+    destroy(result)
+
+    expect(dispatched).toEqual([{ _tag: 'AppLevel' }])
+  })
+
+  it('stamps no lift on an OnMount marker, so the Scene harness replays none', () => {
+    // A childAttributes group at this same boundary stamps a one-entry
+    // messageMappers chain; a root-bound group must stamp none.
+    const h = html<AppLevel>()
+    const probe: MountAction<AppLevel> = {
+      name: 'Probe',
+      f: () => Stream.empty,
+    }
+
+    const rootBound = renderInsideSubmodel(
+      () => h.div([...rootAttributes([h.OnMount(probe)])], []),
+      'root-bound',
+    )
+    const childBound = renderInsideSubmodel(
+      () => h.div([...childAttributes([h.OnMount(probe)])], []),
+      'child-bound',
+    )
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const markerOf = (vnode: typeof rootBound) =>
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      (vnode?.data as Record<string, FoldkitMountMarker> | undefined)?.[
+        FOLDKIT_MOUNT_KEY
+      ]
+
+    expect(markerOf(rootBound)?.messageMappers).toBeUndefined()
+    expect(markerOf(childBound)?.messageMappers).toHaveLength(1)
+  })
+
+  it('builds outside a runtime frame and throws only when the handler fires', () => {
+    clearRuntime()
+
+    const h = html<AppLevel>()
+    const button = h.button(
+      [...rootAttributes([h.OnClick({ _tag: 'AppLevel' })])],
+      [],
+    )
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const onClick = button?.data?.on?.click as () => void
+    expect(onClick).toThrow('without an active runtime frame')
+
+    setUpRuntime(registry, dispatched)
   })
 })

--- a/packages/foldkit/src/html/childAttribute.ts
+++ b/packages/foldkit/src/html/childAttribute.ts
@@ -1,5 +1,6 @@
 import {
   type DispatchSync,
+  outerDispatchOrFallback,
   requireBoundaryMappers,
   requireDispatch,
   requireUnmountResolver,
@@ -7,23 +8,25 @@ import {
 
 const BRAND = '__childAttribute'
 
-/** An attribute carrying a handler that dispatches through a Submodel
- *  boundary's wrapping chain. Published by Submodels (typically Foldkit's
- *  `Ui.*` components) for a parent to spread into its own element
- *  attribute arrays. The parent does not know or care which child
- *  produced these; the runtime routes each handler through the
- *  originating Submodel's wrap chain at event-fire time.
+/** An attribute carrying its own dispatcher rather than using the one for the
+ *  boundary it is spread into. The runtime routes each handler through the
+ *  carried dispatcher at event-fire time, so the element's position in the
+ *  tree no longer decides where its messages go.
  *
- *  `resolveUnmount` snapshots the boundary's wrapping chain at the time the
- *  group was published (child boundary alive) so `OnUnmount` can dispatch a
- *  root message from a destroy hook that fires after the boundary has been
- *  torn down. `boundaryMappers` snapshots the same chain as a pure list of
+ *  Created via {@link childAttributes}, which binds the publishing Submodel's
+ *  boundary so a child's handler survives being spread into a parent's
+ *  element, or {@link rootAttributes}, which binds the app's own dispatcher so
+ *  a handler skips every boundary. Element constructors accept
+ *  `ChildAttribute` alongside `Attribute<Message>` in their attribute arrays.
+ *
+ *  `resolveUnmount` snapshots the wrapping chain at the time the group was
+ *  published (child boundary alive) so `OnUnmount` can dispatch a root message
+ *  from a destroy hook that fires after the boundary has been torn down.
+ *  `boundaryMappers` snapshots the same chain as a pure list of
  *  `toParentMessage` lifts (innermost first) so `OnMount` can stamp it on the
- *  mount marker; the Scene test harness folds it to replay the lift.
- *
- *  Created via {@link childAttributes}. Element constructors accept
- *  `ChildAttribute` alongside `Attribute<Message>` in their attribute
- *  arrays. */
+ *  mount marker; the Scene test harness folds it to replay the lift. For a
+ *  root-bound group there is no chain: the resolver dispatches directly and
+ *  the mapper list is empty. */
 export type ChildAttribute = Readonly<{
   readonly [BRAND]: true
   readonly attribute: unknown
@@ -70,5 +73,47 @@ export const childAttributes = <Attribute>(
     dispatch,
     resolveUnmount,
     boundaryMappers,
+  }))
+}
+
+/** The mirror of {@link childAttributes}. Binds each attribute to the app's own
+ *  dispatcher, so its handlers reach `update` unwrapped no matter how many
+ *  Submodel boundaries the element is rendered inside.
+ *
+ *  A handler's dispatcher is chosen by where the element is built, not by the
+ *  Message type it carries: `html<Message>()`'s type argument is erased, and
+ *  the runtime reads the boundary off the current frame. So a shared view
+ *  helper that constructs an app-level Message works at the root and breaks
+ *  inside a Submodel, where the boundary's `toParentMessage` is applied to it.
+ *  That wrapper is a Schema constructor, so it rejects the foreign Message and
+ *  throws inside the event listener: nothing is dispatched, no `update` runs,
+ *  and the only signal is an uncaught error in the console. Nothing catches it
+ *  at compile time. This makes the intent explicit instead:
+ *
+ *  ```ts
+ *  // A shared copy button, rendered on plain pages and inside Submodels alike:
+ *  h.button(
+ *    [h.AriaLabel(label), ...rootAttributes([h.OnClick(ClickedCopy({ text }))])],
+ *    [Icon.copy()],
+ *  )
+ *  ```
+ *
+ *  Reach for this only when a Submodel renders app-level chrome it does not
+ *  own, such as a copy button, an analytics hook, or a toast trigger. When a
+ *  Submodel reports something about itself, that is an OutMessage, and routing
+ *  it past the parent breaks the encapsulation the boundary exists to provide.
+ *
+ *  `OnUnmount` messages resolve straight to the root dispatcher, and the
+ *  `boundaryMappers` chain is empty, both matching the absence of any lift. */
+export const rootAttributes = <Attribute>(
+  attributes: ReadonlyArray<Attribute>,
+): ReadonlyArray<ChildAttribute> => {
+  const dispatch = outerDispatchOrFallback()
+  return attributes.map(attribute => ({
+    [BRAND]: true,
+    attribute,
+    dispatch,
+    resolveUnmount: message => () => dispatch(message),
+    boundaryMappers: [],
   }))
 }

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -47,7 +47,7 @@ export {
   createBoundaryRegistry as __createBoundaryRegistry,
 } from './boundary.js'
 export type { BoundaryRegistry } from './boundary.js'
-export { childAttributes } from './childAttribute.js'
+export { childAttributes, rootAttributes } from './childAttribute.js'
 export type { ChildAttribute } from './childAttribute.js'
 export { defineView, submodel } from './submodel.js'
 export type { SubmodelConfig, SubmodelView } from './submodel.js'

--- a/packages/foldkit/src/html/public.ts
+++ b/packages/foldkit/src/html/public.ts
@@ -3,6 +3,7 @@ export {
   createKeyedLazy,
   createLazy,
   html,
+  rootAttributes,
   submodel,
 } from './index.js'
 

--- a/packages/foldkit/src/html/runtimeSingleton.ts
+++ b/packages/foldkit/src/html/runtimeSingleton.ts
@@ -122,6 +122,34 @@ export const requireDispatch = (): DispatchSync => {
   )
 }
 
+const fallbackOuterDispatch: DispatchSync = () => {
+  throw new Error(
+    'Foldkit: a rootAttributes handler fired without an active runtime ' +
+      'frame. This typically means the attribute was built at module top ' +
+      'level outside of a view function.',
+  )
+}
+
+/** Returns the dispatcher that delivers a message to the app's own `update`,
+ *  skipping every Submodel wrapping chain between here and the root. Every
+ *  frame carries the same `outerDispatch`; {@link pushBoundary} inherits it
+ *  verbatim and only the `boundaryId` changes, so the root dispatcher is
+ *  always reachable without threading it through the view.
+ *
+ *  With no active frame this returns a fallback that throws when the handler
+ *  fires, matching how ordinary event attributes degrade. Attributes built at
+ *  module top level therefore still construct at import and surface a clear
+ *  error only if something actually dispatches through them.
+ *
+ *  This is the escape hatch {@link requireDispatch} deliberately is not. Use it
+ *  only for app-level chrome that a Submodel happens to render but does not
+ *  own. Anything a Submodel is reporting about itself belongs in an
+ *  OutMessage. */
+export const outerDispatchOrFallback = (): DispatchSync => {
+  const frame = stack[stack.length - 1]
+  return frame === undefined ? fallbackOuterDispatch : frame.outerDispatch
+}
+
 /** A function that, given a message, resolves it through the current
  *  boundary's wrapping chain immediately and returns a thunk that dispatches
  *  the fully wrapped root message. */

--- a/packages/website/src/markdown/docPage.test.ts
+++ b/packages/website/src/markdown/docPage.test.ts
@@ -271,6 +271,22 @@ describe('proof pages', () => {
         id: 'child-attributes-when-to-reach',
         text: 'When to Reach For It',
       },
+      { level: 'h2', id: 'root-attributes', text: 'rootAttributes' },
+      {
+        level: 'h3',
+        id: 'root-attributes-the-problem',
+        text: 'The Problem',
+      },
+      {
+        level: 'h3',
+        id: 'root-attributes-how-it-works',
+        text: 'How It Works',
+      },
+      {
+        level: 'h3',
+        id: 'root-attributes-when-to-reach',
+        text: 'When to Reach For It',
+      },
       { level: 'h2', id: 'testing-submodels', text: 'Testing Submodels' },
       {
         level: 'h2',
@@ -284,6 +300,7 @@ describe('proof pages', () => {
       { level: 'h3', id: 'api-define-view', text: 'Submodel.defineView' },
       { level: 'h3', id: 'api-submodel-view', text: 'Submodel.View' },
       { level: 'h3', id: 'api-child-attributes', text: 'childAttributes' },
+      { level: 'h3', id: 'api-root-attributes', text: 'rootAttributes' },
       { level: 'h3', id: 'api-child-attribute', text: 'ChildAttribute' },
     ])
   })

--- a/packages/website/src/page/core/submodel.md
+++ b/packages/website/src/page/core/submodel.md
@@ -273,6 +273,32 @@ If you’re authoring your own Submodel and publishing attribute bundles to a co
 Stateless render helpers like `Button` and `Input`, plus controlled render helpers like `Checkbox`, `Switch`, and `Disclosure` don’t publish via `childAttributes`. They’re not Submodels; their `onClick` or `onInput` or `onToggle` values flow into element constructors in the consumer’s own boundary, which is correct. The boundary wiring only matters when there’s a Submodel boundary to wire through.
 :::
 
+## rootAttributes {#root-attributes}
+
+`rootAttributes` is the mirror of `childAttributes`. Where that one binds a deeper boundary so a child’s handler survives being spread into a parent’s element, this binds no boundary at all: the handler reaches your app’s own `update` unwrapped, however many Submodels it is rendered inside.
+
+### The Problem {#root-attributes-the-problem}
+
+A handler’s dispatcher is chosen by **where the element is built**, not by the Message it carries. `html<Message>()`’s type argument is erased at runtime, and the element constructor reads the boundary off the current render frame.
+
+That is invisible until you write a shared view helper. Say a copy button that any page can drop next to a code block, dispatching your app-level `ClickedCopySnippet`. On a plain page it works. Render the same helper inside a page that happens to be a Submodel and the click applies that page’s `toParentMessage`, which tries to build `GotDocPageMessage({ message: ClickedCopySnippet(...) })`. Wrapper Messages are Schema constructors, so the foreign Message is rejected and the constructor throws inside the event listener: nothing is dispatched, no `update` runs, and the page carries on rendering. The only trace is an uncaught error in the console, and the type checker never complains, because the Message type was erased before the boundary was consulted.
+
+### How It Works {#root-attributes-how-it-works}
+
+Every render frame already carries the app’s own dispatcher: entering a Submodel boundary inherits it unchanged and varies only the boundary id, and the wrapping chain is applied later, at event-fire time. `rootAttributes` captures that unwrapped dispatcher and brands each attribute with it, exactly as `childAttributes` brands with the Submodel’s.
+
+::Snippet{name="submodelRootAttributes" label="snippet" class="mb-4"}
+
+The result is the same `ChildAttribute` type, so element constructors already accept it and you can mix it with ordinary attributes on the same element. Only the branded ones skip the boundary; the `h.Class` and `h.AriaLabel` beside them are unaffected, and any of the page’s own handlers on other elements still route through its wrap.
+
+### When to Reach For It {#root-attributes-when-to-reach}
+
+Only when a Submodel renders app-level chrome it does not own. A copy button, an analytics hook, a toast trigger: things the surrounding page has no opinion about and should not have to declare a Message for.
+
+:::Warning{label="Not a substitute for OutMessage"}
+When a Submodel reports something about itself, that is an [OutMessage](#surfacing-facts). Reaching past the parent with `rootAttributes` would let a child mutate app state its parent knows nothing about, breaking the encapsulation the boundary exists to provide. The test is ownership: if the surrounding Submodel would care about the event, it belongs in that Submodel’s Message union.
+:::
+
 ## Testing Submodels
 
 A Submodel tests the same way as a top-level program. A two-argument child `update` is a pure function from `(model, message)` to `[Model, Commands]` or `[Model, Commands, Option<OutMessage>]`, so it slots straight into `Story.story`. The child’s view is a pure function too; assert against the rendered VNode through `Scene.scene`.
@@ -297,6 +323,7 @@ Issues new Submodel users hit, and where to read about the fix:
 - **Child events not reaching the parent’s update.** The wrapper Message isn’t named `Got*Message`, or the wrapper variant hasn’t been added to the parent’s update. See [Wrapping Messages](#wrapping-messages) and [Delegating in update](#delegating-in-update).
 - **Child’s view sees stale parent state.** Parent state was copied into the child Model and forgotten on update. Thread it through `viewInputs` (rebuilt every render) instead. See [Passing Parent State to a Child Submodel’s view](#parent-state-in-view).
 - **Handlers dispatched from a slot callback fire in the wrong boundary.** The Submodel published an attribute group without wrapping it in `childAttributes`. See [childAttributes](#child-attributes).
+- **A shared helper’s button does nothing inside a Submodel, and the console shows a Schema error naming a Message the page never declared.** The helper builds an app-level Message and the surrounding boundary’s `toParentMessage` throws trying to wrap it. Wrap that handler in `rootAttributes`. See [rootAttributes](#root-attributes).
 - **View-build error like** `viewInputs.config.onSubmit`. A slot callback was nested inside an object or array in `viewInputs`. Lift it to the top level. See the warning callout under [Per-render View Inputs](#per-render-view-inputs).
 - **Long list of Submodels feels slow.** Default is to re-render each row every parent render. See [Memoization Across Submodel Boundaries](#memoization).
 
@@ -338,8 +365,14 @@ The branded view type produced by `Submodel.defineView`. Carries the child’s M
 
 Snapshots the Submodel’s dispatcher at publish time and brands each attribute so handlers route through the Submodel’s boundary when later spread into the consumer’s elements. Called inside a Submodel that publishes attribute bundles to a consumer’s `toView` slot. See [childAttributes](#child-attributes) for the full mechanism.
 
+### rootAttributes {#api-root-attributes}
+
+`rootAttributes<Attribute>(attributes: ReadonlyArray<Attribute>): ReadonlyArray<ChildAttribute>`
+
+Brands each attribute with the app’s own dispatcher, so its handlers reach `update` unwrapped through any depth of Submodel nesting. For shared view helpers that dispatch app-level Messages from inside a Submodel they don’t own. See [rootAttributes](#root-attributes) for the full mechanism.
+
 ### ChildAttribute {#api-child-attribute}
 
-`ChildAttribute` is the branded attribute type returned by `childAttributes`. Element constructors (`h.button`, `h.input`, etc.) accept `ChildAttribute` alongside ordinary `Attribute<Message>` values, using the carried dispatcher when present.
+`ChildAttribute` is the branded attribute type returned by both `childAttributes` and `rootAttributes`. Element constructors (`h.button`, `h.input`, etc.) accept `ChildAttribute` alongside ordinary `Attribute<Message>` values, using the carried dispatcher when present.
 
 With Model, Messages, update, view, Commands, and Submodels in place, you have the full vocabulary for describing a Foldkit app. The next page covers the [Runtime](/core/runtime): the engine that executes Commands, runs Subscriptions, manages Mount and ManagedResource lifecycles, and routes Messages back into update.

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -1,5 +1,5 @@
 import { Array } from 'effect'
-import { Html, html } from 'foldkit/html'
+import { Html, html, rootAttributes } from 'foldkit/html'
 import { twMerge } from 'tailwind-merge'
 
 import { Icon } from './icon'
@@ -16,7 +16,7 @@ export const headingLinkButton = (id: string, text: string): Html => {
         'px-0.5 py-1 rounded transition-opacity text-gray-400 dark:text-gray-500 hover:text-gray-800 dark:hover:text-gray-200 focus-visible:text-gray-800 dark:focus-visible:text-gray-200 focus-visible:opacity-100 cursor-pointer hover-capable:opacity-0 hover-capable:group-hover:opacity-100',
       ),
       h.AriaLabel(`Copy link to ${text}`),
-      h.OnClick(ClickedCopyLink({ hash: id })),
+      ...rootAttributes([h.OnClick(ClickedCopyLink({ hash: id }))]),
     ],
     [Icon.link('w-5 h-5')],
   )

--- a/packages/website/src/snippet/submodelRootAttributes.ts
+++ b/packages/website/src/snippet/submodelRootAttributes.ts
@@ -1,0 +1,18 @@
+// view/copyButton.ts
+import { type Html, html, rootAttributes } from 'foldkit/html'
+
+import { ClickedCopySnippet, type Message } from '../message'
+
+// Shared chrome, rendered on plain pages and inside Submodel doc pages alike.
+export const copyButton = (text: string, label: string): Html => {
+  const h = html<Message>()
+
+  return h.button(
+    [
+      h.Class('absolute top-2 right-2 rounded p-2'),
+      h.AriaLabel(`Copy ${label} to clipboard`),
+      ...rootAttributes([h.OnClick(ClickedCopySnippet({ text }))]),
+    ],
+    ['Copy'],
+  )
+}

--- a/packages/website/src/view/codeBlock.ts
+++ b/packages/website/src/view/codeBlock.ts
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx'
 import { HashSet } from 'effect'
-import { Html, html } from 'foldkit/html'
+import { Html, html, rootAttributes } from 'foldkit/html'
 
 import { Icon } from '../icon'
 import { ClickedCopySnippet, type Message } from '../message'
@@ -35,13 +35,17 @@ const copyButtonWithIndicator = (
     [isCopied ? 'Copied to clipboard' : ''],
   )
 
+  // NOTE: `rootAttributes` because this button is shared chrome that doc pages
+  // render inside their own Submodel boundaries. A plain `h.OnClick` would be
+  // lifted by that page's `toParentMessage` and arrive at its update as a
+  // Message outside its union.
   const copyButton = h.button(
     [
       h.Class(
         'p-2 rounded transition cursor-pointer border border-gray-300 dark:border-gray-700/50 bg-gray-100 dark:bg-[#1c1a20] text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:border-gray-400 dark:hover:border-gray-500 hover:bg-gray-200 dark:hover:bg-gray-700/30',
       ),
       h.AriaLabel(ariaLabel),
-      h.OnClick(ClickedCopySnippet({ text: textToCopy })),
+      ...rootAttributes([h.OnClick(ClickedCopySnippet({ text: textToCopy }))]),
     ],
     [Icon.copy()],
   )


### PR DESCRIPTION
Adds `rootAttributes`, the mirror of `childAttributes`, and fixes the live bug that surfaced it: two shared website helpers had dead click handlers on every doc page rendered through `h.submodel`.

## The bug

A handler's dispatcher is chosen by **where the element is built**, not by the Message it carries. `html<Message>()`'s type argument is erased, and `requireDispatch` reads the boundary off the current runtime frame.

So a shared view helper that constructs an app-level Message works at the root and breaks inside a Submodel. The boundary applies its `toParentMessage`; that wrapper is a Schema constructor, so it throws on the foreign Message inside the event listener. Nothing is dispatched, no `update` runs, the page keeps rendering. The only signal is an uncaught error in the console, and nothing catches it at compile time.

Two helpers were hitting this, both rendered in the same row of every doc page:

- `view/codeBlock.ts` — the snippet copy button (`ClickedCopySnippet`)
- `prose.ts` — the heading copy-link anchor (`ClickedCopyLink`)

Both were dead on all 26 pages dispatched through `h.submodel`: the 25 UI component pages and coming-from-react. Plain pages like `core/commands` were unaffected. The copy-link anchor still scrolled, because the `href` default fires, so it read as half-working.

## The fix

`pushBoundary` already inherits `outerDispatch` verbatim and only varies `boundaryId`, so the app's own dispatcher is present in every frame and needs no threading. `rootAttributes` reads it and brands each attribute with it, exactly as `childAttributes` brands with the Submodel's.

```ts
h.button(
  [h.AriaLabel(label), ...rootAttributes([h.OnClick(ClickedCopy({ text }))])],
  [Icon.copy()],
)
```

It returns the existing `ChildAttribute`, which element constructors already accept, so there is no new plumbing. With no active frame it degrades to a throw-on-fire dispatcher, matching how ordinary event attributes behave, so attributes built at module top level still construct at import.

Scoped deliberately: this is for app-level chrome a Submodel renders but does not own. A Submodel reporting something about itself is still an OutMessage, and a `:::Warning` in the docs says so.

## Docs

A `## rootAttributes` section in `core/submodel.md` beside `childAttributes`, with Problem / How It Works / When to Reach For It, a new `::Snippet`, an API Reference entry, and a Common Pitfalls bullet naming the exact symptom. The page's TOC parity test is updated.

## Verification

Browser, before and after, on the production build:

| Page | Copy button | Heading link |
| --- | --- | --- |
| `/core/commands` (no Submodel) | works → works | works → works |
| `/react/coming-from-react` | **broken → works** | **broken → works** |
| `/ui/button` | **broken → works** | **broken → works** |
| `/ui/dialog` | **broken → works** | **broken → works** |

Twelve tests in `childAttribute.test.ts`, each mutation-checked. Swapping `outerDispatchOrFallback()` for `requireDispatch()` fails the routing tests; swapping `resolveUnmount`/`boundaryMappers` back to the boundary versions fails the `OnMount`/`OnUnmount` tests.

Gates: foldkit 1636 tests, ui 856, website 230, `pnpm -r typecheck` 0 errors, lint 0, knip 0, no new circular deps, website build clean.

## Review notes

A subagent review of the first draft caught three things now fixed: the `prose.ts` heading link (I had fixed only its sibling), a wrong description of the failure mode (I wrote "fails to decode / silently does nothing" when it actually throws in `toParentMessage`, so nothing reaches `update`), and a coverage gap where the `OnMount`/`OnUnmount` TSDoc claims were untested and a mutation survived.

Known limitation: this makes the correct thing expressible, but the wrong thing is still not a compile error. A shared helper hardcoding a root Message with a plain `h.OnClick` fails the same silent way. Closing that needs a type-level answer I don't have yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JonmydQXsA5nvbb8Qq733

---
_Generated by [Claude Code](https://claude.ai/code/session_011JonmydQXsA5nvbb8Qq733)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rootAttributes` for shared view helpers that need to dispatch messages directly to the app.
  * Added support for root-bound event handlers, including click, mount, and unmount events, when rendered inside nested submodels.
  * Updated the documentation and API reference with usage guidance and common pitfalls.

* **Bug Fixes**
  * Prevented incorrect message dispatch and runtime errors for app-level handlers rendered within submodels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->