### PR TITLE
Remove warning on missing snippets; catch at test time

### DIFF
--- a/.changeset/force-include-effect-boolean.md
+++ b/.changeset/force-include-effect-boolean.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/vite-plugin': patch
+---
+
+Force-include `effect/Boolean` in the dep optimizer. Foldkit's compiled dist imports the `Boolean` namespace from bare `'effect'`, so a consumer that never names it in their own source got a prebundled `effect.js` without it and crashed at runtime in dev.

--- a/packages/vite-plugin-foldkit/src/index.ts
+++ b/packages/vite-plugin-foldkit/src/index.ts
@@ -73,6 +73,7 @@ export type FoldkitPluginOptions = Readonly<{
 // source by `scripts/check-effect-prebundle.ts` (runs in `pnpm check`).
 const FORCE_INCLUDED_EFFECT_NAMESPACES: ReadonlyArray<string> = [
   'effect/Array',
+  'effect/Boolean',
   'effect/Cause',
   'effect/Clock',
   'effect/Context',

--- a/packages/website/src/markdown/islands.ts
+++ b/packages/website/src/markdown/islands.ts
@@ -11,23 +11,6 @@ import { lookupSnippet } from './snippets'
 
 // ISLANDS
 
-const createWarnOnce = (buildMessage: (name: string) => string) => {
-  const warned = new Set<string>()
-
-  return (name: string): void => {
-    if (!warned.has(name)) {
-      warned.add(name)
-      console.warn(buildMessage(name))
-    }
-  }
-}
-
-const warnMissingSnippetOnce = createWarnOnce(
-  name =>
-    `[docs] No snippet registered for "${name}". ` +
-    'Add the file under src/snippet, or fix the ::Snippet name attribute.',
-)
-
 /**
  * The site's island views, paired with {@link islandAttributes} so attributes
  * arrive already decoded. `Snippet` renders a build-time highlighted source file
@@ -37,15 +20,16 @@ const warnMissingSnippetOnce = createWarnOnce(
  * name; `Faq` hands its rendered children to the page's collapsible shell. The
  * page's slots live in the app Model, so the views close over `slots`; the copy
  * state rides inside the slots' `renderCopyButton`.
+ *
+ * A `::Snippet` name with no matching file under `src/snippet` renders nothing,
+ * which the snippet registration test is there to catch. The views stay pure, so
+ * a missing snippet reports at test time rather than warning from a render.
  */
 export const docIslands = (slots: Slots<string>): Markdown.Islands => {
   return Markdown.islandsFor(islandAttributes, {
     Snippet: ({ name, label, class: className }) =>
       Option.match(lookupSnippet(name), {
-        onNone: () => {
-          warnMissingSnippetOnce(name)
-          return ih.empty
-        },
+        onNone: () => ih.empty,
         onSome: snippet =>
           highlightedCodeBlock(
             ih.div(


### PR DESCRIPTION
## Summary

Removes runtime warnings for missing snippet registrations and shifts validation to test time. The views now stay pure by rendering nothing for missing snippets, with the snippet registration test catching the issue instead.

## Changes

- **packages/website/src/markdown/islands.ts**
  - Removed `createWarnOnce` utility and `warnMissingSnippetOnce` warning function
  - Simplified `Snippet` island to return empty when `lookupSnippet` returns `None`, without warning
  - Updated docstring to clarify that missing snippets render nothing and are caught by the snippet registration test

- **packages/vite-plugin-foldkit/src/index.ts**
  - Added `'effect/Boolean'` to `FORCE_INCLUDED_EFFECT_NAMESPACES` to ensure the Boolean namespace is included in the dependency optimizer prebundle
  - Fixes a runtime crash in dev when consumers don't directly import from `effect/Boolean` but Foldkit's compiled dist does

- **Changeset**
  - Documents the `effect/Boolean` force-include fix as a patch for `@foldkit/vite-plugin`

## Implementation Details

The `Snippet` island view called a warn-once helper from its `onNone` branch, so rendering a page performed a side effect: a `console.warn` plus a mutation of a module-level `Set`. Foldkit confines side effects to Commands, Mount, flags, Subscriptions, Resources, and ManagedResources, and a warn fired mid-render belongs to none of them. A Command was not reachable either, since the island view runs inside `Markdown.view`'s fold with no dispatch channel out.

The warn was also redundant. The snippet island registration test in `packages/website/src/markdown/docPage.test.ts` globs `src/snippet` and asserts that every `::Snippet{name}` resolves, covering all 83 markdown pages under `src/page`. An unregistered name already fails CI, naming both the offending page and the snippet.

This trades feedback latency for purity rather than improving it. A browser warn fires as soon as you load the page, while the test waits for a test run. The case for removing it is that the test already covered the case, so the warn only restated a CI-known fact somewhere nobody acts on, and it shipped to production rather than being gated to development the way the `schemaSegment` warn in `packages/foldkit/src/route/parser.ts` is.

https://claude.ai/code/session_01GqGgh63BMkeP3p9CJ81hsm