### PR TITLE
docs: correct the Document return in the 0.134.0 migration snippet

### DIFF
--- a/.changeset/correct-document-migration-snippet.md
+++ b/.changeset/correct-document-migration-snippet.md
@@ -1,0 +1,9 @@
+---
+'create-foldkit-app': patch
+'@foldkit/devtools': patch
+'@foldkit/markdown': patch
+'@foldkit/ui': patch
+'foldkit': patch
+---
+
+Correct the root view example in the 0.134.0 migration guide. The snippet returned an `Html` value annotated as `Document`, which does not compile. `Document` is `{ title, body, ... }`, so both the before and after form now return that struct.

--- a/packages/create-foldkit-app/CHANGELOG.md
+++ b/packages/create-foldkit-app/CHANGELOG.md
@@ -18,12 +18,17 @@
   // before
   export const view = (model: Model): Document => {
     const h = html<Message>()
-    return h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+    return {
+      title: 'Example',
+      body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+    }
   }
 
   // after
-  export const view = (model: Model, h: HtmlBuilder<Message>): Document =>
-    h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+  export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
+    title: 'Example',
+    body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+  })
   ```
 
   The same applies to `crash.view`, which now takes `(context, h)`, and to `Scene.scene`'s `view`.

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -18,12 +18,17 @@
   // before
   export const view = (model: Model): Document => {
     const h = html<Message>()
-    return h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+    return {
+      title: 'Example',
+      body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+    }
   }
 
   // after
-  export const view = (model: Model, h: HtmlBuilder<Message>): Document =>
-    h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+  export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
+    title: 'Example',
+    body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+  })
   ```
 
   The same applies to `crash.view`, which now takes `(context, h)`, and to `Scene.scene`'s `view`.

--- a/packages/foldkit/CHANGELOG.md
+++ b/packages/foldkit/CHANGELOG.md
@@ -18,12 +18,17 @@
   // before
   export const view = (model: Model): Document => {
     const h = html<Message>()
-    return h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+    return {
+      title: 'Example',
+      body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+    }
   }
 
   // after
-  export const view = (model: Model, h: HtmlBuilder<Message>): Document =>
-    h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+  export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
+    title: 'Example',
+    body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+  })
   ```
 
   The same applies to `crash.view`, which now takes `(context, h)`, and to `Scene.scene`'s `view`.

--- a/packages/markdown/CHANGELOG.md
+++ b/packages/markdown/CHANGELOG.md
@@ -18,12 +18,17 @@
   // before
   export const view = (model: Model): Document => {
     const h = html<Message>()
-    return h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+    return {
+      title: 'Example',
+      body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+    }
   }
 
   // after
-  export const view = (model: Model, h: HtmlBuilder<Message>): Document =>
-    h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+  export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
+    title: 'Example',
+    body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+  })
   ```
 
   The same applies to `crash.view`, which now takes `(context, h)`, and to `Scene.scene`'s `view`.

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -18,12 +18,17 @@
   // before
   export const view = (model: Model): Document => {
     const h = html<Message>()
-    return h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+    return {
+      title: 'Example',
+      body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+    }
   }
 
   // after
-  export const view = (model: Model, h: HtmlBuilder<Message>): Document =>
-    h.div([], [h.button([h.OnClick(Clicked())], ['go'])])
+  export const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
+    title: 'Example',
+    body: h.div([], [h.button([h.OnClick(Clicked())], ['go'])]),
+  })
   ```
 
   The same applies to `crash.view`, which now takes `(context, h)`, and to `Scene.scene`'s `view`.


### PR DESCRIPTION
The 0.134.0 migration guide showed a root view returning `h.div(...)` annotated as `Document`. `Document` is `{ title, body, ... }` (`packages/foldkit/src/html/index.ts:163`), so the snippet consumers were told to copy does not compile.

Both the before and after form now return that struct. The corrected `after` matches the shape of every real root view in the repo, for example `examples/counter/src/main.ts:53`.

## Scope

The error lived in the changeset body, so changesets replicated it into five package CHANGELOGs: `foldkit`, `@foldkit/ui`, `@foldkit/markdown`, `create-foldkit-app`, and `@foldkit/devtools`. All five are corrected. Historical entries further down those files are untouched.

No source changed. Every real root view in the repo was already correct.

## Changeset

Patch across all five, since `CHANGELOG.md` ships in each published tarball and the incorrect guide is currently on npm.

`@foldkit/markdown` is included because its `package.json` has `private: false`, even though it is absent from the commit skill's published-package list. Worth a look in case that list is the thing that is out of date.

## Not covered here

The already-published `foldkit@0.134.0` tarball is immutable, and the GitHub release body still carries the original snippet. That release page is the URL currently circulating, so it needs a separate manual edit.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLHWrc37pL4XbLV9qPLzMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLHWrc37pL4XbLV9qPLzMd)_