### PR TITLE
refactor(ui): rename the create factory result type to Bundle

### DIFF
--- a/.changeset/create-factory-bundle-type.md
+++ b/.changeset/create-factory-bundle-type.md
@@ -1,0 +1,22 @@
+---
+'@foldkit/ui': minor
+---
+
+Export a `Bundle` type alongside every `create` factory, covering `Menu`, `Tabs`, `Listbox`, `Listbox.Multi`, `Combobox`, and `Combobox.Multi`.
+
+Each factory declared its return type inline, so what `create` produced had no name. That stays invisible while the value is only ever called at module scope, since inference covers it. It surfaces when a consumer emits its own declarations: TypeScript has to write the factory's result into the generated `.d.ts`, and with no name to reference it expands the whole structure at every use site. Where that expansion reaches a type the consumer cannot name, the compiler refuses and reports the inferred type as not portable without an explicit annotation.
+
+`Bundle` is that name. It takes the same type parameters as the factory that returns it, so `Menu.Bundle<Action>` describes exactly what `Menu.create<Action>()` produces, with `Action` threaded through `view`, `update`, and the programmatic helpers the same way.
+
+Naming the result also makes a bundle something you can pass around rather than only call. A config object with a field typed `Combobox.Bundle<City>`, or a helper that accepts a created bundle instead of calling `create` itself, previously had no way to spell the annotation.
+
+```ts
+const ColorListbox = Listbox.create<Color>()
+
+const toPickerView = (listbox: Listbox.Bundle<Color>, colors: ReadonlyArray<Color>): Html =>
+  h.submodel({ view: listbox.view, viewInputs: { items: colors, ... }, ... })
+```
+
+Additive only. The object each factory builds is unchanged, every existing call site keeps compiling, and nothing needs updating to take the new type.
+
+Thanks @IMax153 for contributing this fix!

--- a/.changeset/tidy-menus-travel.md
+++ b/.changeset/tidy-menus-travel.md
@@ -1,5 +1,0 @@
----
-'@foldkit/ui': patch
----
-
-Export named `Created` types for Menu, Tabs, Listbox, and Combobox factories so consumer declarations stay portable and concise.

--- a/packages/ui/src/combobox/multi.ts
+++ b/packages/ui/src/combobox/multi.ts
@@ -92,9 +92,14 @@ export type ViewInputs<Item extends string> = BaseViewInputs<Item>
 
 const internalView = makeView<Model>({ ariaMultiSelectable: true })
 
