### PR TITLE
feat(ui): write data-placement on every anchored panel

### DIFF
--- a/.changeset/anchor-unconditional-data-placement.md
+++ b/.changeset/anchor-unconditional-data-placement.md
@@ -1,0 +1,11 @@
+---
+'@foldkit/ui': minor
+---
+
+Write `data-placement` on every anchored panel, not only the placement-locked ones.
+
+`anchorSetup` set `data-placement` inside the `isPlacementLocked` branch and removed it on cleanup under the same condition. A panel that did not opt into placement locking exposed nothing to CSS, so side-specific rules such as an arrow's edge styling or a `data-[placement=top]` reordering had no attribute to match. The only way to get the attribute was to lock the placement, which also drops `flip` from every later update. That is a positioning decision, unrelated to wanting to style the side the panel landed on.
+
+The attribute is now written on every reposition. Without `isPlacementLocked` it tracks the side each update resolves to, including the ones `flip` moves. With `isPlacementLocked` it holds the locked side, exactly as before. Cleanup removes it either way.
+
+This affects Popover, Tooltip, Listbox, Menu, Combobox, and DatePicker panels, all of which position through `anchorSetup`. Any `data-[placement=...]` rule already written against a panel that is not placement-locked was inert and now applies.

--- a/packages/ui/src/anchor.isPlacementLocked.test.ts
+++ b/packages/ui/src/anchor.isPlacementLocked.test.ts
@@ -177,7 +177,7 @@ describe('anchorSetup isPlacementLocked', () => {
     expect(middlewareNamesOfCall(1)).toEqual(['offset', 'shift', 'size'])
   })
 
