### PR TITLE
fix: align every example's devtools MCP port with the server default

### DIFF
--- a/examples/canvas-art/vite.config.ts
+++ b/examples/canvas-art/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { foldkitAliases } from '../vite.aliases'
 
 export default defineConfig({
-  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9989 })],
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
   resolve: {
     alias: foldkitAliases(__dirname),
   },

--- a/examples/charting/vite.config.ts
+++ b/examples/charting/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { foldkitAliases } from '../vite.aliases'
 
 export default defineConfig({
-  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9998 })],
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
   resolve: {
     alias: foldkitAliases(__dirname),
   },

--- a/examples/counters/vite.config.ts
+++ b/examples/counters/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { foldkitAliases } from '../vite.aliases'
 
 export default defineConfig({
-  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9989 })],
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
   resolve: {
     alias: foldkitAliases(__dirname),
   },

--- a/examples/generative-art/vite.config.ts
+++ b/examples/generative-art/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { foldkitAliases } from '../vite.aliases'
 
 export default defineConfig({
-  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9990 })],
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
   resolve: {
     alias: foldkitAliases(__dirname),
   },

--- a/examples/interrupting-commands/vite.config.ts
+++ b/examples/interrupting-commands/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { foldkitAliases } from '../vite.aliases'
 
 export default defineConfig({
-  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9993 })],
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
   resolve: {
     alias: foldkitAliases(__dirname),
   },

--- a/examples/managed-resource-layer/vite.config.ts
+++ b/examples/managed-resource-layer/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { foldkitAliases } from '../vite.aliases'
 
 export default defineConfig({
-  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9991 })],
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
   resolve: {
     alias: foldkitAliases(__dirname),
   },

--- a/examples/route-transitions/vite.config.ts
+++ b/examples/route-transitions/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { foldkitAliases } from '../vite.aliases'
 
 export default defineConfig({
-  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9992 })],
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
   resolve: {
     alias: foldkitAliases(__dirname),
   },

--- a/examples/state-machine/vite.config.ts
+++ b/examples/state-machine/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { foldkitAliases } from '../vite.aliases'
 
 export default defineConfig({
-  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9994 })],
+  plugins: [tailwindcss(), foldkit({ devToolsMcpPort: 9988 })],
   resolve: {
     alias: foldkitAliases(__dirname),
   },


### PR DESCRIPTION
Follow-up to #846. Eight one-line changes.

## Problem

`devToolsMcpPort` is one half of a connection whose other half is configured somewhere else entirely.

The Vite plugin **binds** a WebSocket relay on the port from `vite.config.ts`:

```ts
yield* Effect.forkScoped(startMcpRelay(options.devToolsMcpPort, enqueue))
```

`@foldkit/devtools-mcp` **dials** a port it reads from the environment:

```ts
const port = Number(process.env['FOLDKIT_DEVTOOLS_MCP_PORT'] ?? DEFAULT_PORT)  // 9988
const wsClient = yield* connectWebSocketClient(`ws://${host}:${port}`)
```

Nothing under `examples/` sets `FOLDKIT_DEVTOOLS_MCP_PORT`, and the examples carry no `.mcp.json` to put it in. So every example off the default was listening where the MCP server would never call, and the `foldkit_*` devtools tools could not attach to it.

Running two such examples at once is worse than a plain failure. With one on 9988 and another on 9992, the MCP server connects to 9988 and **succeeds against the wrong app**, with nothing signalling the mix-up.

## Fix

Point every example at `9988`.

That is the only value the MCP server dials without extra setup, and `AGENTS.md` tells contributors to reach for the devtools tools when debugging examples. The relay already handles a busy port by retrying and then reporting a message that names both settings, so the collision the unique ports were meant to avoid now degrades with a clear explanation rather than silence.

| Example | Was | Now |
| --- | --- | --- |
| `canvas-art` | 9989 | 9988 |
| `counters` | 9989 | 9988 |
| `generative-art` | 9990 | 9988 |
| `managed-resource-layer` | 9991 | 9988 |
| `route-transitions` | 9992 | 9988 |
| `interrupting-commands` | 9993 | 9988 |
| `state-machine` | 9994 | 9988 |
| `charting` | 9998 | 9988 |

`state-machine` is the one #846 introduced; the other seven predate it and are fixed here too.

## Why not keep unique ports and set the variable

There is nowhere natural to put it. The examples have no `.mcp.json`, and adding per-example MCP configuration to carry a port is a much larger change than the problem warrants.

The unique ports were also never a maintained allocation. They arrived in a single sweep as incidental values, and `canvas-art` and `counters` were both given 9989, so the scheme did not deliver the uniqueness it existed for.

## Verification

`typecheck` clean on all eight examples, `pnpm format:check` clean. No published package is touched, so no changeset.