### PR TITLE
fix(foldkit): defer a Command's execute body until execution

### DIFF
--- a/.changeset/command-defer-execute-body.md
+++ b/.changeset/command-defer-execute-body.md
@@ -1,0 +1,16 @@
+---
+'foldkit': patch
+'@foldkit/ui': patch
+---
+
+Defer a Command's `execute` body until the runtime executes it.
+
+`Command.define` invoked the `execute` body as soon as update constructed the Command. Only the resulting Effect was deferred, so every expression the body evaluated on the way to returning that Effect ran immediately, inside a pure reducer.
+
+A body that reaches for a browser API therefore threw from update itself. `Popover.update` raised `ReferenceError: CSS is not defined` outside a browser, because `InertOthers` builds its selectors with `CSS.escape` and update constructs that Command unconditionally. It threw for a non-modal popover too, where the Command is built and then discarded. That made `@foldkit/ui` popovers, and the picker, combobox, menu, and date picker built on them, unusable in a headless Story even though no Effect ever ran.
+
+The body is now suspended, so constructing a Command runs none of it. No side effect the body performs and no exception it raises can reach update, a Command that update builds and discards runs nothing at all, and a throwing body surfaces as a contained Effect failure the runtime reports with the Message that caused it, rather than an exception escaping the reducer.
+
+This applies to Commands that declare `args`, on both the plain and the interruptible paths. A Command with no `args` already received `execute` as an Effect value and never had the problem. Interrupt keys are still derived at construction, so nothing about interrupt addressing changes.
+
+Thanks @artile for the report and the diagnosis.

--- a/packages/foldkit/src/command/define.test.ts
+++ b/packages/foldkit/src/command/define.test.ts
@@ -1,0 +1,118 @@
+import { Effect, Schema as S } from 'effect'
+import { expect } from 'vitest'
+
+import { describe, it } from '@effect/vitest'
+
+import { m } from '../message/index.js'
+import * as Command from './index.js'
+import { __CurrentRegistry, __makeRegistry } from './interruptible/index.js'
+
+const CompletedRunTask = m('CompletedRunTask', { taskId: S.Number })
+const CompletedReadBrowserGlobal = m('CompletedReadBrowserGlobal')
+const CompletedMeasureElement = m('CompletedMeasureElement')
+const CompletedSaveDraft = m('CompletedSaveDraft', { draftId: S.Number })
+const CompletedDoWork = m('CompletedDoWork')
+
+describe('Command.define defers its execute body', () => {
+  it('does not run the body of an args Command until the effect runs', () => {
+    let bodyRunCount = 0
+
+    const RunTask = Command.define('RunTask', {
+      args: { taskId: S.Number },
+      messages: [CompletedRunTask],
+      execute: ({ taskId }) => {
+        bodyRunCount = bodyRunCount + 1
+        return Effect.succeed(CompletedRunTask({ taskId }))
+      },
+    })
+
+    const instance = RunTask({ taskId: 7 })
+    expect(bodyRunCount).toBe(0)
+
+    expect(Effect.runSync(instance.effect)).toEqual(
+      CompletedRunTask({ taskId: 7 }),
+    )
+    expect(bodyRunCount).toBe(1)
+  })
+
+  it('never runs the body of a Command that update constructs and discards', () => {
+    let bodyRunCount = 0
+
+    const ReadBrowserGlobal = Command.define('ReadBrowserGlobal', {
+      args: { id: S.String },
+      messages: [CompletedReadBrowserGlobal],
+      execute: () => {
+        bodyRunCount = bodyRunCount + 1
+        return Effect.succeed(CompletedReadBrowserGlobal())
+      },
+    })
+
+    ReadBrowserGlobal({ id: 'discarded' })
+
+    expect(bodyRunCount).toBe(0)
+  })
+
+  it('surfaces a throwing body as an effect failure rather than a construction throw', () => {
+    const MeasureElement = Command.define('MeasureElement', {
+      args: { id: S.String },
+      messages: [CompletedMeasureElement],
+      execute: () => {
+        throw new Error('reads a browser global')
+      },
+    })
+
+    const instance = MeasureElement({ id: 'panel' })
+
+    const exit = Effect.runSyncExit(instance.effect)
+    expect(exit._tag).toBe('Failure')
+  })
+
+  it('defers the body of an interruptible args Command while keying at construction', () => {
+    let bodyRunCount = 0
+
+    const SaveDraft = Command.define('SaveDraft', {
+      args: { draftId: S.Number },
+      messages: [CompletedSaveDraft],
+      interrupt: {
+        keyFields: ['draftId'],
+        toKey: ({ draftId }) => draftId.toString(),
+      },
+      execute: ({ draftId }) => {
+        bodyRunCount = bodyRunCount + 1
+        return Effect.succeed(CompletedSaveDraft({ draftId }))
+      },
+    })
+
+    const instance = SaveDraft({ draftId: 3 })
+    expect(instance.key).toBe('SaveDraft:3')
+    expect(bodyRunCount).toBe(0)
+
+    const result = Effect.runSync(
+      Effect.provideService(
+        instance.effect,
+        __CurrentRegistry,
+        __makeRegistry(),
+      ),
+    )
+    expect(result).toEqual(CompletedSaveDraft({ draftId: 3 }))
+    expect(bodyRunCount).toBe(1)
+  })
+
+  it('still runs a no-args Command effect, which is already a value', () => {
+    let effectRunCount = 0
+
+    const DoWork = Command.define('DoWork', {
+      messages: [CompletedDoWork],
+      execute: Effect.sync(() => {
+        effectRunCount = effectRunCount + 1
+        return CompletedDoWork()
+      }),
+    })
+
+    const instance = DoWork()
+    expect(effectRunCount).toBe(0)
+
+    expect(Effect.runSync(instance.effect)).toEqual(CompletedDoWork())
+    expect(effectRunCount).toBe(1)
+  })
+})

