### PR TITLE
test(examples-e2e): cover the DevTools interaction blocker

### DIFF
--- a/packages/examples-e2e/e2e/view-transitions.spec.ts
+++ b/packages/examples-e2e/e2e/view-transitions.spec.ts
@@ -1,6 +1,59 @@
-import { expect, test } from '@playwright/test'
+import {
+  type Locator,
+  type Page as PlaywrightPage,
+  expect,
+  test,
+} from '@playwright/test'
 
 import * as Page from '../page'
+
+const DEVTOOLS_HOST_ID = 'foldkit-devtools'
+const BLOCKER_CLASS = 'dt-interaction-blocker'
+
+type Point = Readonly<{ x: number; y: number }>
+
+type HitTest = Readonly<{
+  topElement: string | null
+  shadowElementClass: string | null
+  blockerPointerEvents: string | null
+}>
+
+const centerOf = async (locator: Locator): Promise<Point> => {
+  const box = await locator.boundingBox()
+  if (box === null) {
+    throw new Error('Expected the target element to have a bounding box')
+  }
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+const hitTestAt = (page: PlaywrightPage, point: Point): Promise<HitTest> =>
+  page.evaluate(
+    ({ x, y, hostId, blockerClass }) => {
+      const host = document.getElementById(hostId)
+      const shadowRoot = host?.shadowRoot ?? null
+      const blocker = shadowRoot?.querySelector(`.${blockerClass}`) ?? null
+      const topElement = document.elementFromPoint(x, y)
+      const shadowElement = shadowRoot?.elementFromPoint(x, y) ?? null
+      const elementLabel = (element: Element): string =>
+        `${element.tagName.toLowerCase()}${element.id ? `#${element.id}` : ''}`
+
+      return {
+        topElement: topElement ? elementLabel(topElement) : null,
+        shadowElementClass: shadowElement
+          ? shadowElement.getAttribute('class')
+          : null,
+        blockerPointerEvents: blocker
+          ? getComputedStyle(blocker).pointerEvents
+          : null,
+      }
+    },
+    {
+      x: point.x,
+      y: point.y,
+      hostId: DEVTOOLS_HOST_ID,
+      blockerClass: BLOCKER_CLASS,
+    },
+  )
 
 test.describe('view-transitions example', () => {
   test.use({ contextOptions: { reducedMotion: 'no-preference' } })
@@ -65,5 +118,52 @@ test.describe('view-transitions example', () => {
     await page.getByPlaceholder('Filter by title').fill('moss')
     await expect(page.getByRole('link', { name: 'Moss Study' })).toBeVisible()
     expect(await transitionCount()).toBe(2)
+  })
+
+  test('DevTools time travel blocks application clicks until resumed', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    const badge = page.locator('.dt-badge')
+    const blocker = page.locator(`.${BLOCKER_CLASS}`)
+    await expect(badge).toBeVisible()
+    await expect(blocker).toHaveCount(0)
+
+    await badge.click()
+    await expect(page.locator('.dt-panel')).toBeVisible()
+
+    const filterInput = page.getByPlaceholder('Filter by title')
+    await filterInput.fill('gradient')
+    await filterInput.fill('dawn')
+
+    const historyRows = page.locator('.dt-row')
+    await expect(historyRows).toHaveCount(3)
+
+    await historyRows.filter({ hasText: 'UpdatedFilterText' }).last().click()
+    await expect(page.locator('.dt-resume-button')).toBeVisible()
+    await expect(blocker).toHaveCount(1)
+
+    const artworkPoint = await centerOf(
+      page.getByRole('link', { name: 'Dawn Chorus' }),
+    )
+
+    const hitTest = await hitTestAt(page, artworkPoint)
+    expect(hitTest.topElement).toBe(`div#${DEVTOOLS_HOST_ID}`)
+    expect(hitTest.shadowElementClass).toContain(BLOCKER_CLASS)
+    expect(hitTest.blockerPointerEvents).toBe('auto')
+
+    await page.mouse.click(artworkPoint.x, artworkPoint.y)
+    await expect(page).toHaveURL(/\/$/)
+    await expect(historyRows).toHaveCount(3)
+
+    await page.locator('.dt-resume-button').click()
+    await expect(blocker).toHaveCount(0)
+    await expect(page).toHaveURL(/\/$/)
+    await expect(historyRows).toHaveCount(3)
+
+    await page.mouse.click(artworkPoint.x, artworkPoint.y)
+    await expect(page).toHaveURL(/\/artwork\/1$/)
+    await expect(page.getByText('A warm wash of first light')).toBeVisible()
   })
 })


### PR DESCRIPTION
Fixes #906.

## What

Adds one Playwright test to `packages/examples-e2e/e2e/view-transitions.spec.ts` asserting that `.dt-interaction-blocker` actually intercepts pointer events while the runtime is paused through DevTools time travel.

It lives in the existing spec file because `playwright.config.ts` sets `testMatch: **/${exampleSlug}.spec.ts`, so a test against the `view-transitions` example has to be in that file.

## How it drives the real overlay

1. Load `/`, assert the DEV badge is present and no blocker exists yet.
2. Click the badge to open the panel.
3. Dispatch two Messages through the filter input (`gradient`, then `dawn`), so history holds `init` plus two `UpdatedFilterText` entries.
4. Click the older history row to pause. Assert the Resume button appears and the blocker mounts.
5. Hit-test a point over an artwork card: `document.elementFromPoint` must resolve to `div#foldkit-devtools`, `shadowRoot.elementFromPoint` must resolve to the blocker, and computed `pointer-events` on the blocker must be `auto`.
6. Raw `page.mouse.click` at that point. Assert the URL and history are unchanged, both while still paused and again after resuming.
7. Resume, assert the blocker unmounts, then click the same coordinate again and assert it navigates to `/artwork/1`.

## Verification

- Passes 8/8 with `--repeat-each=8 --retries=0`.
- Reintroducing the regression from the issue (host set to `pointer-events: none` with the `.fixed` opt-in the blocker does not carry) fails the test. The behavioral assertions fail on their own with the hit-test assertions removed, and the failure is the exact signature the issue describes: the URL moves to `/artwork/1`.
- Moving the probe coordinate off the card also fails the test, so the probe cannot silently go vacuous.

## Two design notes

**The blocker check is asserted while paused, not only after resume.** Asserting only after resume would quietly depend on `resume` never truncating history past `pausedAtIndex`. It does not truncate today, but that is a store internal the test should not lean on. Both points are now asserted.

**The last step re-clicks the same raw coordinate rather than using a locator.** Because the blocker is `position: fixed; inset: 0`, `elementFromPoint` returns the DevTools host and `pointer-events` reads `auto` at any point in the viewport. Nothing else in the test establishes that a click at that coordinate would navigate if the blocker were gone, so a layout shift moving the card off the probe point would leave every assertion passing against a click that could never have navigated. Reusing the coordinate for the "interactive again" step makes it the positive control.

## Not included

No changeset: `@foldkit/examples-e2e` is `private` and listed in the `.changeset/config.json` ignore list. No workflow change: `view-transitions` is already in the `examples-e2e.yml` matrix. No paused guard on `enqueueMessage`, which the issue puts out of scope.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXKFqdp5uwc7AJK9nxsEtv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for time-travel debugging.
  * Verified that application interactions are blocked while paused, history is preserved, and navigation works after resuming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->