-  it('keeps flip and writes no attribute without isPlacementLocked', async () => {
+  it('keeps flip and follows the resolved side without isPlacementLocked', async () => {
     computePositionMock
       .mockResolvedValueOnce({ x: 10, y: 20, placement: 'top-start' })
       .mockResolvedValueOnce({ x: 11, y: 21, placement: 'bottom-start' })
@@ -189,14 +189,14 @@ describe('anchorSetup isPlacementLocked', () => {
     await waitForPosition(element, 10, 20)
 
     expect(middlewareNamesOfCall(0)).toContain('flip')
-    expect(element.hasAttribute('data-placement')).toBe(false)
+    expect(element.getAttribute('data-placement')).toBe('top')
 
     triggerUpdate(0)
     await waitForPosition(element, 11, 21)
 
     expect(middlewareNamesOfCall(1)).toContain('flip')
     expect(optionsOfCall(1).placement).toBe('bottom-start')
-    expect(element.hasAttribute('data-placement')).toBe(false)
+    expect(element.getAttribute('data-placement')).toBe('bottom')
   })
 
   it('clamps negative available height to zero', async () => {
@@ -340,6 +340,25 @@ describe('anchorSetup isPlacementLocked', () => {
     const { element, cleanup } = mountAnchor({
       placement: 'bottom-start',
       isPlacementLocked: true,
+      portal: false,
+    })
+
+    await waitForPosition(element, 10, 20)
+    expect(element.getAttribute('data-placement')).toBe('top')
+
+    cleanup()
+
+    expect(element.hasAttribute('data-placement')).toBe(false)
+  })
+
+  it('removes data-placement on cleanup without isPlacementLocked', async () => {
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: 'top-start',
+    })
+    const { element, cleanup } = mountAnchor({
+      placement: 'bottom-start',
       portal: false,
     })
 

--- a/packages/ui/src/anchor.ts
+++ b/packages/ui/src/anchor.ts
@@ -105,11 +105,11 @@ const toSide = (placement: FloatingPlacement): string =>
  *  requestAnimationFrame so the element is painted before focus fires.
  *  `focusSelector` optionally targets a descendant (e.g. a calendar grid
  *  inside a popover panel) instead of the panel itself.
- *  When `isPlacementLocked` is true, the element keeps the side that the first
- *  positioning picks, and `flip` is removed from every later update. The locked
- *  side is also written to `data-placement` on the element, so CSS can react to
- *  it. None of this happens unless `isPlacementLocked` is set, so existing
- *  callers render exactly as before. */
+ *  The side the element currently sits on is written to `data-placement`, so
+ *  CSS can react to it. When `isPlacementLocked` is true, the element keeps the
+ *  side that the first positioning picks, `flip` is removed from every later
+ *  update, and `data-placement` holds that locked side. Otherwise the attribute
+ *  tracks the side each update resolves to, including the ones `flip` moves. */
 export const anchorSetup =
   (config: {
     buttonId: string
@@ -214,10 +214,13 @@ export const anchorSetup =
           element.style.top = `${y}px`
 
           if (isPlacementLockEnabled) {
-            const nextLockedPlacement = lockedPlacement ?? resolvedPlacement
-            lockedPlacement = nextLockedPlacement
-            element.setAttribute('data-placement', toSide(nextLockedPlacement))
+            lockedPlacement = lockedPlacement ?? resolvedPlacement
           }
+
+          element.setAttribute(
+            'data-placement',
+            toSide(lockedPlacement ?? resolvedPlacement),
+          )
 
           if (isFirstUpdate) {
             isFirstUpdate = false
@@ -273,9 +276,7 @@ export const anchorSetup =
         element.removeEventListener('keydown', handleTabKey)
       }
 
-      if (isPlacementLockEnabled) {
-        element.removeAttribute('data-placement')
-      }
+      element.removeAttribute('data-placement')
 
       portalCleanup?.()
     }

--- a/packages/website/src/page/ui/comboboxPage.md
+++ b/packages/website/src/page/ui/comboboxPage.md
@@ -56,13 +56,13 @@ Combobox is headless. The `itemToConfig` callback controls all item markup. Styl
 
 The items panel is portaled to the document body and positioned relative to the input wrapper with Floating UI. Ancestor stacking contexts and overflow clipping no longer apply, so a clipped container or a sibling overlay wrapper cannot hide the open panel. The panel still stacks at the document level: give it a z-index above elevated content like sticky headers or toasts, as the demos on this page do with `z-10`. Pass `anchor: { portal: false }` to keep the panel inside the wrapper instead.
 
-| Attribute        | Condition                                                                                                       |
-| ---------------- | --------------------------------------------------------------------------------------------------------------- |
-| `data-active`    | Present on the item currently highlighted by keyboard or pointer.                                               |
-| `data-selected`  | Present on the selected item(s).                                                                                |
-| `data-disabled`  | Present on disabled items.                                                                                      |
-| `data-closed`    | Present during close animation when isAnimated is true.                                                         |
-| `data-placement` | Present on the items panel when isPlacementLocked is true, set to the locked side: top, right, bottom, or left. |
+| Attribute        | Condition                                                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data-active`    | Present on the item currently highlighted by keyboard or pointer.                                                                                               |
+| `data-selected`  | Present on the selected item(s).                                                                                                                                |
+| `data-disabled`  | Present on disabled items.                                                                                                                                      |
+| `data-closed`    | Present during close animation when isAnimated is true.                                                                                                         |
+| `data-placement` | Present on the items panel, set to the side it currently sits on: top, right, bottom, or left. Fixed to the first resolved side when isPlacementLocked is true. |
 
 ## Keyboard Interaction
 

--- a/packages/website/src/page/ui/datePickerPage.md
+++ b/packages/website/src/page/ui/datePickerPage.md
@@ -32,7 +32,7 @@ DatePicker is headless. You control the trigger button via `triggerContent` and 
 | `data-outside-month` | (Days mode only.) Present on cells that fall outside the currently-viewed month (leading/trailing grid rows).                                                                 |
 | `data-disabled`      | Present on cells disabled by min/max, disabledDaysOfWeek, or disabledDates.                                                                                                   |
 | `data-open`          | Present on the trigger button and wrapper while the popover is open.                                                                                                          |
-| `data-placement`     | Present on the calendar panel when isPlacementLocked is true, set to the locked side: top, right, bottom, or left.                                                            |
+| `data-placement`     | Present on the calendar panel, set to the side it currently sits on: top, right, bottom, or left. Fixed to the first resolved side when isPlacementLocked is true.            |
 
 ## Keyboard Interaction
 

--- a/packages/website/src/page/ui/listboxPage.md
+++ b/packages/website/src/page/ui/listboxPage.md
@@ -46,15 +46,15 @@ The items panel is portaled to the document body and positioned relative to the 
 
 To make the items panel match the trigger button width, set `width: var(--button-width)` (or Tailwind `w-(--button-width)`) on the items class. The anchor system writes the trigger button’s measured width to this CSS variable on the items element every time it positions the panel, so the panel always matches the button even as content or viewport sizes change. Without it, the items panel sizes to its content.
 
-| Attribute        | Condition                                                                                                       |
-| ---------------- | --------------------------------------------------------------------------------------------------------------- |
-| `data-open`      | Present on button and wrapper when the dropdown is open.                                                        |
-| `data-active`    | Present on the item currently highlighted by keyboard or pointer.                                               |
-| `data-selected`  | Present on selected item(s).                                                                                    |
-| `data-disabled`  | Present on disabled items and on the button when the listbox is disabled.                                       |
-| `data-invalid`   | Present on the button and wrapper when isInvalid is true.                                                       |
-| `data-closed`    | Present during close animation when isAnimated is true.                                                         |
-| `data-placement` | Present on the items panel when isPlacementLocked is true, set to the locked side: top, right, bottom, or left. |
+| Attribute        | Condition                                                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data-open`      | Present on button and wrapper when the dropdown is open.                                                                                                        |
+| `data-active`    | Present on the item currently highlighted by keyboard or pointer.                                                                                               |
+| `data-selected`  | Present on selected item(s).                                                                                                                                    |
+| `data-disabled`  | Present on disabled items and on the button when the listbox is disabled.                                                                                       |
+| `data-invalid`   | Present on the button and wrapper when isInvalid is true.                                                                                                       |
+| `data-closed`    | Present during close animation when isAnimated is true.                                                                                                         |
+| `data-placement` | Present on the items panel, set to the side it currently sits on: top, right, bottom, or left. Fixed to the first resolved side when isPlacementLocked is true. |
 
 ## Keyboard Interaction
 

--- a/packages/website/src/page/ui/menuPage.md
+++ b/packages/website/src/page/ui/menuPage.md
@@ -36,13 +36,13 @@ The items panel is portaled to the document body and positioned relative to the 
 
 When `isAnimated` is true, enter/leave animations flow through the [Animation](/ui/animation) module. Style with CSS transitions or CSS keyframe animations. Animation advances once every animation on the element has settled.
 
-| Attribute        | Condition                                                                                                       |
-| ---------------- | --------------------------------------------------------------------------------------------------------------- |
-| `data-open`      | Present on the button when the menu is open.                                                                    |
-| `data-active`    | Present on the highlighted menu item.                                                                           |
-| `data-disabled`  | Present on disabled menu items.                                                                                 |
-| `data-closed`    | Present during close animation.                                                                                 |
-| `data-placement` | Present on the items panel when isPlacementLocked is true, set to the locked side: top, right, bottom, or left. |
+| Attribute        | Condition                                                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data-open`      | Present on the button when the menu is open.                                                                                                                    |
+| `data-active`    | Present on the highlighted menu item.                                                                                                                           |
+| `data-disabled`  | Present on disabled menu items.                                                                                                                                 |
+| `data-closed`    | Present during close animation.                                                                                                                                 |
+| `data-placement` | Present on the items panel, set to the side it currently sits on: top, right, bottom, or left. Fixed to the first resolved side when isPlacementLocked is true. |
 
 ## Keyboard Interaction
 

--- a/packages/website/src/page/ui/popoverPage.md
+++ b/packages/website/src/page/ui/popoverPage.md
@@ -40,12 +40,12 @@ Popover is headless. The `toView` callback receives attribute bundles for the bu
 
 When `isAnimated` is true, enter/leave animations flow through the [Animation](/ui/animation) module. Style with CSS transitions or CSS keyframe animations. Animation advances once every animation on the element has settled.
 
-| Attribute        | Condition                                                                                                 |
-| ---------------- | --------------------------------------------------------------------------------------------------------- |
-| `data-open`      | Present on button and panel when open.                                                                    |
-| `data-disabled`  | Present on the button when disabled.                                                                      |
-| `data-closed`    | Present during close animation.                                                                           |
-| `data-placement` | Present on the panel when isPlacementLocked is true, set to the locked side: top, right, bottom, or left. |
+| Attribute        | Condition                                                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data-open`      | Present on button and panel when open.                                                                                                                    |
+| `data-disabled`  | Present on the button when disabled.                                                                                                                      |
+| `data-closed`    | Present during close animation.                                                                                                                           |
+| `data-placement` | Present on the panel, set to the side it currently sits on: top, right, bottom, or left. Fixed to the first resolved side when isPlacementLocked is true. |
 
 ## Keyboard Interaction
 

--- a/packages/website/src/page/ui/tooltipPage.md
+++ b/packages/website/src/page/ui/tooltipPage.md
@@ -22,11 +22,11 @@ Hover or tab into the trigger to reveal the tooltip. Hover waits for `showDelay`
 
 Tooltip is headless. The `toView` callback receives attribute bundles for the trigger and panel, and the consumer composes the markup. The panel is rendered with `pointer-events: none` so it never captures hover or clicks, which keeps the open/close logic tied to the trigger.
 
-| Attribute        | Condition                                                                                                 |
-| ---------------- | --------------------------------------------------------------------------------------------------------- |
-| `data-open`      | Present on trigger and panel when the tooltip is visible.                                                 |
-| `data-disabled`  | Present on the trigger when disabled.                                                                     |
-| `data-placement` | Present on the panel when isPlacementLocked is true, set to the locked side: top, right, bottom, or left. |
+| Attribute        | Condition                                                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data-open`      | Present on trigger and panel when the tooltip is visible.                                                                                                 |
+| `data-disabled`  | Present on the trigger when disabled.                                                                                                                     |
+| `data-placement` | Present on the panel, set to the side it currently sits on: top, right, bottom, or left. Fixed to the first resolved side when isPlacementLocked is true. |
 
 ## Keyboard Interaction
 


### PR DESCRIPTION
## What

`anchorSetup` set `data-placement` inside the `isPlacementLocked` branch and removed it on cleanup under the same condition. A panel that did not opt into placement locking exposed nothing to CSS, so side-specific rules had no attribute to match. I hit this building a panel that needed side-aware styling without wanting the panel pinned to one side.

The only way to get the attribute was to lock the placement, which also drops `flip` from every later update. Those are two separate wants. Locking is a positioning decision about a panel that must not move sides while open. Knowing which side the panel landed on is a styling concern, and it applies just as much, arguably more, to a panel that is free to flip. An arrow, a shadow that leans away from the trigger, a `data-[placement=top]` content reversal: each of those has to follow the panel wherever `flip` puts it, and none of them wants the panel pinned.

The attribute is now written on every reposition. Without `isPlacementLocked` it tracks the side each update resolves to, including the ones `flip` moves. With `isPlacementLocked` it holds the locked side, exactly as before.

## Changes

- `packages/ui/src/anchor.ts`: the `setAttribute` call moves out of the `isPlacementLocked` branch. `lockedPlacement` still latches only on that path, so the write reads `lockedPlacement ?? resolvedPlacement` and needs no second condition. Cleanup removes the attribute unconditionally. TSDoc rewritten so `data-placement` is no longer described as a placement-lock feature.
- `packages/ui/src/anchor.isPlacementLocked.test.ts`: the unlocked test asserted `hasAttribute === false` twice; it now asserts the side tracking `flip` across two updates. Added a cleanup test for the unlocked path.
- `packages/website/src/page/ui/{popover,tooltip,listbox,menu,combobox,datePicker}Page.md`: the `data-placement` row in each attribute table said "Present on the panel when isPlacementLocked is true".
- Changeset: `minor` for `@foldkit/ui`.

## Design decision

Worth flagging directly, since it reverses something I wrote: the `isPlacementLocked` changeset in 0.137.0 (d31d95a) promised that "a caller that does not opt in is positioned exactly as before and gets no new attribute." That promise is what this PR gives up.

I think it was the wrong line to draw. It was written to make the feature strictly additive, which was the right instinct for a positioning change, and it got applied to the attribute by association. But the attribute is not part of the locking behavior, it is a read-only report of where the panel is, and there was never a reason to withhold it from an unlocked panel except that both landed in the same commit. Coupling the two means a consumer who only wants side-aware styling has to accept a positioning behavior they did not ask for.

Positioning itself is untouched. `flip` is still dropped only when locked, `lockedPlacement` still latches only when locked, and no consumer's panel moves differently because of this PR.

Alternative considered: an `isPlacementExposed` flag, keeping the attribute opt-in but decoupled from locking. Rejected. It is a config field to buy back a behavior nobody has asked to suppress, and it would leave two flags whose difference readers have to work out.

## Compatibility

The attribute becoming visible on unlocked panels is a real behavior change, which is why this is `minor` rather than `patch`. A `data-[placement=...]` rule that a consumer already wrote against an unlocked panel was inert and now applies.

Nothing in this repo depends on it that way. `grep` for `data-[placement` across the workspace turns up no CSS at all, and the only `data-placement` assertions are the ui-showcase e2e checks on a placement-locked combobox, which are unaffected.

## Verification

Full pre-push suite green: build, all workspace typechecks, `oxlint`, dead-code, all package and example tests (869 in `@foldkit/ui`), and the website Chromium e2e.

The two rewritten assertions in the unlocked test fail on `main` and pass here, which is what pins the actual change rather than the refactor around it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Anchored panels now consistently expose a `data-placement` attribute showing their current resolved position.
  * Placement locking continues to preserve the panel’s initial resolved position.
  * The attribute is removed when the panel is cleaned up.

* **Documentation**
  * Updated Popover, Tooltip, Listbox, Menu, Combobox, and DatePicker guidance to describe placement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->