### PR TITLE
fix(website): build API reference and example detail chrome in the parent's boundary

### DIFF
--- a/packages/website/src/page/apiReference/view.ts
+++ b/packages/website/src/page/apiReference/view.ts
@@ -6,7 +6,11 @@ import { Html, createKeyedLazy, html } from 'foldkit/html'
 import { Disclosure } from '@foldkit/ui'
 
 import { Icon } from '../../icon'
-import { heading, headingLinkButton, pageTitle } from '../../prose'
+import {
+  type RenderHeadingLink,
+  headingWithContent,
+  pageTitle,
+} from '../../prose'
 import {
   type ApiFunction,
   type ApiInterface,
@@ -52,6 +56,7 @@ const functionView = (
   apiFunction: ApiFunction,
   isSignatureDisclosureOpen: boolean | undefined,
   highlights: Highlights,
+  renderHeadingLink: RenderHeadingLink,
 ): Html => {
   const h = html<Message>()
   const id = scopedId('function', moduleName, apiFunction.name)
@@ -89,7 +94,7 @@ const functionView = (
               ...sourceLink(apiFunction.sourceUrl, apiFunction.name),
             ],
           ),
-          headingLinkButton(id, apiFunction.name),
+          renderHeadingLink(id, apiFunction.name),
         ],
       ),
       signaturesView(id, apiFunction, isSignatureDisclosureOpen, highlights),
@@ -377,6 +382,7 @@ const typeView = (
   moduleName: string,
   type: ApiType,
   highlights: Highlights,
+  renderHeadingLink: RenderHeadingLink,
 ): Html => {
   const h = html<Message>()
   const id = scopedId('type', moduleName, type.name)
@@ -415,7 +421,7 @@ const typeView = (
               ...sourceLink(type.sourceUrl, type.name),
             ],
           ),
