### PR TITLE
fix(website): build shared doc-page chrome in the parent's boundary

### DIFF
--- a/.changeset/boundary-lift-diagnostic.md
+++ b/.changeset/boundary-lift-diagnostic.md
@@ -1,0 +1,9 @@
+---
+'foldkit': patch
+---
+
+Explain why a Message could not cross a Submodel boundary.
+
+A wrapper Message is normally a Schema constructor, so handing it a Message outside the child's union throws a Schema error naming the two shapes and nothing else. That error fires inside a DOM listener, the app keeps rendering, and reading it requires already knowing that a boundary sits between the handler and `update`, which makes a real bug look like noise.
+
+The boundary now catches that rejection and reframes it, naming the boundary, the Message, and the cause that accounts for almost every occurrence: a shared view helper building an app-level Message inside a Submodel's view, where a handler's dispatcher is chosen by the frame it is built in rather than by the Message it carries. The original rejection is preserved as `cause`.

--- a/packages/foldkit/src/html/boundary.test.ts
+++ b/packages/foldkit/src/html/boundary.test.ts
@@ -7,6 +7,7 @@ import {
   composeBoundary,
   createBoundaryRegistry,
   getOrCreateBoundaryDispatch,
+  resolveBoundaryDispatchThunk,
 } from './boundary.js'
 import type { DispatchSync } from './runtimeSingleton.js'
 
@@ -95,5 +96,99 @@ describe('getOrCreateBoundaryDispatch', () => {
     expect(getOrCreateBoundaryDispatch(registry, dispatch, ROOT_BOUNDARY)).toBe(
       dispatch,
     )
+  })
+
+  it('names the boundary, the Message, and the likely cause when toParentMessage rejects', () => {
+    // A wrapper Message is normally a Schema constructor, so a Message
+    // outside the child's union throws a Schema error naming only the two
+    // shapes. On its own that is undiagnosable from inside a DOM listener,
+    // so the boundary reframes it.
+    const registry = createBoundaryRegistry()
+    registry.wraps.set('ui-Button', {
+      toParentMessage: message => {
+        if (Reflect.get(Object(message), '_tag') !== 'ClickedButtonDemo') {
+          throw new Error('Expected { readonly "_tag": "ClickedButtonDemo" }')
+        }
+        return { _tag: 'GotUiPageMessage', message }
+      },
+    })
+
+    const dispatcher = getOrCreateBoundaryDispatch(
+      registry,
+      () => {},
+      'ui-Button',
+    )
+
+    expect(() => dispatcher({ _tag: 'ClickedCopySnippet' })).toThrow(
+      /boundary "ui-Button".*`ClickedCopySnippet`.*shared view helper/s,
+    )
+  })
+
+  it('describes a Message whose _tag throws without masking the rejection', () => {
+    const registry = createBoundaryRegistry()
+    const original = new Error('schema said no')
+    registry.wraps.set('child', {
+      toParentMessage: () => {
+        throw original
+      },
+    })
+
+    const hostile = new Proxy(
+      { _tag: 'Foreign' },
+      {
+        get: () => {
+          throw new Error('proxy trap')
+        },
+      },
+    )
+
+    const dispatcher = getOrCreateBoundaryDispatch(registry, () => {}, 'child')
+
+    expect(() => dispatcher(hostile)).toThrow(/could not be lifted/)
+    expect(() => dispatcher(hostile)).toThrow(
+      expect.objectContaining({ cause: original }),
+    )
+  })
+
+  it('keeps the original rejection as the cause', () => {
+    const registry = createBoundaryRegistry()
+    const original = new Error('schema said no')
+    registry.wraps.set('child', {
+      toParentMessage: () => {
+        throw original
+      },
+    })
+
+    const dispatcher = getOrCreateBoundaryDispatch(registry, () => {}, 'child')
+
+    expect(() => dispatcher({ _tag: 'Foreign' })).toThrow(
+      expect.objectContaining({ cause: original }),
+    )
+  })
+})
+
+describe('resolveBoundaryDispatchThunk', () => {
+  it('reframes an OnUnmount rejection the same way live dispatch does', () => {
+    // OnUnmount resolves its lift eagerly, so a rejection surfaces here rather
+    // than through dispatchAcrossBoundary and needs the same framing.
+    const registry = createBoundaryRegistry()
+    const original = new Error('schema said no')
+    registry.wraps.set('ui-Button', {
+      toParentMessage: () => {
+        throw original
+      },
+    })
+
+    expect(() =>
+      resolveBoundaryDispatchThunk(registry, () => {}, 'ui-Button', {
+        _tag: 'ClickedCopySnippet',
+      }),
+    ).toThrow(/boundary "ui-Button".*`ClickedCopySnippet`/s)
+
+    expect(() =>
+      resolveBoundaryDispatchThunk(registry, () => {}, 'ui-Button', {
+        _tag: 'ClickedCopySnippet',
+      }),
+    ).toThrow(expect.objectContaining({ cause: original }))
   })
 })

