### PR TITLE
fix(ui): return no Commands when closing an already-closed Popover

### DIFF
--- a/.changeset/popover-close-no-commands-when-closed.md
+++ b/.changeset/popover-close-no-commands-when-closed.md
@@ -1,0 +1,9 @@
+---
+'@foldkit/ui': patch
+---
+
+Closing an already-closed Popover no longer returns commands. `RequestedClose` on a closed Popover returned the caller's command list unchanged, so the `FocusButton` command survived and focus jumped to a trigger whose panel was never open. A modal Popover also returned `UnlockScroll` and `RestoreInert` for a scroll lock and an inert tree it never applied, and the same leak reached `BlurredPanel`. The docs already described `Popover.close` on a closed model as a no-op, and Dialog already behaves that way, so this brings the code in line with both.
+
+An open Popover is unchanged. It still returns `FocusButton`, still returns the modal commands when `isModal` is set, still emits `Closed`, and an animated Popover still runs its full leave cascade. Only the already-closed path changed, and it now returns an empty command list and no OutMessage, matching `RequestedOpen` on an already-open Popover.
+
+DatePicker picks this up for free, since its `Closed` message delegates to `Popover.close`.

--- a/.changeset/popover-close-no-commands-when-closed.md
+++ b/.changeset/popover-close-no-commands-when-closed.md
@@ -2,8 +2,10 @@
 '@foldkit/ui': patch
 ---
 
-Closing an already-closed Popover no longer returns commands. `RequestedClose` on a closed Popover returned the caller's command list unchanged, so the `FocusButton` command survived and focus jumped to a trigger whose panel was never open. A modal Popover also returned `UnlockScroll` and `RestoreInert` for a scroll lock and an inert tree it never applied, and the same leak reached `BlurredPanel`. The docs already described `Popover.close` on a closed model as a no-op, and Dialog already behaves that way, so this brings the code in line with both.
+Closing an already-closed Popover no longer returns Commands. `RequestedClose` on a closed Popover returned the caller's Commands unchanged, so `FocusButton` survived and focus jumped to a trigger whose panel was never open. A modal Popover also returned `UnlockScroll` and `RestoreInert` for a scroll lock and an inert tree it never applied, and the same leak reached `BlurredPanel`. The docs already described `Popover.close` on a closed Model as a no-op, and Dialog already behaves that way, so this brings the code in line with both.
 
-An open Popover is unchanged. It still returns `FocusButton`, still returns the modal commands when `isModal` is set, still emits `Closed`, and an animated Popover still runs its full leave cascade. Only the already-closed path changed, and it now returns an empty command list and no OutMessage, matching `RequestedOpen` on an already-open Popover.
+An open Popover is unchanged. It still returns `FocusButton`, still returns the modal Commands when `isModal` is set, still emits `Closed`, and an animated Popover still runs its full leave cascade. Only the already-closed path changed, and it now returns no Commands and no OutMessage, matching `RequestedOpen` on an already-open Popover.
 
