### PR TITLE
refactor: use evo in every counter example

### DIFF
--- a/.changeset/counter-examples-evo.md
+++ b/.changeset/counter-examples-evo.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Update the counter example in the README to use `evo` instead of building the next Model by hand, matching the counter in `examples/counter` and every other counter across the docs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,11 @@ jobs:
           # merge base rather than the base tip. Otherwise a base branch that
           # has moved on makes its own commits look like this branch's changes.
           base=$(git merge-base "$BASE_SHA" HEAD || echo "$BASE_SHA")
-          pnpm -r --filter "...[$base]" run --if-present typecheck
+          # NOTE: excluding foldkit-monorepo is not redundant. A changeset or
+          # any other root-level file makes the root project itself "changed",
+          # and its own scripts recurse over the whole workspace, so leaving it
+          # in runs every package a second time concurrently.
+          pnpm -r --filter "...[$base]" --filter '!foldkit-monorepo' run --if-present typecheck
 
       - name: Smoke test create-foldkit-app
         if: steps.scope.outputs.create_foldkit_smoke == 'true'
@@ -136,7 +140,13 @@ jobs:
           # merge base rather than the base tip. Otherwise a base branch that
           # has moved on makes its own commits look like this branch's changes.
           base=$(git merge-base "$BASE_SHA" HEAD || echo "$BASE_SHA")
-          pnpm -r --filter "...[$base]" run --if-present test
+          # NOTE: excluding foldkit-monorepo is not redundant. A changeset or
+          # any other root-level file makes the root project itself "changed",
+          # and the root test script recurses over the whole workspace, so
+          # leaving it in runs a second copy of every package's tests
+          # concurrently with this one. Two `vitest run --coverage` processes
+          # in the same package then race on coverage/.tmp.
+          pnpm -r --filter "...[$base]" --filter '!foldkit-monorepo' run --if-present test
 
       - name: Install Playwright browsers
         if: steps.scope.outputs.website == 'true'

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ import { Match as M, Schema as S } from 'effect'
 import { Command, Runtime } from 'foldkit'
 import { Document, HtmlBuilder } from 'foldkit/html'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 // MODEL
 
@@ -73,9 +74,9 @@ export const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedDecrement: () => [{ count: model.count - 1 }, []],
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
-      ClickedReset: () => [{ count: 0 }, []],
+      ClickedDecrement: () => [evo(model, { count: count => count - 1 }), []],
+      ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
+      ClickedReset: () => [evo(model, { count: () => 0 }), []],
     }),
   )
 

--- a/examples/personal-blog/src/island/counter.ts
+++ b/examples/personal-blog/src/island/counter.ts
@@ -1,6 +1,7 @@
 import { Match as M, Schema as S } from 'effect'
 import { Command, Submodel } from 'foldkit'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 import { Button } from '@foldkit/ui'
 
@@ -30,8 +31,8 @@ export const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedDecrement: () => [{ count: model.count - 1 }, []],
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
+      ClickedDecrement: () => [evo(model, { count: count => count - 1 }), []],
+      ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
     }),
   )
 

--- a/packages/foldkit/README.md
+++ b/packages/foldkit/README.md
@@ -43,6 +43,7 @@ import { Match as M, Schema as S } from 'effect'
 import { Command, Runtime } from 'foldkit'
 import { Document, HtmlBuilder } from 'foldkit/html'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 // MODEL
 
@@ -73,9 +74,9 @@ export const update = (
       readonly [Model, ReadonlyArray<Command.Command<Message>>]
     >(),
     M.tagsExhaustive({
-      ClickedDecrement: () => [{ count: model.count - 1 }, []],
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
-      ClickedReset: () => [{ count: 0 }, []],
+      ClickedDecrement: () => [evo(model, { count: count => count - 1 }), []],
+      ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
+      ClickedReset: () => [evo(model, { count: () => 0 }), []],
     }),
   )
 

