### PR TITLE
feat(ui): add isReadOnly to Checkbox

### DIFF
--- a/.changeset/checkbox-read-only.md
+++ b/.changeset/checkbox-read-only.md
@@ -1,0 +1,9 @@
+---
+'@foldkit/ui': minor
+---
+
+Add `isReadOnly` to Checkbox's `ViewConfig`.
+
+A read-only Checkbox emits `aria-readonly="true"` and `data-readonly`, remains focusable, and omits its click and Space handlers. `isReadOnly` and `isDisabled` are independent, and either one removes the interaction handlers.
+
+Thanks @wmaurer!

--- a/packages/ui/src/checkbox/index.ts
+++ b/packages/ui/src/checkbox/index.ts
@@ -33,13 +33,18 @@ export type CheckboxAttributes<Message> = Readonly<{
  *    the checkbox or its label, or presses Space. Handle it in the parent's
  *    `update` by storing the value.
  *  - `toView`: receives the {@link CheckboxAttributes} and lays out the
- *    checkbox. */
+ *    checkbox.
+ *  - `isReadOnly`: prevents toggling while exposing read-only semantics with
+ *    `aria-readonly="true"` and `data-readonly`. The checkbox remains
+ *    focusable. Independent of `isDisabled`: setting both emits both
+ *    attribute sets, and either one removes the interaction handlers. */
 export type ViewConfig<Message> = Readonly<{
   id: string
   isChecked: boolean
   onToggle: (isChecked: boolean) => Message
   toView: (attributes: CheckboxAttributes<Message>) => Html
   isDisabled?: boolean
+  isReadOnly?: boolean
   isIndeterminate?: boolean
   name?: string
   value?: string
@@ -83,6 +88,7 @@ export const view = <Message>(
     onToggle,
     toView,
     isDisabled = false,
+    isReadOnly = false,
     isIndeterminate = false,
     name,
     value: formValue = 'on',
@@ -110,6 +116,12 @@ export const view = <Message>(
     ? [h.AriaDisabled(true), h.DataAttribute('disabled', '')]
     : []
 
+  const readOnlyAttributes = isReadOnly
+    ? [h.AriaReadonly(true), h.DataAttribute('readonly', '')]
+    : []
+
+  const isInteractive = !isDisabled && !isReadOnly
+
   const checkboxAttributes = [
     h.Role('checkbox'),
     h.AriaChecked(isIndeterminate ? 'mixed' : isChecked),
@@ -118,17 +130,15 @@ export const view = <Message>(
     h.Tabindex(0),
     ...resolveStateAttributes(),
     ...disabledAttributes,
-    ...(isDisabled
-      ? []
-      : [
-          h.OnClick(onToggle(nextChecked)),
-          h.OnKeyUpPreventDefault(handleKeyUp),
-        ]),
+    ...readOnlyAttributes,
+    ...(isInteractive
+      ? [h.OnClick(onToggle(nextChecked)), h.OnKeyUpPreventDefault(handleKeyUp)]
+      : []),
   ]
 
   const labelAttributes = [
     h.Id(labelId(id)),
-    ...(isDisabled ? [] : [h.OnClick(onToggle(nextChecked))]),
+    ...(isInteractive ? [h.OnClick(onToggle(nextChecked))] : []),
   ]
 
   const descriptionAttributes = [h.Id(descriptionId(id))]

--- a/packages/ui/src/checkbox/scene.test.ts
+++ b/packages/ui/src/checkbox/scene.test.ts
@@ -30,8 +30,13 @@ const update = (model: Model, message: Message): UpdateReturn =>
 const testView =
   ({
     isDisabled = false,
+    isReadOnly = false,
     isIndeterminate = false,
-  }: { isDisabled?: boolean; isIndeterminate?: boolean } = {}) =>
+  }: {
+    isDisabled?: boolean
+    isReadOnly?: boolean
+    isIndeterminate?: boolean
+  } = {}) =>
   (model: Model, h: HtmlBuilder<Message>) =>
     view(
       {
@@ -39,6 +44,7 @@ const testView =
         isChecked: model.isChecked,
         onToggle: isChecked => Toggled({ isChecked }),
         isDisabled,
+        isReadOnly,
         isIndeterminate,
         toView: ({ checkbox, label }) =>
           h.div(
@@ -88,6 +94,39 @@ describe('Checkbox controlled view', () => {
       Scene.given({ isChecked: false }),
       Scene.expect(checkbox).toBeDisabled(),
       Scene.expect(checkbox).toHaveAttr('data-disabled', ''),
+    )
+  })
+
+  it('emits read-only attributes without disabled attributes', () => {
+    Scene.scene(
+      { update, view: testView({ isReadOnly: true }) },
+      Scene.given({ isChecked: false }),
+      Scene.expect(checkbox).toHaveAttr('aria-readonly', 'true'),
+      Scene.expect(checkbox).toHaveAttr('data-readonly', ''),
+      Scene.expect(checkbox).not.toBeDisabled(),
+      Scene.expect(checkbox).not.toHaveAttr('data-disabled'),
+    )
+  })
+
+  it('stays focusable but drops every handler when read-only', () => {
+    Scene.scene(
+      { update, view: testView({ isReadOnly: true }) },
+      Scene.given({ isChecked: false }),
+      Scene.expect(checkbox).toHaveAttr('tabIndex', '0'),
+      Scene.expect(checkbox).not.toHaveHandler('click'),
+      Scene.expect(checkbox).not.toHaveHandler('keyup'),
+      Scene.expect(label).not.toHaveHandler('click'),
+    )
+  })
+
+  it('emits both attribute sets when disabled and read-only are combined', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true, isReadOnly: true }) },
+      Scene.given({ isChecked: false }),
+      Scene.expect(checkbox).toBeDisabled(),
+      Scene.expect(checkbox).toHaveAttr('data-disabled', ''),
+      Scene.expect(checkbox).toHaveAttr('aria-readonly', 'true'),
+      Scene.expect(checkbox).toHaveAttr('data-readonly', ''),
     )
   })
 