-export interface Created<Item extends string = string> {
-  readonly view: SubmodelView<Model, Message, ViewInputs<Item>>
-  readonly update: (
+/** The `view`, `update`, and programmatic helpers that
+ *  `Combobox.Multi.create` returns, bound to one `Item` type. Name it to
+ *  annotate a value that holds a created bundle, such as a field on a
+ *  config object or a function parameter that takes the bundle rather than
+ *  calling `create` itself. */
+export type Bundle<Item extends string = string> = Readonly<{
+  view: SubmodelView<Model, Message, ViewInputs<Item>>
+  update: (
     model: Model,
     message: Message,
   ) => readonly [
@@ -102,7 +107,7 @@ export interface Created<Item extends string = string> {
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Item>>,
   ]
-  readonly selectItem: (
+  selectItem: (
     model: Model,
     item: Item,
   ) => readonly [
@@ -110,26 +115,26 @@ export interface Created<Item extends string = string> {
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Item>>,
   ]
-  readonly open: (
+  open: (
     model: Model,
   ) => readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Item>>,
   ]
-  readonly close: (
+  close: (
     model: Model,
   ) => readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Item>>,
   ]
-}
+}>
 
 /** Pairs the multi-select combobox's `view` and `update` (and programmatic
  *  helpers) behind a single Item-typed entry point. `selectItem` emits
  *  `Selected({ value })`; the parent toggles the value's membership. */
-export const create = <Item extends string = string>(): Created<Item> => {
+export const create = <Item extends string = string>(): Bundle<Item> => {
   type UpdateReturn = readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,

--- a/packages/ui/src/combobox/multiPublic.ts
+++ b/packages/ui/src/combobox/multiPublic.ts
@@ -1,3 +1,3 @@
 export { init, create, Model } from './multi.js'
 export { inputId } from './shared.js'
-export type { Created, InitConfig, ViewInputs } from './multi.js'
+export type { Bundle, InitConfig, ViewInputs } from './multi.js'

--- a/packages/ui/src/combobox/public.ts
+++ b/packages/ui/src/combobox/public.ts
@@ -50,7 +50,7 @@ export type {
   BaseViewInputsCommon,
 } from './shared.js'
 
-export type { Created, InitConfig, ViewInputs } from './single.js'
+export type { Bundle, InitConfig, ViewInputs } from './single.js'
 
 export type { AnchorConfig } from '../anchor.js'
 

--- a/packages/ui/src/combobox/single.ts
+++ b/packages/ui/src/combobox/single.ts
@@ -117,9 +117,14 @@ export type ViewInputs<Item extends string> = BaseViewInputsCommon<Item> &
 
 const internalView = makeView<Model>({ ariaMultiSelectable: false })
 
-export interface Created<Item extends string = string> {
-  readonly view: SubmodelView<Model, Message, ViewInputs<Item>>
-  readonly update: (
+/** The `view`, `update`, and programmatic helpers that `Combobox.create`
+ *  returns, bound to one `Item` type. Name it to annotate a value that
+ *  holds a created bundle, such as a field on a config object or a
+ *  function parameter that takes the bundle rather than calling `create`
+ *  itself. */
+export type Bundle<Item extends string = string> = Readonly<{
+  view: SubmodelView<Model, Message, ViewInputs<Item>>
+  update: (
     model: Model,
     message: Message,
   ) => readonly [
@@ -127,7 +132,7 @@ export interface Created<Item extends string = string> {
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Item>>,
   ]
-  readonly selectItem: (
+  selectItem: (
     model: Model,
     item: Item,
     displayText: string,
@@ -136,14 +141,14 @@ export interface Created<Item extends string = string> {
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Item>>,
   ]
-  readonly open: (
+  open: (
     model: Model,
   ) => readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Item>>,
   ]
-  readonly close: (
+  close: (
     model: Model,
     restingInputValue: string,
   ) => readonly [
@@ -151,7 +156,7 @@ export interface Created<Item extends string = string> {
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Item>>,
   ]
-}
+}>
 
 /** Pairs the single-select combobox's `view` and `update` (and programmatic
  *  helpers) behind a single Item-typed entry point. See `Listbox.create`
@@ -159,7 +164,7 @@ export interface Created<Item extends string = string> {
  *  `selectItem` taking both `item` and `displayText`. `selectItem` emits
  *  `Selected({ value })` with the input resting on `displayText`; what the
  *  selection becomes is the parent's fold to decide. */
-export const create = <Item extends string = string>(): Created<Item> => {
+export const create = <Item extends string = string>(): Bundle<Item> => {
   type UpdateReturn = readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,

--- a/packages/ui/src/listbox/multi.ts
+++ b/packages/ui/src/listbox/multi.ts
@@ -68,12 +68,17 @@ export type ViewInputs<Item, Value extends string = string> = BaseViewInputs<
 
 const internalView = makeView<Model>({ ariaMultiSelectable: true })
 
-export interface Created<
+/** The `view`, `update`, and programmatic helpers that
+ *  `Listbox.Multi.create` returns, bound to one `Item` and `Value` pair.
+ *  Name it to annotate a value that holds a created bundle, such as a
+ *  field on a config object or a function parameter that takes the bundle
+ *  rather than calling `create` itself. */
+export type Bundle<
   Item = string,
   Value extends string = Item extends string ? Item : string,
-> {
-  readonly view: SubmodelView<Model, Message, ViewInputs<Item, Value>>
-  readonly update: (
+> = Readonly<{
+  view: SubmodelView<Model, Message, ViewInputs<Item, Value>>
+  update: (
     model: Model,
     message: Message,
   ) => readonly [
@@ -81,7 +86,7 @@ export interface Created<
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Value>>,
   ]
-  readonly selectItem: (
+  selectItem: (
     model: Model,
     item: Value,
   ) => readonly [
@@ -89,21 +94,21 @@ export interface Created<
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Value>>,
   ]
-  readonly open: (
+  open: (
     model: Model,
   ) => readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Value>>,
   ]
-  readonly close: (
+  close: (
     model: Model,
   ) => readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Value>>,
   ]
-}
+}>
 
 /** Pairs the multi-select listbox's `view` and `update` (and programmatic
  *  helpers) behind a single Item-typed entry point. Same shape as
@@ -113,7 +118,7 @@ export interface Created<
 export const create = <
   Item = string,
   Value extends string = Item extends string ? Item : string,
->(): Created<Item, Value> => {
+>(): Bundle<Item, Value> => {
   type UpdateReturn = readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,

--- a/packages/ui/src/listbox/multiPublic.ts
+++ b/packages/ui/src/listbox/multiPublic.ts
@@ -1,3 +1,3 @@
 export { init, create, Model } from './multi.js'
 export { buttonId } from './shared.js'
-export type { Created, InitConfig, ViewInputs } from './multi.js'
+export type { Bundle, InitConfig, ViewInputs } from './multi.js'

--- a/packages/ui/src/listbox/public.ts
+++ b/packages/ui/src/listbox/public.ts
@@ -53,7 +53,7 @@ export type {
   ItemToValueInput,
 } from './shared.js'
 
-export type { Created, InitConfig, ViewInputs } from './single.js'
+export type { Bundle, InitConfig, ViewInputs } from './single.js'
 
 export type { AnchorConfig } from '../anchor.js'
 

--- a/packages/ui/src/listbox/single.ts
+++ b/packages/ui/src/listbox/single.ts
@@ -90,12 +90,17 @@ const singleViewImpl = defineView<Model, Message, ViewInputs<unknown, string>>(
     ),
 )
 
-export interface Created<
+/** The `view`, `update`, and programmatic helpers that `Listbox.create`
+ *  returns, bound to one `Item` and `Value` pair. Name it to annotate a
+ *  value that holds a created bundle, such as a field on a config object
+ *  or a function parameter that takes the bundle rather than calling
+ *  `create` itself. */
+export type Bundle<
   Item = string,
   Value extends string = Item extends string ? Item : string,
-> {
-  readonly view: SubmodelView<Model, Message, ViewInputs<Item, Value>>
-  readonly update: (
+> = Readonly<{
+  view: SubmodelView<Model, Message, ViewInputs<Item, Value>>
+  update: (
     model: Model,
     message: Message,
   ) => readonly [
@@ -103,7 +108,7 @@ export interface Created<
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Value>>,
   ]
-  readonly selectItem: (
+  selectItem: (
     model: Model,
     item: Value,
   ) => readonly [
@@ -111,21 +116,21 @@ export interface Created<
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Value>>,
   ]
-  readonly open: (
+  open: (
     model: Model,
   ) => readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Value>>,
   ]
-  readonly close: (
+  close: (
     model: Model,
   ) => readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,
     Option.Option<OutMessage<Value>>,
   ]
-}
+}>
 
 /** Pairs the single-select listbox's `view` and `update` (and programmatic
  *  helpers) behind a single Item-typed entry point. Declaring the listbox
@@ -150,7 +155,7 @@ export interface Created<
 export const create = <
   Item = string,
   Value extends string = Item extends string ? Item : string,
->(): Created<Item, Value> => {
+>(): Bundle<Item, Value> => {
   type UpdateReturn = readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,

--- a/packages/ui/src/menu/index.ts
+++ b/packages/ui/src/menu/index.ts
@@ -843,41 +843,6 @@ type ViewForItem<Item extends string> = SubmodelView<
   ViewInputs<Item>
 >
 
-export interface Created<Item extends string = string> {
-  readonly view: ViewForItem<Item>
-  readonly update: (
-    model: Model,
-    message: Message,
-  ) => readonly [
-    Model,
-    ReadonlyArray<Command.Command<Message>>,
-    Option.Option<OutMessage<Item>>,
-  ]
-  readonly selectItem: (
-    model: Model,
-    item: Item,
-    index: number,
-  ) => readonly [
-    Model,
-    ReadonlyArray<Command.Command<Message>>,
-    Option.Option<OutMessage<Item>>,
-  ]
-  readonly open: (
-    model: Model,
-  ) => readonly [
-    Model,
-    ReadonlyArray<Command.Command<Message>>,
-    Option.Option<OutMessage<Item>>,
-  ]
-  readonly close: (
-    model: Model,
-  ) => readonly [
-    Model,
-    ReadonlyArray<Command.Command<Message>>,
-    Option.Option<OutMessage<Item>>,
-  ]
-}
-
 const internalView = <Item extends string>() =>
   /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
   menuViewImpl as unknown as ViewForItem<Item>
@@ -1333,6 +1298,46 @@ const menuViewImpl = defineView<Model, Message, ViewInputs<string>>(
   },
 )
 
+/** The `view`, `update`, and programmatic helpers that `Menu.create`
+ *  returns, bound to one `Item` type. Name it to annotate a value that
+ *  holds a created bundle, such as a field on a config object or a
+ *  function parameter that takes the bundle rather than calling `create`
+ *  itself. */
+export type Bundle<Item extends string = string> = Readonly<{
+  view: SubmodelView<Model, Message, ViewInputs<Item>>
+  update: (
+    model: Model,
+    message: Message,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command.Command<Message>>,
+    Option.Option<OutMessage<Item>>,
+  ]
+  selectItem: (
+    model: Model,
+    item: Item,
+    index: number,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command.Command<Message>>,
+    Option.Option<OutMessage<Item>>,
+  ]
+  open: (
+    model: Model,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command.Command<Message>>,
+    Option.Option<OutMessage<Item>>,
+  ]
+  close: (
+    model: Model,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command.Command<Message>>,
+    Option.Option<OutMessage<Item>>,
+  ]
+}>
+
 /** Pairs the menu's `view` and `update` (and programmatic helpers)
  *  behind a single Item-typed entry point. Declaring the menu once at
  *  module scope ensures the view's `Item` type and the OutMessage's
@@ -1349,7 +1354,7 @@ const menuViewImpl = defineView<Model, Message, ViewInputs<string>>(
  *  // maybeOutMessage: Option<Menu.OutMessage<Action>>
  *  ```
  */
-export const create = <Item extends string = string>(): Created<Item> => {
+export const create = <Item extends string = string>(): Bundle<Item> => {
   type GenericReturn = readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,

--- a/packages/ui/src/menu/public.ts
+++ b/packages/ui/src/menu/public.ts
@@ -51,7 +51,7 @@ export type {
   ViewInputs,
   ItemConfig,
   GroupHeading,
-  Created,
+  Bundle,
 } from './index.js'
 
 export type { AnchorConfig } from '../anchor.js'

--- a/packages/ui/src/tabs/index.ts
+++ b/packages/ui/src/tabs/index.ts
@@ -198,18 +198,6 @@ export type ViewInputs<Value extends string = string> = Readonly<{
   orientation?: Orientation
 }>
 
-export interface Created<Value extends string = string> {
-  readonly view: SubmodelView<Model, Message, ViewInputs<Value>>
-  readonly update: (
-    model: Model,
-    message: Message,
-  ) => readonly [
-    Model,
-    ReadonlyArray<Command.Command<Message>>,
-    Option.Option<OutMessage<Value>>,
-  ]
-}
-
 const internalView = defineView<Model, Message, ViewInputs>(
   (model, viewInputs, h): Html => {
     const { id, activationMode, maybeFocusedIndex } = model
@@ -366,6 +354,22 @@ const internalView = defineView<Model, Message, ViewInputs>(
   },
 )
 
+/** The `view` and `update` pair that `Tabs.create` returns, bound to one
+ *  `Value` type. Name it to annotate a value that holds a created bundle,
+ *  such as a field on a config object or a function parameter that takes
+ *  the bundle rather than calling `create` itself. */
+export type Bundle<Value extends string = string> = Readonly<{
+  view: SubmodelView<Model, Message, ViewInputs<Value>>
+  update: (
+    model: Model,
+    message: Message,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command.Command<Message>>,
+    Option.Option<OutMessage<Value>>,
+  ]
+}>
+
 /** Pairs the tabs `view` and `update` behind a single Value-typed entry
  *  point. Declare once at module scope so consumers receive
  *  `tab.value: Value` in `toView` and the `Selected` OutMessage without an
@@ -384,7 +388,7 @@ const internalView = defineView<Model, Message, ViewInputs>(
  *  The internal view stays typed `ReadonlyArray<string>`; consumers can
  *  pass a `ReadonlyArray<MyUnion>` (assignable) and the fenced cast inside
  *  `create` types `TabInfo.value` as `MyUnion`. */
-export const create = <Value extends string = string>(): Created<Value> => {
+export const create = <Value extends string = string>(): Bundle<Value> => {
   type GenericReturn = readonly [
     Model,
     ReadonlyArray<Command.Command<Message>>,

--- a/packages/ui/src/tabs/public.ts
+++ b/packages/ui/src/tabs/public.ts
@@ -18,5 +18,5 @@ export type {
   ViewInputs,
   RenderInfo,
   TabInfo,
-  Created,
+  Bundle,
 } from './index.js'

--- a/packages/website/src/page/ui/comboboxPage.md
+++ b/packages/website/src/page/ui/comboboxPage.md
@@ -8,6 +8,8 @@ Embed Combobox via the [`create<Item>()` factory](/ui/selection-submodels) at mo
 
 For programmatic control in update functions, use `CityCombobox.open(model)`, `CityCombobox.close(model, restingInputValue)`, and `CityCombobox.selectItem(model, item, displayText)`. Each returns `[Model, Commands, Option<OutMessage>]` directly. Single-select `close` takes the resting input text (the selected display text, or empty); `Combobox.Multi` closes with `close(model)` since the multi-select input always rests empty.
 
+What the factory returns is typed [`Combobox.Bundle<Item>`](/ui/selection-submodels#bundle-type) (`Combobox.Multi.Bundle` for the multi-select variant), for the cases where a created bundle has to be named rather than called directly.
+
 :::Info{label="See it in an app"}
 Check out how Combobox is wired up in a [real Foldkit app](https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/ui/view/combobox.ts).
 :::

--- a/packages/website/src/page/ui/listboxPage.md
+++ b/packages/website/src/page/ui/listboxPage.md
@@ -8,6 +8,8 @@ Embed Listbox via the [`create<Item, Value?>()` factory](/ui/selection-submodels
 
 For programmatic control in update functions, use the factory instance helpers `PlanListbox.open(model)`, `PlanListbox.close(model)`, and `PlanListbox.selectItem(model, item)`. Each returns `[Model, Commands, Option<OutMessage>]` directly.
 
+What the factory returns is typed [`Listbox.Bundle<Item, Value>`](/ui/selection-submodels#bundle-type) (`Listbox.Multi.Bundle` for the multi-select variant), for the cases where a created bundle has to be named rather than called directly.
+
 :::Info{label="See it in an app"}
 Check out how Listbox is wired up in a [real Foldkit app](https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/ui/view/listbox.ts).
 :::

--- a/packages/website/src/page/ui/menuPage.md
+++ b/packages/website/src/page/ui/menuPage.md
@@ -6,6 +6,8 @@ A dropdown menu for actions, like a macOS context menu. Menu is fire-and-forget:
 
 For programmatic control in update functions, use the factory’s `open(model)`, `close(model)`, and `selectItem(model, item, index)` methods. Each returns the same `[Model, Commands, Option<OutMessage>]` tuple as `update`.
 
+What `Menu.create<Item>()` returns is typed [`Menu.Bundle<Item>`](/ui/selection-submodels#bundle-type), for the cases where a created bundle has to be named rather than called directly.
+
 :::Info{label="See it in an app"}
 Check out how Menu is wired up in a [real Foldkit app](https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/ui/view/menu.ts).
 :::

--- a/packages/website/src/page/ui/selectionSubmodelsPage.md
+++ b/packages/website/src/page/ui/selectionSubmodelsPage.md
@@ -16,6 +16,14 @@ A call to `Listbox.create<Plan>()` returns an object whose entry points are all 
 
 There is no inbound reflect helper for the selection: the parent owns it outright and passes it in as `maybeSelectedValue` (`selectedValues` for multi-select), so there is nothing on the Listbox or Combobox to reflect onto. When an external value (a URL parameter, restored storage, a server push) changes the selection, the parent writes its own field. The `reflect*` family lives on the components with configuration the parent feeds in: `reflectMinDate`, `reflectMaxDate`, `reflectDisabledDates`, and `reflectDisabledDaysOfWeek` on Calendar and DatePicker, and `reflectRange` on Slider. See [Reflecting External State](/core/submodel#reflecting-external-state) for the concept.
 
+## Naming What `create` Returns {#bundle-type}
+
+Each component exports a `Bundle` type for what its factory returns, taking the same type parameters as the factory itself. `Listbox.Bundle<Plan>` is what `Listbox.create<Plan>()` produces, `Menu.Bundle<Action>` is what `Menu.create<Action>()` produces, and the multi-select variants export their own under `Listbox.Multi.Bundle` and `Combobox.Multi.Bundle`.
+
+Declaring the factory at module scope and using it directly needs no annotation, since inference covers it. Reach for `Bundle` when a created bundle has to be named instead. For example: a config object with a field typed `Combobox.Bundle<City>`, or a view helper whose parameter is `Listbox.Bundle<Plan>` because it receives the bundle rather than calling `create` itself.
+
+The name also matters to consumers that emit their own declarations. Without it, TypeScript has to expand the factory's whole result into the generated `.d.ts` at every use site, and it refuses where that expansion reaches a type the consumer cannot name.
+
 ## The Submodel Doesn’t Own Your Selection {#submodel-doesnt-own-selection}
 
 A common first question is: if the Listbox is Item-typed, why does my own Model still hold an `Option<Plan>` for the picked value? Isn’t that the same state twice?

--- a/packages/website/src/page/ui/tabsPage.md
+++ b/packages/website/src/page/ui/tabsPage.md
@@ -6,6 +6,8 @@ Tab panel navigation with roving tabindex keyboard support, horizontal and verti
 
 Tabs is a Submodel that keeps its own keyboard-focus state, but the parent owns the active tab. Store the active value in your Model, pass it in as `selectedValue`, and fold the `Selected` OutMessage back into that field in your `GotTabsMessage` handler.
 
+What `Tabs.create<Value>()` returns is typed [`Tabs.Bundle<Value>`](/ui/selection-submodels#bundle-type), for the cases where a created bundle has to be named rather than called directly.
+
 :::Info{label="See it in an app"}
 Check out how Tabs is wired up in a [real Foldkit app](https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/ui/view/tabs.ts).
 :::


### PR DESCRIPTION
Follow-up to #887, which named the `create` factory result type and landed it as `Created`. Nothing in that PR was wrong: it typechecked, CI was green, and it fixed a real downstream declaration-emit failure. This brings it in line with repository conventions before any of it ships, and makes one scope call beyond pure cleanup.

Because #887's changeset never shipped, none of this is user-visible churn. The release notes will describe `Bundle` and nothing else.

## The name

`Created*` is the past-tense Message verb prefix in this repository. In `tabs/public.ts` the type sat directly beneath `Selected`, `SelectedTab`, `FocusedTab`, and `CompletedFocusTab`, where `Tabs.Created` reads as one more Message.

`Bundle` is the word the selection Submodels page already used for what a factory returns: "use the same bundle at every site that needs it." The type now matches the prose that describes it.

## The declaration form

The per-property `readonly` in #887 was not a style choice, it was forced. An interface body is a member list, so each member carries its own modifiers, and a mapped type cannot be an interface body. Picking `interface` is what put `readonly` on every field against the `Readonly<{...}>` convention. The two were one decision.

The interface is not load-bearing for the goal. Both forms emit a named reference, verified by building the package and reading the six emitted signatures back:

```ts
export declare const create: <Value extends string = string>() => Bundle<Value>;
export declare const create: <Item extends string = string>() => Bundle<Item>;
export declare const create: <Item = string, Value extends string = Item extends string ? Item : string>() => Bundle<Item, Value>;
```

Each still names `Bundle` with the mapped type unexpanded, so the portability fix is fully preserved.

The repository's one interface-over-`Readonly` precedent does not transfer either. `Group` in `canvas/shape.ts` documents its own justification as recursion under lazy interface evaluation, and none of these types are recursive.

## Menu's `view` field

The one change here that goes past style, flagged because it is a scope call rather than cleanup.

`Menu.Bundle.view` was typed `ViewForItem<Item>`, a module-private alias listed in typedoc's `intentionallyNotExported`. The other five spell out `SubmodelView<Model, Message, ViewInputs<Item>>` using only exported types.

A public type whose field names a type consumers cannot reference is the same defect #887 set out to fix, one level down: a consumer who pulls `.view` off a bundle and annotates it hits exactly the unnameable-type error again. Menu now spells it out like its siblings. `ViewForItem` stays for internal use by `internalView`.

## TSDoc and placement

Each type gains the TSDoc that every other public export in these modules carries, and moves next to the `create` it describes. In `menu/index.ts` it sat five hundred lines away, wedged between a private alias and the internal view; in `tabs/index.ts`, roughly two hundred.

## Changeset

Replaced `tidy-menus-travel.md` with `create-factory-bundle-type.md`, and `patch` with `minor`.

Six new public exports widen the API surface, which is what this repository bumps minor for, matching `anchor-lock-placement` and `document-lang-dir`. The prose is rewritten to describe the type for release notes rather than the commit that introduced it, and it thanks @IMax153 the way `anchor-lock-placement` thanks its contributor.

## Docs

Added a `#bundle-type` section to the selection Submodels page, which covers all four components and already used the word, and linked to it from the Menu, Tabs, Listbox, and Combobox pages.

Deliberately no fenced code block. There are zero `ts` fences anywhere under `packages/website/src/page/`, because TypeScript examples go through `::Snippet` files instead. Those snippets are excluded from typecheck (`tsconfig.json`), lint (`.oxlintrc.json`), and dead-code analysis (`knip.json`), and the existing ones are page-scale pseudocode walkthroughs rather than four-line illustrations, so adding a snippet file for a single annotation would be out of proportion. The example is carried in prose instead.

## Verification

Full pre-push suite green, which is what gated the push: `prettier --check`, `oxlint`, knip dead-code, effect prebundle, circular deps, `pnpm build`, `pnpm -r typecheck`, the full test suite, and the website Chromium e2e. `@foldkit/ui` is 868 tests across 35 files.

`changeset status --since=origin/main` reports `@foldkit/ui` at minor, with `foldkit` and `@foldkit/devtools` following as dependents.

Also confirmed along the way: the two typedoc warnings this package emits are identical on `main`, so none are introduced here, and `api-ui.json` is generated at build time rather than committed, so there is nothing to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kwd1ciBG2zTrhhnYo6Ddmp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named, typed `Bundle` exports for Menu, Tabs, Listbox, and Combobox factories, including multi-select variants.
  * Factory-created bundles can now be explicitly annotated while preserving existing behavior.

* **Documentation**
  * Updated UI component documentation with the new `Bundle` types and guidance for naming factory results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->