### PR TITLE
docs: use evo for Model updates in the counter examples

### DIFF
--- a/examples/counter/src/main.ts
+++ b/examples/counter/src/main.ts
@@ -2,6 +2,7 @@ import { Match as M, Schema as S } from 'effect'
 import { Command, Runtime } from 'foldkit'
 import { Document, HtmlBuilder } from 'foldkit/html'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 import { Button } from '@foldkit/ui'
 
@@ -34,9 +35,9 @@ export const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedDecrement: () => [{ count: model.count - 1 }, []],
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
-      ClickedReset: () => [{ count: 0 }, []],
+      ClickedDecrement: () => [evo(model, { count: count => count - 1 }), []],
+      ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
+      ClickedReset: () => [evo(model, { count: () => 0 }), []],
     }),
   )
 

--- a/examples/counters/src/counter.ts
+++ b/examples/counters/src/counter.ts
@@ -1,6 +1,7 @@
 import { Match as M, Schema as S } from 'effect'
 import { Command, Submodel } from 'foldkit'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 import { Button } from '@foldkit/ui'
 
@@ -30,8 +31,8 @@ export const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedDecrement: () => [{ count: model.count - 1 }, []],
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
+      ClickedDecrement: () => [evo(model, { count: count => count - 1 }), []],
+      ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
     }),
   )
 

--- a/packages/website/src/page/core/update.md
+++ b/packages/website/src/page/core/update.md
@@ -14,6 +14,8 @@ Add a new Message to your app and forget to handle it here? The compiler tells y
 
 ::Snippet{name="counterUpdate" label="update example"}
 
+Each branch builds the next Model with [evo](/best-practices/immutability#immutable-updates), which evolves the Model you already have instead of rebuilding it. Every field you name takes a function from its current value to its next one, and fields you leave out keep their existing references. The counter has a single field today, so there’s nothing else to carry, but the shape stays the same as the Model grows.
+
 Notice that update returns a tuple: the new Model and an array of Commands. Commands represent side effects: HTTP requests, timers, browser API calls. Each Command carries a name for tracing and testing. For the counter, the Commands array is always empty. But when we add a delayed reset on the [Commands](/core/commands) page, that will change.
 
 Before we get to side effects, there’s one more piece of the counter to understand: the view function, which turns your Model into what the user sees on screen.

--- a/packages/website/src/snippet/counter.ts
+++ b/packages/website/src/snippet/counter.ts
@@ -2,6 +2,7 @@ import { Match as M, Schema as S } from 'effect'
 import { Command, Runtime } from 'foldkit'
 import type { Document, HtmlBuilder } from 'foldkit/html'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 // MODEL
 
@@ -34,9 +35,9 @@ export const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedDecrement: () => [{ count: model.count - 1 }, []],
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
-      ClickedReset: () => [{ count: 0 }, []],
+      ClickedDecrement: () => [evo(model, { count: count => count - 1 }), []],
+      ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
+      ClickedReset: () => [evo(model, { count: () => 0 }), []],
     }),
   )
 

--- a/packages/website/src/snippet/counterCommands.ts
+++ b/packages/website/src/snippet/counterCommands.ts
@@ -1,6 +1,7 @@
 import { Effect, Match as M } from 'effect'
 import { Command } from 'foldkit'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 const ClickedResetAfterDelay = m('ClickedResetAfterDelay')
 const CompletedDelayReset = m('CompletedDelayReset')
@@ -25,6 +26,6 @@ const update = (
     >(),
     M.tagsExhaustive({
       ClickedResetAfterDelay: () => [model, [DelayReset()]],
-      CompletedDelayReset: () => [{ count: 0 }, []],
+      CompletedDelayReset: () => [evo(model, { count: () => 0 }), []],
     }),
   )

--- a/packages/website/src/snippet/counterUpdate.ts
+++ b/packages/website/src/snippet/counterUpdate.ts
@@ -1,5 +1,6 @@
 import { Match as M } from 'effect'
 import { Command } from 'foldkit'
+import { evo } from 'foldkit/struct'
 
 // UPDATE
 
@@ -12,8 +13,8 @@ const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedDecrement: () => [{ count: model.count - 1 }, []],
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
-      ClickedReset: () => [{ count: 0 }, []],
+      ClickedDecrement: () => [evo(model, { count: count => count - 1 }), []],
+      ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
+      ClickedReset: () => [evo(model, { count: () => 0 }), []],
     }),
   )


### PR DESCRIPTION
## What and why

The counter is the first code a reader sees, and it built each new Model as an object literal while every other update in the docs used `evo`.

The docs already contradicted themselves on this. `foldkitCounterAutoCount.ts`, rendered on the React comparison page, shows the same counter with `evo`:

```ts
ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
```

And `packages/create-foldkit-app/templates/base/AGENTS.md` ships that same line to every scaffolded app, followed by "Use `evo()` from `foldkit/struct` for immutable model updates. Never spread or `Object.assign`." So a reader met the literal on the first page, met `evo` later with no explained transition, and their new project's agent file told them the first form was wrong.

The literal also only works because the Model happens to have exactly one field. The counter grows one on the Subscriptions page, at which point `{ count: model.count + 1 }` stops typechecking and the tempting fix is a spread, which is the habit the Performance and View Memoization pages then have to un-teach.

## What changed

| File | Change |
| --- | --- |
| `packages/website/src/snippet/counter.ts` | 3 branches to `evo` |
| `packages/website/src/snippet/counterUpdate.ts` | 3 branches to `evo` |
| `packages/website/src/snippet/counterCommands.ts` | `CompletedDelayReset` to `evo` |
| `examples/counter/src/main.ts` | 3 branches to `evo` |
| `examples/counters/src/counter.ts` | 2 branches to `evo` |
| `packages/website/src/page/core/update.md` | one paragraph introducing `evo` where the snippet is |

`init` literals and Story/Scene fixtures are untouched. There is no prior Model to evolve there, so the literal is correct.

## Decisions, and what I rejected

**Lambda over point-free.** I used `count: count => count + 1` rather than `count: Number.increment`. The strict reading of the `evo` style rule prefers point-free when the update depends only on that field's current value, but the two places that already show this exact branch with `evo` (`foldkitCounterAutoCount.ts` and the scaffolded `AGENTS.md`) both use the lambda. Point-free here would have traded one inconsistency for another. The lambda also makes the "function from current value to next value" idea legible on first read, which is exactly what the Immutability page claims about `evo`.

**Reset goes through `evo` too**, as `count: () => 0`, so all three branches construct the same way. Keeping `{ count: 0 }` there was defensible, but a three-branch match that switches construction style mid-block invites a first-time reader to hunt for a meaning that isn't there.

## Verification

- `pnpm format:check`, `pnpm lint`, `pnpm check:dead-code`, `pnpm build`, `pnpm -r typecheck`, `pnpm test` all green via the pre-push hook.
- `counter-example` and `counters-example` tests pass (21 tests). These are Story and Scene tests, so increment, decrement, and reset are exercised at runtime rather than only typechecked.
- Website e2e was skipped locally for missing Playwright browsers. CI runs it.
- No changeset. `website`, `counter-example`, and `counters-example` are all private, and `changeset status --since=origin/main` reports nothing to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhiAZ6yVa3yMn1g78d7RNi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that model updates immutably preserve unspecified fields and references.

- **Examples**
  - Updated counter examples to use immutable state evolution for increment, decrement, and reset actions.

- **Bug Fixes**
  - Ensured counter resets and updates are derived from the current model while preserving unrelated state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->