### PR TITLE
test(auth): split the login Scene tests by ownership

### DIFF
--- a/examples/auth/src/page/loggedOut/page/login.scene.test.ts
+++ b/examples/auth/src/page/loggedOut/page/login.scene.test.ts
@@ -1,0 +1,107 @@
+import { Scene } from 'foldkit'
+import { Valid } from 'foldkit/fieldValidation'
+import { describe, test } from 'vitest'
+
+import {
+  FailedSimulateAuthRequest,
+  Model,
+  SimulateAuthRequest,
+  initModel,
+  update,
+  view,
+} from './login'
+
+const validModel = Model.make({
+  ...initModel(),
+  email: Valid({ value: 'alice@example.com' }),
+  password: Valid({ value: 'password' }),
+})
+
+const heading = Scene.role('heading', { name: 'Sign In' })
+const emailField = Scene.label('Email')
+const passwordField = Scene.label('Password')
+const submitButton = Scene.role('button', { name: 'Sign In' })
+const submittingButton = Scene.role('button', { name: 'Signing in...' })
+
+describe('login', () => {
+  test('renders the heading, both fields, and the submit button', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initModel()),
+      Scene.expect(heading).toExist(),
+      Scene.expect(emailField).toExist(),
+      Scene.expect(passwordField).toExist(),
+      Scene.expect(submitButton).toExist(),
+    )
+  })
+
+  test('submit button starts disabled', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initModel()),
+      Scene.expect(submitButton).toBeDisabled(),
+    )
+  })
+
+  test('typing a valid email shows the checkmark', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initModel()),
+      Scene.type(emailField, 'alice@example.com'),
+      Scene.expect(Scene.text('✓')).toExist(),
+    )
+  })
+
+  test('typing an invalid email shows the error message', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initModel()),
+      Scene.type(emailField, 'notanemail'),
+      Scene.expect(Scene.text('Please enter a valid email')).toExist(),
+    )
+  })
+
+  test('submit button is enabled after typing a valid email and password', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(initModel()),
+      Scene.type(emailField, 'alice@example.com'),
+      Scene.type(passwordField, 'password'),
+      Scene.expect(submitButton).toBeEnabled(),
+    )
+  })
+
+  test('submitting with valid fields shows the loading state and requests auth', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(validModel),
+      Scene.submit(Scene.role('form')),
+      Scene.expect(submittingButton).toExist(),
+      Scene.expect(submittingButton).toBeDisabled(),
+      Scene.Command.expectExact(SimulateAuthRequest),
+      Scene.Command.resolve(
+        SimulateAuthRequest,
+        FailedSimulateAuthRequest({ error: '' }),
+      ),
+    )
+  })
+
+  test('failed auth shows the error and leaves submit disabled until the password changes', () => {
+    Scene.scene(
+      { update, view },
+      Scene.with(validModel),
+      Scene.submit(Scene.role('form')),
+      Scene.Command.expectExact(SimulateAuthRequest),
+      Scene.Command.resolve(
+        SimulateAuthRequest,
+        FailedSimulateAuthRequest({ error: 'Invalid credentials' }),
+      ),
+      Scene.expect(
+        Scene.within(Scene.role('form'), Scene.text('Invalid credentials')),
+      ).toExist(),
+      Scene.expect(submitButton).toBeDisabled(),
+      Scene.type(passwordField, 'correcthorse'),
+      Scene.expect(submitButton).toBeEnabled(),
+    )
+  })
+})

