### PR TITLE
ci: scope validation and deployments to what changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Plan change-scoped checks
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/plan-ci.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
@@ -64,7 +71,7 @@ jobs:
         run: pnpm changeset status --since=origin/main
 
       - name: Lint
-        run: pnpm lint
+        run: pnpm --filter @foldkit/oxlint-plugin build && pnpm lint:ci
 
       - name: Check dead code
         run: pnpm check:dead-code
@@ -75,23 +82,66 @@ jobs:
       - name: Typecheck scripts
         run: pnpm typecheck:scripts
 
-      - name: Build packages
-        run: pnpm -r --filter './packages/**' build
+      - name: Test scripts
+        run: pnpm test:scripts
+
+      - name: Build reusable packages
+        if: steps.scope.outputs.workspace_packages == 'true' || steps.scope.outputs.create_foldkit_smoke == 'true' || steps.scope.outputs.website == 'true' || steps.scope.outputs.typing_game == 'true'
+        run: pnpm build:packages && pnpm --filter @typing-game/shared build
 
       - name: Check Effect prebundle namespaces
         run: pnpm check:effect-prebundle
 
       - name: Typecheck
+        if: steps.scope.outputs.full_workspace_checks == 'true'
         run: pnpm -r typecheck
 
+      - name: Typecheck affected packages
+        if: steps.scope.outputs.full_workspace_checks == 'false'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          # NOTE: pnpm compares the ref against the working tree, so pass the
+          # merge base rather than the base tip. Otherwise a base branch that
+          # has moved on makes its own commits look like this branch's changes.
+          base=$(git merge-base "$BASE_SHA" HEAD || echo "$BASE_SHA")
+          pnpm -r --filter "...[$base]" run --if-present typecheck
+
       - name: Smoke test create-foldkit-app
-        run: pnpm check:create-foldkit-app-smoke
+        if: steps.scope.outputs.create_foldkit_smoke == 'true'
+        run: pnpm check:create-foldkit-app-smoke:ci
+
+      - name: Build website
+        if: steps.scope.outputs.website == 'true'
+        run: pnpm --filter website build
+
+      - name: Build typing game client
+        if: steps.scope.outputs.typing_game == 'true'
+        run: pnpm --filter @typing-game/client build
+
+      - name: Build typing game server
+        if: steps.scope.outputs.typing_game == 'true'
+        run: pnpm --filter @typing-game/server build
 
       - name: Test
+        if: steps.scope.outputs.full_workspace_checks == 'true'
         run: pnpm test
 
+      - name: Test affected packages
+        if: steps.scope.outputs.full_workspace_checks == 'false'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          # NOTE: pnpm compares the ref against the working tree, so pass the
+          # merge base rather than the base tip. Otherwise a base branch that
+          # has moved on makes its own commits look like this branch's changes.
+          base=$(git merge-base "$BASE_SHA" HEAD || echo "$BASE_SHA")
+          pnpm -r --filter "...[$base]" run --if-present test
+
       - name: Install Playwright browsers
+        if: steps.scope.outputs.website == 'true'
         run: pnpm --filter website exec playwright install --with-deps chromium
 
       - name: E2E smoke test
+        if: steps.scope.outputs.website == 'true'
         run: pnpm --filter website test:e2e

--- a/.github/workflows/deploy-pixel-art.yml
+++ b/.github/workflows/deploy-pixel-art.yml
@@ -11,6 +11,10 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-pixel-art.yml'
 
+concurrency:
+  group: deploy-pixel-art-production
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,20 +33,21 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter pixel-art-example...
 
       - name: Build foldkit and vite plugin
         run: pnpm --filter foldkit build && pnpm --filter @foldkit/vite-plugin build
 
       - name: Build pixel art
         working-directory: examples/pixel-art
-        run: npx vite build
+        run: pnpm exec vite build
 
       - name: Deploy to Vercel
         working-directory: examples/pixel-art
         run: |
-          npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+          pnpm dlx vercel@55.0.0 pull --yes --environment=production --token "$VERCEL_TOKEN"
+          pnpm dlx vercel@55.0.0 deploy --prod --token "$VERCEL_TOKEN"
         env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.PIXEL_ART_VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-typing-game.yml
+++ b/.github/workflows/deploy-typing-game.yml
@@ -8,9 +8,15 @@ on:
       - 'packages/typing-game/client/**'
       - 'packages/typing-game/shared/**'
       - 'packages/foldkit/**'
-      - 'packages/foldkit-vite-plugin/**'
+      - 'packages/ui/**'
+      - 'packages/devtools/**'
+      - 'packages/vite-plugin-foldkit/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-typing-game.yml'
+
+concurrency:
+  group: deploy-typing-game-production
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -30,7 +36,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter @typing-game/client...
 
       - name: Build typing game client
         run: pnpm build:typing-game:client
@@ -40,8 +46,9 @@ jobs:
       - name: Deploy to Vercel
         working-directory: packages/typing-game/client
         run: |
-          npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-          npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+          pnpm dlx vercel@55.0.0 pull --yes --environment=production --token "$VERCEL_TOKEN"
+          pnpm dlx vercel@55.0.0 deploy --prod --token "$VERCEL_TOKEN"
         env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -12,9 +12,15 @@ on:
       - 'packages/markdown/**'
       - 'packages/vite-plugin-foldkit/**'
       - 'examples/**'
-      - 'scripts/**'
+      - 'scripts/build-examples.ts'
+      - 'scripts/example-bridge.js'
+      - 'scripts/restore-website-fonts.sh'
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-website.yml'
+
+concurrency:
+  group: deploy-website-production
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -34,10 +40,10 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter . --filter website... --filter '{examples/**}...'
 
       - name: Build core packages
-        run: pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/markdown --filter @foldkit/vite-plugin... build
+        run: pnpm --filter 'website^...' build
 
       - name: Build examples
         run: pnpm build:examples
@@ -62,7 +68,7 @@ jobs:
           echo "count=${count}" >> "$GITHUB_OUTPUT"
 
       - name: Build website
-        run: pnpm build:website
+        run: pnpm --filter website build
         env:
           FOLDKIT_GITHUB_STAR_COUNT: ${{ steps.github-stars.outputs.count }}
 
@@ -160,7 +166,8 @@ jobs:
           EOF
 
       - name: Deploy to Vercel
