### PR TITLE
Document community branding policy

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -1,0 +1,21 @@
+# Foldkit Community Branding
+
+Foldkit wants community projects to feel like part of the same ecosystem. You do not need advance permission to:
+
+- use “Foldkit” in a project name, including names such as `foldkit-*`
+- use the Foldkit logo to show that a project is built for or related to Foldkit, including as part of the project's own branding
+- borrow from the visual style of the Foldkit website
+- describe something as a Foldkit community project
+
+The main boundary is genuine confusion about who is behind a project. Community projects must not present themselves as officially maintained, owned, or endorsed by Foldkit when they are not.
+
+The following are reserved for official Foldkit use unless the maintainers grant permission:
+
+- describing a project as “official”
+- any use of Foldkit branding that misleadingly implies official ownership or endorsement
+
+You are welcome to use the Foldkit logo prominently or incorporate it into your community project's branding. When ownership could reasonably be unclear, include a small note. For example:
+
+> A Foldkit community project by [name].
+
+There is no need for every project to call itself “unofficial.” “Community project” is usually the friendlier and clearer description. If a project's presentation creates genuine confusion about who maintains it, Foldkit may ask for a reasonable clarification.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Some of what you can build with Foldkit. [See all example apps on foldkit.dev](h
 - **[UI Showcase](https://foldkit.dev/example-apps/ui-showcase)**: Interactive showcase of every Foldkit UI component
 - **[Typing Game](packages/typing-game)**: Multiplayer typing game with Effect RPC backend ([play it live](https://typingterminal.com))
 
+## Community Projects
+
+Building something for the Foldkit ecosystem? You're welcome to use the Foldkit name, logo, and visual language without advance permission. See the [community branding guidelines](./BRANDING.md).
+
 ## Development
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the checks, commit conventions, and changeset expectations, and [AGENTS.md](./AGENTS.md) for code style.


### PR DESCRIPTION
## Summary

- add permissive community branding guidelines for the Foldkit name, logo, and visual language
- reserve official claims while using genuine maintainer confusion as the main boundary
- link the policy from the root README without adding a duplicate website page

## Why

Foldkit did not have written guidance for community projects that want to share its name or visual identity. This policy gives builders clear, friendly permission while protecting against misleading claims of official ownership or endorsement.

## Impact

Community builders can name and brand Foldkit-related projects without advance permission. Maintainers have a concise policy to reference when a project's ownership is unclear.

## Validation

- `pnpm format`
- full `pnpm pre-push` suite, including formatting, lint, builds, typechecks, unit tests, and the website Chromium smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added community branding guidelines covering permitted use of the Foldkit name, logo, visual style, and “community project” descriptions.
  * Clarified that official, endorsement, and ownership claims require maintainer permission, with restrictions on misleading branding.
  * Added recommended wording to clearly describe ownership.
  * Updated the README with a Community Projects section linking to the branding guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->