--- a/packages/foldkit/src/html/boundary.ts
+++ b/packages/foldkit/src/html/boundary.ts
@@ -218,6 +218,59 @@ export const deregisterBoundaryWrap = (
   registry.wraps.delete(boundaryId)
 }
 
+// NOTE: reading `_tag` can itself throw, through a getter or a Proxy trap. This
+// runs while reporting another failure, so an escape here would replace the
+// error being described with an unrelated one.
+const describeMessage = (message: unknown): string => {
+  try {
+    if (typeof message === 'object' && message !== null && '_tag' in message) {
+      const tag = Reflect.get(message, '_tag')
+      if (typeof tag === 'string') {
+        return `\`${tag}\``
+      }
+    }
+  } catch {
+    return 'the Message'
+  }
+  return 'the Message'
+}
+
+/** Applies one boundary's `toParentMessage`, translating a rejection into an
+ *  error that names the cause.
+ *
+ *  A wrapper Message is normally a Schema constructor, so handing it a Message
+ *  outside the child's union throws a Schema error naming both shapes and
+ *  nothing else. That error is accurate and nearly undiagnosable: it fires
+ *  inside a DOM listener, the app keeps rendering, and reading it requires
+ *  already knowing that a boundary sits between the handler and `update`. The
+ *  overwhelmingly common cause is a shared view helper that built an app-level
+ *  Message inside a Submodel's view, where the dispatcher is chosen by the
+ *  current render frame rather than by the Message's type. */
+const liftAcrossBoundary = (
+  descriptor: WrapDescriptor,
+  boundaryId: BoundaryId,
+  message: unknown,
+): unknown => {
+  try {
+    return descriptor.toParentMessage(message)
+  } catch (cause) {
+    throw new Error(
+      `Foldkit: a Message dispatched from inside Submodel boundary ` +
+        `"${boundaryId}" could not be lifted into its parent's Message type. ` +
+        `Its \`toParentMessage\` rejected ${describeMessage(message)}, which ` +
+        `means that Message is not part of the Submodel's own Message union. ` +
+        `The usual cause is a shared view helper building an app-level Message ` +
+        `inside a Submodel's view: a handler's dispatcher is chosen by where ` +
+        `the element is built, not by the Message it carries, so the boundary ` +
+        `tried to wrap a Message the Submodel does not own. Either move the ` +
+        `Message into the Submodel's union, or have the parent supply the ` +
+        `element through a \`viewInputs\` slot callback so it is built in the ` +
+        `parent's boundary.`,
+      { cause },
+    )
+  }
+}
+
 /** Applies the wrapping chain for `boundaryId` from innermost to
  *  outermost, then dispatches the fully-wrapped message via
  *  `outerDispatch`. Called at event-fire time by the dispatcher closure
@@ -257,7 +310,7 @@ const dispatchAcrossBoundary = (
           `wrap was registered in one copy and read from another.`,
       )
     }
-    wrapped = descriptor.toParentMessage(wrapped)
+    wrapped = liftAcrossBoundary(descriptor, ancestorBoundary, wrapped)
   }
   outerDispatch(wrapped)
 }
@@ -297,7 +350,7 @@ export const resolveBoundaryDispatchThunk = (
           `at resolve time, which should not happen during a live render.`,
       )
     }
-    wrapped = descriptor.toParentMessage(wrapped)
+    wrapped = liftAcrossBoundary(descriptor, ancestorBoundary, wrapped)
   }
   const rootMessage = wrapped
   return () => outerDispatch(rootMessage)

--- a/packages/website/src/markdown/docPage.test.ts
+++ b/packages/website/src/markdown/docPage.test.ts
@@ -255,6 +255,11 @@ describe('proof pages', () => {
         id: 'reflecting-external-state',
         text: 'Reflecting External State',
       },
+      {
+        level: 'h2',
+        id: 'which-boundary',
+        text: 'Which Boundary a Handler Dispatches Through',
+      },
       { level: 'h2', id: 'child-attributes', text: 'childAttributes' },
       {
         level: 'h3',

--- a/packages/website/src/markdown/docPage.ts
+++ b/packages/website/src/markdown/docPage.ts
@@ -20,7 +20,13 @@ const renderDocument = (
   slots: Slots<string>,
 ): Html =>
   Markdown.view(document, {
-    views: docViews({ pageId, idByHeading, copiedSnippets }),
+    views: docViews({
+      pageId,
+      idByHeading,
+      copiedSnippets,
+      renderCopyButton: slots.renderCopyButton,
+      renderHeadingLink: slots.renderHeadingLink,
+    }),
     islands: docIslands(copiedSnippets, slots),
   })
 

--- a/packages/website/src/markdown/islands.ts
+++ b/packages/website/src/markdown/islands.ts
@@ -61,6 +61,7 @@ export const docIslands = (
               : `Copy ${label} to clipboard`,
             copiedSnippets,
             className ?? 'mb-8',
+            slots.renderCopyButton,
           ),
       }),
 

--- a/packages/website/src/markdown/slots.ts
+++ b/packages/website/src/markdown/slots.ts
@@ -1,6 +1,9 @@
 import { Option, Record as Record_ } from 'effect'
 import { Html, html } from 'foldkit/html'
 
+import type { RenderHeadingLink } from '../prose'
+import type { RenderCopyButton } from '../view/codeBlock'
+
 // SLOTS
 
 /**
@@ -26,6 +29,16 @@ export type RenderFaq = (
 export type Slots<DemoName extends string> = Readonly<{
   demos: Demos<DemoName>
   renderFaq?: RenderFaq
+  /**
+   * Chrome the page does not own but its markdown renders: the snippet copy
+   * button and the heading copy-link. A page embedded with `h.submodel` must
+   * pass these down from its parent through `viewInputs`, so they are built in
+   * the parent's boundary and their app-level Messages reach `update`
+   * unwrapped. Left unset, they build themselves, which is correct for a page
+   * rendered outside any Submodel.
+   */
+  renderCopyButton?: RenderCopyButton
+  renderHeadingLink?: RenderHeadingLink
 }>
 
 /** The slots a page with no interactive islands contributes, which is none. */