-        run: npx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@55.0.0 deploy --prebuilt --prod --token "$VERCEL_TOKEN"
         env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -13,42 +13,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      example-count: ${{ steps.plan.outputs.example-count }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Plan affected examples
+        id: plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/plan-examples-e2e.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
   examples-e2e:
-    name: ${{ matrix.example }}
+    name: Shard ${{ matrix.shard }}
+    needs: plan
+    if: needs.plan.outputs.example-count != '0'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        example:
-          - counter
-          - counters
-          - todo
-          - stopwatch
-          - crash-view
-          - slow-warnings
-          - form
-          - job-application
-          - weather
-          - api-cache
-          - routing
-          - route-transitions
-          - interrupting-commands
-          - view-transitions
-          - query-sync
-          - snake
-          - auth
-          - shopping-cart
-          - state-machine
-          - pixel-art
-          - websocket-chat
-          - kanban
-          - map
-          - canvas-art
-          - generative-art
-          - web-components
-          - embedding
-          - ui-showcase
-          - personal-blog
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,23 +54,66 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        env:
+          EXAMPLES: ${{ matrix.examples }}
+        run: |
+          filters=(--filter '@foldkit/examples-e2e...' --filter '@foldkit/markdown...')
+          for example in $EXAMPLES; do
+            filters+=(--filter "{examples/$example}...")
+          done
+          pnpm install --frozen-lockfile "${filters[@]}"
 
-      - name: Build workspace packages
-        run: pnpm -r --filter './packages/**' build
+      - name: Build E2E prerequisites
+        run: pnpm --filter foldkit --filter @foldkit/markdown --filter @foldkit/vite-plugin build
 
       - name: Install Playwright browsers
         run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium
 
-      - name: Run examples e2e for ${{ matrix.example }}
+      - name: Run example E2E shard
         env:
-          EXAMPLE_SLUG: ${{ matrix.example }}
-        run: pnpm --filter @foldkit/examples-e2e test:e2e
+          EXAMPLES: ${{ matrix.examples }}
+        run: |
+          failed_examples=()
+          for example in $EXAMPLES; do
+            if ! EXAMPLE_SLUG="$example" pnpm --filter @foldkit/examples-e2e test:e2e; then
+              failed_examples+=("$example")
+            fi
+          done
 
-      - name: Upload Playwright report on failure
+          if [ "${#failed_examples[@]}" -gt 0 ]; then
+            echo "Failed examples: ${failed_examples[*]}"
+            exit 1
+          fi
+
+      - name: Upload Playwright traces on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-${{ matrix.example }}
-          path: packages/examples-e2e/playwright-report/
+          name: playwright-traces-shard-${{ matrix.shard }}
+          path: packages/examples-e2e/test-results/
           retention-days: 7
+
+  result:
+    name: Examples E2E
+    needs:
+      - plan
+      - examples-e2e
+    # NOTE: not always(). A run superseded by a newer push cancels its shards,
+    # and always() would turn that cancellation into a failed required check on
+    # the abandoned commit. !cancelled() still reports genuine shard failures
+    # and still runs when the shards are skipped because nothing was affected.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check E2E result
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          E2E_RESULT: ${{ needs.examples-e2e.result }}
+        run: |
+          if [ "$PLAN_RESULT" != 'success' ]; then
+            exit 1
+          fi
+
+          if [ "$E2E_RESULT" != 'success' ] && [ "$E2E_RESULT" != 'skipped' ]; then
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,23 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.changeset/**'
+      - 'packages/foldkit/**'
+      - 'packages/ui/**'
+      - 'packages/devtools/**'
+      - 'packages/markdown/**'
+      - 'packages/vite-plugin-foldkit/**'
+      - 'packages/create-foldkit-app/**'
+      - 'packages/oxlint-plugin-foldkit/**'
+      - 'packages/devtools-mcp/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'scripts/check-changeset-ignore.ts'
+      - 'scripts/check-create-foldkit-app-smoke.ts'
+      - 'scripts/reset-peer-deps.ts'
+      - '.github/workflows/release.yml'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -39,7 +56,7 @@ jobs:
           npm --version
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Verify changeset ignore list
         run: pnpm check:changeset-ignore

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {
-      "entry": ["scripts/*.{ts,js,sh}"],
+      "entry": ["scripts/*.{ts,js,mjs,sh}", "scripts/**/*.test.mjs"],
       "project": ["scripts/**"]
     },
     "packages/foldkit": {
@@ -83,5 +83,5 @@
   },
   "ignore": ["**/*.css", "packages/website/public/**"],
   "ignoreDependencies": ["@foldkit/oxlint-plugin", "tailwindcss", "madge"],
