### PR TITLE
docs: fix two wording errors in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Foldkit is a pnpm workspace.
 pnpm install
 ```
 
-Node `>=20.19.0` (or `>=22.12.0`) and pnpm `>=11`. The repository pins `pnpm@11.8.0` via `packageManager`, so Corepack will select the right version on its own.
+Node `>=20.19.0` and pnpm `>=11`. The repository pins `pnpm@11.8.0` via `packageManager`, so Corepack will select the right version on its own.
 
 `pnpm install` also installs the git hooks. Two of them run:
 
@@ -90,7 +90,7 @@ Four things the tool will not do for you:
 
 **Pick the right bump.** Anything that widens the public API surface is `minor`, including a new export, a new config field, or a new function. `patch` is for fixes that leave the surface unchanged. Breaking changes are also `minor`, because the repository is pre-1.0 and `major` is rejected outright. Note that `foldkit`, `@foldkit/ui`, and `@foldkit/devtools` are version-fixed, so bumping one bumps all three.
 
-**Write it as release notes.** The changeset is what users read in the changelog, so it is not a commit message and not a one-line summary. Explain what changed, what was wrong or missing before, how the new thing behaves, and what stays the same. Multiple paragraphs is normal, and a short code example is welcome. `.changeset/` in the git history has the models; `anchor-lock-placement.md` from release 0.137.0 is a good one.
+**Write it as release notes.** The changeset is what users read in the changelog, so it is not a commit message and not a one-line summary. Explain what changed, what was wrong or missing before, how the new thing behaves, and what stays the same. Writing multiple paragraphs is normal, and a short code example is welcome. `.changeset/` in the git history has the models; `anchor-lock-placement.md` from release 0.137.0 is a good one.
 
 **Credit the contributor.** When a changeset ships someone else's work, thank them by handle at the end, the way existing changesets do.
 


### PR DESCRIPTION
Two review findings on #898 arrived after it merged, so they land here instead.

## The Node range

The setup section gave the requirement as Node `>=20.19.0` (or `>=22.12.0`), mirroring the `engines` range in the root `package.json`. That range uses `>=` on both sides:

```json
"node": ">=20.19.0 || >=22.12.0"
```

so the second clause is subsumed by the first and the union is just `>=20.19.0`. The parenthetical read as though a second boundary mattered, when nothing in the repository treats `22.12.0` as significant. The guide now states the effective requirement.

I checked this rather than assuming, because the shape is one character away from Vite's `^20.19.0 || >=22.12.0`, where the caret makes the second clause load-bearing by excluding 21.x and 22.0 through 22.11. Here it is `>=`, so it genuinely collapses.

## The paragraph sentence

The changeset section said "Multiple paragraphs is normal". The reviewer read that as a plural subject with a singular verb and asked for "are".

The singular was defensible. A plural noun phrase denoting an amount takes a singular verb all the time, which is why "500 words is normal" and "three paragraphs is normal" both read fine. What breaks it here is "multiple" specifically: it patterns with *several* and *many* rather than with a bare numeral, and those resist the unit-amount reading.

Rather than flip the verb and lose the intended sense, the sentence now reads:

> Writing multiple paragraphs is normal, and a short code example is welcome.

That keeps the singular, makes its subject explicit, and stops the same comment from coming back on a later pass.

## What this deliberately leaves alone

The `engines` range in `package.json` is untouched. Simplifying it there is a separate change, and given how close its shape is to Vite's, it may have been meant as `^20.19.0 || >=22.12.0`. Rewriting it either way is a support-matrix decision rather than a wording fix, so it wants its own pull request and a deliberate call on whether Node 21.x and early 22.x are supported.

## Verification

`prettier --check .` passes. The diff is two single-line prose changes in `CONTRIBUTING.md` with no code, config, or script changes, so the full pre-push suite was skipped at your direction.

No changeset: this touches no publishable package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kwd1ciBG2zTrhhnYo6Ddmp