--- a/packages/website/src/markdown/views.ts
+++ b/packages/website/src/markdown/views.ts
@@ -5,8 +5,18 @@ import type { Alignment } from '@foldkit/markdown'
 import type * as Markdown from '@foldkit/markdown'
 
 import type { Message } from '../message'
-import { diagram, headingWithContent, inlineCode, pageTitle } from '../prose'
-import { type CopiedSnippets, codeBlock } from '../view/codeBlock'
+import {
+  type RenderHeadingLink,
+  diagram,
+  headingWithContent,
+  inlineCode,
+  pageTitle,
+} from '../prose'
+import {
+  type CopiedSnippets,
+  type RenderCopyButton,
+  codeBlock,
+} from '../view/codeBlock'
 import { parseHeadingId, stripHeadingIdMarker } from './slug'
 import { type HeadingIds, headingId } from './tableOfContents'
 
@@ -17,6 +27,8 @@ export type DocViewConfig = Readonly<{
   pageId: string
   idByHeading: HeadingIds
   copiedSnippets: CopiedSnippets
+  renderCopyButton?: RenderCopyButton | undefined
+  renderHeadingLink?: RenderHeadingLink | undefined
 }>
 
 const linkClassName =
@@ -104,11 +116,51 @@ export const docViews = (config: DocViewConfig): Partial<Markdown.Views> => {
       return M.value(heading.level).pipe(
         M.withReturnType<Html>(),
         M.when(1, () => pageTitle(config.pageId, text)),
-        M.when(2, () => headingWithContent('h2', id, text, displayContent)),
-        M.when(3, () => headingWithContent('h3', id, text, displayContent)),
-        M.when(4, () => headingWithContent('h4', id, text, displayContent)),
-        M.when(5, () => headingWithContent('h5', id, text, displayContent)),
-        M.when(6, () => headingWithContent('h6', id, text, displayContent)),
+        M.when(2, () =>
+          headingWithContent(
+            'h2',
+            id,
+            text,
+            displayContent,
+            config.renderHeadingLink,
+          ),
+        ),
+        M.when(3, () =>
+          headingWithContent(
+            'h3',
+            id,
+            text,
+            displayContent,
+            config.renderHeadingLink,
+          ),
+        ),
+        M.when(4, () =>
+          headingWithContent(
+            'h4',
+            id,
+            text,
+            displayContent,
+            config.renderHeadingLink,
+          ),
+        ),
+        M.when(5, () =>
+          headingWithContent(
+            'h5',
+            id,
+            text,
+            displayContent,
+            config.renderHeadingLink,
+          ),
+        ),
+        M.when(6, () =>
+          headingWithContent(
+            'h6',
+            id,
+            text,
+            displayContent,
+            config.renderHeadingLink,
+          ),
+        ),
         M.exhaustive,
       )
     },