--- a/packages/foldkit/src/command/index.ts
+++ b/packages/foldkit/src/command/index.ts
@@ -113,6 +113,20 @@ type DefineConfig = Readonly<{
   execute: any
 }>
 
+// NOTE: The suspend is load bearing, not a redundant wrapper. Without it the
+// `execute` body runs the moment update constructs the Command, so any
+// expression it evaluates on the way to returning its Effect runs inside a pure
+// reducer. Every side effect the body performs runs there, and every exception
+// it raises escapes update, even when update discards the Command instead of
+// returning it. Reading a missing browser global is one instance, the one that
+// surfaced this, not the boundary of it. Suspending defers the body to
+// execution, where the runtime can contain any failure it produces.
+// A no-args `execute` is already an Effect value and needs no equivalent.
+const suspendExecute = (
+  config: DefineConfig,
+  args: any,
+): Effect.Effect<any, any, any> => Effect.suspend(() => config.execute(args))
+
 /**
  * Defines a Command. Every input is a named field: `args` declares the args
  * Schema, `messages` lists the Messages this Command can produce, `execute`
@@ -121,6 +135,11 @@ type DefineConfig = Readonly<{
  * `args` is optional. Omit it and `execute` is a bare Effect and the Definition
  * is callable as `Definition()`; declare it and `execute` receives the args and
  * the Definition is callable as `Definition(args)`.
+ *
+ * Constructing a Command never runs `execute`. When `args` is declared the body
+ * is deferred until the runtime executes the Command, so no side effect the
+ * body performs and no exception it raises can reach update, and a Command that
+ * update builds and then discards runs nothing at all.
  *
  * With `interrupt`, every invocation registers under a key in the runtime's
  * interrupt registry for the duration of its Effect, and the returned Definition
@@ -290,7 +309,7 @@ export function define(name: string, config: DefineConfig): unknown {
       const definition = (args: any) => ({
         name,
         args,
-        effect: config.execute(args),
+        effect: suspendExecute(config, args),
         messageMappers: [],
       })
       brandAsDefinition(definition, name)
@@ -335,7 +354,7 @@ export function define(name: string, config: DefineConfig): unknown {
       key: name,
       effect: Interruptible.__registerKeyWhileRunning(
         name,
-        config.execute(args),
+        suspendExecute(config, args),
       ),
       messageMappers: [],
     })
@@ -357,7 +376,7 @@ export function define(name: string, config: DefineConfig): unknown {
       key,
       effect: Interruptible.__registerKeyWhileRunning(
         key,
-        config.execute(args),
+        suspendExecute(config, args),
       ),
       messageMappers: [],
     }


### PR DESCRIPTION
Fixes #876.

## What

`Command.define` invoked the `execute` body as soon as update constructed the Command. Only the resulting Effect was deferred, so every expression the body evaluated on the way to returning that Effect ran immediately, inside a pure reducer.

A body that reaches for a browser API therefore threw from update itself. `Popover.update` raised `ReferenceError: CSS is not defined` outside a browser, because `InertOthers` builds its selectors with `CSS.escape` and update constructs that Command unconditionally. It threw for a non-modal popover too, where the Command is built and then discarded. That made `@foldkit/ui` popovers, and the picker, combobox, menu, and date picker built on them, unusable in a headless Story even though no Effect ever ran.

The body is now suspended, so constructing a Command runs none of it.

## Changes

- `packages/foldkit/src/command/index.ts`: a `suspendExecute` helper applied at the three sites that called `config.execute(args)` eagerly, one on the plain args path and two on the interruptible args path. A `NOTE:` records why the suspend is load bearing, since a bare wrapper reads as removable. The `define` TSDoc now states the deferral as a guarantee.
- `packages/foldkit/src/command/define.test.ts`: regression coverage.
- Changeset: `patch` for `foldkit` and `@foldkit/ui`.

## Design decision

The report offered three shapes. I took the root cause rather than either narrow fix.

The deciding argument is an inconsistency inside the existing API. A no-args Command is already lazy, because `execute` is handed over as an `Effect` value and nothing runs at construction. An args Command ran its body immediately. Same `Command.define`, two different purity contracts, and which one you got depended on whether you declared `args`. Fixing the primitive removes that split and covers every present and future instance instead of the one popover hit.

`Effect.suspend` keeps `effect` typed as an `Effect`, so the deferral lives inside the Effect rather than in the Command's shape. The public `Command` type is unchanged and the three readers of `.effect` are untouched. **The popover needs no change at all**, which is the signal that the fix landed where the cause was.

Rejected alternatives:

- **Guarding `idSelector`.** `CSS.escape` is load bearing for correctness per its own TSDoc, since digit-leading UUID ids need it. A guard would return an unescaped selector outside the browser, trading a loud throw for a quiet wrong selector, and it would leave the hazard for every other browser global.
- **Making `OptionExt.when` lazy in its value.** Once the primitive is fixed, the only remaining benefit is avoiding a discarded object allocation, paid for with thunk churn at every call site.

One consequence worth naming: `Effect.suspend` re-evaluates the body per run of that Effect. The runtime forks each Command's effect exactly once (`runtime/runtime.ts:1878`), so this is inert today, but it would become observable if a Command's effect were ever retried or replayed.

## Verification

Reproduced first, on `main`, with a bare `Popover.update` under Node:

```
init ok
THREW: ReferenceError: CSS is not defined
```

After the fix, both modes return cleanly and the `CSS` access happens only when the effect runs, where it surfaces as a contained failure:

```
isModal=false: isOpen=true commands=[]
isModal=true:  isOpen=true commands=[LockScroll, InertOthers]
   LockScroll effect -> Failure
   InertOthers effect -> Failure
```

The new tests were confirmed to fail without the fix. Reverting the three sites turns 4 of the 5 red, and the one that stays green is the no-args case that was never affected. All 1674 `foldkit` tests pass with the fix in place, and `foldkit` typechecks clean.

Note for the record: the report quoted the older positional `Command.define(name, args, message)(builder)` signature, so its line numbers do not match `main`. The bug survived the move to the options-object form intact, so the diagnosis held.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q43enz48LZBnU6CT5Bj1Ks)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred command execution until commands are actually run, preventing discarded commands from triggering side effects.
  * Converted execution exceptions into contained effect failures.
  * Applied consistent behavior to commands with arguments and interruptible commands.
  * Preserved reducer purity and unchanged interrupt-key derivation.

* **Documentation**
  * Clarified that constructing or discarding argument-bearing commands does not execute their bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->