### PR TITLE
Export Orientation as value from Tabs

### DIFF
--- a/.changeset/tabs-orientation-value-export.md
+++ b/.changeset/tabs-orientation-value-export.md
@@ -1,0 +1,15 @@
+---
+'@foldkit/ui': minor
+---
+
+Export `Orientation` as a value from `Tabs`, matching `Listbox` and `RadioGroup`.
+
+Three components define an `Orientation` literal schema for the same consumer-facing config field. `Listbox` and `RadioGroup` re-exported it from their barrel as a value. `Tabs` listed it under `export type { ... }`, which re-exports the type and shadows the value, so the schema was unreachable.
+
+```ts
+import { Tabs } from '@foldkit/ui'
+
+typeof Tabs.Orientation // was 'undefined', now 'function'
+```
+
+`ActivationMode` on `Tabs` and `ActivationTrigger` on `Combobox`, `Listbox`, and `Menu` stay type-only. No barrel exports either of them as a value, so they are already consistent, and promoting them would widen the public surface rather than settle a disagreement between barrels. `AnchorConfig` stays type-only as well, since its runtime side is the subject of a separate question about the anchor surface.

--- a/packages/ui/src/tabs/public.ts
+++ b/packages/ui/src/tabs/public.ts
@@ -9,10 +9,10 @@ export {
   FocusedTab,
   CompletedFocusTab,
   FocusTab,
+  Orientation,
 } from './index.js'
 
 export type {
-  Orientation,
   ActivationMode,
   InitConfig,
   ViewInputs,


### PR DESCRIPTION
## Summary

Export `Orientation` as a value from the `Tabs` barrel, matching the pattern used by `Listbox` and `RadioGroup`. This makes the `Orientation` schema accessible at runtime.

## Changes

- Moved `Orientation` from `export type { ... }` to the value exports in `packages/ui/src/tabs/public.ts`

## Details

Three components (`Tabs`, `Listbox`, `RadioGroup`) define an `Orientation` literal schema for the same configuration field. `Listbox` and `RadioGroup` already re-export it as a value from their barrels, but `Tabs` only exported it as a type. This type-only export shadowed the runtime value, making the schema unreachable.

With this change:
```ts
import { Tabs } from '@foldkit/ui'

typeof Tabs.Orientation // now 'function' (was 'undefined')
```

This aligns `Tabs` with the established pattern in `Listbox` and `RadioGroup`, ensuring consistent public API surface across these three components.

https://claude.ai/code/session_01DzduCj7DbbWCVoUdWNFtnf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Tabs.Orientation` is now available as a runtime value for use in applications.

* **Documentation**
  * Added release notes documenting this minor update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->