@@ -122,6 +174,7 @@ export const docViews = (config: DocViewConfig): Partial<Markdown.Views> => {
             config.copiedSnippets,
             'mb-8',
             Option.getOrUndefined(maybeLanguage),
+            config.renderCopyButton,
           ),
 
     List: (list, items) => {

--- a/packages/website/src/page/comingFromReact/view.ts
+++ b/packages/website/src/page/comingFromReact/view.ts
@@ -6,7 +6,11 @@ import { Disclosure } from '@foldkit/ui'
 
 import { Icon } from '../../icon'
 import { slotDocPage } from '../../markdown'
-import { type CopiedSnippets } from '../../view/codeBlock'
+import { type RenderHeadingLink } from '../../prose'
+import {
+  type CopiedSnippets,
+  type RenderCopyButton,
+} from '../../view/codeBlock'
 import raw from './comingFromReact.md'
 import { type Message, ToggledFaq } from './message'
 import type { Model } from './model'
@@ -87,13 +91,24 @@ const { tableOfContents, view: renderPage } = slotDocPage(
 
 export { tableOfContents }
 
-type ViewInputs = Readonly<{ copiedSnippets: CopiedSnippets }>
+// NOTE: `renderCopyButton` and `renderHeadingLink` arrive as slot callbacks
+// rather than being built here. Both dispatch app-level Messages, and a handler
+// built inside this Submodel's view would be lifted by its `toParentMessage`
+// and rejected. As top-level `viewInputs` functions they run in the parent's
+// boundary instead.
+type ViewInputs = Readonly<{
+  copiedSnippets: CopiedSnippets
+  renderCopyButton: RenderCopyButton
+  renderHeadingLink: RenderHeadingLink
+}>
 
 export const view = Submodel.defineView<Model, Message, ViewInputs>(
-  (model, { copiedSnippets }): Html =>
+  (model, { copiedSnippets, renderCopyButton, renderHeadingLink }): Html =>
     renderPage(copiedSnippets, {
       demos: {},
       renderFaq: (id, question, content) =>
         faqItem(id, question, content, model),
+      renderCopyButton,
+      renderHeadingLink,
     }),
 )

--- a/packages/website/src/page/core/submodel.md
+++ b/packages/website/src/page/core/submodel.md
@@ -237,6 +237,25 @@ The child never calls its own `reflect*`. It is the sanctioned way for the owner
 
 Across the stateful Foldkit UI components the choice-based setters keep domain verbs (`selectItem`, `selectDate`), and they emit. The `reflect*` family is the uniform name for the silent inbound setter: the `reflectMinDate` / `reflectMaxDate` / `reflectDisabledDates` / `reflectDisabledDaysOfWeek` constraint setters (Calendar, DatePicker), and `reflectRange` (Slider). It is a framework convention any Submodel can adopt; the stateful Foldkit UI components are the canonical adopters.
 
+## Which Boundary a Handler Dispatches Through {#which-boundary}
+
+A handler’s dispatcher is chosen by **where the element is built**, not by the Message it carries. `html<Message>()`’s type argument is erased at runtime, so the element constructor reads the boundary off the current render frame and the compiler never sees the question.
+
+Inside a Submodel there are two frames, with opposite defaults:
+
+| Where you build the element                       | Dispatches through        | To change it                                                            |
+| ------------------------------------------------- | ------------------------- | ----------------------------------------------------------------------- |
+| The child’s own view body                         | the **child’s** boundary  | have the parent supply the element through a `viewInputs` slot callback |
+| A slot callback the parent passed in `viewInputs` | the **parent’s** boundary | [`childAttributes`](#child-attributes) binds it back to the child       |
+
+Both defaults are usually what you want. The child’s view body is full of the child’s own Messages, and a parent’s slot callback is full of the parent’s.
+
+The case that bites is a **shared view helper** rendered inside a Submodel: a copy button, an analytics hook, a toast trigger. It builds an app-level Message in the child’s view body, so the child’s `toParentMessage` is applied to a Message the child does not own. That wrapper is a Schema constructor, so it throws inside the event listener: nothing dispatches, no `update` runs, the page keeps rendering, and the type checker never complained. Foldkit reframes that error to name the boundary and the Message, but the fix is structural. Let the parent build it and pass it down:
+
+::Snippet{name="submodelSharedChrome" label="shared chrome"}
+
+Because the renderer is a function at the top level of `viewInputs`, it runs in the parent’s boundary, so the Message it builds reaches `update` unwrapped no matter how deep the child renders it.
+
 ## childAttributes {#child-attributes}
 
 Some Submodels (Tooltip, Dialog, Popover, the selection family) hand the consumer **attribute bundles** rather than rendering their own DOM. The consumer spreads those attributes onto their own elements, deciding markup and styling, while the Submodel keeps owning the wiring. The snippets below evolve the CommandMenu from [Per-render View Inputs](#per-render-view-inputs): instead of rendering its own DOM, it publishes attribute bundles plus slot data, and the parent renders the button and the items.

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -6,6 +6,16 @@ import { Icon } from './icon'
 import { type TableOfContentsEntry } from './main'
 import { ClickedCopyLink, type Message } from './message'
 
+/**
+ * Builds the copy-link control beside a section heading.
+ *
+ * A page rendered through `h.submodel` must supply one of these from its
+ * parent, for the same reason {@link RenderCopyButton} exists: a handler's
+ * dispatcher comes from the frame it is built in, so an app-level Message
+ * built inside a Submodel's view is rejected by that Submodel's boundary.
+ */
+export type RenderHeadingLink = (id: string, text: string) => Html
+
 export const headingLinkButton = (id: string, text: string): Html => {
   const h = html<Message>()
 
@@ -94,6 +104,7 @@ export const headingWithContent = (
   id: string,
   ariaText: string,
   content: ReadonlyArray<string | Html>,
+  renderHeadingLink: RenderHeadingLink | undefined = headingLinkButton,
 ): Html => {
   const h = html()
 
@@ -104,7 +115,7 @@ export const headingWithContent = (
     [h.Class(config.wrapperClassName)],
     [
       tag[level]([h.Class(config.textClassName), h.Id(id)], content),
-      headingLinkButton(id, ariaText),
+      renderHeadingLink(id, ariaText),
     ],
   )
 }

--- a/packages/website/src/snippet/submodelSharedChrome.ts
+++ b/packages/website/src/snippet/submodelSharedChrome.ts
@@ -1,0 +1,16 @@
+// view/docs.ts (parent)
+const h = html<Message>()
+
+h.submodel({
+  slotId: 'coming-from-react',
+  model: model.comingFromReact,
+  view: Page.ComingFromReact.view,
+  viewInputs: {
+    copiedSnippets: model.copiedSnippets,
+    // Built in the parent's boundary, so ClickedCopySnippet reaches update
+    // unwrapped however deep the child renders it.
+    renderCopyButton: defaultRenderCopyButton(model.copiedSnippets),
+    renderHeadingLink: headingLinkButton,
+  },
+  toParentMessage: message => GotComingFromReactMessage({ message }),
+})

--- a/packages/website/src/view/codeBlock.ts
+++ b/packages/website/src/view/codeBlock.ts
@@ -9,6 +9,20 @@ const PagefindIgnore = html<Message>().DataAttribute('pagefind-ignore', '')
 
 export type CopiedSnippets = HashSet.HashSet<string>
 
+/**
+ * Builds the copy control for a code block.
+ *
+ * A page rendered through `h.submodel` must supply one of these from its
+ * parent, because a handler's dispatcher is chosen by where the element is
+ * built. Left to build itself inside a Submodel's view, the button's app-level
+ * Message meets that Submodel's `toParentMessage` and is rejected.
+ */
+export type RenderCopyButton = (
+  textToCopy: string,
+  ariaLabel: string,
+  positionClass: string,
+) => Html
+
 const copyButtonWithIndicator = (
   textToCopy: string,
   ariaLabel: string,
@@ -52,12 +66,24 @@ const copyButtonWithIndicator = (
   )
 }
 
+/** Builds the copy control directly, which is correct outside a Submodel. */
+export const defaultRenderCopyButton =
+  (copiedSnippets: CopiedSnippets): RenderCopyButton =>
+  (textToCopy, ariaLabel, positionClass) =>
+    copyButtonWithIndicator(
+      textToCopy,
+      ariaLabel,
+      copiedSnippets,
+      positionClass,
+    )
+
 export const codeBlock = (
   code: string,
   ariaLabel: string,
   copiedSnippets: CopiedSnippets,
   className?: string,
   language?: string,
+  renderCopyButton?: RenderCopyButton | undefined,
 ) => {
   const h = html<Message>()
 
@@ -86,10 +112,9 @@ export const codeBlock = (
     ],
     [
       content,
-      copyButtonWithIndicator(
+      (renderCopyButton ?? defaultRenderCopyButton(copiedSnippets))(
         code,
         ariaLabel,
-        copiedSnippets,
         'top-1/2 -translate-y-1/2 right-2',
       ),
     ],
@@ -102,11 +127,19 @@ export const highlightedCodeBlock = (
   ariaLabel: string,
   copiedSnippets: CopiedSnippets,
   className?: string,
+  renderCopyButton?: RenderCopyButton | undefined,
 ) => {
   const h = html<Message>()
 
   return h.div(
     [PagefindIgnore, h.Class(clsx('relative min-w-0 mt-8', className))],
-    [content, copyButtonWithIndicator(rawCode, ariaLabel, copiedSnippets)],
+    [
+      content,
+      (renderCopyButton ?? defaultRenderCopyButton(copiedSnippets))(
+        rawCode,
+        ariaLabel,
+        'top-2 right-2',
+      ),
+    ],
   )
 }

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -22,8 +22,10 @@ import {
   type Message,
 } from '../message'
 import * as Page from '../page'
+import { headingLinkButton } from '../prose'
 import { type DocsRoute, homeRouter } from '../route'
 import * as Search from '../search'
+import { defaultRenderCopyButton } from './codeBlock'
 import { betaTag, emailFormView, iconLink, skipNavLink } from './shared'
 import { sidebarView } from './sidebar'
 import {
@@ -417,7 +419,11 @@ export const docsView = (model: Model, docsRoute: DocsRoute) => {
             slotId: 'coming-from-react',
             model: model.comingFromReact,
             view: Page.ComingFromReact.view,
-            viewInputs: { copiedSnippets: model.copiedSnippets },
+            viewInputs: {
+              copiedSnippets: model.copiedSnippets,
+              renderCopyButton: defaultRenderCopyButton(model.copiedSnippets),
+              renderHeadingLink: headingLinkButton,
+            },
             toParentMessage: message => GotComingFromReactMessage({ message }),
           }),
           Page.ComingFromReact.tableOfContents,

--- a/scripts/cloud-session-setup.sh
+++ b/scripts/cloud-session-setup.sh
@@ -49,18 +49,40 @@ prerequisite_packages=(
   '@typing-game/shared:packages/typing-game/shared'
 )
 
+#   * Stale dist/       -> the same failure as a missing one, because the build
+#     output predates the sources it claims to export.
+#
+# Compares against the oldest file inside dist/, not the directory itself: a
+# directory's mtime tracks entries added or removed, so it can be newer than the
+# stale contents it holds and report a rebuilt tree that never was.
+is_dist_stale() {
+  local dir="$1"
+  [[ -d "$dir/dist" && -d "$dir/src" && -r "$dir/src" ]] || return 0
+
+  local oldest_built
+  oldest_built=$(find "$dir/dist" -type f -printf '%T@ %p\n' 2>/dev/null |
+    sort -n | head -1 | cut -d' ' -f2-)
+  [[ -n "$oldest_built" ]] || return 0
+
+  local newer_source scan_status
+  newer_source=$(find "$dir/src" -type f -newer "$oldest_built" -print -quit 2>/dev/null)
+  scan_status=$?
+
+  [[ $scan_status -ne 0 || -n "$newer_source" ]]
+}
+
 build_filters=()
 for spec in "${prerequisite_packages[@]}"; do
   pkg="${spec%%:*}"
   dir="${spec#*:}"
-  if [[ ! -d "$dir/dist" ]]; then
+  if is_dist_stale "$dir"; then
     build_filters+=("-F" "$pkg")
   fi
 done
 
 if (( ${#build_filters[@]} > 0 )); then
-  echo "[setup] building prerequisite packages: ${build_filters[*]}"
+  echo "[setup] building prerequisite packages (missing or stale dist/): ${build_filters[*]}"
   pnpm "${build_filters[@]}" build
 else
-  echo "[setup] prerequisite package dist/ directories already present"
+  echo "[setup] prerequisite package dist/ directories present and up to date"
 fi


### PR DESCRIPTION
Replaces #833, which fixed the same bug by adding a `rootAttributes` escape hatch to `foldkit`. This does it with existing primitives instead, so no new public API.

## The bug

A handler's dispatcher is chosen by **where the element is built**, not by the Message it carries. `html<Message>()`'s type argument is erased and the element constructor reads the boundary off the current render frame.

So a shared view helper that constructs an app-level Message works at the root and breaks inside a Submodel. The boundary applies its `toParentMessage`; that wrapper is a Schema constructor, so it throws on the foreign Message inside the event listener. Nothing dispatches, no `update` runs, the page keeps rendering, and nothing was visible at compile time.

Two helpers were hitting it, both in the same row of every doc page:

- `view/codeBlock.ts` — the snippet copy button (`ClickedCopySnippet`)
- `prose.ts` — the heading copy-link anchor (`ClickedCopyLink`)

The anchor still scrolled, because the `href` default fires, so it read as half-working rather than dead.

## The fix: let the parent build them

`codeBlock`, `highlightedCodeBlock`, and `headingWithContent` now accept the renderer rather than always constructing it, and `Slots` carries the pair down through the markdown pipeline. A page embedded with `h.submodel` receives them as top-level `viewInputs` functions, which the runtime already executes in the parent's boundary, so their Messages reach `update` unwrapped however deep the child renders them.

Left unset, the helpers build their own, which stays correct for any page rendered outside a Submodel. Nothing else changes.

## Also in here

**The boundary explains itself now.** `dispatchAcrossBoundary` catches a `toParentMessage` rejection and reframes it, naming the boundary, the Message, and the cause that accounts for nearly every occurrence. Previously you got a bare Schema mismatch fired from inside a DOM listener, which is accurate and nearly undiagnosable. The original is preserved as `cause`.

**Docs for the trap.** A new section documents the two opposing frame defaults, which is the thing that makes this confusing: a child's view body dispatches through the child, a parent's slot callback through the parent, and `childAttributes` only overrides the second.

**`cloud-session-setup.sh` rebuilds stale `dist/`, not just missing.** A `dist/` older than its own `src/` fails downstream typechecks with `has no exported member` against a symbol that plainly exists in source, which reads as a break in the branch under review. That script is what the contributor docs point you at for exactly that symptom, and it was skipping the case. I hit this at the start of this work and chased it as a real failure.

## Verification

Browser, production build, before and after:

| Page | Copy button | Heading link |
| --- | --- | --- |
| `/core/commands` (no Submodel) | works → works | works → works |
| `/react/coming-from-react` | **broken → works** | **broken → works** |

Two new tests on the reframed error, both mutation-checked: reverting to the plain `toParentMessage` call fails them.

Gates: foldkit 1630 tests, website 230, `tsc` 0, lint 0, knip 0, no new circular deps, website build clean.

## Deliberately not in here

The 25 hand-written UI component pages need the same threading across 41 copy-block and 267 heading call sites, and one site each in `api-reference` and `example-detail`. Those follow in a separate PR. They are the pages slated to become markdown, at which point they route through the single `Slots` seam this PR establishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JonmydQXsA5nvbb8Qq733

---
_Generated by [Claude Code](https://claude.ai/code/session_011JonmydQXsA5nvbb8Qq733)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved “submodel boundary” failure messages by including the boundary name and message involved, while preserving the original underlying error as the cause.
- **New Features**
  - Documentation submodels now support customizable code-block copy buttons and per-heading “copy link” controls, with existing defaults used when no customization is provided.
- **Documentation**
  - Added “Which Boundary a Handler Dispatches Through” guidance (and updated the documentation table of contents).
- **Chores**
  - Updated build setup to rebuild prerequisite outputs only when `dist/` is missing or stale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->