--- a/packages/website/src/page/ui/checkboxPage.md
+++ b/packages/website/src/page/ui/checkboxPage.md
@@ -28,19 +28,20 @@ Pass `isIndeterminate: true` to show a mixed state. This is typically computed f
 
 ## Styling
 
-Checkbox is headless. Your `toView` callback controls all markup and styling. Use the data attributes below to style checked, indeterminate, and disabled states.
+Checkbox is headless. Your `toView` callback controls all markup and styling. Use the data attributes below to style checked, indeterminate, disabled, and read-only states.
 
 | Attribute            | Condition                                   |
 | -------------------- | ------------------------------------------- |
 | `data-checked`       | Present when checked and not indeterminate. |
 | `data-indeterminate` | Present when isIndeterminate is true.       |
 | `data-disabled`      | Present when isDisabled is true.            |
+| `data-readonly`      | Present when isReadOnly is true.            |
 
 ## Keyboard Interaction
 
-| Key     | Description           |
-| ------- | --------------------- |
-| `Space` | Toggles the checkbox. |
+| Key     | Description                                                               |
+| ------- | ------------------------------------------------------------------------- |
+| `Space` | Toggles the Checkbox when `isDisabled` and `isReadOnly` are both `false`. |
 
 ## Accessibility
 
@@ -48,22 +49,33 @@ The checkbox element receives `role="checkbox"` and `aria-checked` which is set 
 
 The `label` attribute group includes an id (accessible via `Checkbox.labelId(id)`) and the `description` group includes an id (accessible via `Checkbox.descriptionId(id)`), so a consumer can reference either element without re-declaring the naming convention.
 
