### PR TITLE
fix(form): split submission success and failure Messages

### DIFF
--- a/examples/form/src/main.ts
+++ b/examples/form/src/main.ts
@@ -72,12 +72,8 @@ export const CompletedValidateEmail = m('CompletedValidateEmail', {
 })
 export const UpdatedMessageText = m('UpdatedMessageText', { value: S.String })
 export const ClickedFormSubmit = m('ClickedFormSubmit')
-export const CompletedSubmitForm = m('CompletedSubmitForm', {
-  success: S.Boolean,
-  name: S.String,
-  email: S.String,
-  messageText: S.String,
-})
+export const SucceededSubmitForm = m('SucceededSubmitForm', { name: S.String })
+export const FailedSubmitForm = m('FailedSubmitForm')
 
 export const Message = S.Union([
   UpdatedName,
@@ -85,7 +81,8 @@ export const Message = S.Union([
   CompletedValidateEmail,
   UpdatedMessageText,
   ClickedFormSubmit,
-  CompletedSubmitForm,
+  SucceededSubmitForm,
+  FailedSubmitForm,
 ])
 export type Message = typeof Message.Type
 
@@ -227,30 +224,26 @@ export const update = (
         ]
       },
 
-      CompletedSubmitForm: ({ success, name }) => {
-        if (success) {
-          return [
-            evo(model, {
-              submission: () =>
-                SubmitSuccess({
-                  confirmationText: `Welcome to the waitlist, ${name}! We'll be in touch soon.`,
-                }),
+      SucceededSubmitForm: ({ name }) => [
+        evo(model, {
+          submission: () =>
+            SubmitSuccess({
+              confirmationText: `Welcome to the waitlist, ${name}! We'll be in touch soon.`,
             }),
-            [],
-          ]
-        } else {
-          return [
-            evo(model, {
-              submission: () =>
-                SubmitError({
-                  error:
-                    'Sorry, there was an error adding you to the waitlist. Please try again.',
-                }),
+        }),
+        [],
+      ],
+
+      FailedSubmitForm: () => [
+        evo(model, {
+          submission: () =>
+            SubmitError({
+              error:
+                'Sorry, there was an error adding you to the waitlist. Please try again.',
             }),
-            [],
-          ]
-        }
-      },
+        }),
+        [],
+      ],
     }),
   )
 
@@ -260,19 +253,17 @@ const FAKE_API_DELAY_MS = 500
 
 export const SubmitForm = Command.define('SubmitForm', {
   args: { name: S.String, email: S.String, messageText: S.String },
-  messages: [CompletedSubmitForm],
-  execute: ({ name, email, messageText }) =>
+  messages: [SucceededSubmitForm, FailedSubmitForm],
+  execute: ({ name }) =>
     Effect.gen(function* () {
       yield* Effect.sleep(`${FAKE_API_DELAY_MS} millis`)
 
-      const success = yield* Random.nextBoolean
-
-      return CompletedSubmitForm({
-        success,
-        name,
-        email,
-        messageText,
-      })
+      const isSuccess = yield* Random.nextBoolean
+      if (isSuccess) {
+        return SucceededSubmitForm({ name })
+      } else {
+        return FailedSubmitForm()
+      }
     }),
 })
 

--- a/examples/form/src/scene.test.ts
+++ b/examples/form/src/scene.test.ts
@@ -13,9 +13,10 @@ import {
 import { describe, test } from 'vitest'
 
 import {
-  CompletedSubmitForm,
   CompletedValidateEmail,
+  FailedSubmitForm,
   SubmitForm,
+  SucceededSubmitForm,
   ValidateEmail,
   initialModel,
   update,
@@ -128,15 +129,7 @@ describe('view', () => {
       click(role('button', { name: 'Join Waitlist' })),
       expect(role('button', { name: 'Joining...' })).toBeDisabled(),
       Command.expectExact(SubmitForm),
-      Command.resolve(
-        SubmitForm,
-        CompletedSubmitForm({
-          success: true,
-          name: 'Alice',
-          email: 'alice@example.com',
-          messageText: '',
-        }),
-      ),
+      Command.resolve(SubmitForm, SucceededSubmitForm({ name: 'Alice' })),
       expect(role('status')).toContainText('Welcome to the waitlist, Alice!'),
       expect(role('button', { name: 'Join Waitlist' })).toExist(),
     )
@@ -154,15 +147,7 @@ describe('view', () => {
       given(validModel),
       submit(role('form')),
       Command.expectExact(SubmitForm),
-      Command.resolve(
-        SubmitForm,
-        CompletedSubmitForm({
-          success: false,
-          name: 'Alice',
-          email: 'alice@example.com',
-          messageText: '',
-        }),
-      ),
+      Command.resolve(SubmitForm, FailedSubmitForm()),
       expect(role('alert')).toContainText('Sorry, there was an error'),
     )
   })

--- a/examples/form/src/story.test.ts
+++ b/examples/form/src/story.test.ts
@@ -4,10 +4,11 @@ import { describe, expect, test } from 'vitest'
 
 import {
   ClickedFormSubmit,
-  CompletedSubmitForm,
   CompletedValidateEmail,
+  FailedSubmitForm,
   type Model,
   SubmitForm,
+  SucceededSubmitForm,
   UpdatedEmail,
   UpdatedMessageText,
   UpdatedName,
@@ -167,15 +168,7 @@ describe('update', () => {
           expect(model.submission._tag).toBe('Submitting')
         }),
         Command.expectHas(SubmitForm),
-        Command.resolve(
-          SubmitForm,
-          CompletedSubmitForm({
-            success: true,
-            name: 'Alice',
-            email: 'alice@example.com',
-            messageText: '',
-          }),
-        ),
+        Command.resolve(SubmitForm, SucceededSubmitForm({ name: 'Alice' })),
         model(model => {
           expect(model.submission._tag).toBe('SubmitSuccess')
           if (model.submission._tag === 'SubmitSuccess') {
@@ -185,20 +178,12 @@ describe('update', () => {
       )
     })
 
-    test('failed CompletedSubmitForm sets SubmitError', () => {
+    test('FailedSubmitForm sets SubmitError', () => {
       story(
         update,
         given(validModel),
         message(ClickedFormSubmit()),
-        Command.resolve(
-          SubmitForm,
-          CompletedSubmitForm({
-            success: false,
-            name: 'Alice',
-            email: 'alice@example.com',
-            messageText: '',
-          }),
-        ),
+        Command.resolve(SubmitForm, FailedSubmitForm()),
         model(model => {
           expect(model.submission._tag).toBe('SubmitError')
         }),


### PR DESCRIPTION
## Summary

- replace the boolean-bearing `CompletedSubmitForm` result with
  `SucceededSubmitForm` and `FailedSubmitForm`
- carry only the submitter name required by the success reducer
- update the form Story and Scene coverage for both outcomes

## Why

PR #871 established that Commands with meaningful failure outcomes use distinct
`Succeeded*` and `Failed*` Messages. The form example still encoded that outcome
as `CompletedSubmitForm({ success: boolean })`, even though failure transitions
the Model to `SubmitError`.

This follow-up addresses the outside-diff CodeRabbit finding that was missed in
the original review pass.

## Validation

- full Foldkit pre-push suite
- all workspace builds and typechecks
- all package and example tests
- website Chromium smoke test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form submission handling by clearly distinguishing successful and failed submissions.
  * Successful submissions now display a personalized confirmation message.
  * Failed submissions consistently display an error message.
* **Tests**
  * Updated form interaction tests to verify the revised success and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->