### PR TITLE
fix(ui): return no Commands when closing an already-closed Menu or Listbox

### DIFF
--- a/.changeset/menu-listbox-close-no-commands-when-closed.md
+++ b/.changeset/menu-listbox-close-no-commands-when-closed.md
@@ -1,0 +1,11 @@
+---
+'@foldkit/ui': patch
+---
+
+Closing an already-closed Menu or Listbox no longer returns Commands. `closeMenu` and `closeListbox` had no open check, so `Closed` on a closed component returned `FocusButton` and focus jumped to a trigger whose panel was never open. A modal Menu or Listbox also returned `UnlockScroll` and `RestoreInert` for a scroll lock and an inert tree it never applied, the same pair leaked when the items container blurred while closed, and an animated component started a leave cascade for a panel that was not showing. Popover and Dialog already treat closing a closed Model as a no-op, and this brings Menu and Listbox in line with them.
+
+An open Menu or Listbox is unchanged. It still returns `FocusButton`, still returns the modal Commands when `isModal` is set, still emits `Selected` on selection, and an animated one still runs its full leave cascade.
+
+`SelectedItem` on a closed Menu or single-select Listbox still emits the `Selected` OutMessage. Selection is independent of the open-state transition: programmatic selection has no open precondition, and multi-select Listbox also emits while closed. This fix changes only the leaked Commands.
+
+Thanks @artile!