+`isReadOnly` and `isDisabled` both stop the Checkbox from reacting to clicks and Space. They differ in the semantics exposed to assistive technology, so they are not interchangeable.
+
+`aria-disabled="true"`, which `isDisabled` emits, communicates that the Checkbox is unavailable. `aria-readonly="true"`, which `isReadOnly` emits, communicates that its value cannot be changed but remains relevant to the user. Both states keep `tabindex="0"`, following Foldkit's convention that unavailable controls remain discoverable by keyboard and assistive technology.
+
+Assistive technology support for `aria-readonly` on checkboxes varies. Pair it with a visible read-only treatment or explanatory text when users must distinguish it from disabled, and test the browser and assistive technology combinations your app supports.
+
+Use `isReadOnly` when the checked state is still information the user needs, such as a decision that was already made, and `isDisabled` when the Checkbox is unavailable.
+
+The two flags are independent. Setting both emits both sets of attributes, and either one on its own removes the click and Space handlers.
+
 ## API Reference
 
 ### ViewConfig {#view-config}
 
 Configuration object passed to `Checkbox.view()`.
 
-| Name              | Type                                       | Default | Description                                                                                                                      |
-| ----------------- | ------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `id`              | `string`                                   | —       | Unique ID for the checkbox instance. Used to link the label and description via ARIA.                                            |
-| `isChecked`       | `boolean`                                  | —       | The current checked state, read from your Model. `aria-checked` and the `data-checked` marker derive from it.                    |
-| `onToggle`        | `(isChecked: boolean) => Message`          | —       | Maps the new checked state to a Message when the user toggles the checkbox. Your update handler just stores the value.           |
-| `toView`          | `(attributes: CheckboxAttributes) => Html` | —       | Callback that receives attribute groups for the checkbox, label, description, and hidden input elements.                         |
-| `isDisabled`      | `boolean`                                  | `false` | Whether the checkbox is disabled.                                                                                                |
-| `isIndeterminate` | `boolean`                                  | `false` | Whether to show the indeterminate (mixed) state. Useful for "select all" checkboxes where some but not all children are checked. |
-| `name`            | `string`                                   | —       | Form field name. When provided, a hidden input is included for native form submission.                                           |
-| `value`           | `string`                                   | `'on'`  | Value sent in the form when checked.                                                                                             |
+| Name              | Type                                       | Default | Description                                                                                                                            |
+| ----------------- | ------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`              | `string`                                   | —       | Unique ID for the checkbox instance. Used to link the label and description via ARIA.                                                  |
+| `isChecked`       | `boolean`                                  | —       | The current checked state, read from your Model. `aria-checked` and the `data-checked` marker derive from it.                          |
+| `onToggle`        | `(isChecked: boolean) => Message`          | —       | Maps the new checked state to a Message when the user toggles the checkbox. Your update handler just stores the value.                 |
+| `toView`          | `(attributes: CheckboxAttributes) => Html` | —       | Callback that receives attribute groups for the checkbox, label, description, and hidden input elements.                               |
+| `isDisabled`      | `boolean`                                  | `false` | Whether the checkbox is disabled.                                                                                                      |
+| `isReadOnly`      | `boolean`                                  | `false` | Whether the checkbox is readable but not toggleable. Carries `aria-readonly` rather than `aria-disabled`. Independent of `isDisabled`. |
+| `isIndeterminate` | `boolean`                                  | `false` | Whether to show the indeterminate (mixed) state. Useful for "select all" checkboxes where some but not all children are checked.       |
+| `name`            | `string`                                   | —       | Form field name. When provided, a hidden input is included for native form submission.                                                 |
+| `value`           | `string`                                   | `'on'`  | Value sent in the form when checked.                                                                                                   |
 
 ### CheckboxAttributes {#checkbox-attributes}
 


### PR DESCRIPTION
`@foldkit/ui` had no way to render a Checkbox whose checked state remains
relevant but cannot be changed. `isDisabled` removes interaction, but it
exposes disabled semantics and applies disabled styling.

Add `isReadOnly` to Checkbox's `ViewConfig`. A read-only Checkbox emits
`aria-readonly="true"` and `data-readonly`, remains focusable, and omits click
and Space handlers from both the checkbox and label attribute groups.
`isReadOnly` and `isDisabled` are independent. Either removes interaction
handlers, and setting both emits both attribute sets.

Scene tests cover read-only attributes, focusability, handler removal, and the
combined disabled/read-only state. The website documents styling, keyboard
behavior, the accessibility distinction, and the fact that assistive
technology support for read-only checkboxes varies.

Follow-up support for other applicable value controls is tracked in #925.