-          headingLinkButton(id, type.name),
+          renderHeadingLink(id, type.name),
         ],
       ),
       ...Option.match(maybeHighlighted, {
@@ -452,6 +458,7 @@ const interfaceView = (
   moduleName: string,
   apiInterface: ApiInterface,
   highlights: Highlights,
+  renderHeadingLink: RenderHeadingLink,
 ): Html => {
   const h = html<Message>()
   const id = scopedId('interface', moduleName, apiInterface.name)
@@ -490,7 +497,7 @@ const interfaceView = (
               ...sourceLink(apiInterface.sourceUrl, apiInterface.name),
             ],
           ),
-          headingLinkButton(id, apiInterface.name),
+          renderHeadingLink(id, apiInterface.name),
         ],
       ),
       ...Option.match(maybeHighlighted, {
@@ -527,6 +534,7 @@ const variableView = (
   moduleName: string,
   variable: ApiVariable,
   highlights: Highlights,
+  renderHeadingLink: RenderHeadingLink,
 ): Html => {
   const h = html<Message>()
   const id = scopedId('const', moduleName, variable.name)
@@ -565,7 +573,7 @@ const variableView = (
               ...sourceLink(variable.sourceUrl, variable.name),
             ],
           ),
-          headingLinkButton(id, variable.name),
+          renderHeadingLink(id, variable.name),
         ],
       ),
       ...Option.match(maybeHighlighted, {
@@ -602,12 +610,19 @@ const section = <T extends { readonly name: string }>(
   moduleName: string,
   label: string,
   items: ReadonlyArray<T>,
+  renderHeadingLink: RenderHeadingLink,
   itemView: (item: T) => Html,
 ): ReadonlyArray<Html> =>
   Array.match(items, {
     onEmpty: () => [],
     onNonEmpty: items => [
-      heading('h2', sectionId(moduleName, label), label),
+      headingWithContent(
+        'h2',
+        sectionId(moduleName, label),
+        label,
+        [label],
+        renderHeadingLink,
+      ),
       ...Array.map(items, itemView),
     ],
   })
@@ -615,50 +630,88 @@ const section = <T extends { readonly name: string }>(
 type ViewInputs = Readonly<{
   module: ApiModule
   highlights: Highlights
+  renderHeadingLink: RenderHeadingLink
 }>
 
+/**
+ * Renders one API module: its sections and every function, type, interface, and
+ * constant it exports.
+ *
+ * The page is dispatched through `h.submodel`, so it takes `renderHeadingLink`
+ * from its parent rather than building the copy-link itself. The control carries
+ * an app-level Message, and a handler's dispatcher comes from the frame the
+ * element is built in, so one built here would be rejected by this Submodel's
+ * `toParentMessage`.
+ */
 export const view = Submodel.defineView<Model, Message, ViewInputs>(
-  (model, { module, highlights }): Html => {
+  (model, { module, highlights, renderHeadingLink }): Html => {
     const h = html<Message>()
 
     return h.div(
       [h.DataAttribute('pagefind-meta', 'kind:API Reference')],
       [
         pageTitle(module.name, module.name),
-        ...section(module.name, 'Functions', module.functions, apiFunction => {
-          const key = scopedId('function', module.name, apiFunction.name)
-          return lazyItem(key, functionView, [
-            module.name,
-            apiFunction,
-            model.disclosures[key],
-            highlights,
-          ])
-        }),
-        ...section(module.name, 'Types', module.types, type => {
-          const key = scopedId('type', module.name, type.name)
-          return lazyItem(key, typeView, [module.name, type, highlights])
-        }),
+        ...section(
+          module.name,
+          'Functions',
+          module.functions,
+          renderHeadingLink,
+          apiFunction => {
+            const key = scopedId('function', module.name, apiFunction.name)
+            return lazyItem(key, functionView, [
+              module.name,
+              apiFunction,
+              model.disclosures[key],
+              highlights,
+              renderHeadingLink,
+            ])
+          },
+        ),
+        ...section(
+          module.name,
+          'Types',
+          module.types,
+          renderHeadingLink,
+          type => {
+            const key = scopedId('type', module.name, type.name)
+            return lazyItem(key, typeView, [
+              module.name,
+              type,
+              highlights,
+              renderHeadingLink,
+            ])
+          },
+        ),
         ...section(
           module.name,
           'Interfaces',
           module.interfaces,
+          renderHeadingLink,
           apiInterface => {
             const key = scopedId('interface', module.name, apiInterface.name)
             return lazyItem(key, interfaceView, [
               module.name,
               apiInterface,
               highlights,
+              renderHeadingLink,
             ])
           },
         ),
-        ...section(module.name, 'Constants', module.variables, variable => {
-          const key = scopedId('const', module.name, variable.name)
-          return lazyItem(key, variableView, [
-            module.name,
-            variable,
-            highlights,
-          ])
-        }),
+        ...section(
+          module.name,
+          'Constants',
+          module.variables,
+          renderHeadingLink,
+          variable => {
+            const key = scopedId('const', module.name, variable.name)
+            return lazyItem(key, variableView, [
+              module.name,
+              variable,
+              highlights,
+              renderHeadingLink,
+            ])
+          },
+        ),
       ],
     )
   },

--- a/packages/website/src/page/example/exampleDetail.ts
+++ b/packages/website/src/page/example/exampleDetail.ts
@@ -20,7 +20,11 @@ import { exampleSourceHref } from '../../link'
 import type { TableOfContentsEntry } from '../../main'
 import { pageTitle, para } from '../../prose'
 import { examplesRouter, playgroundRouter } from '../../route'
-import { type CopiedSnippets, highlightedCodeBlock } from '../../view/codeBlock'
+import {
+  type CopiedSnippets,
+  type RenderCopyButton,
+  highlightedCodeBlockFor,
+} from '../../view/codeBlock'
 import { type ExampleMeta, findBySlug } from './meta'
 import {
   type ExampleSourceFile,
@@ -475,8 +479,10 @@ const sourceCodeView = (
   activeSourceFilePath: string,
   copiedSnippets: CopiedSnippets,
   isNarrowViewport: boolean,
+  renderCopyButton: RenderCopyButton,
 ): Html => {
   const h = html<Message>()
+  const highlightedCodeBlock = highlightedCodeBlockFor(renderCopyButton)
 
   const filePaths = Array.map(files, file => file.path)
 
@@ -649,10 +655,24 @@ type ViewInputs = Readonly<{
   copiedSnippets: CopiedSnippets
   isNarrowViewport: boolean
   isChromium: boolean
+  renderCopyButton: RenderCopyButton
 }>
 
+/**
+ * Renders one example app: its header, the live preview, and the source files
+ * behind a Tabs Submodel.
+ *
+ * The page is dispatched through `h.submodel`, so it takes `renderCopyButton`
+ * from its parent rather than building the copy control itself. The control
+ * carries an app-level Message, and a handler's dispatcher comes from the frame
+ * the element is built in, so one built here would be rejected by this
+ * Submodel's `toParentMessage`.
+ */
 export const view = Submodel.defineView<Model, Message, ViewInputs>(
-  (model, { slug, copiedSnippets, isNarrowViewport, isChromium }): Html => {
+  (
+    model,
+    { slug, copiedSnippets, isNarrowViewport, isChromium, renderCopyButton },
+  ): Html => {
     const h = html<Message>()
 
     return Option.match(findBySlug(slug), {
@@ -690,6 +710,7 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
                             ),
                             copiedSnippets,
                             isNarrowViewport,
+                            renderCopyButton,
                           ),
                         ],
                       }),

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -372,7 +372,7 @@ const renderApiReference = (
     slotId: `api-reference-${module.name}`,
     model: apiReference,
     view: Page.ApiReference.view,
-    viewInputs: { module, highlights },
+    viewInputs: { module, highlights, renderHeadingLink: headingLinkButton },
     toParentMessage: toApiReferenceMessage,
   })
 }
@@ -499,6 +499,7 @@ export const docsView = (model: Model, docsRoute: DocsRoute) => {
               copiedSnippets: model.copiedSnippets,
               isNarrowViewport: model.isNarrowViewport,
               isChromium: model.isChromium,
+              renderCopyButton: defaultRenderCopyButton(model.copiedSnippets),
             },
             toParentMessage: message => GotExampleDetailMessage({ message }),
           }),


### PR DESCRIPTION
Finishes the sweep started in #836 and #837. These were the last two places a shared helper built an app-level Message inside a Submodel, where the boundary's `toParentMessage` rejects it and nothing reaches `update`.

## The API reference was worse than we recorded

When we deferred this, I described it as four dead heading links, the `section` h2s. That was wrong, and it was a grep artifact: I searched `heading(`, which does not match `headingLinkButton(`.

There are five sites. Alongside `section`, the page renders a copy-link for every function, type, interface, and constant, each calling `headingLinkButton` directly. So **every symbol on every `/api-reference/*` page** had a dead control, not just the section headers.

`renderHeadingLink` now threads through `section` and the four item views. Passing it through `lazyItem` is safe because the renderer is a stable module-level reference, so `argsEqual` in `html/lazy.ts` still short-circuits and memoization is unchanged. I checked that rather than assuming it.

## Example detail

`sourceCodeView` renders its code block inside a Tabs Submodel nested in exampleDetail's own, so the copy button was dead on every `/example-apps/*` page. It now takes the renderer and binds `highlightedCodeBlockFor` once.

## Verification

Browser, production build, with mutation testing in both directions:

| | fixed | apiReference reverted | exampleDetail reverted |
| --- | --- | --- | --- |
| `/api-reference/command` | PASS | **FAIL** | PASS |
| `/example-apps/counter` | PASS | PASS | **FAIL** |

Each mutation kills only its own check, so neither check is vacuous.

The passing samples confirm both API heading kinds work, which is what the corrected scope required: `#Command-functions` (a `section` h2) and `#const-Command/mapMessages` (a symbol heading from `variableView`). The failures are the #836 boundary diagnostic naming `api-reference-Command` / `ClickedCopyLink` and `example-detail-counter` / `ClickedCopySnippet`.

## The sweep is closed

I redid the completeness pass with the pattern that caught the miss above. `core/submodel.ts` and `landing.ts` use the unbound helpers but build in the root frame, via `lazyDocsContent` and a direct call, so they are correct as they stand. `markdown/views.ts` and `markdown/islands.ts` are the `Slots` seam #836 established.

After this, `headingLinkButton` has exactly one importer, `view/docs.ts`, which is the root frame. No remaining site builds a root-dispatching element inside a Submodel.

Gates: `tsc` 0 errors, website 230 tests, lint 0, knip 0, no new circular deps, prettier clean, build clean.

## Note for what comes next

This closes the instances but not the class. The underlying seam is that `html<M>()` lets you assert a Message type while the runtime ignores it and reads the boundary off the current render frame, so the assertion can be false with nothing to catch it. Fixing these by hand took three PRs and ~30 sites, and I missed four of them on the first pass. That belongs in a framework-level discussion, not another website PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JonmydQXsA5nvbb8Qq733

---
_Generated by [Claude Code](https://claude.ai/code/session_011JonmydQXsA5nvbb8Qq733)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API reference section headings (functions, types, interfaces, constants) now support customizable heading links.
  * Example source code blocks now support configurable copy-button behavior.

* **Improvements**
  * Documentation pages now consistently pass the enhanced heading-link and code-copy controls through the relevant view components.
  
* **Documentation**
  * API Reference and Example detail pages render with the updated, configurable UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->