### PR TITLE
fix(ui): export Message constructors that were re-exported as types

### DIFF
--- a/.changeset/public-message-constructors.md
+++ b/.changeset/public-message-constructors.md
@@ -1,0 +1,32 @@
+---
+'@foldkit/ui': minor
+---
+
+Export the Message constructors that `Combobox`, `Listbox`, `Menu`, `Popover`, and `Slider` only re-exported as types.
+
+Each of these barrels listed part of its Message union under `export type { ... }`. That re-exports the type and shadows the value, so the constructor was unreachable even though it was implemented and exported from the module behind the barrel. The deep import path resolved to the same barrel, so there was no way around it.
+
+```ts
+import { Combobox } from '@foldkit/ui'
+
+typeof Combobox.Selected // 'function'
+typeof Combobox.UpdatedInputValue // was 'undefined', now 'function'
+```
+
+42 constructors across the five components are now callable. Each already had both a `const` and a matching type alias in its source module, so a value re-export carries the type as well and nothing that referenced these names as types has to change.
+
+| Namespace  | Union members | Previously constructible | Restored |
+| ---------- | ------------- | ------------------------ | -------- |
+| `Combobox` | 22            | 13                       | 9        |
+| `Listbox`  | 24            | 13                       | 11       |
+| `Menu`     | 25            | 13                       | 12       |
+| `Popover`  | 15            | 11                       | 4        |
+| `Slider`   | 6             | 0                        | 6        |
+
+This matters for writing a headless `Story` against a component that embeds one of these, where driving the component means dispatching its Messages. It also matters for tooling that reads a Message union as a schema, such as the DevTools surface, which advertised tags that could not be built.
+
+`AnchorConfig` stays type-only, since exposing the schema value is the subject of a separate question about the anchor runtime surface. So do the `ActivationTrigger` and `ActivationMode` literal schemas, which name no Message and need no constructor. `Orientation` is a literal schema of the same kind, already exported as a value by `Listbox` and type-only on `Tabs`, and this change leaves both as they were.
+
+A test now audits every component barrel and fails when a Message union declares a tag the barrel does not export as a callable.
+
+Thanks @artile for the report.