-  "ignoreBinaries": ["typecheck", "vercel"]
+  "ignoreBinaries": ["typecheck"]
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "scripts": {
     "prepare": "test -z \"$CI\" && simple-git-hooks || true",
     "build": "pnpm -r --if-present build",
+    "build:packages": "pnpm --filter foldkit --filter @foldkit/ui --filter @foldkit/devtools --filter @foldkit/markdown --filter @foldkit/vite-plugin --filter create-foldkit-app --filter @foldkit/oxlint-plugin --filter @foldkit/devtools-mcp build",
     "check": "pnpm -F foldkit -F @foldkit/vite-plugin -F @typing-game/shared build && pnpm typecheck:scripts && pnpm -r typecheck && pnpm lint && pnpm check:dead-code && pnpm check:effect-prebundle",
     "lint": "pnpm --filter @foldkit/oxlint-plugin build && oxlint --disable-nested-config",
+    "lint:ci": "oxlint --disable-nested-config",
     "check:dead-code": "knip --no-progress --include files,dependencies,unlisted,unresolved,binaries,duplicates,catalog --treat-config-hints-as-errors",
     "check:effect-prebundle": "tsx scripts/check-effect-prebundle.ts",
     "check:changeset-ignore": "tsx scripts/check-changeset-ignore.ts",
@@ -19,9 +21,11 @@
     "check:changeset-unwrapped": "tsx scripts/check-changeset-unwrapped.ts",
     "check:circular-deps": "bash scripts/check-circular-deps.sh",
     "check:create-foldkit-app-smoke": "tsx scripts/check-create-foldkit-app-smoke.ts",
-    "pre-push": "pnpm check:no-claude-comments && pnpm check:commit-message-line-length && pnpm check:changeset-unwrapped && pnpm format:check && pnpm check:skill-version && pnpm check:no-major-changesets && pnpm check:changeset-ignore && pnpm changeset status --since=origin/main && pnpm lint && pnpm check:dead-code && pnpm typecheck:scripts && pnpm check:effect-prebundle && pnpm check:circular-deps && pnpm build && pnpm -r typecheck && pnpm test && bash scripts/run-website-e2e.sh",
+    "check:create-foldkit-app-smoke:ci": "tsx scripts/check-create-foldkit-app-smoke.ts --skip-build",
+    "pre-push": "pnpm check:no-claude-comments && pnpm check:commit-message-line-length && pnpm check:changeset-unwrapped && pnpm format:check && pnpm check:skill-version && pnpm check:no-major-changesets && pnpm check:changeset-ignore && pnpm changeset status --since=origin/main && pnpm lint && pnpm check:dead-code && pnpm typecheck:scripts && pnpm test:scripts && pnpm check:effect-prebundle && pnpm check:circular-deps && pnpm build && pnpm -r typecheck && pnpm test && bash scripts/run-website-e2e.sh",
     "test": "pnpm -r --filter './examples/*' --filter './packages/*' run --if-present test",
     "typecheck:scripts": "tsc -p scripts/tsconfig.json --noEmit",
+    "test:scripts": "bash scripts/run-script-tests.sh",
     "test:e2e": "pnpm --filter website test:e2e",
     "format": "prettier -w .",
     "format:check": "prettier --check .",
@@ -67,7 +71,7 @@
     "dev:example:view-transitions": "pnpm --filter view-transitions-example dev",
     "changeset": "changeset",
     "version-packages": "changeset version && tsx scripts/reset-peer-deps.ts && pnpm install --no-frozen-lockfile",
-    "release": "pnpm -r build && changeset publish"
+    "release": "pnpm build:packages && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/packages/examples-e2e/e2e/charting.spec.ts
+++ b/packages/examples-e2e/e2e/charting.spec.ts
@@ -126,9 +126,10 @@ test.describe('charting example', () => {
     await expect(
       page.getByRole('heading', { name: 'Foldkit Adoption Observatory' }),
     ).toBeVisible()
-    await page.getByRole('button', { name: 'Velocity' }).click()
-    await expect(
-      page.getByRole('button', { name: 'Velocity' }),
-    ).toHaveAttribute('aria-pressed', 'true')
+    await page.getByRole('radio', { name: 'Velocity' }).click()
+    await expect(page.getByRole('radio', { name: 'Velocity' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
   })
 })

--- a/packages/examples-e2e/playwright.config.ts
+++ b/packages/examples-e2e/playwright.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   forbidOnly: Boolean(process.env['CI']),
   retries: process.env['CI'] ? 2 : 1,
   reporter: process.env['CI'] ? 'github' : 'list',
+  outputDir: `./test-results/${exampleSlug}`,
   timeout: 60_000,
   use: {
     baseURL: BASE_URL,

--- a/scripts/build-examples.ts
+++ b/scripts/build-examples.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import {
   copyFileSync,
   existsSync,
@@ -21,29 +21,56 @@ const OUTPUT_DIR = resolve(
 )
 const BRIDGE_SCRIPT_PATH = resolve(REPO_ROOT, 'scripts/example-bridge.js')
 const BRIDGE_SCRIPT_TAG = '<script src="bridge.js"></script></head>'
+const MAX_CONCURRENT_EXAMPLE_BUILDS = 4
 
-const buildExample = (slug: string): void => {
+const runViteBuild = (
+  exampleDir: string,
+  slug: string,
+  outputDir: string,
+): Promise<void> =>
+  new Promise((resolvePromise, rejectPromise) => {
+    const childProcess = spawn(
+      'pnpm',
+      [
+        'exec',
+        'vite',
+        'build',
+        '--base',
+        `/example-apps-embed/${slug}/`,
+        '--outDir',
+        outputDir,
+      ],
+      { cwd: exampleDir, stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+
+    const writePrefixed = (chunk: Buffer): void => {
+      for (const line of chunk.toString().split('\n')) {
+        if (line !== '') {
+          console.log(`[${slug}] ${line}`)
+        }
+      }
+    }
+
+    childProcess.stdout?.on('data', writePrefixed)
+    childProcess.stderr?.on('data', writePrefixed)
+
+    childProcess.once('error', rejectPromise)
+    childProcess.once('close', exitCode => {
+      if (exitCode === 0) {
+        resolvePromise()
+      } else {
+        rejectPromise(new Error(`Example build failed: ${slug}`))
+      }
+    })
+  })
+
+const buildExample = async (slug: string): Promise<void> => {
   console.log(`Building example: ${slug}`)
 
   const exampleDir = resolve(EXAMPLES_DIR, slug)
   const outputDir = resolve(OUTPUT_DIR, slug)
 
-  const result = spawnSync(
-    'npx',
-    [
-      'vite',
-      'build',
-      '--base',
-      `/example-apps-embed/${slug}/`,
-      '--outDir',
-      outputDir,
-    ],
-    { cwd: exampleDir, stdio: 'inherit' },
-  )
-
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1)
-  }
+  await runViteBuild(exampleDir, slug, outputDir)
 
   copyFileSync(BRIDGE_SCRIPT_PATH, resolve(outputDir, 'bridge.js'))
 
@@ -57,14 +84,31 @@ const buildExample = (slug: string): void => {
   console.log(`  → ${outputDir}`)
 }
 
-if (existsSync(OUTPUT_DIR)) {
-  rmSync(OUTPUT_DIR, { recursive: true, force: true })
-}
-mkdirSync(OUTPUT_DIR, { recursive: true })
+const main = async (): Promise<void> => {
+  if (existsSync(OUTPUT_DIR)) {
+    rmSync(OUTPUT_DIR, { recursive: true, force: true })
+  }
+  mkdirSync(OUTPUT_DIR, { recursive: true })
 
-for (const slug of exampleSlugs) {
-  buildExample(slug)
+  const batchCount = Math.ceil(
+    exampleSlugs.length / MAX_CONCURRENT_EXAMPLE_BUILDS,
+  )
+  const exampleBatches = Array.from({ length: batchCount }, (_, batchIndex) =>
+    exampleSlugs.slice(
+      batchIndex * MAX_CONCURRENT_EXAMPLE_BUILDS,
+      (batchIndex + 1) * MAX_CONCURRENT_EXAMPLE_BUILDS,
+    ),
+  )
+
+  for (const exampleBatch of exampleBatches) {
+    await Promise.all(exampleBatch.map(buildExample))
+  }
+
+  console.log('')
+  console.log(`Built ${exampleSlugs.length} examples into ${OUTPUT_DIR}`)
 }
 
-console.log('')
-console.log(`Built ${exampleSlugs.length} examples into ${OUTPUT_DIR}`)
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/check-create-foldkit-app-smoke.ts
+++ b/scripts/check-create-foldkit-app-smoke.ts
@@ -27,6 +27,7 @@ const PNPM_WORKSPACE_POLICY_PATH = join(
 const PNPM_WORKSPACE_POLICY = `allowBuilds:
   msgpackr-extract: false
 `
+const isSkipBuild = process.argv.includes('--skip-build')
 const LINT_SMOKE_SOURCE = `const Command = {
   define: (name: string) => () => ({ name }),
 }
@@ -348,18 +349,20 @@ const main = (): void => {
   try {
     assertTemplateTooling()
     assertPnpmWorkspacePolicy()
-    runRequired(
-      'Building create-foldkit-app...',
-      'pnpm',
-      ['--filter', 'create-foldkit-app', 'build'],
-      { inherit: true },
-    )
-    runRequired(
-      'Building @foldkit/oxlint-plugin...',
-      'pnpm',
-      ['--filter', '@foldkit/oxlint-plugin', 'build'],
-      { inherit: true },
-    )
+    if (!isSkipBuild) {
+      runRequired(
+        'Building create-foldkit-app...',
+        'pnpm',
+        ['--filter', 'create-foldkit-app', 'build'],
+        { inherit: true },
+      )
+      runRequired(
+        'Building @foldkit/oxlint-plugin...',
+        'pnpm',
+        ['--filter', '@foldkit/oxlint-plugin', 'build'],
+        { inherit: true },
+      )
+    }
 
     const tarballPath = packPackage(
       'Packing create-foldkit-app tarball...',

--- a/scripts/lib/changed-files.mjs
+++ b/scripts/lib/changed-files.mjs
@@ -1,0 +1,45 @@
+import { spawnSync } from 'node:child_process'
+
+const isPlaceholderSha = sha => /^0+$/.test(sha)
+
+/**
+ * Resolve the files a change touched, from CLI arguments shaped as
+ * `<baseSha> <headSha> [...changedFiles]`.
+ *
+ * Passing an explicit file list bypasses git entirely, which is how the
+ * planners are exercised without a repository.
+ *
+ * `isUnknownDiff` is the fail-safe signal. It is true when the range could not
+ * be resolved, and every caller must treat that as "everything changed" so a
+ * planning failure over-selects work rather than silently skipping checks.
+ */
+export const resolveChangedFiles = argv => {
+  const [baseSha, headSha, ...providedChangedFiles] = argv
+  const isChangedFileListProvided = providedChangedFiles.at(0) !== undefined
+
+  const isUnknownBase =
+    !baseSha ||
+    !headSha ||
+    isPlaceholderSha(baseSha) ||
+    isPlaceholderSha(headSha)
+
+  const diffResult =
+    isUnknownBase || isChangedFileListProvided
+      ? undefined
+      : spawnSync(
+          'git',
+          ['diff', '--name-only', '-z', `${baseSha}...${headSha}`],
+          { encoding: 'utf8' },
+        )
+
+  const changedFiles = isChangedFileListProvided
+    ? providedChangedFiles
+    : diffResult?.status === 0
+      ? diffResult.stdout.split('\0').filter(fileName => fileName !== '')
+      : []
+
+  const isUnknownDiff =
+    !isChangedFileListProvided && (isUnknownBase || diffResult?.status !== 0)
+
+  return { changedFiles, isUnknownDiff }
+}

--- a/scripts/lib/changed-files.test.mjs
+++ b/scripts/lib/changed-files.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+
+import { resolveChangedFiles } from './changed-files.mjs'
+
+const ZERO_SHA = '0'.repeat(40)
+const MISSING_SHA_A = 'deadbeef'.repeat(5)
+const MISSING_SHA_B = 'cafebabe'.repeat(5)
+
+test('an explicit file list is used verbatim', () => {
+  const { changedFiles, isUnknownDiff } = resolveChangedFiles([
+    'base',
+    'head',
+    'a.ts',
+    'b.ts',
+  ])
+
+  assert.deepEqual(changedFiles, ['a.ts', 'b.ts'])
+  assert.equal(isUnknownDiff, false)
+})
+
+test('an explicit file list wins over unresolvable revisions', () => {
+  const { changedFiles, isUnknownDiff } = resolveChangedFiles([
+    MISSING_SHA_A,
+    MISSING_SHA_B,
+    'a.ts',
+  ])
+
+  assert.deepEqual(changedFiles, ['a.ts'])
+  assert.equal(isUnknownDiff, false)
+})
+
+test('no revisions is an unknown diff', () => {
+  const { changedFiles, isUnknownDiff } = resolveChangedFiles([])
+
+  assert.deepEqual(changedFiles, [])
+  assert.equal(isUnknownDiff, true)
+})
+
+test('a missing head revision is an unknown diff', () => {
+  assert.equal(resolveChangedFiles(['base']).isUnknownDiff, true)
+})
+
+test('an all-zero base revision is an unknown diff', () => {
+  assert.equal(resolveChangedFiles([ZERO_SHA, 'head']).isUnknownDiff, true)
+})
+
+test('an all-zero head revision is an unknown diff', () => {
+  assert.equal(resolveChangedFiles(['base', ZERO_SHA]).isUnknownDiff, true)
+})
+
+test('a failed git diff is an unknown diff rather than an empty one', () => {
+  const { changedFiles, isUnknownDiff } = resolveChangedFiles([
+    MISSING_SHA_A,
+    MISSING_SHA_B,
+  ])
+
+  assert.deepEqual(changedFiles, [])
+  assert.equal(isUnknownDiff, true)
+})
+
+test('a real revision range resolves the files it touched', () => {
+  const { changedFiles, isUnknownDiff } = resolveChangedFiles([
+    'HEAD~1',
+    'HEAD',
+  ])
+
+  assert.equal(isUnknownDiff, false)
+  assert.ok(changedFiles.length > 0)
+  assert.ok(changedFiles.every(fileName => fileName !== ''))
+})
+
+const git = (repositoryDir, ...args) => {
+  const result = spawnSync(
+    'git',
+    [
+      '-C',
+      repositoryDir,
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'user.name=Test',
+      '-c',
+      'commit.gpgsign=false',
+      ...args,
+    ],
+    { encoding: 'utf8' },
+  )
+
+  assert.equal(result.status, 0, `git ${args.join(' ')}: ${result.stderr}`)
+
+  return result.stdout.trim()
+}
+
+const commitFile = (repositoryDir, fileName) => {
+  writeFileSync(join(repositoryDir, fileName), fileName)
+  git(repositoryDir, 'add', fileName)
+  git(repositoryDir, 'commit', '-m', `add ${fileName}`)
+
+  return git(repositoryDir, 'rev-parse', 'HEAD')
+}
+
+test('a diverged base does not leak its own commits into the diff', () => {
+  const repositoryDir = mkdtempSync(join(tmpdir(), 'changed-files-'))
+  const originalCwd = process.cwd()
+
+  try {
+    git(repositoryDir, 'init', '-b', 'main')
+    commitFile(repositoryDir, 'common.txt')
+
+    git(repositoryDir, 'checkout', '-b', 'base')
+    const baseSha = commitFile(repositoryDir, 'only-on-base.txt')
+
+    git(repositoryDir, 'checkout', 'main')
+    git(repositoryDir, 'checkout', '-b', 'head')
+    const headSha = commitFile(repositoryDir, 'only-on-head.txt')
+
+    process.chdir(repositoryDir)
+    const { changedFiles, isUnknownDiff } = resolveChangedFiles([
+      baseSha,
+      headSha,
+    ])
+
+    assert.equal(isUnknownDiff, false)
+    assert.deepEqual(changedFiles, ['only-on-head.txt'])
+  } finally {
+    process.chdir(originalCwd)
+    rmSync(repositoryDir, { recursive: true, force: true })
+  }
+})

--- a/scripts/plan-ci.mjs
+++ b/scripts/plan-ci.mjs
@@ -1,0 +1,83 @@
+import { resolveChangedFiles } from './lib/changed-files.mjs'
+
+const { changedFiles, isUnknownDiff } = resolveChangedFiles(
+  process.argv.slice(2),
+)
+
+const hasChanged = ({ files = [], prefixes = [] }) =>
+  isUnknownDiff ||
+  changedFiles.some(
+    fileName =>
+      files.includes(fileName) ||
+      prefixes.some(prefix => fileName.startsWith(prefix)),
+  )
+
+// NOTE: a workspace-wide change implies every application scope below. Root
+// config such as tsconfig.base.json or .npmrc can break a bundle or an install
+// while `tsc --noEmit` stays green, so the builds must not be skipped just
+// because no package directory was touched.
+const fullWorkspaceChecks = hasChanged({
+  files: [
+    '.github/workflows/ci.yml',
+    '.npmrc',
+    'examples/vite.aliases.ts',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'scripts/lib/changed-files.mjs',
+    'scripts/plan-ci.mjs',
+    'tsconfig.base.json',
+  ],
+})
+const createFoldkitSmoke =
+  fullWorkspaceChecks ||
+  hasChanged({
+    files: ['scripts/check-create-foldkit-app-smoke.ts'],
+    prefixes: [
+      'packages/create-foldkit-app/',
+      'packages/oxlint-plugin-foldkit/',
+    ],
+  })
+const typingGame =
+  fullWorkspaceChecks ||
+  hasChanged({
+    prefixes: [
+      'packages/typing-game/client/',
+      'packages/typing-game/server/',
+      'packages/typing-game/shared/',
+      'packages/foldkit/',
+      'packages/devtools/',
+      'packages/vite-plugin-foldkit/',
+    ],
+  })
+const website =
+  fullWorkspaceChecks ||
+  hasChanged({
+    prefixes: [
+      'packages/website/',
+      'packages/foldkit/',
+      'packages/ui/',
+      'packages/devtools/',
+      'packages/markdown/',
+      'packages/vite-plugin-foldkit/',
+    ],
+  })
+const workspacePackages = hasChanged({
+  files: [
+    '.github/workflows/ci.yml',
+    '.npmrc',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'scripts/lib/changed-files.mjs',
+    'scripts/plan-ci.mjs',
+    'tsconfig.base.json',
+  ],
+  prefixes: ['comparisons/', 'examples/', 'internal/', 'packages/'],
+})
+
+process.stdout.write(`create_foldkit_smoke=${createFoldkitSmoke}\n`)
+process.stdout.write(`typing_game=${typingGame}\n`)
+process.stdout.write(`website=${website}\n`)
+process.stdout.write(`full_workspace_checks=${fullWorkspaceChecks}\n`)
+process.stdout.write(`workspace_packages=${workspacePackages}\n`)

--- a/scripts/plan-ci.test.mjs
+++ b/scripts/plan-ci.test.mjs
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const SCRIPT_PATH = 'scripts/plan-ci.mjs'
+const ZERO_SHA = '0'.repeat(40)
+const MISSING_SHA_A = 'deadbeef'.repeat(5)
+const MISSING_SHA_B = 'cafebabe'.repeat(5)
+const SCOPES = [
+  'create_foldkit_smoke',
+  'typing_game',
+  'website',
+  'full_workspace_checks',
+  'workspace_packages',
+]
+
+const planCi = (...args) => {
+  const result = spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 0, `plan-ci.mjs exited ${result.status}`)
+
+  return Object.fromEntries(
+    result.stdout
+      .split('\n')
+      .filter(line => line !== '')
+      .map(line => {
+        const separatorIndex = line.indexOf('=')
+        return [line.slice(0, separatorIndex), line.slice(separatorIndex + 1)]
+      }),
+  )
+}
+
+const planCiForFile = fileName => planCi('base', 'head', fileName)
+
+test('emits every scope exactly once as a boolean', () => {
+  const scopes = planCiForFile('README.md')
+
+  assert.deepEqual(Object.keys(scopes).sort(), [...SCOPES].sort())
+  for (const value of Object.values(scopes)) {
+    assert.ok(value === 'true' || value === 'false', `not a boolean: ${value}`)
+  }
+})
+
+test('a documentation-only change selects nothing', () => {
+  const scopes = planCiForFile('README.md')
+
+  for (const scope of SCOPES) {
+    assert.equal(scopes[scope], 'false', `${scope} should be false`)
+  }
+})
+
+test('a foldkit change reaches the website and the typing game', () => {
+  const scopes = planCiForFile('packages/foldkit/src/runtime/runtime.ts')
+
+  assert.equal(scopes['website'], 'true')
+  assert.equal(scopes['typing_game'], 'true')
+  assert.equal(scopes['workspace_packages'], 'true')
+  assert.equal(scopes['full_workspace_checks'], 'false')
+})
+
+test('a markdown change reaches the website', () => {
+  const scopes = planCiForFile('packages/markdown/src/index.ts')
+
+  assert.equal(scopes['website'], 'true')
+  assert.equal(scopes['typing_game'], 'false')
+})
+
+test('a create-foldkit-app change selects the smoke test', () => {
+  assert.equal(
+    planCiForFile('packages/create-foldkit-app/src/index.ts')[
+      'create_foldkit_smoke'
+    ],
+    'true',
+  )
+})
+
+test('an oxlint plugin change selects the smoke test', () => {
+  assert.equal(
+    planCiForFile('packages/oxlint-plugin-foldkit/src/index.ts')[
+      'create_foldkit_smoke'
+    ],
+    'true',
+  )
+})
+
+test('a typing game change stays out of the website scope', () => {
+  const scopes = planCiForFile('packages/typing-game/client/src/main.ts')
+
+  assert.equal(scopes['typing_game'], 'true')
+  assert.equal(scopes['website'], 'false')
+})
+
+test('a lockfile change selects everything, including the typing game', () => {
+  const scopes = planCiForFile('pnpm-lock.yaml')
+
+  for (const scope of SCOPES) {
+    assert.equal(scopes[scope], 'true', `${scope} should be true`)
+  }
+})
+
+test('changing the planner forces the conservative fallback', () => {
+  const scopes = planCiForFile(SCRIPT_PATH)
+
+  assert.equal(scopes['full_workspace_checks'], 'true')
+  assert.equal(scopes['workspace_packages'], 'true')
+})
+
+test('changing the shared diff helper forces the conservative fallback', () => {
+  const scopes = planCiForFile('scripts/lib/changed-files.mjs')
+
+  assert.equal(scopes['full_workspace_checks'], 'true')
+  assert.equal(scopes['workspace_packages'], 'true')
+})
+
+test('a workspace-wide change also selects every application scope', () => {
+  for (const fileName of ['tsconfig.base.json', '.npmrc', 'pnpm-lock.yaml']) {
+    const scopes = planCiForFile(fileName)
+
+    assert.equal(scopes['full_workspace_checks'], 'true', fileName)
+    for (const scope of SCOPES) {
+      assert.equal(scopes[scope], 'true', `${fileName} should select ${scope}`)
+    }
+  }
+})
+
+test('an all-zero base revision selects everything', () => {
+  const scopes = planCi(ZERO_SHA, 'head')
+
+  for (const scope of SCOPES) {
+    assert.equal(scopes[scope], 'true', `${scope} should be true`)
+  }
+})
+
+test('an unresolvable revision range selects everything', () => {
+  const scopes = planCi(MISSING_SHA_A, MISSING_SHA_B)
+
+  for (const scope of SCOPES) {
+    assert.equal(scopes[scope], 'true', `${scope} should be true`)
+  }
+})

--- a/scripts/plan-examples-e2e.mjs
+++ b/scripts/plan-examples-e2e.mjs
@@ -1,0 +1,80 @@
+import { readdirSync } from 'node:fs'
+
+import { resolveChangedFiles } from './lib/changed-files.mjs'
+
+const MAX_SHARD_COUNT = 10
+const SPEC_SUFFIX = '.spec.ts'
+const ALL_EXAMPLES_FILES = new Set([
+  '.github/workflows/examples-e2e.yml',
+  '.npmrc',
+  'examples/vite.aliases.ts',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'scripts/lib/changed-files.mjs',
+  'scripts/plan-examples-e2e.mjs',
+  'tsconfig.base.json',
+])
+const ALL_EXAMPLES_PREFIXES = [
+  'packages/devtools/',
+  'packages/foldkit/',
+  'packages/markdown/',
+  'packages/ui/',
+  'packages/vite-plugin-foldkit/',
+]
+
+const exampleSlugs = readdirSync('packages/examples-e2e/e2e')
+  .filter(fileName => fileName.endsWith(SPEC_SUFFIX))
+  .map(fileName => fileName.slice(0, -SPEC_SUFFIX.length))
+  .sort()
+
+const { changedFiles, isUnknownDiff } = resolveChangedFiles(
+  process.argv.slice(2),
+)
+
+const isE2eHarnessFile = changedFiles.some(
+  fileName =>
+    fileName.startsWith('packages/examples-e2e/') &&
+    !(
+      fileName.startsWith('packages/examples-e2e/e2e/') &&
+      fileName.endsWith(SPEC_SUFFIX)
+    ),
+)
+
+const isAllExamplesAffected =
+  isUnknownDiff ||
+  isE2eHarnessFile ||
+  changedFiles.some(
+    fileName =>
+      ALL_EXAMPLES_FILES.has(fileName) ||
+      ALL_EXAMPLES_PREFIXES.some(prefix => fileName.startsWith(prefix)),
+  )
+
+const affectedExampleSlugs = isAllExamplesAffected
+  ? exampleSlugs
+  : exampleSlugs.filter(exampleSlug =>
+      changedFiles.some(
+        fileName =>
+          fileName.startsWith(`examples/${exampleSlug}/`) ||
+          fileName === `packages/examples-e2e/e2e/${exampleSlug}${SPEC_SUFFIX}`,
+      ),
+    )
+
+const shardCount = Math.max(
+  1,
+  Math.min(MAX_SHARD_COUNT, affectedExampleSlugs.length),
+)
+const shards = Array.from({ length: shardCount }, (_, shardIndex) =>
+  affectedExampleSlugs.filter(
+    (_, exampleIndex) => exampleIndex % shardCount === shardIndex,
+  ),
+)
+const matrix = {
+  include: shards.map((exampleShard, shardIndex) => ({
+    shard: shardIndex + 1,
+    examples: exampleShard.join(' '),
+  })),
+}
+
+process.stdout.write(`matrix=${JSON.stringify(matrix)}\n`)
+process.stdout.write(`example-count=${affectedExampleSlugs.length}\n`)

--- a/scripts/plan-examples-e2e.test.mjs
+++ b/scripts/plan-examples-e2e.test.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const SCRIPT_PATH = 'scripts/plan-examples-e2e.mjs'
+const SPEC_SUFFIX = '.spec.ts'
+const MAX_SHARD_COUNT = 10
+const ZERO_SHA = '0'.repeat(40)
+const MISSING_SHA_A = 'deadbeef'.repeat(5)
+const MISSING_SHA_B = 'cafebabe'.repeat(5)
+
+const allExampleSlugs = readdirSync(
+  resolve(REPO_ROOT, 'packages/examples-e2e/e2e'),
+)
+  .filter(fileName => fileName.endsWith(SPEC_SUFFIX))
+  .map(fileName => fileName.slice(0, -SPEC_SUFFIX.length))
+  .sort()
+
+const planExamples = (...args) => {
+  const result = spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  })
+
+  assert.equal(
+    result.status,
+    0,
+    `plan-examples-e2e.mjs exited ${result.status}`,
+  )
+
+  const outputs = Object.fromEntries(
+    result.stdout
+      .split('\n')
+      .filter(line => line !== '')
+      .map(line => {
+        const separatorIndex = line.indexOf('=')
+        return [line.slice(0, separatorIndex), line.slice(separatorIndex + 1)]
+      }),
+  )
+
+  const matrix = JSON.parse(outputs['matrix'])
+
+  return {
+    exampleCount: Number(outputs['example-count']),
+    matrix,
+    shardedSlugs: matrix.include.flatMap(entry =>
+      entry.examples === '' ? [] : entry.examples.split(' '),
+    ),
+  }
+}
+
+const planExamplesForFile = fileName => planExamples('base', 'head', fileName)
+
+test('a documentation-only change selects no examples', () => {
+  const { exampleCount, shardedSlugs } = planExamplesForFile('README.md')
+
+  assert.equal(exampleCount, 0)
+  assert.deepEqual(shardedSlugs, [])
+})
+
+test('an example change selects only that example', () => {
+  const { exampleCount, shardedSlugs } = planExamplesForFile(
+    'examples/counter/src/main.ts',
+  )
+
+  assert.equal(exampleCount, 1)
+  assert.deepEqual(shardedSlugs, ['counter'])
+})
+
+test('a spec change selects only that example', () => {
+  const { exampleCount, shardedSlugs } = planExamplesForFile(
+    `packages/examples-e2e/e2e/snake${SPEC_SUFFIX}`,
+  )
+
+  assert.equal(exampleCount, 1)
+  assert.deepEqual(shardedSlugs, ['snake'])
+})
+
+test('a foldkit change selects every example', () => {
+  const { exampleCount, shardedSlugs } = planExamplesForFile(
+    'packages/foldkit/src/runtime/runtime.ts',
+  )
+
+  assert.equal(exampleCount, allExampleSlugs.length)
+  assert.deepEqual([...shardedSlugs].sort(), allExampleSlugs)
+})
+
+test('a markdown change selects every example', () => {
+  assert.equal(
+    planExamplesForFile('packages/markdown/src/index.ts').exampleCount,
+    allExampleSlugs.length,
+  )
+})
+
+test('an E2E harness change selects every example', () => {
+  assert.equal(
+    planExamplesForFile('packages/examples-e2e/playwright.config.ts')
+      .exampleCount,
+    allExampleSlugs.length,
+  )
+})
+
+test('changing the shared diff helper selects every example', () => {
+  assert.equal(
+    planExamplesForFile('scripts/lib/changed-files.mjs').exampleCount,
+    allExampleSlugs.length,
+  )
+})
+
+test('an all-zero base revision selects every example', () => {
+  assert.equal(
+    planExamples(ZERO_SHA, 'head').exampleCount,
+    allExampleSlugs.length,
+  )
+})
+
+test('an unresolvable revision range selects every example', () => {
+  assert.equal(
+    planExamples(MISSING_SHA_A, MISSING_SHA_B).exampleCount,
+    allExampleSlugs.length,
+  )
+})
+
+test('shards stay bounded and cover each example exactly once', () => {
+  const { matrix, shardedSlugs } = planExamplesForFile(
+    'packages/foldkit/src/runtime/runtime.ts',
+  )
+
+  assert.equal(
+    matrix.include.length,
+    Math.min(MAX_SHARD_COUNT, allExampleSlugs.length),
+  )
+  assert.deepEqual([...shardedSlugs].sort(), allExampleSlugs)
+  assert.equal(new Set(shardedSlugs).size, shardedSlugs.length)
+
+  const shardNumbers = matrix.include.map(entry => entry.shard)
+  assert.deepEqual(
+    shardNumbers,
+    Array.from({ length: matrix.include.length }, (_, index) => index + 1),
+  )
+
+  for (const entry of matrix.include) {
+    assert.notEqual(entry.examples, '', `shard ${entry.shard} is empty`)
+  }
+})
+
+test('shard sizes stay within one example of each other', () => {
+  const { matrix } = planExamplesForFile('packages/foldkit/src/runtime.ts')
+
+  const shardSizes = matrix.include.map(
+    entry => entry.examples.split(' ').length,
+  )
+
+  assert.ok(Math.max(...shardSizes) - Math.min(...shardSizes) <= 1)
+})
+
+test('fewer examples than the cap produce one shard each', () => {
+  const { matrix } = planExamples(
+    'base',
+    'head',
+    'examples/counter/src/main.ts',
+    'examples/snake/src/main.ts',
+  )
+
+  assert.equal(matrix.include.length, 2)
+})

--- a/scripts/run-script-tests.sh
+++ b/scripts/run-script-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# NOTE: knip's Node.js plugin enables itself for every workspace when it finds
+# `node ... --test` in the root package.json, which makes it treat `**/test/**`
+# across the whole repository (including the vendored repos/ subtrees) as entry
+# points. Only these scripts use the built-in runner, so the invocation lives
+# here rather than in a package.json script.
+
+node --test "scripts/**/*.test.mjs"


### PR DESCRIPTION
Supersedes #717. Same approach, rebased onto current main as a single commit, with the merge-blocking bugs fixed. #717 was based on stale main, had merge conflicts, and never ran CI, so none of it was validated.

## What this does

Most pull requests touch a small slice of the workspace but pay for the whole thing: every check runs, every package builds, and the examples E2E workflow spawns one job per example regardless of the diff.

`scripts/plan-ci.mjs` and `scripts/plan-examples-e2e.mjs` diff the base against the head and emit GitHub Actions outputs describing what the change actually affects. Both run on bare node before install, so planning costs nothing, and both share `scripts/lib/changed-files.mjs` so the fail-safe is defined once: an unknown base or a failed diff selects everything.

CI gates the expensive work on those outputs — the website build, the typing game builds, the create-foldkit-app smoke test — and falls back to a merge-base `pnpm --filter` closure for typecheck and test when the change is not workspace wide. Cheap checks stay unconditional. Examples E2E replaces its hand-maintained matrix with shards derived from the spec files, so the list can no longer drift from what exists, and a stable `Examples E2E` job reports the aggregate result.

Deployments install only the filtered dependency closure they need, pin the Vercel CLI instead of resolving latest on every run, pass its token through the step environment, and cancel superseded production runs. The release workflow only fires on paths that can affect a published package. Embedded example builds run four at a time, each line prefixed with its example.

## Measured result

Examples E2E on this branch: **Plan plus 10 shards covering all 30 examples in about 2.5 minutes**, against 30 separate jobs before. A docs-only change now selects zero examples and zero affected packages.

## Bugs fixed relative to #717

**The website build in CI could not work.** #717 used `pnpm --filter website exec vite build` to skip TypeDoc, but `packages/website/src/generated/api.json` is gitignored and only produced by the `prebuild` hook, which `pnpm exec` bypasses. `vite.config.ts` reads it unconditionally, so the build fails with `ENOENT ... src/generated/api.json`. TypeDoc is not redundant here. Reverted to `pnpm --filter website build`.

**`release` would have published `@foldkit/markdown` unbuilt.** #717 narrowed `release` from `pnpm -r build` to a new `build:packages` that omits `@foldkit/markdown`, which is public and not in the changeset ignore list. `build:packages` now equals the publishable set exactly.

**The personal-blog E2E shard would have failed.** `examples/vite.aliases.ts` aliases most foldkit packages to source, but `examples/personal-blog/vite.config.ts` imports `@foldkit/markdown/vite` at config-load time, which Vite resolves through Node rather than the aliases.

**A markdown change triggered no website or example validation.** `packages/markdown/` was missing from the `website` scope and from `ALL_EXAMPLES_PREFIXES`, so CI and `deploy-website.yml` disagreed about what markdown affects.

**The charting E2E spec was broken and had never run.** The old hand-maintained matrix omitted it. It drove the chart mode control as a button with `aria-pressed`, but the example renders a `RadioGroup`. It now asserts `role="radio"` and `aria-checked`, matching the example's own scene test.

**`release.yml` could not fire on a markdown-only change**, and **`deploy-typing-game.yml` ignored the DevTools and UI packages its client pulls in.**

## Other changes relative to #717

- **Shard count 5 to 10.** With 30 examples, 5 shards meant 6 serial runs per shard, trading a large runner-minute saving for a worse wall clock on the common path. `MAX_SHARD_COUNT` is a one-line tunable.
- **Two-dot to three-dot diff** in the planners, and a merge-base ref for the pnpm affected filter. A base branch that has moved on otherwise makes its own commits look like this branch's changes.
- **The aggregate job is `if: ${{ !cancelled() }}`, not `always()`.** With `always()`, a run superseded by a newer push turned its own cancellation into a failed required check on the abandoned commit.
- **The circular dependency check is not gated.** It reads as a workspace-wide check but scans only `packages/typing-game/client/src`, so gating it on the typing game scope was correct yet coupled a workflow condition to a shell script's internal `DIRS` array. Adding a directory there later would have silently skipped the check for that directory from the next commit onward. At 8.5s against an ~11.5 minute job, the gate bought roughly nothing, so it runs unconditionally alongside the other cheap checks.

## Tests

`pnpm test:scripts` runs 33 tests over the planners in about 750ms, wired into CI as an unconditional step and into `pre-push`. They cover the scope mapping, the shard invariants, and every fail-safe path.

The suite was mutation-tested rather than assumed. Five deliberate regressions were introduced and all five now fail: dropping `packages/markdown/` from the website scope, making `isUnknownDiff` always false, dropping the shared helper from the conservative trigger lists, raising the shard cap, and reverting the three-dot diff. The last one initially passed, which exposed that the three-dot fix had no coverage, so a test that builds a repo with genuinely diverged branches was added.

The suite uses node's built-in runner, so it needs no toolchain, matching scripts that must run before install. The invocation lives in `scripts/run-script-tests.sh` because knip's Node plugin expands `**/test/**` across every workspace when it sees `node --test` in the root manifest.

## Deliberately out of scope

Three things were raised in review and left for separate changes rather than widened into this diff: pinning actions to commit SHAs plus adding `permissions` and `persist-credentials` blocks, which is repo-wide security policy that should land as one deliberate pass over all seven workflows; enforcing that every website example has an E2E spec, which would fail today because `managed-resource-layer` has none, and is a coverage call for a maintainer; and fencing Vercel production promotion against superseded runs, which needs knowledge of the Vercel project setup and a change to the deploy shape.

## Note on check names

The examples E2E check names change from per-example (`counter`, `todo`, and so on) to `Shard N` plus a stable `Examples E2E` aggregate. The repository has no branch protection rules today, so nothing blocks this merge. If required checks are ever configured, point them at `Examples E2E` rather than the shard names, which vary per run — that job exists to provide one stable name.

## Validation

Locally: `format:check`, `lint`, `typecheck:scripts`, `test:scripts`, `check:dead-code`, `check:effect-prebundle`, `check:changeset-ignore`, `check:circular-deps`, `check:no-claude-comments`, `check:changeset-unwrapped`, `check:no-major-changesets`, `check:skill-version`, and `changeset status` all pass. All workflows parse. The website build succeeds. The publishable package set was enumerated and matches `build:packages` exactly. No changeset, since no publishable source changed.