--- a/examples/auth/src/page/loggedOut/page/login.story.test.ts
+++ b/examples/auth/src/page/loggedOut/page/login.story.test.ts
@@ -6,7 +6,7 @@ import {
   ChangedEmail,
   ChangedPassword,
   FailedSimulateAuthRequest,
-  type Model,
+  Model,
   SimulateAuthRequest,
   SubmittedForm,
   SucceededLogin,
@@ -15,11 +15,11 @@ import {
   update,
 } from './login'
 
-const validModel: Model = {
+const validModel = Model.make({
   ...initModel(),
   email: Valid({ value: 'alice@example.com' }),
   password: Valid({ value: 'password' }),
-}
+})
 
 const aliceSession = { userId: '1', email: 'alice@example.com', name: 'alice' }
 

--- a/examples/auth/src/scene.test.ts
+++ b/examples/auth/src/scene.test.ts
@@ -6,7 +6,6 @@ import { SaveSession } from './command'
 import { CompletedNavigateInternal, SucceededSaveSession } from './message'
 import { LoggedOut } from './model'
 import {
-  FailedSimulateAuthRequest,
   SimulateAuthRequest,
   SucceededSimulateAuthRequest,
   initModel as initLoginModel,
@@ -14,8 +13,6 @@ import {
 import { LoginRoute } from './route'
 import { RedirectToDashboard, update } from './update'
 import { view } from './view'
-
-const initialModel = LoggedOut.init(LoginRoute())
 
 const validModel = LoggedOut.Model({
   route: LoginRoute(),
@@ -28,81 +25,8 @@ const validModel = LoggedOut.Model({
 
 const aliceSession = { userId: '1', email: 'alice@example.com', name: 'alice' }
 
-describe('view', () => {
-  test('initial view renders form with sign in heading, inputs, and submit button', () => {
-    Scene.scene(
-      { update, view },
-      Scene.with(initialModel),
-      Scene.expect(Scene.role('heading', { name: 'Sign In' })).toExist(),
-      Scene.expect(Scene.label('Email')).toExist(),
-      Scene.expect(Scene.label('Password')).toExist(),
-      Scene.expect(Scene.role('button', { name: 'Sign In' })).toExist(),
-    )
-  })
-
-  test('typing a valid email shows checkmark', () => {
-    Scene.scene(
-      { update, view },
-      Scene.with(initialModel),
-      Scene.type(Scene.label('Email'), 'alice@example.com'),
-      Scene.expect(Scene.text('✓')).toExist(),
-    )
-  })
-
-  test('typing an invalid email shows error message', () => {
-    Scene.scene(
-      { update, view },
-      Scene.with(initialModel),
-      Scene.type(Scene.label('Email'), 'notanemail'),
-      Scene.expect(Scene.text('Please enter a valid email')).toExist(),
-    )
-  })
-
-  test('submit button is enabled after typing valid email and password', () => {
-    Scene.scene(
-      { update, view },
-      Scene.with(initialModel),
-      Scene.type(Scene.label('Email'), 'alice@example.com'),
-      Scene.type(Scene.label('Password'), 'password'),
-      Scene.expect(Scene.role('button', { name: 'Sign In' })).toBeEnabled(),
-    )
-  })
-
-  test('submitting with valid fields shows loading state', () => {
-    Scene.scene(
-      { update, view },
-      Scene.with(validModel),
-      Scene.submit(Scene.role('form')),
-      Scene.expect(Scene.role('button', { name: 'Signing in...' })).toExist(),
-      Scene.expect(
-        Scene.role('button', { name: 'Signing in...' }),
-      ).toBeDisabled(),
-      Scene.Command.expectExact(SimulateAuthRequest),
-      Scene.Command.resolve(
-        SimulateAuthRequest,
-        FailedSimulateAuthRequest({ error: '' }),
-      ),
-    )
-  })
-
-  test('failed auth shows error text', () => {
-    Scene.scene(
-      { update, view },
-      Scene.with(validModel),
-      Scene.submit(Scene.role('form')),
-      Scene.Command.expectExact(SimulateAuthRequest),
-      Scene.Command.resolve(
-        SimulateAuthRequest,
-        FailedSimulateAuthRequest({ error: 'Invalid credentials' }),
-      ),
-      Scene.expect(
-        Scene.within(Scene.role('form'), Scene.text('Invalid credentials')),
-      ).toExist(),
-      Scene.expect(Scene.role('button', { name: 'Sign In' })).toExist(),
-    )
-  })
-
-  test('successful login transitions to dashboard', () => {
+describe('login flow', () => {
+  test('successful login saves the session and lands on the dashboard', () => {
     Scene.scene(
       { update, view },
       Scene.with(validModel),


### PR DESCRIPTION
Follow-up to #840, which corrected the Scene testing level rule but left it without a reference implementation in `examples/`. This adds one.

## The example demonstrated the anti-pattern

`examples/auth` drove every login assertion through the root view: heading rendering, email validation feedback, submit-button enablement, the loading state, the failed-auth error. All of that is behavior the login page owns outright, and all of it was asserted through `LoggedOut.Model` wrappers and app-level `update`. That is what the corrected docs argue against, on both counts: the assertion is buried in whole-app setup, and the root suite accumulates a copy of every page's rendering.

## The split

Six cases move into a colocated `page/loggedOut/page/login.scene.test.ts` that drives login's own `update` and `view` directly. Nothing adapts them:

- `Submodel.defineView` already produces the `(model) => Html` shape `Scene.scene` takes. The `toParentMessage` wrap lives at the parent's `h.submodel` call site, not in the child's signature.
- `Scene.scene` accepts login's OutMessage-returning `update` through its three-tuple overload.

The root `scene.test.ts` keeps exactly one test, the flow that genuinely crosses the Submodel boundary: login emits `SucceededLogin`, the parent folds it into `SaveSession` and `RedirectToDashboard`, and the dashboard renders `Welcome back, alice!`. A page-level Scene cannot observe any of that, which is the point of keeping it at the root.

Asserting the OutMessage itself stays with the existing `login.story.test.ts` via `Story.expectOutMessage`, since Scene has no `expectOutMessage` step. So `examples/auth` now shows all three levels in one page: Story for update and OutMessage, page-level Scene for the page's own rendering, root Scene for the cross-boundary flow.

Two cases in the new file are not carried over from the root suite. `submit button starts disabled` was not previously covered, and the loading-state and failed-auth tests now assert against the page's own Command rather than the app-lifted one.

## Fixture construction

Both login fixtures build through `Model.make`. Login's Model is a plain `S.Struct` rather than a `ts` tagged struct, so it is not directly invocable, but `make` is the same constructor the `ts` proxy forwards to (`packages/foldkit/src/schema/index.ts:24`). That constructs the fixture through the schema instead of annotating an object literal.

This also touches `login.story.test.ts`, which is otherwise outside the scope of this change. Its fixture had the same annotation, and leaving the two colocated tests building the same value different ways would be a worse outcome than the small extra diff.

## Note on scope

This deletes root-level coverage rather than only adding a file. Adding the colocated test alone would have left the example asserting the same login rendering twice, once through the whole app, which would demonstrate the pattern and the anti-pattern side by side. The root suite shrinking to one test is the demonstration.

Net coverage is unchanged: 7 tests at the page level replace 6 at the root, plus the 1 that stays. `examples/auth` goes from 7 tests in 2 files to 13 in 3.

## Verification

The full pre-push gate passed: format, lint, dead-code, circular-deps, effect-prebundle, build, typecheck, and the test suite across all packages and examples (`packages/foldkit` 1636 passed / 1 skipped, `packages/website` 230 passed, `examples/auth` 13 passed). The website e2e step was **skipped locally** because the Playwright browsers are absent in this container; CI installs them and runs that suite on this PR.

No changeset: `examples/` holds private packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a full logged-out login page test suite covering initial rendering, input validation messaging, disabled submit behavior, loading state during authentication, failed-auth error display, and recovery after input changes.
  - Streamlined the broader login scenario coverage to a single success-path flow, asserting session saving and redirect with the dashboard welcome message.
  - Updated the login story test to build the valid model using `Model.make` for consistent setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->