--- a/examples/job-application/src/story.test.ts
+++ b/examples/job-application/src/story.test.ts
@@ -175,6 +175,12 @@ describe('update', () => {
         givenInitial,
         message(
           GotStepMenuMessage({
+            message: Menu.Opened({ maybeActiveItemIndex: Option.none() }),
+          }),
+        ),
+        Command.resolve(Menu.FocusItems, Menu.CompletedFocusItems()),
+        message(
+          GotStepMenuMessage({
             message: Menu.SelectedItem({ index: 5, item: 'Attachments' }),
           }),
         ),

--- a/examples/query-sync/src/story.test.ts
+++ b/examples/query-sync/src/story.test.ts
@@ -126,6 +126,12 @@ describe('update', () => {
         given(browseModel),
         message(
           GotDietListboxMessage({
+            message: Listbox.Opened({ maybeActiveItemIndex: Option.none() }),
+          }),
+        ),
+        Command.resolve(Listbox.FocusItems, Listbox.CompletedFocusItems()),
+        message(
+          GotDietListboxMessage({
             message: Listbox.SelectedItem({ item: 'Carnivore' }),
           }),
         ),

--- a/packages/ui/src/listbox/multi.ts
+++ b/packages/ui/src/listbox/multi.ts
@@ -50,8 +50,10 @@ type UpdateReturn = ReturnType<typeof update>
 export const open = (model: Model): UpdateReturn =>
   update(model, Opened({ maybeActiveItemIndex: Option.none() }))
 
-/** Programmatically closes the listbox, updating the model and returning
- *  focus and modal commands. Use this in domain-event handlers to close the listbox. */
+/** Programmatically closes the listbox. If it is open, returns the closed Model
+ *  with focus and modal Commands. If it is already closed, returns the Model
+ *  unchanged with no Commands. Use this in domain-event handlers to close the
+ *  listbox. */
 export const close = (model: Model): UpdateReturn => update(model, Closed())
 
 /** Programmatically activates an item in the multi-select listbox. Emits `Selected({ value })`; the parent toggles the value's membership. */

--- a/packages/ui/src/listbox/shared.ts
+++ b/packages/ui/src/listbox/shared.ts
@@ -494,6 +494,10 @@ export const makeUpdate = <Model extends BaseModel>(
     commands: ReadonlyArray<Command.Command<Message>>,
     maybeOutMessage: Option.Option<OutMessage> = Option.none(),
   ): UpdateReturn => {
+    if (!baseModel.isOpen) {
+      return [baseModel, [], maybeOutMessage]
+    }
+
     const closed = closedModel(baseModel)
 
     if (baseModel.isAnimated) {

--- a/packages/ui/src/listbox/single.test.ts
+++ b/packages/ui/src/listbox/single.test.ts
@@ -231,6 +231,19 @@ describe('Listbox', () => {
           }),
         )
       })
+
+      it('returns no Command and no OutMessage when already closed', () => {
+        Story.story(
+          update,
+          givenClosed,
+          Story.message(Closed()),
+          Story.expectNoOutMessage(),
+          Story.Command.expectNone(),
+          Story.model(model => {
+            expect(model.isOpen).toBe(false)
+          }),
+        )
+      })
     })
 
     describe('BlurredItems', () => {
@@ -549,6 +562,19 @@ describe('Listbox', () => {
           Story.Command.resolve(FocusButton, CompletedFocusButton()),
         )
       })
+
+      it('returns no Command when an item is selected while already closed', () => {
+        Story.story(
+          update,
+          givenClosed,
+          Story.message(SelectedItem({ item: 'apple' })),
+          Story.expectOutMessage(Selected({ value: 'apple' })),
+          Story.Command.expectNone(),
+          Story.model(model => {
+            expect(model.isOpen).toBe(false)
+          }),
+        )
+      })
     })
 
     describe('RequestedItemClick', () => {
@@ -826,6 +852,20 @@ describe('Listbox', () => {
       })
 
       describe('leave flow', () => {
+        it('starts no leave cascade on Closed when already closed', () => {
+          Story.story(
+            update,
+            givenClosedAnimated,
+            Story.message(Closed()),
+            Story.expectNoOutMessage(),
+            Story.Command.expectNone(),
+            Story.model(model => {
+              expect(model.isOpen).toBe(false)
+              expect(model.animation.transitionState).toBe('Idle')
+            }),
+          )
+        })
+
         it('sets LeaveStart on Closed', () => {
           Story.story(
             update,
@@ -1070,6 +1110,19 @@ describe('Listbox', () => {
       )
     })
 
+    it('emits no Commands on Closed when already closed in modal mode', () => {
+      Story.story(
+        update,
+        givenClosedModal,
+        Story.message(Closed()),
+        Story.expectNoOutMessage(),
+        Story.Command.expectNone(),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
     it('emits unlockScroll and restoreInert commands when the items container blurs in modal mode', () => {
       Story.story(
         update,
@@ -1079,6 +1132,19 @@ describe('Listbox', () => {
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedRestoreInert()],
         ),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
+    it('emits no Commands when the items container blurs on a closed listbox in modal mode', () => {
+      Story.story(
+        update,
+        givenClosedModal,
+        Story.message(BlurredItems()),
+        Story.expectNoOutMessage(),
+        Story.Command.expectNone(),
         Story.model(model => {
           expect(model.isOpen).toBe(false)
         }),

--- a/packages/ui/src/listbox/single.ts
+++ b/packages/ui/src/listbox/single.ts
@@ -49,8 +49,10 @@ type UpdateReturn = ReturnType<typeof update>
 export const open = (model: Model): UpdateReturn =>
   update(model, Opened({ maybeActiveItemIndex: Option.none() }))
 
-/** Programmatically closes the listbox, updating the model and returning
- *  focus and modal commands. Use this in domain-event handlers to close the listbox. */
+/** Programmatically closes the listbox. If it is open, returns the closed Model
+ *  with focus and modal Commands. If it is already closed, returns the Model
+ *  unchanged with no Commands. Use this in domain-event handlers to close the
+ *  listbox. */
 export const close = (model: Model): UpdateReturn => update(model, Closed())
 
 /** Programmatically selects an item in the single-select listbox, closing the listbox and emitting a `Selected({ value })` OutMessage. */

--- a/packages/ui/src/menu/index.ts
+++ b/packages/ui/src/menu/index.ts
@@ -495,6 +495,10 @@ export const update = (model: Model, message: Message): UpdateReturn => {
     commands: ReadonlyArray<Command.Command<Message>>,
     maybeOutMessage: Option.Option<OutMessage> = Option.none(),
   ): UpdateReturn => {
+    if (!baseModel.isOpen) {
+      return [baseModel, [], maybeOutMessage]
+    }
+
     const closed = closedModel(baseModel)
 
     if (model.isAnimated) {
@@ -781,8 +785,10 @@ export const PortalMenuBackdrop = Mount.define(
 export const open = (model: Model): UpdateReturn =>
   update(model, Opened({ maybeActiveItemIndex: Option.none() }))
 
-/** Programmatically closes the menu, updating the model and returning
- *  focus and modal commands. Use this in domain-event handlers to close the menu. */
+/** Programmatically closes the menu. If it is open, returns the closed Model
+ *  with focus and modal Commands. If it is already closed, returns the Model
+ *  unchanged with no Commands. Use this in domain-event handlers to close the
+ *  menu. */
 export const close = (model: Model): UpdateReturn => update(model, Closed())
 
 /** Programmatically selects a menu item, closing the menu and returning

--- a/packages/ui/src/menu/story.test.ts
+++ b/packages/ui/src/menu/story.test.ts
@@ -39,6 +39,7 @@ import {
   RestoreInert,
   ScrollIntoView,
   Searched,
+  Selected,
   SelectedItem,
   UnlockScroll,
   buttonId,
@@ -233,6 +234,19 @@ describe('Menu', () => {
               Option.none(),
             )
             expect(model.maybePointerOrigin).toStrictEqual(Option.none())
+          }),
+        )
+      })
+
+      it('returns no Command and no OutMessage when already closed', () => {
+        Story.story(
+          update,
+          givenClosed,
+          Story.message(Closed()),
+          Story.expectNoOutMessage(),
+          Story.Command.expectNone(),
+          Story.model(model => {
+            expect(model.isOpen).toBe(false)
           }),
         )
       })
@@ -739,6 +753,19 @@ describe('Menu', () => {
           }),
         )
       })
+
+      it('returns no Command when an item is selected while already closed', () => {
+        Story.story(
+          update,
+          givenClosed,
+          Story.message(SelectedItem({ index: 2, item: 'item-2' })),
+          Story.expectOutMessage(Selected({ value: 'item-2', index: 2 })),
+          Story.Command.expectNone(),
+          Story.model(model => {
+            expect(model.isOpen).toBe(false)
+          }),
+        )
+      })
     })
 
     describe('RequestedItemClick', () => {
@@ -985,6 +1012,20 @@ describe('Menu', () => {
       })
 
       describe('leave flow', () => {
+        it('starts no leave cascade on Closed when already closed', () => {
+          Story.story(
+            update,
+            givenClosedAnimated,
+            Story.message(Closed()),
+            Story.expectNoOutMessage(),
+            Story.Command.expectNone(),
+            Story.model(model => {
+              expect(model.isOpen).toBe(false)
+              expect(model.animation.transitionState).toBe('Idle')
+            }),
+          )
+        })
+
         it('sets LeaveStart on Closed', () => {
           Story.story(
             update,
@@ -1231,6 +1272,19 @@ describe('Menu', () => {
       )
     })
 
+    it('emits no Commands on Closed when already closed in modal mode', () => {
+      Story.story(
+        update,
+        givenClosedModal,
+        Story.message(Closed()),
+        Story.expectNoOutMessage(),
+        Story.Command.expectNone(),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
     it('emits unlockScroll and restoreInert commands when the items container blurs in modal mode', () => {
       Story.story(
         update,
@@ -1240,6 +1294,19 @@ describe('Menu', () => {
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedRestoreInert()],
         ),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
+    it('emits no Commands when the items container blurs on a closed menu in modal mode', () => {
+      Story.story(
+        update,
+        givenClosedModal,
+        Story.message(BlurredItems()),
+        Story.expectNoOutMessage(),
+        Story.Command.expectNone(),
         Story.model(model => {
           expect(model.isOpen).toBe(false)
         }),


### PR DESCRIPTION
`closeMenu` and `closeListbox` returned their callers' Commands when the Menu
or Listbox was already closed. `Closed` could therefore move focus with
`FocusButton`; modal components also returned `UnlockScroll` and
`RestoreInert` for resources they never acquired, while animated components
started an unnecessary leave flow. `BlurredItems` leaked the same modal
cleanup pair.

Return no Commands from the already-closed path while preserving any
`Selected` OutMessage passed by `SelectedItem`. Programmatic selection has no
open precondition, and multi-select Listbox also emits while closed, so this
fix changes only the leaked Commands. The open path is unchanged: focus
restoration, modal cleanup, animation, and selection emission still run.

Regression stories cover closed, selected, animated, modal, and blur paths for
both Menu and Listbox. The job-application and query-sync stories now open
their component before selecting, so they continue to test the valid
`FocusButton` path.
