### PR TITLE
docs: add a contributing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ If a Mount factory doesn't read or write its element, you've misidentified the c
 
 ## Commits and Releases
 
-- Conventional Commits. Add `!` after the scope for breaking changes (e.g. `refactor(schema)!:`).
+- Conventional Commits. Add `!` after the scope for breaking changes (e.g. `refactor(foldkit)!:`).
 - Valid scopes: package directories (`foldkit`, `ui`, `devtools`, `create-foldkit-app`, `vite-plugin`, `devtools-mcp`, `oxlint-plugin`, `markdown`, `website`, `typing-game`, `examples-e2e`), example directory names, `skills`, `ci`, and `release`. Never internal module names.
 - The `skills` scope means the shipped Foldkit app skills (`skills/foldkit`, `skills/generate-program`, `skills/audit-program`) and their packaging. Do not use it for repo-maintenance helper skills such as `.agents/skills/commit-changes`. Omit the scope when no valid scope fits the whole change.
 - Do not invent broad scopes such as `tooling` or `infrastructure`. Use the literal valid scopes above.
@@ -153,3 +153,5 @@ Apps in `examples/` ship with `@foldkit/devtools-mcp` wired up. When the Foldkit
 No em dashes in prose. You compulsively reach for `—` as a substitute for a period, comma, colon, parentheses, or semicolon, and the user has been removing them by hand for a long time. Default to a period and a fresh sentence. Comma, semicolon, parentheses, or colon also work. Applies to comments, TSDoc, docs, snippets, website copy, conversation, commit messages, and changesets. Document and page titles use a spaced pipe (`|`) as the breadcrumb separator (`"Calendar | API | Foldkit"`), never a dash. The only fine structural use of `—` is as a placeholder value in a table cell, standing in for empty or not applicable. Only fix em dashes when removing them makes the writing clearer.
 
 Never describe our own writing as honest ("an honest note", "an honest ledger", "honestly"). We are honest by default; labeling it reads as a tell and implies the rest is less honest. Delete the label and say the thing plainly. Applies everywhere: docs, page metadata, commit messages, conversation.