--- a/packages/ui/src/combobox/public.ts
+++ b/packages/ui/src/combobox/public.ts
@@ -32,10 +32,6 @@ export {
   ScrollIntoView,
   ClickItem,
   DetectMovementOrAnimationEnd,
-} from './shared.js'
-
-export type {
-  ActivationTrigger,
   Opened,
   Closed,
   BlurredInput,
@@ -45,6 +41,10 @@ export type {
   RequestedItemClick,
   UpdatedInputValue,
   PressedToggleButton,
+} from './shared.js'
+
+export type {
+  ActivationTrigger,
   ItemConfig,
   GroupHeading,
   BaseViewInputsCommon,

--- a/packages/ui/src/listbox/public.ts
+++ b/packages/ui/src/listbox/public.ts
@@ -32,10 +32,6 @@ export {
   ClickItem,
   DelayClearSearch,
   DetectMovementOrAnimationEnd,
-} from './shared.js'
-
-export type {
-  ActivationTrigger,
   Opened,
   Closed,
   BlurredItems,
@@ -47,6 +43,10 @@ export type {
   PressedPointerOnButton,
   IgnoredMouseClick,
   SuppressedSpaceScroll,
+} from './shared.js'
+
+export type {
+  ActivationTrigger,
   ItemConfig,
   GroupHeading,
   BaseViewInputsCommon,

--- a/packages/ui/src/menu/public.ts
+++ b/packages/ui/src/menu/public.ts
@@ -31,10 +31,6 @@ export {
   ClickItem,
   DelayClearSearch,
   DetectMovementOrAnimationEnd,
-} from './index.js'
-
-export type {
-  ActivationTrigger,
   Opened,
   Closed,
   BlurredItems,
@@ -47,6 +43,10 @@ export type {
   ReleasedPointerOnItems,
   IgnoredMouseClick,
   SuppressedSpaceScroll,
+} from './index.js'
+
+export type {
+  ActivationTrigger,
   InitConfig,
   ViewInputs,
   ItemConfig,

--- a/packages/ui/src/popover/public.ts
+++ b/packages/ui/src/popover/public.ts
@@ -30,16 +30,12 @@ export {
   FocusPanel,
   FocusButton,
   DetectMovementOrAnimationEnd,
-} from './index.js'
-
-export type {
   BlurredPanel,
   PressedPointerOnButton,
   IgnoredMouseClick,
   SuppressedSpaceScroll,
-  InitConfig,
-  ViewInputs,
-  RenderInfo,
 } from './index.js'
+
+export type { InitConfig, ViewInputs, RenderInfo } from './index.js'
 
 export type { AnchorConfig } from '../anchor.js'

--- a/packages/ui/src/publicMessageConstructors.test.ts
+++ b/packages/ui/src/publicMessageConstructors.test.ts
@@ -1,0 +1,157 @@
+import { Array, Option, Predicate, pipe } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import * as Animation from './animation/public.js'
+import * as Button from './button/public.js'
+import * as Calendar from './calendar/public.js'
+import * as Checkbox from './checkbox/public.js'
+import * as Combobox from './combobox/public.js'
+import * as DatePicker from './datePicker/public.js'
+import * as Dialog from './dialog/public.js'
+import * as Disclosure from './disclosure/public.js'
+import * as DragAndDrop from './dragAndDrop/public.js'
+import * as Fieldset from './fieldset/public.js'
+import * as FileDrop from './fileDrop/public.js'
+import * as Input from './input/public.js'
+import * as Listbox from './listbox/public.js'
+import * as Menu from './menu/public.js'
+import * as Nav from './nav/public.js'
+import * as Popover from './popover/public.js'
+import * as RadioGroup from './radioGroup/public.js'
+import * as Select from './select/public.js'
+import * as Slider from './slider/public.js'
+import * as Switch from './switch/public.js'
+import * as Tabs from './tabs/public.js'
+import * as Textarea from './textarea/public.js'
+import * as Toast from './toast/public.js'
+import * as Tooltip from './tooltip/public.js'
+import * as VirtualList from './virtualList/public.js'
+
+type BarrelAudit = Readonly<{
+  component: string
+  memberCount: number
+  tags: ReadonlyArray<string>
+  unreachableTags: ReadonlyArray<string>
+}>
+
+const barrelsByComponent: Readonly<Record<string, Record<string, unknown>>> = {
+  animation: Animation,
+  button: Button,
+  calendar: Calendar,
+  checkbox: Checkbox,
+  combobox: Combobox,
+  datePicker: DatePicker,
+  dialog: Dialog,
+  disclosure: Disclosure,
+  dragAndDrop: DragAndDrop,
+  fieldset: Fieldset,
+  fileDrop: FileDrop,
+  input: Input,
+  listbox: Listbox,
+  menu: Menu,
+  nav: Nav,
+  popover: Popover,
+  radioGroup: RadioGroup,
+  select: Select,
+  slider: Slider,
+  switch: Switch,
+  tabs: Tabs,
+  textarea: Textarea,
+  toast: Toast,
+  tooltip: Tooltip,
+  virtualList: VirtualList,
+}
+
+const MINIMUM_COMPONENTS_WITH_A_MESSAGE_UNION = 14
+
+// NOTE: A Schema value is callable, so `Predicate.isObject` rejects it. Reading
+// a property off one has to accept functions as well as plain objects.
+const isIndexable = (
+  value: unknown,
+): value is Readonly<Record<PropertyKey, unknown>> =>
+  Predicate.isObjectKeyword(value)
+
+const isUnknownArray = (value: unknown): value is ReadonlyArray<unknown> =>
+  Array.isArray(value)
+
+const maybeProperty = (value: unknown, key: string): Option.Option<unknown> =>
+  isIndexable(value) ? Option.fromNullishOr(value[key]) : Option.none()
+
+// NOTE: The tag literal sits on the `_tag` field's AST. Reading
+// `fields._tag.literal` instead resolves for a payload-free Message and is
+// undefined for every Message that carries fields, which reads as a union with
+// no tags rather than as an error. The audit asserts a tag was read for every
+// member so that misreading fails instead of passing vacuously.
+const maybeTagOf = (member: unknown): Option.Option<string> =>
+  pipe(
+    maybeProperty(member, 'fields'),
+    Option.flatMap(fields => maybeProperty(fields, '_tag')),
+    Option.flatMap(tag => maybeProperty(tag, 'ast')),
+    Option.flatMap(ast => maybeProperty(ast, 'literal')),
+    Option.filter(Predicate.isString),
+  )
+
+const maybeMessageUnionMembers = (
+  barrel: Record<string, unknown>,
+): Option.Option<ReadonlyArray<unknown>> =>
+  Option.filter(maybeProperty(barrel['Message'], 'members'), isUnknownArray)
+
+const toAudit = (
+  component: string,
+  members: ReadonlyArray<unknown>,
+  barrel: Record<string, unknown>,
+): BarrelAudit => {
+  const tags = pipe(members, Array.map(maybeTagOf), Array.getSomes)
+
+  return {
+    component,
+    memberCount: members.length,
+    tags,
+    unreachableTags: Array.filter(
+      tags,
+      tag => typeof barrel[tag] !== 'function',
+    ),
+  }
+}
+
+const audits: ReadonlyArray<BarrelAudit> = pipe(
+  Object.entries(barrelsByComponent),
+  Array.map(([component, barrel]) =>
+    Option.map(maybeMessageUnionMembers(barrel), members =>
+      toAudit(component, members, barrel),
+    ),
+  ),
+  Array.getSomes,
+)
+
+describe('public Message constructors', () => {
+  it('finds a Message union in the components that declare one', () => {
+    expect(audits.length).toBeGreaterThanOrEqual(
+      MINIMUM_COMPONENTS_WITH_A_MESSAGE_UNION,
+    )
+  })
+
+  it('reads a tag for every member of every Message union', () => {
+    const incomplete = Array.filter(
+      audits,
+      ({ memberCount, tags }) => tags.length !== memberCount,
+    )
+
+    expect(incomplete).toEqual([])
+  })
+
+  it('exports a callable constructor for every tag its Message union declares', () => {
+    const shortfalls = pipe(
+      audits,
+      Array.filter(({ unreachableTags }) =>
+        Array.isReadonlyArrayNonEmpty(unreachableTags),
+      ),
+      Array.map(({ component, unreachableTags }) => ({
+        component,
+        unreachableTags,
+      })),
+    )
+
+    expect(shortfalls).toEqual([])
+  })
+})

--- a/packages/ui/src/slider/public.ts
+++ b/packages/ui/src/slider/public.ts
@@ -10,12 +10,6 @@ export {
   Model,
   Message,
   OutMessage,
-} from './index.js'
-
-export type {
-  InitConfig,
-  ViewInputs,
-  SliderAttributes,
   PressedThumb,
   PressedPointer,
   MovedDragPointer,
@@ -23,3 +17,5 @@ export type {
   CancelledDrag,
   PressedKeyboardNavigation,
 } from './index.js'
+
+export type { InitConfig, ViewInputs, SliderAttributes } from './index.js'


### PR DESCRIPTION
Fixes #877.

## What

`Combobox`, `Listbox`, `Menu`, `Popover`, and `Slider` each listed part of their Message union under `export type { ... }`. That re-exports the type and shadows the value, so the constructor was unreachable even though it was implemented and exported from the module behind the barrel. The deep import path resolves to the same barrel, so there was no way around it.

```ts
import { Combobox } from '@foldkit/ui'

typeof Combobox.Selected // 'function'
typeof Combobox.UpdatedInputValue // was 'undefined', now 'function'
```

## Scope is larger than the issue

The report covered 25 constructors across three components. The same bug is present in `Listbox` and `Slider`, which it did not mention. I swept every `public.ts` in the package rather than take the three named files at face value:

| Namespace  | Union members | Previously constructible | Restored |
| ---------- | ------------- | ------------------------ | -------- |
| `Combobox` | 22            | 13                       | 9        |
| `Listbox`  | 24            | 13                       | 11       |
| `Menu`     | 25            | 13                       | 12       |
| `Popover`  | 15            | 11                       | 4        |
| `Slider`   | 6             | 0                        | 6        |

42 constructors in total. `Combobox`, `Menu`, and `Popover` match the issue's counts exactly. Fixing only the three named components would have left the surface inconsistent in the same way the issue complains about, so I fixed all five.

## What deliberately stays type-only

The sweep also turned up value exports that are type-only on purpose, and I left them alone:

- **`AnchorConfig`**, type-only in five barrels. Exposing the schema value is part of the open question in #875 about the anchor runtime surface, so it is not mine to decide here.
- **`ActivationTrigger`, `Orientation`, `ActivationMode`**, which are `S.Literals` schemas rather than Message constructors. A literal union needs no constructor, and promoting them would widen the public API rather than fix a broken re-export.

Each promoted name already had both a `const` and a matching type alias in its source module, so a value re-export carries the type as well and nothing that referenced these names as types has to change.

## Test

`packages/ui/src/publicMessageConstructors.test.ts` audits every component barrel and fails when a Message union declares a tag the barrel does not export as a callable.

It also asserts that a tag was read for **every** union member. That second assertion is load bearing rather than decorative. My first version of the extractor read `fields._tag.literal`, which resolves only for a payload-free Message and is `undefined` for every Message that carries fields. The test passed while checking almost nothing, and it still passed with the `Slider` fix reverted. The correct path is `fields._tag.ast.literal`. The completeness assertion is what turns that class of mistake into a failure instead of a false green.

## Verification

Rebased onto `main` at `c826cdb`, so this is verified against a base that already contains the `Command.define` deferral from #879 and the version bump from #873.

- Reverting each fixed barrel makes the test fail and name the exact component and unreachable tags. Reverting all five reports all five, 42 tags total. Re-confirmed after the rebase.
- A runtime check confirms all 42 are `typeof === 'function'` after the fix, and that `AnchorConfig` and `ActivationTrigger` are still absent as values.
- Full `@foldkit/ui` suite on the rebased base: 871 tests across 36 files pass. Package typechecks clean, `oxlint` clean.

One commit, rebased onto current `main`, no conflicts.

Local runs skipped the pre-push hook, so the cross-package suites, website e2e, dead-code, and `format:check` were first exercised by CI rather than locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored callable Message constructors across Combobox, Listbox, Menu, Popover, and Slider.
  * Interaction events can now be imported and invoked at runtime as expected.
  * Type-only schemas remain unchanged.

* **Tests**
  * Added coverage verifying that all declared Message tags have corresponding callable exports.

* **Documentation**
  * Added a release note describing the restored public constructors and runtime availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->