### PR TITLE
fix(foldkit): skip the flags Effect when HMR restores a Model

### DIFF
--- a/.changeset/hmr-restore-skips-resources-build.md
+++ b/.changeset/hmr-restore-skips-resources-build.md
@@ -1,0 +1,9 @@
+---
+'foldkit': patch
+---
+
+Stop an HMR reload from running the `flags` Effect when it restores a Model.
+
+Flags resolve before `init`, and the runtime resolved them ahead of the HMR restore decision. A reload that successfully restores a preserved Model skips `init` entirely, so the flags value was computed and then discarded. The resolution now sits behind that decision, so a restored Model never runs `flags` at all. A reload that cannot read the preserved Model still falls back to `init` and resolves them exactly as before.
+
+This shows up two ways on a restore, both development-only, because a production build has no HMR path. A `flags` Effect that performs a side effect of its own, seeding a store or writing a session id, no longer performs it on every reload. A `flags` Effect that requires services no longer forces the `resources` Layer to build, so a Layer holding a connection stops reconnecting on every save. Subscriptions whose pipelines run for the application's lifetime still build the Layer at startup either way.

--- a/packages/foldkit/src/runtime/resources.test.ts
+++ b/packages/foldkit/src/runtime/resources.test.ts
@@ -311,6 +311,99 @@ describe('resources', () => {
     expect(releaseCount).toBe(1)
   })
 
