### PR TITLE
fix(ui): preserve focus during keyboard drag moves

### DIFF
--- a/.changeset/drag-and-drop-preserve-keyboard-focus.md
+++ b/.changeset/drag-and-drop-preserve-keyboard-focus.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': patch
+---
+
+Preserve focus on a draggable item after each keyboard move. Moving a lifted item re-renders it at its next position and can replace or detach the focused element, which previously left focus on the document body until the drag was dropped or cancelled. DragAndDrop now focuses the item again after resolving every keyboard move, matching its existing drop and cancel behavior.
+
+Thanks @artile!

--- a/examples/kanban/src/story.test.ts
+++ b/examples/kanban/src/story.test.ts
@@ -269,6 +269,10 @@ describe('update', () => {
             }),
           }),
         ),
+        Command.resolve(
+          DragAndDrop.FocusItem({ itemId: firstCardId }),
+          DragAndDrop.CompletedFocusItem(),
+        ),
         message(
           GotDragAndDropMessage({
             message: DragAndDrop.ConfirmedKeyboardDrop(),
@@ -308,6 +312,10 @@ describe('update', () => {
               targetIndex: 0,
             }),
           }),
+        ),
+        Command.resolve(
+          DragAndDrop.FocusItem({ itemId: cardId }),
+          DragAndDrop.CompletedFocusItem(),
         ),
         message(
           GotDragAndDropMessage({

--- a/packages/examples-e2e/e2e/kanban.spec.ts
+++ b/packages/examples-e2e/e2e/kanban.spec.ts
@@ -12,4 +12,18 @@ test.describe('kanban example', () => {
     await page.getByRole('button', { name: '+ Add card' }).first().click()
     await expect(page.getByPlaceholder('Card title...')).toBeVisible()
   })
+
+  test('keyboard dragging preserves focus while moving a card', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    const card = page.locator('[data-draggable-id="card-1"]')
+    await card.focus()
+    await card.press('Space')
+    await page.keyboard.press('Tab')
+    await expect(card).toBeFocused()
+    await page.keyboard.press('ArrowDown')
+    await expect(card).toBeFocused()
+  })
 })

--- a/packages/ui/src/dragAndDrop/index.test.ts
+++ b/packages/ui/src/dragAndDrop/index.test.ts
@@ -529,6 +529,10 @@ describe('DragAndDrop', () => {
             targetIndex: 1,
           }),
         ),
+        Story.Command.resolve(
+          FocusItem({ itemId: 'item-1' }),
+          CompletedFocusItem(),
+        ),
         Story.model(model => {
           expect(model.dragState._tag).toBe('KeyboardDragging')
           if (model.dragState._tag === 'KeyboardDragging') {
@@ -548,6 +552,10 @@ describe('DragAndDrop', () => {
             targetContainerId: 'list-2',
             targetIndex: 3,
           }),
+        ),
+        Story.Command.resolve(
+          FocusItem({ itemId: 'item-1' }),
+          CompletedFocusItem(),
         ),
         Story.model(model => {
           expect(model.dragState._tag).toBe('KeyboardDragging')
@@ -569,6 +577,10 @@ describe('DragAndDrop', () => {
             targetContainerId: 'list-2',
             targetIndex: 1,
           }),
+        ),
+        Story.Command.resolve(
+          FocusItem({ itemId: 'item-1' }),
+          CompletedFocusItem(),
         ),
         Story.message(ConfirmedKeyboardDrop()),
         Story.model(model => {

--- a/packages/ui/src/dragAndDrop/index.ts
+++ b/packages/ui/src/dragAndDrop/index.ts
@@ -198,7 +198,7 @@ export const init = (config: InitConfig): Model => ({
 
 type Direction = (typeof PressedArrowKey.Type)['direction']
 
-/** Focuses a draggable item by ID after keyboard drop or cancel. */
+/** Focuses a draggable item by ID after a keyboard move, drop, or cancel. */
 export const FocusItem = Command.define('FocusItem', {
   args: { itemId: S.String },
   messages: [CompletedFocusItem],
@@ -486,7 +486,7 @@ export const update = (model: Model, message: Message): UpdateReturn =>
                   targetIndex,
                 }),
             }),
-            [],
+            [FocusItem({ itemId: keyboardDragging.itemId })],
             Option.none(),
           ]),
           M.orElse(() => [model, [], Option.none()]),


### PR DESCRIPTION
## Summary

- return `FocusItem` after every resolved keyboard drag move
- resolve the new Command in DragAndDrop and Kanban Story coverage
- verify focus after cross-container and within-container moves in the Kanban browser test

## Why

Moving a lifted item can reparent or reorder its DOM element. The browser then
drops focus to the document body, even though the document-level keyboard
subscription continues the drag. DragAndDrop already restores focus after a
keyboard drop or cancel; restoring it after each move keeps the active card
and the user's keyboard position aligned throughout the drag.

Fixes #918

## Verification

- complete repository pre-push gate
- 888 `@foldkit/ui` tests
- 22 Kanban Story and Scene tests
- Kanban Playwright regression covering Tab and ArrowDown moves
- workspace build, typecheck, test suites, and website smoke test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard drag-and-drop now preserves focus on items after each keyboard move, including moves between columns.
  * Focus remains stable when starting a drag, tabbing, repositioning items, and completing a drop.

* **Tests**
  * Added coverage for focus preservation across keyboard drag-and-drop interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->