### PR TITLE
refactor(website): stop scrolling the highlighted demo code into view

### DIFF
--- a/packages/website/src/page/asyncCounterDemo.scene.test.ts
+++ b/packages/website/src/page/asyncCounterDemo.scene.test.ts
@@ -4,9 +4,7 @@ import { describe, test } from 'vitest'
 
 import {
   CompletedDelayAdvancePhase,
-  CompletedScrollDemoHighlight,
   DelayAdvancePhase,
-  ScrollDemoHighlight,
   init,
   update,
   view,
@@ -14,16 +12,13 @@ import {
 
 const [initialModel] = init()
 
-// NOTE: every phase change also scrolls the highlighted lines into view, so
-// each step settles that Command alongside the one driving the animation.
 const advancePhases = (steps: number, generation: number) =>
-  Array.makeBy(steps, () => [
-    Command.resolve(ScrollDemoHighlight, CompletedScrollDemoHighlight()),
+  Array.makeBy(steps, () =>
     Command.resolve(
       DelayAdvancePhase,
       CompletedDelayAdvancePhase({ generation }),
     ),
-  ]).flat()
+  )
 
 describe('async counter demo view', () => {
   test('Add 1 renders the new count', () => {

--- a/packages/website/src/page/asyncCounterDemo.test.ts
+++ b/packages/website/src/page/asyncCounterDemo.test.ts
@@ -43,7 +43,6 @@ describe('async counter demo', () => {
     expect(incremented.generation).toBe(1)
     expect(Array.map(commands, command => command.name)).toStrictEqual([
       'DelayAdvancePhase',
-      'ScrollDemoHighlight',
     ])
 
     const settled = advancePhases(incremented, INCREMENT_PHASE_STEPS)

--- a/packages/website/src/page/asyncCounterDemo.ts
+++ b/packages/website/src/page/asyncCounterDemo.ts
@@ -8,7 +8,7 @@ import {
   Schema as S,
   pipe,
 } from 'effect'
-import { Command, Dom, Submodel } from 'foldkit'
+import { Command, Submodel } from 'foldkit'
 import { Html, type HtmlBuilder, inertHtml as ih } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
@@ -72,14 +72,12 @@ export const ClickedDemoReset = m('ClickedDemoReset')
 export const CompletedDelayAdvancePhase = m('CompletedDelayAdvancePhase', {
   generation: S.Number,
 })
-export const CompletedScrollDemoHighlight = m('CompletedScrollDemoHighlight')
 
 export const Message = S.Union([
   ClickedDemoIncrement,
   ChangedDemoResetDuration,
   ClickedDemoReset,
   CompletedDelayAdvancePhase,
-  CompletedScrollDemoHighlight,
 ])
 export type Message = typeof Message.Type
 
@@ -114,29 +112,15 @@ export const DelayAdvancePhase = Command.define('DelayAdvancePhase', {
     ),
 })
 
-export const ScrollDemoHighlight = Command.define('ScrollDemoHighlight', {
-  args: { phase: AnimationPhase },
-  messages: [CompletedScrollDemoHighlight],
-  execute: ({ phase }) =>
-    Dom.scrollIntoViewIfNotVisible(
-      `.demo-code-panel [data-phases~="${phase}"]`,
-      {
-        block: 'nearest',
-      },
-    ).pipe(Effect.ignore, Effect.as(CompletedScrollDemoHighlight())),
-})
-
 const prependToLog =
   (entry: string) =>
   (messageLog: ReadonlyArray<string>): ReadonlyArray<string> =>
     pipe([entry, ...messageLog], Array.take(MAX_LOG_ENTRIES))
 
-const applyMessage = (model: Model, message: Message): UpdateReturn =>
+export const update = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
     withUpdateReturn,
     M.tagsExhaustive({
-      CompletedScrollDemoHighlight: () => [model, []],
-
       ClickedDemoIncrement: () => {
         const nextModel = evo(model, {
           count: N.increment,
@@ -308,19 +292,6 @@ const applyMessage = (model: Model, message: Message): UpdateReturn =>
       },
     }),
   )
-
-export const update = (model: Model, message: Message): UpdateReturn => {
-  const [nextModel, commands] = applyMessage(model, message)
-
-  if (nextModel.phase === model.phase || nextModel.phase === 'Idle') {
-    return [nextModel, commands]
-  } else {
-    return [
-      nextModel,
-      [...commands, ScrollDemoHighlight({ phase: nextModel.phase })],
-    ]
-  }
-}
 
 // VIEW
 

--- a/packages/website/src/page/notePlayerDemo.ts
+++ b/packages/website/src/page/notePlayerDemo.ts
@@ -11,13 +11,7 @@ import {
   String as Str,
   pipe,
 } from 'effect'
-import {
-  Command,
-  Dom,
-  FieldValidation,
-  ManagedResource,
-  Submodel,
-} from 'foldkit'
+import { Command, FieldValidation, ManagedResource, Submodel } from 'foldkit'
 import { Html, type HtmlBuilder, inertHtml as ih } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { ts } from 'foldkit/schema'
@@ -136,7 +130,6 @@ const CompletedDelayAdvancePhase = m('CompletedDelayAdvancePhase', {
 const SucceededAcquireAudioContext = m('SucceededAcquireAudioContext')
 const FailedAcquireAudioContext = m('FailedAcquireAudioContext')
 const ReleasedAudioContext = m('ReleasedAudioContext')
-const CompletedScrollNoteHighlight = m('CompletedScrollNoteHighlight')
 
 export const Message = S.Union([
   ChangedNoteInput,
@@ -149,7 +142,6 @@ export const Message = S.Union([
   SucceededAcquireAudioContext,
   FailedAcquireAudioContext,
   ReleasedAudioContext,
-  CompletedScrollNoteHighlight,
 ])
 export type Message = typeof Message.Type
 
@@ -233,22 +225,10 @@ const enterNoteCommandPhase = (
   ],
 ]
 
-const ScrollNoteHighlight = Command.define('ScrollNoteHighlight', {
-  args: { phase: NoteHighlightPhase },
-  messages: [CompletedScrollNoteHighlight],
-  execute: ({ phase }) =>
-    Dom.scrollIntoViewIfNotVisible(
-      `.note-demo-code-panel [data-phases~="${phase}"]`,
-      { block: 'nearest' },
-    ).pipe(Effect.ignore, Effect.as(CompletedScrollNoteHighlight())),
-})
-
-const applyMessage = (model: Model, message: Message): UpdateReturn =>
+export const update = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
     withUpdateReturn,
     M.tagsExhaustive({
-      CompletedScrollNoteHighlight: () => [model, []],
-
       ChangedNoteInput: ({ value }) => {
         const uppercased = Str.toUpperCase(value)
         const fieldState = Str.isEmpty(uppercased)
@@ -545,22 +525,6 @@ const PlayNote = Command.define('PlayNote', {
       ),
     ),
 })
-
-export const update = (model: Model, message: Message): UpdateReturn => {
-  const [nextModel, commands] = applyMessage(model, message)
-
-  if (
-    nextModel.highlightPhase === model.highlightPhase ||
-    nextModel.highlightPhase === 'Idle'
-  ) {
-    return [nextModel, commands]
-  } else {
-    return [
-      nextModel,
-      [...commands, ScrollNoteHighlight({ phase: nextModel.highlightPhase })],
-    ]
-  }
-}
 
 // VIEW
 


### PR DESCRIPTION
Both demos in the landing page's "See it work" section scrolled the active code lines into view on every phase change. As the animation stepped through Message, update, and Model, the code panel jumped under the reader, which is uncomfortable to watch.

## Changes

- `asyncCounterDemo.ts`: removed the `ScrollDemoHighlight` Command and its `CompletedScrollDemoHighlight` result Message.
- `notePlayerDemo.ts`: removed `ScrollNoteHighlight` and `CompletedScrollNoteHighlight`.
- In both demos, `update` was a wrapper that called `applyMessage` and appended the scroll Command whenever the phase changed. With the scroll gone the wrapper does nothing, so `applyMessage` became `update` directly.
- Dropped the now-unused `Dom` import from both files.
- Updated the two async counter test files that were settling the scroll Command alongside the phase timer.

The highlight styling is unchanged. Lines still light up per phase, they just no longer pull the viewport along, and the code panel is still scrollable by hand.

## Testing

`pnpm -F website typecheck`, `pnpm lint`, and `prettier --check` are clean. All 282 website tests pass. The pre-push hook ran the full monorepo build, typecheck, and test suite; the website e2e suite was skipped locally because the pinned Playwright browser build is not present in this environment, so CI covers it here.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jQuXGtUSWYbW48Cx68bq3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified async counter and note player demo behavior by removing automatic scroll-highlight actions during animation phases.
  * Updated demo flows and tests to reflect the streamlined animation sequence.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->