+
+Write "For example:" when a colon introduces illustrations rather than the complete set. A bare colon reads as an exhaustive enumeration, so a reader takes three illustrations for the only three cases that exist. Use the bare colon when the list really is exhaustive, which is what makes the distinction worth keeping. Applies to docs, TSDoc, changesets, commit messages, and website copy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to Foldkit
+
+Thanks for contributing. This guide covers the process: how to get set up, what the checks enforce, and what a reviewable change looks like.
+
+For code style, read [`AGENTS.md`](./AGENTS.md). It is the reference for naming, state modeling, view architecture, and file organization, and it applies to human and agent contributions alike. This guide does not repeat it.
+
+## Getting Set Up
+
+Foldkit is a pnpm workspace.
+
+```sh
+pnpm install
+```
+
+Node `>=20.19.0` (or `>=22.12.0`) and pnpm `>=11`. The repository pins `pnpm@11.8.0` via `packageManager`, so Corepack will select the right version on its own.
+
+`pnpm install` also installs the git hooks. Two of them run:
+
+- **commit-msg** rejects a `Co-Authored-By` line naming Claude.
+- **pre-push** runs the full check suite described below.
+
+## Before You Push
+
+The pre-push hook runs `pnpm pre-push`, which is the same suite CI runs. You can run it yourself at any point:
+
+```sh
+pnpm pre-push
+```
+
+It takes several minutes because it builds every package, typechecks the whole workspace, runs every test suite, and finishes with a Chromium end-to-end pass over the website. That is intentional: a green local run means a green CI run.
+
+For a faster inner loop while working, the individual pieces are available:
+
+```sh
+pnpm lint
+pnpm -r typecheck
+pnpm test
+pnpm format
+```
+
+If a typecheck reports something like `Cannot find module 'foldkit'`, the libraries have not been built. Foldkit's `exports` map points at `dist/`, so anything depending on it needs a build before it will typecheck. Run `pnpm build` once, or `pnpm dev:libs` to rebuild in watch mode while you work.
+
+Beyond the usual lint, typecheck, and test steps, the suite enforces a few repository-specific rules that are easy to trip over:
+
+| Check                              | Rule                                                                                                                                                               |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `check:no-claude-comments`         | No unresolved `CLAUDE:` comments in tracked files, apart from the checker itself and the two documents describing the rule. Resolve or remove them before pushing. |
+| `check:commit-message-line-length` | Commit message prose wraps at 80 characters. Unbreakable lines such as URLs are exempt.                                                                            |
+| `check:no-major-changesets`        | No `major` changesets. Foldkit is pre-1.0, so breaking changes ship as `minor`.                                                                                    |
+| `check:changeset-unwrapped`        | Changeset prose is not hard-wrapped. Write each paragraph as one line.                                                                                             |
+| `changeset status`                 | Every change to a publishable package has a changeset.                                                                                                             |
+| `check:dead-code`                  | No unused files, exports, or dependencies.                                                                                                                         |
+
+## Commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/). Add `!` after the scope for a breaking change, as in `refactor(foldkit)!:`.
+
+Valid scopes are package directory names (`foldkit`, `ui`, `devtools`, `create-foldkit-app`, `vite-plugin`, `devtools-mcp`, `oxlint-plugin`, `markdown`, `website`, `typing-game`, `examples-e2e`), example directory names, plus `skills`, `ci`, and `release`. Never an internal module name. Omit the scope when none fits the whole change. Do not invent broad scopes such as `tooling` or `infrastructure`.
+
+`skills` is narrower than it looks. It means the Foldkit app skills shipped under `skills/` and their packaging, not repository-maintenance helpers such as `.agents/skills/commit-changes`, which take no scope.
+
+A comma-separated scope such as `feat(foldkit,ui):` is for a change with real work in both packages. It has happened twice. Documentation does not earn a scope slot: a change to `packages/ui` that updates its docs page is `feat(ui)`, not `feat(ui,website)`, and `website` is the scope only when the site itself is what changed.
+
+Write a subject that names the mechanism or the identifiers, not the category of work:
+
+```text
+BAD:  fix(ui): name factory result types
+GOOD: fix(ui): export a named return type for every create factory
+```
+
+The first could describe a dozen changes. The second says what moved.
+
+**Commits carry a body.** This is the convention most new contributors miss, because it is invisible until you read the log. Every substantive commit in the history explains what was wrong before stating what changed. Read `git log` for a few examples before writing your first one. A one-line commit reads as unfinished here.
+
+Write both against the whole change set rather than the file you touched last. Check what you are describing with `git diff --cached --stat --name-status` before committing. After an amend that adds or drops files, re-check the body against `git show --stat --name-status HEAD`, because a message written for the original diff quietly stops matching the final one.
+
+Do not mention AI assistants or add AI co-author trailers, in commit messages or release notes.
+
+## Changesets
+
+Any change to a publishable package needs a changeset. The publishable set is `foldkit`, `@foldkit/ui`, `@foldkit/devtools`, `create-foldkit-app`, `@foldkit/vite-plugin`, `@foldkit/devtools-mcp`, `@foldkit/oxlint-plugin`, and `@foldkit/markdown`. Examples and the website are in the changeset `ignore` list and need none.
+
+```sh
+pnpm changeset
+```
+
+Four things the tool will not do for you:
+
+**Rename the file.** The generator produces a random slug like `tidy-menus-travel.md`. Rename it to describe the change: `anchor-lock-placement.md`, `command-defer-execute-body.md`, `route-transition-naming.md`. Every changeset in the history is named this way.
+
+**Pick the right bump.** Anything that widens the public API surface is `minor`, including a new export, a new config field, or a new function. `patch` is for fixes that leave the surface unchanged. Breaking changes are also `minor`, because the repository is pre-1.0 and `major` is rejected outright. Note that `foldkit`, `@foldkit/ui`, and `@foldkit/devtools` are version-fixed, so bumping one bumps all three.
+
+**Write it as release notes.** The changeset is what users read in the changelog, so it is not a commit message and not a one-line summary. Explain what changed, what was wrong or missing before, how the new thing behaves, and what stays the same. Multiple paragraphs is normal, and a short code example is welcome. `.changeset/` in the git history has the models; `anchor-lock-placement.md` from release 0.137.0 is a good one.
+
+**Credit the contributor.** When a changeset ships someone else's work, thank them by handle at the end, the way existing changesets do.
+
+## Documentation
+
+A change to a public API updates the docs in the same pull request. The relevant page lives under `packages/website/src/page/`, and each component or concept page carries an `## API Reference` section listing its exported types.
+
+TypeScript examples on docs pages live in `packages/website/src/snippet/` and are pulled in with `::Snippet{name="..." label="..."}`, which renders them in a labeled panel. There is not a single `ts` fence anywhere under `packages/website/src/page/`, so add a snippet rather than starting the first one.
+
+Snippets are excluded from typecheck (`tsconfig.json`), lint (`.oxlintrc.json`), and dead-code analysis (`knip.json`). That is deliberate: most are pseudocode walkthroughs that show the integration points as excerpts, so they reference types they never import and would not compile as written. Do not assume a snippet is checked, and keep them illustrative rather than trying to make them build.
+
+Fences are still right for shell commands, file trees, and plain output, which is what the existing `sh`, `text`, and `diagram` blocks are.
+
+Prose has one hard rule: no em dashes. Use a period and a new sentence, or a comma, colon, semicolon, or parentheses. This applies to documentation, TSDoc, comments, changesets, commit messages, and pull request descriptions.
+
+## Pull Requests
+
+Describe the change the way the commit body does: what was wrong, what you changed, and what you deliberately left alone. Call out scope decisions explicitly so a reviewer can disagree with them directly rather than discovering them in the diff. Say how you verified the change, and be specific about anything you could not verify.
+
+Pull requests are squash-merged, so the description becomes the commit body on `main`. Strip any bot-generated summary sections before merging.
+
+## A Note on Style Review
+
+Foldkit is opinionated, and review comments here tend to be about conventions rather than correctness. For example: a type name that collides with the Message naming scheme, a missing TSDoc on a public export, or an `interface` where the repository uses `Readonly<{...}>`. None of that is a judgment on the change. It is what keeps a codebase this size readable by everyone working in it.
+
+`AGENTS.md` documents most of it. When something comes up in review that is not written down anywhere, that is a gap in these docs, and a pull request fixing it is as welcome as one fixing code.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Some of what you can build with Foldkit. [See all example apps on foldkit.dev](h
 
 ## Development
 
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the checks, commit conventions, and changeset expectations, and [AGENTS.md](./AGENTS.md) for code style.
+
 ```bash
 git clone https://github.com/foldkit/foldkit.git
 cd foldkit

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:e2e": "pnpm --filter website test:e2e",
     "format": "prettier -w .",
     "format:check": "prettier --check .",
-    "dev:libs": "pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/markdown --parallel watch",
+    "dev:libs": "pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/markdown --filter @foldkit/vite-plugin --parallel watch",
     "dev:website": "pnpm --filter website dev",
     "build:examples": "tsx scripts/build-examples.ts",
     "build:website": "pnpm --filter website... build",

--- a/scripts/check-no-claude-comments.sh
+++ b/scripts/check-no-claude-comments.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 # Check for CLAUDE: comments that should be resolved before merging.
-# Searches all tracked (and staged) files, ignoring this script itself.
+# Searches all tracked (and staged) files, ignoring this script itself and the
+# two documents that describe the convention.
 
-MATCHES=$(git grep -n 'CLAUDE:' -- ':!scripts/check-no-claude-comments.sh' ':!AGENTS.md' || true)
+MATCHES=$(git grep -n 'CLAUDE:' -- ':!scripts/check-no-claude-comments.sh' ':!AGENTS.md' ':!CONTRIBUTING.md' || true)
 
 if [ -n "$MATCHES" ]; then
   echo ""


### PR DESCRIPTION
## What

`AGENTS.md` covers code style thoroughly, but nothing documented the process around a change: what the pre-push suite enforces, that commits carry a body, how changesets are named and bumped, or that a public API change updates the docs in the same pull request. A contributor could read every style rule the repository publishes and still get all of that wrong, because none of it was written down anywhere.

This came out of reviewing #887, the first outside contribution from the Effect team. The code was correct and CI was green. Most of the review comments were conventions, and roughly two thirds of them were rules that existed only in the commit history or in a check script's error message.

## What it covers

The parts that are enforced but undocumented:

- `major` changesets are rejected outright, so breaking changes ship as `minor` while the repository is pre-1.0
- Additive exports are `minor` rather than `patch`
- `foldkit`, `@foldkit/ui`, and `@foldkit/devtools` are version-fixed, so bumping one bumps all three
- Changeset prose is not hard-wrapped, and commit message prose wraps at 80 characters
- Unresolved agent comments block a push
- Examples and the website are in the changeset `ignore` list and need none
- The `skills` scope means the shipped app skills under `skills/`, not repository-maintenance helpers such as `.agents/skills/commit-changes`

Conventions visible only by reading the history:

- Changesets are renamed from the generator's random slug to something descriptive
- Changesets are written as release notes, not as a second commit message
- A comma-separated scope is for a change with real work in both packages, which has happened twice. Documentation does not earn a scope slot, so a change to `packages/ui` that updates its docs page is `feat(ui)`, not `feat(ui,website)`
- The commit subject describes the whole change set, checked against the full staged diff, and the body is re-audited after an amend adds or drops files

Documentation gets its own section, including that TypeScript examples live in snippet files rather than fenced blocks. Those snippets are excluded from typecheck (`tsconfig.json`), lint (`.oxlintrc.json`), and dead-code analysis (`knip.json`), which is what lets them stay partial pseudocode excerpts, so the guide tells contributors to keep them illustrative rather than trying to make them build.

Every claim is checked against the scripts and config rather than written from memory. The bump-level guidance matches what `anchor-lock-placement` and `document-lang-dir` actually did; the version-fixed set is read out of `.changeset/config.json`; the publishable package list is the one in `check-changeset-ignore.ts`; the multi-scope rule is counted out of `git log`.

## Scope

Deliberately does not repeat `AGENTS.md`. It links there for style and covers only process, so the two cannot drift into disagreeing. The README's Development section now points at both.

## Two `AGENTS.md` fixes

`AGENTS.md` gave `refactor(schema)!:` as its breaking-change example one line above declaring that internal module names are never scopes. Both documents now use `refactor(foldkit)!:`.

It also gains a prose rule: write "For example:" when a colon introduces illustrations rather than the complete set, since a bare colon reads as an exhaustive enumeration.

## A `dev:libs` fix

Writing the setup section surfaced a gap in what that section had to describe. The guide points contributors at `pnpm dev:libs` to keep the libraries built while they work, but that script watched only `foldkit`, `@foldkit/ui`, `@foldkit/devtools`, and `@foldkit/markdown`. Every example and the website import `@foldkit/vite-plugin` in their vite config (`examples/counter/vite.config.ts:3`, `packages/website/vite.config.ts:8`), and its `exports` map resolves only through `dist/`. A fresh clone following the README's own quickstart could not start an example.

`dev:libs` now watches the plugin too. Both `scripts/cloud-session-setup.sh` (in `prerequisite_packages`) and `pnpm check` already build it as a prerequisite, so `dev:libs` was the one entry point that did not. The other two prerequisites stay out on purpose: `@foldkit/oxlint-plugin` has no `watch` script and `pnpm lint` builds it on every run, and `@typing-game/shared` has no `watch` script and is only needed for the typing-game apps.

## One incidental change

`scripts/check-no-claude-comments.sh` gains a `CONTRIBUTING.md` exclusion. Documenting the rule means naming the marker string it greps for, which tripped the check on its own guide and failed the first push. `AGENTS.md` was already excluded for exactly that reason, so this makes the pair consistent rather than carving out something new.

## Verification

Full pre-push suite green, which is what gated the push: `prettier --check`, `oxlint`, knip dead-code, effect prebundle, circular deps, `pnpm build`, `pnpm -r typecheck`, and the full test suite.

The `dev:libs` fix is verified from a true fresh-clone state: removing both `packages/vite-plugin-foldkit/dist` and its `tsconfig.tsbuildinfo`, then running `pnpm dev:libs`, emits `dist/index.js` and the declaration files. Removing only `dist/` does not, because `tsc -b` reads the stale build info and judges the project up to date, which is why that package's own `build` script cleans both.

`bash scripts/check-no-claude-comments.sh` passes with the new exclusion, and fails without it, so the exclusion is load-bearing rather than speculative.

No changeset: this touches no publishable package. The `dev:libs` change is to the private root `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kwd1ciBG2zTrhhnYo6Ddmp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance covering setup, supported tools, validation, commits, changesets, documentation, and pull requests.
  * Updated development documentation with links to contributor and coding-style guidance.
  * Clarified commit examples and list-writing conventions.

* **Chores**
  * Expanded development watch mode to include the Vite plugin package.
  * Updated comment scanning to correctly handle contributor guidance files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->