+  it('leaves the Layer unbuilt when an HMR restore skips init', async () => {
+    let buildCount = 0
+
+    const CountedResourceLive = Layer.effect(
+      ResourceService,
+      Effect.sync((): ResourceShape => {
+        buildCount += 1
+        return { value: `build-${buildCount}` }
+      }),
+    )
+
+    const element = makeElement({
+      Model,
+      Flags,
+      flags: Effect.succeed({ initialLabel: 'fresh' }),
+      init: ({ initialLabel }) => [{ label: initialLabel }, []],
+      update,
+      view,
+      crash,
+      container,
+      resources: CountedResourceLive,
+    })
+
+    const fiber = Effect.runFork(element.start({ label: 'restored' }))
+
+    try {
+      await awaitBodyText('restored')
+      expect(buildCount).toBe(0)
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('does not run the flags Effect when an HMR restore skips init', async () => {
+    let flagsRunCount = 0
+
+    const element = makeElement({
+      Model,
+      Flags,
+      flags: Effect.sync(() => {
+        flagsRunCount += 1
+        return { initialLabel: 'fresh' }
+      }),
+      init: ({ initialLabel }) => [{ label: initialLabel }, []],
+      update,
+      view,
+      crash,
+      container,
+    })
+
+    const fiber = Effect.runFork(element.start({ label: 'restored' }))
+
+    try {
+      await awaitBodyText('restored')
+      expect(flagsRunCount).toBe(0)
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('builds the Layer when an unreadable HMR Model falls back to init', async () => {
+    let buildCount = 0
+
+    const CountedResourceLive = Layer.effect(
+      ResourceService,
+      Effect.sync((): ResourceShape => {
+        buildCount += 1
+        return { value: `build-${buildCount}` }
+      }),
+    )
+
+    const element = makeElement({
+      Model,
+      Flags,
+      flags: Effect.succeed({ initialLabel: 'fresh' }),
+      init: ({ initialLabel }) => [{ label: initialLabel }, []],
+      update,
+      view,
+      crash,
+      container,
+      resources: CountedResourceLive,
+    })
+
+    const fiber = Effect.runFork(element.start({ notALabel: 0 }))
+
+    try {
+      await awaitBodyText('fresh')
+      expect(buildCount).toBe(1)
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
   it('still reaches the crash view when flags do not consume the failing Layer', async () => {
     const element = makeElement({
       Model,
@@ -485,6 +578,20 @@ describe('resources', () => {
         init: ({ initialLabel }) => [{ label: initialLabel }, [ReadValue()]],
         update,
         view: documentView,
+        container,
+        resources: FailingResourceLive,
+      })
+
+      // NOTE: `init` and `update` here contribute a `ReadonlyArray<never>`
+      // inference candidate for `Resources`, which must not pin it to `never`
+      // and reject a flags Effect the `resources` Layer does satisfy.
+      makeElement({
+        Model,
+        Flags,
+        flags: flagsNeedingResource,
+        init: resourceFreeInit,
+        update: resourceFreeUpdate,
+        view,
         container,
         resources: FailingResourceLive,
       })

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -1666,11 +1666,14 @@ const makeRuntime = <
               }),
           })
 
-        const flags = yield* Option.match(maybeResolveFlags, {
-          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-          onNone: () => Effect.succeed(undefined as Flags),
-          onSome: provideResources,
-        })
+        const resolveFlags: Effect.Effect<Flags> = Option.match(
+          maybeResolveFlags,
+          {
+            /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+            onNone: () => Effect.succeed(undefined as Flags),
+            onSome: provideResources,
+          },
+        )
 
         const ModelJsonCodec = Schema.toCodecJson(
           /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
@@ -1678,6 +1681,32 @@ const makeRuntime = <
         )
         const decodeHmrModel = Schema.decodeUnknownExit(ModelJsonCodec)
         const encodeHmrModel = Schema.encodeUnknownSync(ModelJsonCodec)
+
+        const currentUrl: Option.Option<Url> = Option.fromNullishOr(
+          routingConfig,
+        ).pipe(Option.flatMap(() => urlFromString(window.location.href)))
+
+        type InitResult = ReturnType<typeof init>
+
+        // NOTE: a restored Model skips `init`, so resolving flags on that
+        // path would build the `resources` Layer only to discard what it
+        // produced. Gating the resolution on the restore decision is what
+        // stops a reload from reconnecting whatever the Layer holds. It has
+        // to stay ahead of the preserve-scheduler and HMR finalizers: a
+        // flags Effect that fails after those are registered tears down more
+        // than it used to, and their release defects would bury its cause.
+        const runInit: Effect.Effect<InitResult> = Effect.map(
+          resolveFlags,
+          flags => init(flags, Option.getOrUndefined(currentUrl)),
+        )
+
+        const [initModelRaw, initCommands] = yield* hmrModel !== undefined
+          ? Exit.match(decodeHmrModel(hmrModel), {
+              onFailure: () => runInit,
+              onSuccess: restoredModel =>
+                Effect.succeed<InitResult>([restoredModel, []]),
+            })
+          : runInit
 
         // NOTE: keep `encodeHmrModel` off the dispatch hot path. It walks
         // the entire Model graph (O(modelSize) per call) and blocks input
@@ -1802,28 +1831,6 @@ const makeRuntime = <
 
         const enqueueMessageEffect = (message: Message) =>
           Effect.sync(() => enqueueMessage(message))
-
-        const currentUrl: Option.Option<Url> = Option.fromNullishOr(
-          routingConfig,
-        ).pipe(Option.flatMap(() => urlFromString(window.location.href)))
-
-        const [initModelRaw, initCommands] = Predicate.isNotUndefined(hmrModel)
-          ? Exit.match(decodeHmrModel(hmrModel), {
-              onFailure: () => init(flags, Option.getOrUndefined(currentUrl)),
-              onSuccess: (
-                restoredModel: Model,
-              ): readonly [
-                Model,
-                ReadonlyArray<
-                  AnyCommand<
-                    Message,
-                    never,
-                    Resources | ManagedResourceServices
-                  >
-                >,
-              ] => [restoredModel, []],
-            })
-          : init(flags, Option.getOrUndefined(currentUrl))
 
         const initModel = maybeFreezeModel(initModelRaw)
 


### PR DESCRIPTION
Closes item 1 of #894 and settles the unconfirmed inference note inside item 2. The rest of item 2 and all of item 3 stay open, see below.

## The bug

Flags resolve before `init`, and the runtime resolved them ahead of the HMR restore decision. A reload that successfully restores a preserved Model skips `init` entirely, so the flags value was computed and then thrown away.

## The fix

The resolution now sits behind the restore decision, so a restored Model never runs `flags` at all. A reload that cannot read the preserved Model still falls back to `init` and resolves them exactly as before.

Two things stop happening on a restore, both development-only because a production build has no HMR path:

- A `flags` Effect that performs a side effect of its own, seeding a store or writing a session id, no longer performs it on every reload.
- A `flags` Effect that requires services no longer forces the `resources` Layer to build, so a Layer holding a connection stops reconnecting on every save.

The first is the part that affects already-released versions. Before the unreleased `72e8ea0`, `flags` was typed `Effect<Flags>` and could not build the Layer at all, so for shipped versions the entire delta is that flags stop running on a restore.

## Placement

The resolution moves *up*, to sit directly after the HMR codec and ahead of the preserve-scheduler and HMR finalizer registrations, rather than down at the `init` call site. This is load-bearing, not incidental. Moving it down past those registrations fails two existing tests:

```
AssertionError: expected 'Die(TypeError: hot.off is not a funct…' to contain 'flags blew up on their own'
```

The release defect from those finalizers replaces the cause the failure was reporting.

## Verification

Three runtime tests:

- A restore never invokes `flags` (invocation count 0, no `resources` Layer involved, so it isolates this from the Layer build).
- A restore leaves the `resources` Layer unbuilt (`buildCount` 0).
- An unreadable preserved Model falls back to `init` and builds it (`buildCount` 1), pinning the other branch.

Mutation-checked: restoring the eager resolution fails the first two and only those two. The third is a regression guard for the fallback branch, not evidence for the fix.

Full suite green locally, plus lint, knip, circular-deps, effect-prebundle, build, typecheck, format.

## Item 2, partly settled

The `ReadonlyArray<never>` inference edge recorded in #894 could not be reproduced, so there is no bug to fix. The residue is a type-level case pinning the *correct* behavior: a config where `init` and `update` contribute a `ReadonlyArray<never>` candidate must still infer `Resources` from `resources` and accept a flags Effect that Layer satisfies. Verified load-bearing: changing the signature to `Layer.Layer<NoInfer<Resources>>` makes exactly this case fail to compile, and no pre-existing case catches it.

The headline of item 2, explicit type arguments detaching `Resources` from the Layer, is **unchanged and still open**. It predates this work, affects Commands identically, and #894 records that the fix direction is unclear and probably not worth a breaking signature change on its own. The docs stay correctly qualified rather than promising a guarantee.

## Item 3, deliberately not here

A startup-failure seam needs new public API. `CrashContext` requires a Model, so the crash view cannot be reused for a failure that lands before the first render.

Left out because the shape has open questions I would only be guessing at: whether it also covers first-Command failures, whether it receives the URL, whether it gets a `report` hook, and whether its default renders anything in production. That is a design pass of its own, not a rider on a dev-only HMR fix. #894 stays open with the finding recorded.

A related asymmetry surfaced while scoping it, worth its own issue: `run` goes through `BrowserRuntime.runMain`, which reports unhandled startup failures, while `embed` uses a bare `Effect.runFork` whose fiber is only ever awaited-and-discarded or interrupted. An embedded app whose flags fail appears to die silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot reload behavior by preserving valid restored application state without rerunning initialization or rebuilding resources.
  * Prevented unnecessary flag processing during successful reloads.
  * Reloads with invalid or unavailable state now reliably fall back to normal initialization and resource setup.

* **Tests**
  * Added coverage for successful and fallback hot reload scenarios, including flag and resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->