### PR TITLE
feat(ui): export the checkbox id derivations

### DIFF
--- a/.changeset/checkbox-export-id-derivations.md
+++ b/.changeset/checkbox-export-id-derivations.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': minor
+---
+
+Export `Checkbox.labelId` and `Checkbox.descriptionId`
+
+The checkbox derived `${id}-label` and `${id}-description` from module-private consts, so a consumer that needed to reference the label or description element, to point `aria-details` at it, to style it, or to find it in a test, had to re-declare the convention and hope it did not drift. `Fieldset` already exports its equivalents (`legendId`, `descriptionId`); the checkbox now matches. No behaviour change.

--- a/packages/ui/src/checkbox/index.ts
+++ b/packages/ui/src/checkbox/index.ts
@@ -45,8 +45,11 @@ export type ViewConfig<Message> = Readonly<{
   value?: string
 }>
 
-const labelId = (id: string): string => `${id}-label`
-const descriptionId = (id: string): string => `${id}-description`
+/** Generates the label element ID from the checkbox's base ID. */
+export const labelId = (id: string): string => `${id}-label`
+
+/** Generates the description element ID from the checkbox's base ID. */
+export const descriptionId = (id: string): string => `${id}-description`
 
 /** Renders an accessible checkbox as a stateless controlled component. The
  *  parent owns the checked state (`isChecked`) and receives the new state via

--- a/packages/ui/src/checkbox/public.ts
+++ b/packages/ui/src/checkbox/public.ts
@@ -1,3 +1,3 @@
-export { view } from './index.js'
+export { view, labelId, descriptionId } from './index.js'
 
 export type { ViewConfig, CheckboxAttributes } from './index.js'

--- a/packages/website/src/page/ui/checkboxPage.md
+++ b/packages/website/src/page/ui/checkboxPage.md
@@ -46,6 +46,8 @@ Checkbox is headless. Your `toView` callback controls all markup and styling. Us
 
 The checkbox element receives `role="checkbox"` and `aria-checked` which is set to `"true"`, `"false"`, or `"mixed"` depending on the checked and indeterminate state. The label is linked via `aria-labelledby` and the description via `aria-describedby`.
 
+The `label` attribute group includes an id (accessible via `Checkbox.labelId(id)`) and the `description` group includes an id (accessible via `Checkbox.descriptionId(id)`), so a consumer can reference either element without re-declaring the naming convention.
+
 ## API Reference
 
 ### ViewConfig {#view-config}


### PR DESCRIPTION
## What

`@foldkit/ui/checkbox` derived `${id}-label` and `${id}-description` from module-private
consts. A consumer that needs to reference a checkbox's label or description element, to
point `aria-details` at it, to style it, or to find it in a test, had to re-declare the
convention and hope it did not drift.

`@foldkit/ui/fieldset` already exports its equivalents (`legendId`, `descriptionId`), so
the inconsistency was internal to foldkit rather than deliberate. The checkbox now matches.

## Changes

- `packages/ui/src/checkbox/index.ts`: `labelId` and `descriptionId` are exported, with
  TSDoc copied from the fieldset wording so the two read identically.
- `packages/ui/src/checkbox/public.ts`: both re-exported, so `@foldkit/ui/checkbox` and
  the `Checkbox` namespace expose them.
- `packages/website/src/page/ui/checkboxPage.md`: the Accessibility section names both
  helpers, the way the fieldset page already does.
- Changeset: `minor` for `@foldkit/ui`.

No behaviour change. The generated ids, the ARIA attributes, and the emitted markup are
byte-identical to before; this only widens the export surface.

## Scope

Deliberately just the export. No test was added: this is a pure re-export of two
one-line functions already exercised by `checkbox/scene.test.ts` through the
`aria-labelledby` and `aria-describedby` assertions, and `Fieldset.legendId` /
`Fieldset.descriptionId` ship untested for the same reason. Adding coverage here without
adding it there would leave the pair inconsistent in a second way.

Found while building a component library on top of `@foldkit/ui`, where the workaround was
a local re-declaration pinned by a test that renders foldkit's own checkbox and reads the
ids back out of the emitted ARIA, so a foldkit rename fails a downstream test instead of
silently producing a dangling reference. This export makes that pin unnecessary.

## Verification

`pnpm pre-push` green in full: lint, dead-code, `pnpm -r typecheck`, build, the whole test
suite, and the website e2e smoke test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported `Checkbox.labelId` and `Checkbox.descriptionId` for accessing generated label and description IDs.
  * Preserved existing ID-generation behavior.

* **Documentation**
  * Added guidance on using generated checkbox accessibility IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->