-DatePicker picks this up for free, since its `Closed` message delegates to `Popover.close`.
+DatePicker picks this up for free, since its `Closed` Message delegates to `Popover.close`.
+
+Thanks @artile!

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -346,7 +346,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
     commands: ReadonlyArray<Command.Command<Message>>,
   ): UpdateReturn => {
     if (!baseModel.isOpen) {
-      return [baseModel, commands, Option.none()]
+      return [baseModel, [], Option.none()]
     }
     const closed = closedModel(baseModel)
 
@@ -481,8 +481,9 @@ export const PortalPopoverBackdrop = Mount.define(
 export const open = (model: Model): UpdateReturn =>
   update(model, RequestedOpen())
 
-/** Programmatically closes the popover, updating the model and returning
- *  focus and modal commands plus a `Closed` OutMessage when it was open. */
+/** Programmatically closes the popover. When it was open, updates the model
+ *  and returns focus and modal commands plus a `Closed` OutMessage. When it
+ *  was already closed, it is a no-op: no commands and no OutMessage. */
 export const close = (model: Model): UpdateReturn =>
   update(model, RequestedClose())
 

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -481,9 +481,9 @@ export const PortalPopoverBackdrop = Mount.define(
 export const open = (model: Model): UpdateReturn =>
   update(model, RequestedOpen())
 
-/** Programmatically closes the popover. When it was open, updates the model
- *  and returns focus and modal commands plus a `Closed` OutMessage. When it
- *  was already closed, it is a no-op: no commands and no OutMessage. */
+/** Programmatically closes the popover. When it was open, updates the Model
+ *  and returns focus and modal Commands plus a `Closed` OutMessage. When it
+ *  was already closed, it is a no-op: no Commands and no OutMessage. */
 export const close = (model: Model): UpdateReturn =>
   update(model, RequestedClose())
 

--- a/packages/ui/src/popover/story.test.ts
+++ b/packages/ui/src/popover/story.test.ts
@@ -133,7 +133,7 @@ describe('Popover', () => {
         )
       })
 
-      it('returns no command and no OutMessage when already closed', () => {
+      it('returns no Command and no OutMessage when already closed', () => {
         Story.story(
           update,
           givenClosed,
@@ -570,7 +570,7 @@ describe('Popover', () => {
       )
     })
 
-    it('emits no commands on RequestedClose when already closed in modal mode', () => {
+    it('emits no Commands on RequestedClose when already closed in modal mode', () => {
       Story.story(
         update,
         givenClosedModal,
@@ -598,7 +598,7 @@ describe('Popover', () => {
       )
     })
 
-    it('emits no commands when the panel blurs on a closed popover in modal mode', () => {
+    it('emits no Commands when the panel blurs on a closed popover in modal mode', () => {
       Story.story(
         update,
         givenClosedModal,

--- a/packages/ui/src/popover/story.test.ts
+++ b/packages/ui/src/popover/story.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from '@effect/vitest'
 import * as Animation from '../animation/index.js'
 import {
   BlurredPanel,
+  Closed,
   CompletedFocusButton,
   CompletedFocusPanel,
   CompletedInertOthers,
@@ -120,6 +121,8 @@ describe('Popover', () => {
           update,
           givenOpen,
           Story.message(RequestedClose()),
+          Story.expectOutMessage(Closed()),
+          Story.Command.expectExact(FocusButton),
           Story.Command.resolve(FocusButton, CompletedFocusButton()),
           Story.model(model => {
             expect(model.isOpen).toBe(false)
@@ -130,12 +133,13 @@ describe('Popover', () => {
         )
       })
 
-      it('is idempotent when already closed', () => {
+      it('returns no command and no OutMessage when already closed', () => {
         Story.story(
           update,
           givenClosed,
           Story.message(RequestedClose()),
-          Story.Command.resolve(FocusButton, CompletedFocusButton()),
+          Story.expectNoOutMessage(),
+          Story.Command.expectNone(),
           Story.model(model => {
             expect(model.isOpen).toBe(false)
           }),
@@ -375,6 +379,20 @@ describe('Popover', () => {
           )
         })
 
+        it('starts no leave cascade on RequestedClose when already closed', () => {
+          Story.story(
+            update,
+            givenClosedAnimated,
+            Story.message(RequestedClose()),
+            Story.expectNoOutMessage(),
+            Story.Command.expectNone(),
+            Story.model(model => {
+              expect(model.isOpen).toBe(false)
+              expect(model.animation.transitionState).toBe('Idle')
+            }),
+          )
+        })
+
         it('begins the leave animation when the panel blurs', () => {
           Story.story(
             update,
@@ -552,6 +570,19 @@ describe('Popover', () => {
       )
     })
 
+    it('emits no commands on RequestedClose when already closed in modal mode', () => {
+      Story.story(
+        update,
+        givenClosedModal,
+        Story.message(RequestedClose()),
+        Story.expectNoOutMessage(),
+        Story.Command.expectNone(),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
     it('emits unlockScroll and restoreInert commands when the panel blurs in modal mode', () => {
       Story.story(
         update,
@@ -561,6 +592,19 @@ describe('Popover', () => {
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedRestoreInert()],
         ),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
+    it('emits no commands when the panel blurs on a closed popover in modal mode', () => {
+      Story.story(
+        update,
+        givenClosedModal,
+        Story.message(BlurredPanel()),
+        Story.expectNoOutMessage(),
+        Story.Command.expectNone(),
         Story.model(model => {
           expect(model.isOpen).toBe(false)
         }),


### PR DESCRIPTION
`closePopover` returned its caller's Commands when the Popover was already
closed. `RequestedClose` therefore moved focus with `FocusButton`, and a modal
Popover also returned `UnlockScroll` and `RestoreInert` for resources it never
acquired. `BlurredPanel` leaked the same modal cleanup pair.

Return no Commands from the already-closed path, which continues to emit no
OutMessage. The open path is unchanged: it still restores focus, releases
modal resources, emits `Closed`, and runs the animation leave flow. DatePicker
inherits the fix because its `Closed` Message delegates to `Popover.close`.

Regression stories cover standard, animated, and modal Popovers, plus the
blur path. The open-path story now asserts the `Closed` OutMessage and exact
`FocusButton` Command so the valid close flow cannot be silenced accidentally.