--- a/packages/foldkit/src/devTools/store.test.ts
+++ b/packages/foldkit/src/devTools/store.test.ts
@@ -3,6 +3,7 @@ import {
   Effect,
   HashSet,
   Match,
+  Number,
   Option,
   Schema,
   SubscriptionRef,
@@ -11,6 +12,7 @@ import {
 import { describe, expect, it, vi } from 'vitest'
 
 import { m } from '../message/index.js'
+import { evo } from '../struct/index.js'
 import {
   type Bridge,
   type DevToolsStore,
@@ -130,15 +132,15 @@ const ClickedDecrement = m('ClickedDecrement')
 const CounterMessage = Schema.Union([ClickedIncrement, ClickedDecrement])
 
 const counterReplay = (model: unknown, message: unknown): unknown => {
-  const { count } = Schema.decodeUnknownSync(CounterModel)(model)
+  const counterModel = Schema.decodeUnknownSync(CounterModel)(model)
 
   return pipe(
     message,
     Schema.decodeUnknownSync(CounterMessage),
     Match.value,
     Match.tagsExhaustive({
-      ClickedIncrement: () => ({ count: count + 1 }),
-      ClickedDecrement: () => ({ count: count - 1 }),
+      ClickedIncrement: () => evo(counterModel, { count: Number.increment }),
+      ClickedDecrement: () => evo(counterModel, { count: Number.decrement }),
     }),
   )
 }

--- a/packages/foldkit/src/devTools/webSocketBridge.test.ts
+++ b/packages/foldkit/src/devTools/webSocketBridge.test.ts
@@ -1,7 +1,16 @@
-import { Array, Effect, Match, Option, Schema, SubscriptionRef } from 'effect'
+import {
+  Array,
+  Effect,
+  Match,
+  Number,
+  Option,
+  Schema,
+  SubscriptionRef,
+} from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import { m } from '../message/index.js'
+import { evo } from '../struct/index.js'
 import {
   MAX_DISPATCH_BATCH_SIZE,
   type Request,
@@ -33,8 +42,8 @@ const update = (model: CounterModel, message: CounterMessage): CounterModel =>
   Match.value(message).pipe(
     Match.withReturnType<CounterModel>(),
     Match.tagsExhaustive({
-      ClickedIncrement: () => ({ count: model.count + 1 }),
-      ClickedDecrement: () => ({ count: model.count - 1 }),
+      ClickedIncrement: () => evo(model, { count: Number.increment }),
+      ClickedDecrement: () => evo(model, { count: Number.decrement }),
     }),
   )
 

--- a/packages/foldkit/src/html/htmlBuilder.test.ts
+++ b/packages/foldkit/src/html/htmlBuilder.test.ts
@@ -1,10 +1,11 @@
-import { Context, Schema as S } from 'effect'
+import { Context, Number, Schema as S } from 'effect'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { m } from '../message/index.js'
 import { MountTracker } from '../mount/index.js'
 import { Dispatch } from '../runtime/index.js'
 import { embed, makeElement } from '../runtime/runtime.js'
+import { evo } from '../struct/index.js'
 import { beginRender, createBoundaryRegistry } from './boundary.js'
 import * as HtmlModule from './index.js'
 import {
@@ -284,7 +285,7 @@ describe('HtmlBuilder runtime guarantees', () => {
         model: Model,
         _message: Message,
       ): readonly [Model, ReadonlyArray<never>] => [
-        { count: model.count + 1 },
+        evo(model, { count: Number.increment }),
         [],
       ],
       view: (model, h) =>

--- a/packages/foldkit/src/runtime/bfcacheReload.test.ts
+++ b/packages/foldkit/src/runtime/bfcacheReload.test.ts
@@ -1,4 +1,4 @@
-import { Match as M, Schema as S } from 'effect'
+import { Match as M, Number, Schema as S } from 'effect'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type Document, __htmlBuilder } from '../html/index.js'
@@ -19,7 +19,7 @@ const update = (
 ): readonly [Model, ReadonlyArray<never>] =>
   M.value(message).pipe(
     M.withReturnType<readonly [Model, ReadonlyArray<never>]>(),
-    M.tag('Incremented', () => [evo(model, { count: count => count + 1 }), []]),
+    M.tag('Incremented', () => [evo(model, { count: Number.increment }), []]),
     M.exhaustive,
   )
 

--- a/packages/foldkit/src/runtime/dispatchBench.test.ts
+++ b/packages/foldkit/src/runtime/dispatchBench.test.ts
@@ -1,8 +1,9 @@
-import { Effect, Match as M, Predicate, Schema as S } from 'effect'
+import { Effect, Match as M, Number, Predicate, Schema as S } from 'effect'
 import { describe, it } from 'vitest'
 
 import { Document, __htmlBuilder, __requireDispatch } from '../html/index.js'
 import { m } from '../message/index.js'
+import { evo } from '../struct/index.js'
 import { makeApplication } from './runtime.js'
 
 /**
@@ -75,7 +76,7 @@ const runOnce = async (messageCount: number): Promise<number> => {
     M.value(message).pipe(
       M.withReturnType<readonly [Model, ReadonlyArray<never>]>(),
       M.tagsExhaustive({
-        Increment: () => [{ count: model.count + 1 }, []],
+        Increment: () => [evo(model, { count: Number.increment }), []],
         Done: () => {
           resolveDone()
           return [model, []]

--- a/packages/foldkit/src/runtime/slow.test.ts
+++ b/packages/foldkit/src/runtime/slow.test.ts
@@ -1,9 +1,18 @@
-import { Effect, Fiber, Match as M, Option, Schema as S, Stream } from 'effect'
+import {
+  Effect,
+  Fiber,
+  Match as M,
+  Number,
+  Option,
+  Schema as S,
+  Stream,
+} from 'effect'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Command } from '../command/index.js'
 import { __htmlBuilder } from '../html/index.js'
 import { m } from '../message/index.js'
+import { evo } from '../struct/index.js'
 import * as Subscription from '../subscription/subscription.js'
 import {
   type SlowContext,
@@ -27,7 +36,7 @@ const update = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
     M.withReturnType<UpdateReturn>(),
     M.tagsExhaustive({
-      ClickedIncrement: () => [{ count: model.count + 1 }, []],
+      ClickedIncrement: () => [evo(model, { count: Number.increment }), []],
       ClickedKeptModel: () => [model, []],
     }),
   )

--- a/packages/foldkit/src/update/update.test.ts
+++ b/packages/foldkit/src/update/update.test.ts
@@ -1,4 +1,4 @@
-import { Effect, HashMap, Match as M, Option } from 'effect'
+import { Effect, HashMap, Match as M, Number, Option } from 'effect'
 import { expect, expectTypeOf } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
@@ -6,6 +6,7 @@ import { describe, it } from '@effect/vitest'
 import * as AsyncData from '../asyncData/index.js'
 import { type Command } from '../command/index.js'
 import { m } from '../message/index.js'
+import { evo } from '../struct/index.js'
 import {
   type Commands,
   type Return,
@@ -32,12 +33,12 @@ const loadTags = makeLoad('LoadTags')
 const loadFolders = makeLoad('LoadFolders')
 
 const incrementCount: Step<TestModel, TestMessage> = model => [
-  { count: model.count + 1 },
+  evo(model, { count: Number.increment }),
   [],
 ]
 
 const doubleCount: Step<TestModel, TestMessage> = model => [
-  { count: model.count * 2 },
+  evo(model, { count: Number.multiply(2) }),
   [],
 ]
 
@@ -52,7 +53,7 @@ const emitLoadTagsAndFolders: Step<TestModel, TestMessage> = model => [
 ]
 
 const incrementAndEmitLoadNotes: Step<TestModel, TestMessage> = model => [
-  { count: model.count + 1 },
+  evo(model, { count: Number.increment }),
   [loadNotes],
 ]
 
@@ -287,7 +288,7 @@ describe('types', () => {
       M.value(message).pipe(
         withUpdateReturn,
         M.tagsExhaustive({
-          IncrementedCount: () => [{ count: model.count + 1 }, []],
+          IncrementedCount: () => [evo(model, { count: Number.increment }), []],
           CompletedLoad: () => [model, []],
         }),
       )

--- a/packages/website/src/snippet/counterHttpCommand.ts
+++ b/packages/website/src/snippet/counterHttpCommand.ts
@@ -2,6 +2,7 @@ import { Effect, Match as M, Schema as S } from 'effect'
 import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { Command, Http } from 'foldkit'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 const ClickedFetchCount = m('ClickedFetchCount')
 const SucceededFetchCount = m('SucceededFetchCount', {
@@ -45,7 +46,10 @@ const update = (
     >(),
     M.tagsExhaustive({
       ClickedFetchCount: () => [model, [FetchCount()]],
-      SucceededFetchCount: ({ count }) => [{ count }, []],
+      SucceededFetchCount: ({ count }) => [
+        evo(model, { count: () => count }),
+        [],
+      ],
       FailedFetchCount: () => [model, []],
     }),
   )

--- a/packages/website/src/snippet/foldkitCounter.ts
+++ b/packages/website/src/snippet/foldkitCounter.ts
@@ -2,10 +2,13 @@ import { Match as M, Schema as S } from 'effect'
 import { Command } from 'foldkit'
 import type { Document, HtmlBuilder } from 'foldkit/html'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
 
 // MODEL - Your entire application state
 
-const Model = S.Number
+const Model = S.Struct({
+  count: S.Number,
+})
 type Model = typeof Model.Type
 
 // MESSAGE - Events that can happen in your app
@@ -24,18 +27,18 @@ const update = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
     withUpdateReturn,
     M.tagsExhaustive({
-      ClickedIncrement: () => [model + 1, []],
+      ClickedIncrement: () => [evo(model, { count: count => count + 1 }), []],
     }),
   )
 
 // VIEW - A pure function from Model to a Document
 
 const view = (model: Model, h: HtmlBuilder<Message>): Document => ({
-  title: `Count: ${model}`,
+  title: `Count: ${model.count}`,
   body: h.div(
     [],
     [
-      h.p([], [`Count: ${model}`]),
+      h.p([], [`Count: ${model.count}`]),
       h.button([h.OnClick(ClickedIncrement())], ['Increment']),
     ],
   ),


### PR DESCRIPTION
The counter is the first Foldkit code most people read, and several copies
of it still built the next Model by hand with an object literal. That is the
one pattern the docs and skills tell readers never to use, so the canonical
example was teaching the opposite of the rule.

Switch every counter to `evo`: the README counters (root and the published
foldkit package), the personal-blog counter island, the website's HTTP
Command snippet, and the counter fixtures behind the DevTools store,
WebSocket bridge, HtmlBuilder, slow-warning, dispatch benchmark, and update
combine tests.

The `foldkitCounter` snippet on the Coming from React page modeled state as
a bare `S.Number`, which has no fields to evolve. Give it a
`S.Struct({ count: S.Number })` Model so it uses `evo` like the rest, and so
the Model shape no longer changes out from under the reader between that
snippet and the auto-count one that follows it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated counter examples across the README, package, personal blog, and website to demonstrate consistent immutable state updates.
  * Examples now preserve existing model data while changing counter values.

* **Bug Fixes**
  * Counter updates retain unrelated model fields during increment, decrement, reset, and successful request handling.

* **Tests**
  * Updated counter-related scenarios to use consistent state updates while preserving expected behavior.

* **Chores**
  * Improved CI execution to avoid duplicate workspace runs and coverage-directory conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->