### PR TITLE
fix: make modal overlay lifecycles verifiable

### DIFF
--- a/.changeset/bright-overlays-settle.md
+++ b/.changeset/bright-overlays-settle.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `Story.Command.resolveAllExact` and `Scene.Command.resolveAllExact` for asserting that every expected Command was dispatched while preserving the carry-forward behavior of `resolveAll`. Both batch resolver APIs now type-check each result Message against its Command, so previously accepted mismatched pairs must be corrected. Resolve `Dom.inertOthers` selectors after the pending render commits so portaled modal content remains interactive, and invalidate pending inert work when an overlay closes before that commit.

--- a/.changeset/calm-comboboxes-close.md
+++ b/.changeset/calm-comboboxes-close.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/ui': patch
+---
+
+Release scroll locks and inert page content whenever a modal Combobox closes, while keeping multi-select Comboboxes open and modal after selection.

--- a/packages/foldkit/src/dom/index.test.ts
+++ b/packages/foldkit/src/dom/index.test.ts
@@ -1,8 +1,9 @@
-import { Effect } from 'effect'
+import { Effect, Fiber } from 'effect'
 import { expect, vi } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
+import { RenderCommit, createCommitNotifier } from '../render/commit.js'
 import {
   ElementNotFound,
   closeDialog,
@@ -276,6 +277,88 @@ describe('inertOthers', () => {
       expect(items.inert).toBeFalsy()
 
       yield* restoreInert('test')
+      cleanupDom()
+    }),
+  )
+
+  it.effect('resolves the allowed elements after the render commits', () =>
+    Effect.gen(function* () {
+      const main = document.createElement('main')
+      const button = document.createElement('button')
+      button.id = 'menu-button'
+      main.appendChild(button)
+
+      const portalRoot = document.createElement('div')
+      portalRoot.id = 'portal-root'
+      const footer = document.createElement('footer')
+      document.body.appendChild(main)
+      document.body.appendChild(portalRoot)
+      document.body.appendChild(footer)
+
+      const notifier = createCommitNotifier()
+      notifier.markCommitPending()
+
+      expect(document.querySelector('#menu-items')).toBeNull()
+
+      const fiber = yield* Effect.forkChild(
+        inertOthers('test', ['#menu-button', '#menu-items']).pipe(
+          Effect.provideService(RenderCommit, notifier.service),
+        ),
+        { startImmediately: true },
+      )
+
+      yield* Effect.promise(
+        () =>
+          new Promise<void>(resolve => {
+            queueMicrotask(() => {
+              const items = document.createElement('div')
+              items.id = 'menu-items'
+              portalRoot.appendChild(items)
+              resolve()
+            })
+          }),
+      )
+
+      expect(document.querySelector('#menu-items')).not.toBeNull()
+      expect(fiber.pollUnsafe()).toBeUndefined()
+
+      notifier.notifyCommitted()
+      yield* Fiber.join(fiber)
+
+      expect(portalRoot.inert).toBeFalsy()
+      expect(portalRoot.getAttribute('aria-hidden')).toBeNull()
+      expect(footer.inert).toBe(true)
+      expect(footer.getAttribute('aria-hidden')).toBe('true')
+
+      yield* restoreInert('test')
+      cleanupDom()
+    }),
+  )
+
+  it.effect('stays restored when closed before the render commits', () =>
+    Effect.gen(function* () {
+      const { header, footer } = buildDom()
+      const notifier = createCommitNotifier()
+      notifier.markCommitPending()
+
+      const fiber = yield* Effect.forkChild(
+        inertOthers('test', ['#menu-button', '#menu-items']).pipe(
+          Effect.provideService(RenderCommit, notifier.service),
+        ),
+        { startImmediately: true },
+      )
+
+      expect(fiber.pollUnsafe()).toBeUndefined()
+
+      yield* restoreInert('test')
+      notifier.notifyCommitted()
+      yield* Fiber.join(fiber)
+
+      expect(header.inert).toBeFalsy()
+      expect(header.getAttribute('aria-hidden')).toBeNull()
+      expect(footer.inert).toBeFalsy()
+      expect(footer.getAttribute('aria-hidden')).toBeNull()
+
       cleanupDom()
     }),
   )

--- a/packages/foldkit/src/dom/inert.ts
+++ b/packages/foldkit/src/dom/inert.ts
@@ -1,5 +1,7 @@
 import { Array, Effect, Number, Option, Predicate, Result, pipe } from 'effect'
 
+import { afterCommit } from '../render/render.js'
+
 const inertState = {
   originals: new Map<
     HTMLElement,
@@ -7,6 +9,7 @@ const inertState = {
   >(),
   counts: new Map<HTMLElement, number>(),
   cleanups: new Map<string, ReadonlyArray<() => void>>(),
+  requests: new Map<string, symbol>(),
 }
 
 const markInert = (element: HTMLElement): (() => void) => {
@@ -89,7 +92,8 @@ const inertableSiblings = (
  * Marks all DOM elements outside the given selectors as `inert` and
  * `aria-hidden="true"`. Walks each allowed element up to `document.body`,
  * marking siblings that don't contain an allowed element. Uses reference
- * counting so nested calls are safe.
+ * counting so nested calls are safe. A restore before the pending render
+ * commits invalidates the request before it can change the DOM.
  *
  * @example
  * ```typescript
@@ -100,7 +104,19 @@ export const inertOthers = (
   id: string,
   allowedSelectors: ReadonlyArray<string>,
 ): Effect.Effect<void> =>
-  Effect.sync(() => {
+  Effect.gen(function* () {
+    const request = yield* Effect.sync(() => {
+      const nextRequest = Symbol()
+      inertState.requests.set(id, nextRequest)
+      return nextRequest
+    })
+
+    yield* afterCommit
+
+    if (inertState.requests.get(id) !== request) {
+      return
+    }
+
     const allowedElements = resolveElements(allowedSelectors)
 
     const cleanupFunctions = pipe(
@@ -126,6 +142,8 @@ export const inertOthers = (
  */
 export const restoreInert = (id: string): Effect.Effect<void> =>
   Effect.sync(() => {
+    inertState.requests.delete(id)
+
     const cleanupFunctions = inertState.cleanups.get(id)
 
     if (cleanupFunctions) {

--- a/packages/foldkit/src/test/apps/formChild.ts
+++ b/packages/foldkit/src/test/apps/formChild.ts
@@ -13,13 +13,13 @@ export type ChildModel = typeof ChildModel.Type
 // CHILD MESSAGE
 
 export const SubmittedForm = m('SubmittedForm')
-export const SucceededSubmit = m('SucceededSubmit', { id: S.String })
+export const SucceededSubmitForm = m('SucceededSubmitForm', { id: S.String })
 export const CancelledForm = m('CancelledForm')
 export const CompletedResetForm = m('CompletedResetForm')
 
 export const ChildMessage = S.Union([
   SubmittedForm,
-  SucceededSubmit,
+  SucceededSubmitForm,
   CancelledForm,
   CompletedResetForm,
 ])
@@ -36,8 +36,8 @@ export type ChildOutMessage = typeof ChildOutMessage.Type
 // CHILD COMMAND
 
 export const SubmitForm = Command.define('SubmitForm', {
-  messages: [SucceededSubmit],
-  execute: Effect.sync(() => SucceededSubmit({ id: 'abc' })),
+  messages: [SucceededSubmitForm],
+  execute: Effect.sync(() => SucceededSubmitForm({ id: 'abc' })),
 })
 
 export const ResetForm = Command.define('ResetForm', {
@@ -73,7 +73,7 @@ export const childUpdate = (
         [SubmitForm()],
         Option.none(),
       ],
-      SucceededSubmit: ({ id }) => [
+      SucceededSubmitForm: ({ id }) => [
         { status: 'Submitted' },
         [ResetForm()],
         Option.some(RequestedSave({ id })),

--- a/packages/foldkit/src/test/internal.ts
+++ b/packages/foldkit/src/test/internal.ts
@@ -1,9 +1,11 @@
 import { Array, Equal, Option, Order, Predicate, pipe } from 'effect'
+import type { Effect } from 'effect'
 
 import {
   type CommandDefinition,
   CommandDefinitionTypeId,
 } from '../command/index.js'
+import type * as Interruptible from '../command/interruptible/index.js'
 import { type MountDefinition, MountDefinitionTypeId } from '../mount/index.js'
 
 /** A Command in a test simulation. Carries `name` and optionally the `args`
@@ -42,6 +44,44 @@ export type AnyCommand = Readonly<{
  *  test is verifying, the right assertion is usually against the Model that
  *  the Command's result fed through update, not a partial Command shape. */
 export type CommandMatcher = CommandDefinition<string, unknown> | AnyCommand
+
+/** A typed Command instance carrying the result Message type through its
+ * `effect` field. */
+export type AnyCommandInstance<ResultMessage = unknown> = Readonly<{
+  name: string
+  args?: Record<string, unknown>
+  effect: Effect.Effect<ResultMessage, any, any>
+}>
+
+/** A Command Definition whose result Message can be supplied by Story and
+ * Scene resolution APIs. */
+export type ResolvableCommandDefinition<Name extends string, ResultMessage> =
+  | CommandDefinition<Name, ResultMessage>
+  | Interruptible.DefinitionNoArgs<Name, Effect.Effect<ResultMessage, any, any>>
+  | Interruptible.DefinitionWithArgs<
+      Name,
+      any,
+      any,
+      Effect.Effect<ResultMessage, any, any>
+    >
+  | Interruptible.DefinitionWithArgsNameKeyed<
+      Name,
+      any,
+      Effect.Effect<ResultMessage, any, any>
+    >
+
+/** A Definition or Command instance accepted by Story and Scene resolution
+ * APIs. */
+export type ResolvableCommandMatcher =
+  | ResolvableCommandDefinition<string, unknown>
+  | AnyCommandInstance<unknown>
+
+type ResultMessageForMatcher<Matcher extends ResolvableCommandMatcher> =
+  Matcher extends ResolvableCommandDefinition<string, infer ResultMessage>
+    ? ResultMessage
+    : Matcher extends AnyCommandInstance<infer ResultMessage>
+      ? ResultMessage
+      : never
 
 const isCommandDefinitionMatcher = (
   matcher: CommandMatcher,
@@ -136,11 +176,10 @@ type UpdateResult<Model, OutMessage> =
  *  name; an Instance matcher resolves only the pending Command whose name AND
  *  args match. The matched Command's own message-mapping chain is applied to
  *  the result, so pass the child's raw result Message, not a parent-wrapped
- *  one. */
-export type Resolver<ResultMessage = unknown> = readonly [
-  CommandMatcher,
-  ResultMessage,
-]
+ *  one. The result Message must belong to the matched Command. */
+export type Resolver<
+  Matcher extends ResolvableCommandMatcher = ResolvableCommandMatcher,
+> = readonly [Matcher, ResultMessageForMatcher<Matcher>]
 
 /** A Mount matcher (Definition or Instance) paired with the raw result Message
  *  to resolve it with. Mirrors `Resolver` for Commands. When the mount lives
@@ -161,6 +200,11 @@ export type MountResolver<ResultMessage = unknown> = readonly [
 export type ResolverEntry = Readonly<{
   matcher: CommandMatcher
   resultMessage: unknown
+}>
+
+type MatchedResolver = Readonly<{
+  entry: ResolverEntry
+  resolverIndex: number
 }>
 
 /** Base shape of an internal simulation — shared between Story and Scene. */
@@ -207,11 +251,11 @@ const foldMessageMappers = (
  *  chain to `resultMessage` first. Returns `undefined` when no pending Command
  *  matches. Definition matchers match by name; Instance matchers match by
  *  name + args. */
-export const resolveByMatcher = <Model, Message>(
-  internal: BaseInternal<Model, Message, unknown>,
+export const resolveByMatcher = <Model, Message, OutMessage>(
+  internal: BaseInternal<Model, Message, OutMessage>,
   matcher: CommandMatcher,
   resultMessage: unknown,
-): BaseInternal<Model, Message, unknown> | undefined =>
+): BaseInternal<Model, Message, OutMessage> | undefined =>
   pipe(
     internal.commands,
     Array.findFirstIndex(command => commandMatches(matcher, command)),
@@ -260,6 +304,24 @@ const matcherFingerprint = (matcher: CommandMatcher): string =>
     ? `def:${matcher.name}`
     : `inst:${matcher.name}:${JSON.stringify(matcher.args ?? null)}`
 
+const findNextMatch = (
+  commands: ReadonlyArray<AnyCommand>,
+  resolvers: ReadonlyArray<ResolverEntry>,
+): Option.Option<MatchedResolver> => {
+  const toMatchedResolver = (
+    command: AnyCommand,
+  ): Option.Option<MatchedResolver> =>
+    pipe(
+      resolvers,
+      Array.findFirstWithIndex(({ matcher }) =>
+        commandMatches(matcher, command),
+      ),
+      Option.map(([entry, resolverIndex]) => ({ entry, resolverIndex })),
+    )
+
+  return Array.findFirst(commands, toMatchedResolver)
+}
+
 /** Resolves all listed Commands, cascading through any Commands produced by
  *  the result. Each entry is consumed by exactly one matching dispatch in
  *  declaration order; for N identical responses, compose with
@@ -288,25 +350,8 @@ export const resolveAllInternal = <Model, Message, OutMessage>(
     resolvers: [...survivingExisting, ...newEntries],
   } as BaseInternal<Model, Message, unknown>
 
-  const findNextMatch = (
-    state: BaseInternal<Model, Message, unknown>,
-  ): Option.Option<{ entry: ResolverEntry; resolverIndex: number }> =>
-    Array.findFirst(state.commands, command =>
-      pipe(
-        state.resolvers,
-        Array.findFirstIndex(({ matcher }) => commandMatches(matcher, command)),
-        Option.flatMap(resolverIndex =>
-          pipe(
-            state.resolvers,
-            Array.get(resolverIndex),
-            Option.map(entry => ({ entry, resolverIndex })),
-          ),
-        ),
-      ),
-    )
-
   for (let depth = 0; depth < MAX_CASCADE_DEPTH; depth++) {
-    const matched = findNextMatch(current)
+    const matched = findNextMatch(current.commands, current.resolvers)
 
     if (Option.isNone(matched)) {
       break
@@ -337,6 +382,64 @@ export const resolveAllInternal = <Model, Message, OutMessage>(
 
   return current as BaseInternal<Model, Message, OutMessage>
   /* eslint-enable @typescript-eslint/consistent-type-assertions */
+}
+
+/** Resolves only the listed Command resolvers, cascading through result
+ *  Messages, and throws unless every resolver matches one dispatched Command.
+ *  Unlike `resolveAllInternal`, unmatched entries never carry forward. */
+export const resolveAllExactInternal = <Model, Message, OutMessage>(
+  internal: BaseInternal<Model, Message, OutMessage>,
+  resolvers: ReadonlyArray<Resolver>,
+): BaseInternal<Model, Message, OutMessage> => {
+  let remainingResolvers: ReadonlyArray<ResolverEntry> = Array.map(
+    resolvers,
+    ([matcher, resultMessage]) => ({ matcher, resultMessage }),
+  )
+
+  let current = internal
+
+  for (let depth = 0; depth < MAX_CASCADE_DEPTH; depth++) {
+    const matched = findNextMatch(current.commands, remainingResolvers)
+
+    if (Option.isNone(matched)) {
+      break
+    }
+
+    const next = resolveByMatcher(
+      current,
+      matched.value.entry.matcher,
+      matched.value.entry.resultMessage,
+    )
+
+    if (Predicate.isUndefined(next)) {
+      break
+    }
+
+    current = next
+    remainingResolvers = Array.remove(
+      remainingResolvers,
+      matched.value.resolverIndex,
+    )
+
+    if (depth === MAX_CASCADE_DEPTH - 1) {
+      throw new Error(
+        'resolveAllExact hit the maximum cascade depth (100). ' +
+          'This usually means Commands are producing Commands in an infinite cycle.',
+      )
+    }
+  }
+
+  if (Array.isReadonlyArrayNonEmpty(remainingResolvers)) {
+    throw new Error(
+      `resolveAllExact expected Commands that were not dispatched:\n\n${formatMatcherList(
+        Array.map(remainingResolvers, ({ matcher }) => matcher),
+      )}\n\nPending Commands after resolving matches:\n\n${formatCommandList(current.commands)}`,
+    )
+  }
+
+  assertAllCommandsResolved(current.commands)
+
+  return current
 }
 
 const formatCommandList = (commands: ReadonlyArray<AnyCommand>): string =>

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -2287,6 +2287,11 @@ describe('scene errors', () => {
 })
 
 describe('scene with resolveAll', () => {
+  test('requires each result Message to belong to its Command', () => {
+    // @ts-expect-error CompletedAction is not an Authenticate result Message
+    Scene.Command.resolveAll([Authenticate, CompletedAction()])
+  })
+
   test('resolveAll works in scene context', () => {
     Scene.scene(
       { update, view },
@@ -2297,6 +2302,43 @@ describe('scene with resolveAll', () => {
         SucceededAuthenticate({ username: 'bob' }),
       ]),
       Scene.expect(Scene.role('status')).toHaveText('Welcome, bob!'),
+    )
+  })
+})
+
+describe('scene with resolveAllExact', () => {
+  test('requires each result Message to belong to its Command', () => {
+    // @ts-expect-error CompletedAction is not an Authenticate result Message
+    Scene.Command.resolveAllExact([Authenticate, CompletedAction()])
+  })
+
+  test('resolveAllExact works in scene context', () => {
+    Scene.scene(
+      { update, view },
+      Scene.given(initialModel),
+      Scene.submit(Scene.role('form')),
+      Scene.Command.resolveAllExact([
+        Authenticate,
+        SucceededAuthenticate({ username: 'bob' }),
+      ]),
+      Scene.expect(Scene.role('status')).toHaveText('Welcome, bob!'),
+    )
+  })
+
+  test('resolveAllExact rejects an unmatched expected Command', () => {
+    expect(() =>
+      Scene.scene(
+        { update, view },
+        Scene.given(initialModel),
+        Scene.submit(Scene.role('form')),
+        Scene.Command.resolveAllExact(
+          [Authenticate, SucceededAuthenticate({ username: 'bob' })],
+          [FetchCount, SucceededFetchCount({ count: 1 })],
+        ),
+      ),
+    ).toThrow(
+      'resolveAllExact expected Commands that were not dispatched:\n\n' +
+        '    FetchCount',
     )
   })
 })

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -12,8 +12,6 @@ import {
 } from 'effect'
 import { dual } from 'effect/Function'
 
-import type { CommandDefinition } from '../command/index.js'
-import type * as Interruptible from '../command/interruptible/index.js'
 import { kebabToPascal } from '../customElement/index.js'
 import type { CustomElementSpec } from '../customElement/index.js'
 import type { File } from '../file/index.js'
@@ -38,12 +36,15 @@ import { Dispatch } from '../runtime/index.js'
 import type { VNode } from '../vdom.js'
 import type {
   AnyCommand,
+  AnyCommandInstance,
   AnyMount,
   BaseInternal,
   CommandMatcher,
   MountMatcher,
   MountResolver,
   PendingMount,
+  ResolvableCommandDefinition,
+  ResolvableCommandMatcher,
   Resolver,
   ResolverEntry,
 } from './internal.js'
@@ -66,6 +67,7 @@ import {
   formatMountList,
   formatMountMatcher,
   mountMatches,
+  resolveAllExactInternal,
   resolveAllInternal,
   resolveByMatcher,
   resolveMountByMatcher,
@@ -231,35 +233,6 @@ type InternalSceneSimulation<
     scope: Option.Option<Locator>
     mountSlots: ReadonlyArray<MountSlotState>
   }>
-
-/** A typed Command instance carrying the result Message type via its
- *  `effect` field, so passing `FetchWeather({ zipCode })` to `Scene.Command.resolve`
- *  preserves the link between the Command and its declared result Message. */
-type SceneCommandInstance<ResultMessage = unknown> = Readonly<{
-  name: string
-  args?: Record<string, unknown>
-  effect: Effect.Effect<ResultMessage, any, any>
-}>
-
-/** A Command Definition accepted by `Scene.Command.resolve` as a name matcher:
- *  a plain `Command.define` Definition or an interruptible
- *  interruptible `Command.define` Definition. Both carry the
- *  `CommandDefinitionTypeId` brand and match by name at runtime, so `resolve`
- *  accepts either, the way `expectHas`/`expectExact` already do. */
-type ResolvableCommandDefinition<Name extends string, ResultMessage> =
-  | CommandDefinition<Name, ResultMessage>
-  | Interruptible.DefinitionNoArgs<Name, Effect.Effect<ResultMessage, any, any>>
-  | Interruptible.DefinitionWithArgs<
-      Name,
-      any,
-      any,
-      Effect.Effect<ResultMessage, any, any>
-    >
-  | Interruptible.DefinitionWithArgsNameKeyed<
-      Name,
-      any,
-      Effect.Effect<ResultMessage, any, any>
-    >
 
 const slotKey = ({ name, occurrence }: PendingMount): string =>
   `${name}#${occurrence}`
@@ -669,7 +642,7 @@ const resolveCommand: {
     simulation: SceneSimulation<Model, Message, OutMessage>,
   ) => SceneSimulation<Model, Message, OutMessage>
   <ResultMessage>(
-    instance: SceneCommandInstance<ResultMessage>,
+    instance: AnyCommandInstance<ResultMessage>,
     resultMessage: ResultMessage,
   ): <Model, Message, OutMessage = undefined>(
     simulation: SceneSimulation<Model, Message, OutMessage>,
@@ -679,14 +652,9 @@ const resolveCommand: {
   <Model, Message, OutMessage = undefined>(
     simulation: SceneSimulation<Model, Message, OutMessage>,
   ): SceneSimulation<Model, Message, OutMessage> => {
-    /* eslint-disable @typescript-eslint/consistent-type-assertions */
     const internal = toInternal(simulation)
     assertResolveUnambiguous(internal.commands, matcher)
-    const next = resolveByMatcher(
-      internal as BaseInternal<Model, Message, unknown>,
-      matcher,
-      resultMessage,
-    )
+    const next = resolveByMatcher(internal, matcher, resultMessage)
 
     if (Predicate.isUndefined(next)) {
       const pending = Array.match(internal.commands, {
@@ -705,8 +673,7 @@ const resolveCommand: {
       )
     }
 
-    return next as unknown as SceneSimulation<Model, Message, OutMessage>
-    /* eslint-enable @typescript-eslint/consistent-type-assertions */
+    return { ...internal, ...next }
   }
 
 /** Resolves listed Commands with their result Messages, cascading through any
@@ -719,8 +686,8 @@ const resolveCommand: {
  *  entry replaces any leftover resolvers sharing its Definition or Instance
  *  shape (latest wins). */
 const resolveAllCommands =
-  <R extends ReadonlyArray<unknown>>(
-    ...resolvers: { [K in keyof R]: Resolver<R[K]> }
+  <Matchers extends ReadonlyArray<ResolvableCommandMatcher>>(
+    ...resolvers: { [K in keyof Matchers]: Resolver<Matchers[K]> }
   ) =>
   <Model, Message, OutMessage = undefined>(
     simulation: SceneSimulation<Model, Message, OutMessage>,
@@ -730,6 +697,22 @@ const resolveAllCommands =
       toInternal(simulation),
       resolvers,
     ) as unknown as SceneSimulation<Model, Message, OutMessage>
+
+/** Resolves listed Commands with their result Messages, cascading through any
+ *  Commands the results produce. Every resolver must match one dispatch in
+ *  this call, and no actual Commands may remain unresolved. Supplied resolvers
+ *  do not carry forward. */
+const resolveAllExactCommands =
+  <Matchers extends ReadonlyArray<ResolvableCommandMatcher>>(
+    ...resolvers: { [K in keyof Matchers]: Resolver<Matchers[K]> }
+  ) =>
+  <Model, Message, OutMessage = undefined>(
+    simulation: SceneSimulation<Model, Message, OutMessage>,
+  ): SceneSimulation<Model, Message, OutMessage> => {
+    const internal = toInternal(simulation)
+    const next = resolveAllExactInternal(internal, resolvers)
+    return { ...internal, ...next }
+  }
 
 /** Asserts that every given matcher matches a pending Command. Definition
  *  matchers match by name only; Instance matchers match by name + args. */
@@ -1182,6 +1165,10 @@ export const Command = {
    *  identical responses. Resolvers carry across calls; a new entry replaces
    *  any leftovers sharing its Definition or Instance shape (latest wins). */
   resolveAll: resolveAllCommands,
+  /** Resolves listed Commands and throws unless every resolver matches one
+   *  dispatch and no actual Commands remain unresolved. Entries apply only to
+   *  this call and never carry forward. */
+  resolveAllExact: resolveAllExactCommands,
   /** Asserts that every given Command is among the pending Commands. */
   expectHas: expectHasCommandsStep,
   /** Asserts that the pending Commands match the given definitions exactly (order-independent). */

--- a/packages/foldkit/src/test/story.test.ts
+++ b/packages/foldkit/src/test/story.test.ts
@@ -31,7 +31,7 @@ import {
   ResetForm,
   SubmitForm,
   SubmittedForm,
-  SucceededSubmit,
+  SucceededSubmitForm,
   childUpdate,
   initialParentModel,
   parentUpdate,
@@ -100,7 +100,7 @@ describe('resolve', () => {
         update,
         Story.given({ count: 0, log: [] }),
         Story.message(ClickedFetch()),
-        Story.Command.resolve(SubmitForm, SucceededSubmit({ id: 'abc' })),
+        Story.Command.resolve(SubmitForm, SucceededSubmitForm({ id: 'abc' })),
       ),
     ).toThrow(
       'I tried to resolve "SubmitForm" but no matching pending Command was found',
@@ -174,7 +174,7 @@ describe('resolveAll', () => {
       Story.given({ status: 'Idle' }),
       Story.message(SubmittedForm()),
       Story.Command.resolveAll(
-        [SubmitForm, SucceededSubmit({ id: 'abc' })],
+        [SubmitForm, SucceededSubmitForm({ id: 'abc' })],
         [ResetForm, CompletedResetForm()],
       ),
       Story.model(model => {
@@ -316,6 +316,99 @@ describe('resolveAll', () => {
         expect(model.log).toEqual([7])
       }),
     )
+  })
+
+  test('requires each result Message to belong to its Command', () => {
+    // @ts-expect-error CompletedResetForm is not a FetchCount result Message
+    Story.Command.resolveAll([FetchCount, CompletedResetForm()])
+  })
+})
+
+describe('resolveAllExact', () => {
+  test('requires each result Message to belong to its Command', () => {
+    // @ts-expect-error CompletedResetForm is not a FetchCount result Message
+    Story.Command.resolveAllExact([FetchCount, CompletedResetForm()])
+  })
+
+  test('resolves cascading Commands', () => {
+    Story.story(
+      childUpdate,
+      Story.given({ status: 'Idle' }),
+      Story.message(SubmittedForm()),
+      Story.Command.resolveAllExact(
+        [SubmitForm, SucceededSubmitForm({ id: 'abc' })],
+        [ResetForm, CompletedResetForm()],
+      ),
+      Story.model(model => {
+        expect(model.status).toBe('Idle')
+      }),
+    )
+  })
+
+  test('resolves repeated Definition entries in declaration order', () => {
+    Story.story(
+      update,
+      Story.given({ count: 0, log: [] }),
+      Story.message(StartedThreeFetches()),
+      Story.Command.resolveAllExact(
+        [FetchCount, SucceededFetchCount({ count: 1 })],
+        [FetchCount, SucceededFetchCount({ count: 2 })],
+        [FetchCount, SucceededFetchCount({ count: 3 })],
+      ),
+      Story.model(model => {
+        expect(model.log).toEqual([1, 2, 3])
+      }),
+    )
+  })
+
+  test('throws with every expected Command that was not dispatched', () => {
+    expect(() =>
+      Story.story(
+        update,
+        Story.given({ count: 0, log: [] }),
+        Story.message(ClickedFetch()),
+        Story.Command.resolveAllExact(
+          [FetchCount, SucceededFetchCount({ count: 1 })],
+          [SubmitForm, SucceededSubmitForm({ id: 'abc' })],
+          [ResetForm, CompletedResetForm()],
+        ),
+      ),
+    ).toThrow(
+      'resolveAllExact expected Commands that were not dispatched:\n\n' +
+        '    SubmitForm\n' +
+        '    ResetForm',
+    )
+  })
+
+  test('throws when repeated entries outnumber matching dispatches', () => {
+    expect(() =>
+      Story.story(
+        update,
+        Story.given({ count: 0, log: [] }),
+        Story.message(ClickedFetch()),
+        Story.Command.resolveAllExact(
+          [FetchCount, SucceededFetchCount({ count: 1 })],
+          [FetchCount, SucceededFetchCount({ count: 2 })],
+        ),
+      ),
+    ).toThrow(
+      'resolveAllExact expected Commands that were not dispatched:\n\n' +
+        '    FetchCount',
+    )
+  })
+
+  test('retains the unresolved actual Command failure', () => {
+    expect(() =>
+      Story.story(
+        update,
+        Story.given({ count: 0, log: [] }),
+        Story.message(StartedThreeFetches()),
+        Story.Command.resolveAllExact(
+          [FetchCount, SucceededFetchCount({ count: 1 })],
+          [FetchCount, SucceededFetchCount({ count: 2 })],
+        ),
+      ),
+    ).toThrow('I found Commands without resolvers:\n\n    FetchCount')
   })
 })
 
@@ -674,7 +767,7 @@ describe('outMessage', () => {
       Story.given({ status: 'Idle' }),
       Story.message(SubmittedForm()),
       Story.expectNoOutMessage(),
-      Story.Command.resolve(SubmitForm, SucceededSubmit({ id: 'abc' })),
+      Story.Command.resolve(SubmitForm, SucceededSubmitForm({ id: 'abc' })),
       Story.expectOutMessage(RequestedSave({ id: 'abc' })),
       Story.Command.resolve(ResetForm, CompletedResetForm()),
       Story.expectNoOutMessage(),
@@ -701,7 +794,7 @@ describe("resolve applies the Command's own message mapping", () => {
         expect(model.child.status).toBe('Submitting')
       }),
       Story.Command.expectHas(SubmitForm),
-      Story.Command.resolve(SubmitForm, SucceededSubmit({ id: 'abc' })),
+      Story.Command.resolve(SubmitForm, SucceededSubmitForm({ id: 'abc' })),
       Story.model(model => {
         expect(model.child.status).toBe('Submitted')
         expect(model.savedIds).toEqual(['abc'])
@@ -725,7 +818,7 @@ describe("resolveAll applies each Command's own message mapping", () => {
         expect(model.child.status).toBe('Submitting')
       }),
       Story.Command.resolveAll(
-        [SubmitForm, SucceededSubmit({ id: 'abc' })],
+        [SubmitForm, SucceededSubmitForm({ id: 'abc' })],
         [ResetForm, CompletedResetForm()],
       ),
       Story.model(model => {

--- a/packages/foldkit/src/test/story.ts
+++ b/packages/foldkit/src/test/story.ts
@@ -1,11 +1,11 @@
-import { Array, Effect, Equal, Option, Predicate, pipe } from 'effect'
+import { Array, Equal, Option, Predicate, pipe } from 'effect'
 
-import type { CommandDefinition } from '../command/index.js'
-import type * as Interruptible from '../command/interruptible/index.js'
 import type {
   AnyCommand,
-  BaseInternal,
+  AnyCommandInstance,
   CommandMatcher,
+  ResolvableCommandDefinition,
+  ResolvableCommandMatcher,
   Resolver,
   ResolverEntry,
 } from './internal.js'
@@ -18,40 +18,12 @@ import {
   assertZeroCommands,
   formatCommand,
   formatMatcher,
+  resolveAllExactInternal,
   resolveAllInternal,
   resolveByMatcher,
 } from './internal.js'
 
 export type { AnyCommand, CommandMatcher, Resolver }
-
-/** A typed Command instance carrying the result Message type via its
- *  `effect` field, so passing `FetchWeather({ zipCode })` to `Story.Command.resolve`
- *  preserves the link between the Command and its declared result Message. */
-type AnyCommandInstance<ResultMessage = unknown> = Readonly<{
-  name: string
-  args?: Record<string, unknown>
-  effect: Effect.Effect<ResultMessage, any, any>
-}>
-
-/** A Command Definition accepted by `Story.Command.resolve` as a name matcher:
- *  a plain `Command.define` Definition or an interruptible
- *  interruptible `Command.define` Definition. Both carry the
- *  `CommandDefinitionTypeId` brand and match by name at runtime, so `resolve`
- *  accepts either, the way `expectHas`/`expectExact` already do. */
-type ResolvableCommandDefinition<Name extends string, ResultMessage> =
-  | CommandDefinition<Name, ResultMessage>
-  | Interruptible.DefinitionNoArgs<Name, Effect.Effect<ResultMessage, any, any>>
-  | Interruptible.DefinitionWithArgs<
-      Name,
-      any,
-      any,
-      Effect.Effect<ResultMessage, any, any>
-    >
-  | Interruptible.DefinitionWithArgsNameKeyed<
-      Name,
-      any,
-      Effect.Effect<ResultMessage, any, any>
-    >
 
 /** An immutable test simulation of a Foldkit program. */
 export type StorySimulation<Model, Message, OutMessage = undefined> = Readonly<{
@@ -178,14 +150,9 @@ const resolveCommand: {
   <Model, Message, OutMessage = undefined>(
     simulation: StorySimulation<Model, Message, OutMessage>,
   ): StorySimulation<Model, Message, OutMessage> => {
-    /* eslint-disable @typescript-eslint/consistent-type-assertions */
     const internal = toInternal(simulation)
     assertResolveUnambiguous(internal.commands, matcher)
-    const next = resolveByMatcher(
-      internal as BaseInternal<Model, Message, unknown>,
-      matcher,
-      resultMessage,
-    )
+    const next = resolveByMatcher(internal, matcher, resultMessage)
 
     if (Predicate.isUndefined(next)) {
       const pending = Array.match(internal.commands, {
@@ -204,8 +171,7 @@ const resolveCommand: {
       )
     }
 
-    return next as StorySimulation<Model, Message, OutMessage>
-    /* eslint-enable @typescript-eslint/consistent-type-assertions */
+    return next
   }
 
 /** Resolves listed Commands with their result Messages, cascading through any
@@ -218,8 +184,8 @@ const resolveCommand: {
  *  entry replaces any leftover resolvers sharing its Definition or Instance
  *  shape (latest wins). */
 const resolveAllCommands =
-  <R extends ReadonlyArray<unknown>>(
-    ...resolvers: { [K in keyof R]: Resolver<R[K]> }
+  <Matchers extends ReadonlyArray<ResolvableCommandMatcher>>(
+    ...resolvers: { [K in keyof Matchers]: Resolver<Matchers[K]> }
   ) =>
   <Model, Message, OutMessage = undefined>(
     simulation: StorySimulation<Model, Message, OutMessage>,
@@ -230,6 +196,19 @@ const resolveAllCommands =
       Message,
       OutMessage
     >
+
+/** Resolves listed Commands with their result Messages, cascading through any
+ *  Commands the results produce. Every resolver must match one dispatch in
+ *  this call, and no actual Commands may remain unresolved. Supplied resolvers
+ *  do not carry forward. */
+const resolveAllExactCommands =
+  <Matchers extends ReadonlyArray<ResolvableCommandMatcher>>(
+    ...resolvers: { [K in keyof Matchers]: Resolver<Matchers[K]> }
+  ) =>
+  <Model, Message, OutMessage = undefined>(
+    simulation: StorySimulation<Model, Message, OutMessage>,
+  ): StorySimulation<Model, Message, OutMessage> =>
+    resolveAllExactInternal(toInternal(simulation), resolvers)
 
 /** Runs an assertion function against the current Model. */
 export const model = <Model>(f: (model: Model) => void): ModelStep<Model> => ({
@@ -283,6 +262,10 @@ export const Command = {
    *  identical responses. Resolvers carry across calls; a new entry replaces
    *  any leftovers sharing its Definition or Instance shape (latest wins). */
   resolveAll: resolveAllCommands,
+  /** Resolves listed Commands and throws unless every resolver matches one
+   *  dispatch and no actual Commands remain unresolved. Entries apply only to
+   *  this call and never carry forward. */
+  resolveAllExact: resolveAllExactCommands,
   /** Asserts that every given Command is among the pending Commands. */
   expectHas: expectHasCommandsStep,
   /** Asserts that the pending Commands match the given definitions exactly (order-independent). */

--- a/packages/ui/src/combobox/multi.test.ts
+++ b/packages/ui/src/combobox/multi.test.ts
@@ -16,15 +16,23 @@ import {
   Closed,
   CompletedAnchorCombobox,
   CompletedFocusInput,
+  CompletedInertOthers,
+  CompletedLockScroll,
   CompletedPortalComboboxBackdrop,
+  CompletedRestoreInert,
   CompletedScrollIntoView,
+  CompletedUnlockScroll,
   FocusInput,
+  InertOthers,
+  LockScroll,
   type Message,
   Opened,
   PortalComboboxBackdrop,
+  RestoreInert,
   ScrollIntoView,
   Selected,
   SelectedItem,
+  UnlockScroll,
   inputId,
 } from './shared.js'
 
@@ -255,6 +263,52 @@ describe('Combobox.Multi', () => {
           }),
         )
       })
+    })
+  })
+
+  describe('modal commands', () => {
+    const givenOpenModal = flow(
+      Story.given(init({ id: 'test', isModal: true })),
+      Story.message(Opened({ maybeActiveItemIndex: Option.some(0) })),
+      Story.Command.resolveAllExact(
+        [LockScroll, CompletedLockScroll()],
+        [InertOthers, CompletedInertOthers()],
+      ),
+    )
+
+    it('unwinds modal commands when closed', () => {
+      Story.story(
+        update,
+        givenOpenModal,
+        Story.message(Closed({ restingInputValue: '' })),
+        Story.Command.resolveAllExact(
+          [FocusInput, CompletedFocusInput()],
+          [UnlockScroll, CompletedUnlockScroll()],
+          [RestoreInert, CompletedRestoreInert()],
+        ),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
+    it('stays open without unwinding modal commands after selection', () => {
+      Story.story(
+        update,
+        givenOpenModal,
+        Story.message(
+          SelectedItem({
+            item: 'apple',
+            displayText: 'Apple',
+            wasSelected: false,
+          }),
+        ),
+        Story.Command.expectNone(),
+        Story.model(model => {
+          expect(model.isOpen).toBe(true)
+        }),
+        Story.expectOutMessage(Selected({ value: 'apple' })),
+      )
     })
   })
 

--- a/packages/ui/src/combobox/shared.ts
+++ b/packages/ui/src/combobox/shared.ts
@@ -301,11 +301,15 @@ export const closedBaseModel = <Model extends BaseModel>(model: Model): Model =>
 
 // UPDATE FACTORY
 
-/** Context passed to the `handleSelectedItem` handler with commands for focus management and modal cleanup. */
-export type SelectedItemContext = Readonly<{
-  focusInput: Command.Command<Message>
-  maybeUnlockScroll: Option.Option<Command.Command<Message>>
-  maybeRestoreInert: Option.Option<Command.Command<Message>>
+type SelectedItemContext<Model extends BaseModel> = Readonly<{
+  closeWithFocus: (
+    model: Model,
+    maybeOutMessage?: Option.Option<OutMessage>,
+  ) => readonly [
+    Model,
+    ReadonlyArray<Command.Command<Message>>,
+    Option.Option<OutMessage>,
+  ]
 }>
 
 /** Prevents page scrolling while the combobox popup is open in modal mode. */
@@ -434,7 +438,7 @@ export const makeUpdate = <Model extends BaseModel>(
       item: string,
       displayText: string,
       wasSelected: boolean,
-      context: SelectedItemContext,
+      context: SelectedItemContext<Model>,
     ) => readonly [
       Model,
       ReadonlyArray<Command.Command<Message>>,
@@ -466,6 +470,38 @@ export const makeUpdate = <Model extends BaseModel>(
     )
 
     const focusInput = FocusInput({ id: model.id })
+
+    const closeWithFocusCommands = [
+      focusInput,
+      ...Array.getSomes([maybeUnlockScroll, maybeRestoreInert]),
+    ]
+
+    const closeWithoutFocusCommands = Array.getSomes([
+      maybeUnlockScroll,
+      maybeRestoreInert,
+    ])
+
+    const closeSelectedItemWithFocus = (
+      nextModel: Model,
+      maybeOutMessage: Option.Option<OutMessage> = Option.none(),
+    ): UpdateReturn => {
+      const didClose = model.isOpen && !nextModel.isOpen
+      const commands = didClose ? closeWithFocusCommands : [focusInput]
+
+      if (didClose && model.isAnimated) {
+        const [transitionedModel, animationCommands] = delegateToAnimation(
+          nextModel,
+          AnimationHid(),
+        )
+        return [
+          transitionedModel,
+          [...commands, ...animationCommands],
+          maybeOutMessage,
+        ]
+      }
+
+      return [nextModel, commands, maybeOutMessage]
+    }
 
     const openCombobox = (baseModel: Model): UpdateReturn => {
       if (model.isAnimated) {
@@ -551,12 +587,12 @@ export const makeUpdate = <Model extends BaseModel>(
         // restingInputValue or re-emit ClearedSelection while closed.
         Closed: ({ restingInputValue }) =>
           model.isOpen
-            ? closeCombobox(model, [focusInput], restingInputValue)
+            ? closeCombobox(model, closeWithFocusCommands, restingInputValue)
             : [model, [], Option.none()],
 
         BlurredInput: ({ restingInputValue }) =>
           model.isOpen
-            ? closeCombobox(model, [], restingInputValue)
+            ? closeCombobox(model, closeWithoutFocusCommands, restingInputValue)
             : [model, [], Option.none()],
 
         ActivatedItem: ({
@@ -623,28 +659,10 @@ export const makeUpdate = <Model extends BaseModel>(
               ]
             : [model, [], Option.none()],
 
-        SelectedItem: ({ item, displayText, wasSelected }) => {
-          const [nextModel, commands, maybeOutMessage] =
-            handlers.handleSelectedItem(model, item, displayText, wasSelected, {
-              focusInput,
-              maybeUnlockScroll,
-              maybeRestoreInert,
-            })
-
-          if (model.isOpen && !nextModel.isOpen && model.isAnimated) {
-            const [transitionedModel, animationCommands] = delegateToAnimation(
-              nextModel,
-              AnimationHid(),
-            )
-            return [
-              transitionedModel,
-              [...commands, ...animationCommands],
-              maybeOutMessage,
-            ]
-          }
-
-          return [nextModel, commands, maybeOutMessage]
-        },
+        SelectedItem: ({ item, displayText, wasSelected }) =>
+          handlers.handleSelectedItem(model, item, displayText, wasSelected, {
+            closeWithFocus: closeSelectedItemWithFocus,
+          }),
 
         RequestedItemClick: ({ index }) => [
           model,
@@ -677,7 +695,11 @@ export const makeUpdate = <Model extends BaseModel>(
 
         PressedToggleButton: ({ restingInputValue }) => {
           if (model.isOpen) {
-            return closeCombobox(model, [focusInput], restingInputValue)
+            return closeCombobox(
+              model,
+              closeWithFocusCommands,
+              restingInputValue,
+            )
           }
 
           const [nextModel, commands] = openCombobox(

--- a/packages/ui/src/combobox/single.test.ts
+++ b/packages/ui/src/combobox/single.test.ts
@@ -922,7 +922,7 @@ describe('Combobox', () => {
     const givenOpenModal = flow(
       givenClosedModal,
       Story.message(Opened({ maybeActiveItemIndex: Option.some(0) })),
-      Story.Command.resolveAll(
+      Story.Command.resolveAllExact(
         [LockScroll, CompletedLockScroll()],
         [InertOthers, CompletedInertOthers()],
       ),
@@ -933,7 +933,7 @@ describe('Combobox', () => {
         update,
         givenClosedModal,
         Story.message(Opened({ maybeActiveItemIndex: Option.some(0) })),
-        Story.Command.resolveAll(
+        Story.Command.resolveAllExact(
           [LockScroll, CompletedLockScroll()],
           [InertOthers, CompletedInertOthers()],
         ),
@@ -948,7 +948,7 @@ describe('Combobox', () => {
         update,
         givenOpenModal,
         Story.message(Closed({ restingInputValue: '' })),
-        Story.Command.resolveAll(
+        Story.Command.resolveAllExact(
           [FocusInput, CompletedFocusInput()],
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedRestoreInert()],
@@ -964,7 +964,7 @@ describe('Combobox', () => {
         update,
         givenOpenModal,
         Story.message(BlurredInput({ restingInputValue: '' })),
-        Story.Command.resolveAll(
+        Story.Command.resolveAllExact(
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedRestoreInert()],
         ),
@@ -985,13 +985,48 @@ describe('Combobox', () => {
             wasSelected: false,
           }),
         ),
-        Story.Command.resolveAll(
+        Story.Command.resolveAllExact(
           [FocusInput, CompletedFocusInput()],
           [UnlockScroll, CompletedUnlockScroll()],
           [RestoreInert, CompletedRestoreInert()],
         ),
         Story.model(model => {
           expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
+    it('emits unlockScroll and restoreInert commands when the toggle button closes a modal combobox', () => {
+      Story.story(
+        update,
+        givenOpenModal,
+        Story.message(PressedToggleButton({ restingInputValue: '' })),
+        Story.Command.resolveAllExact(
+          [FocusInput, CompletedFocusInput()],
+          [UnlockScroll, CompletedUnlockScroll()],
+          [RestoreInert, CompletedRestoreInert()],
+        ),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+        }),
+      )
+    })
+
+    it('does not emit cleanup commands for a stale close message', () => {
+      Story.story(
+        update,
+        givenOpenModal,
+        Story.message(Closed({ restingInputValue: '' })),
+        Story.Command.resolveAllExact(
+          [FocusInput, CompletedFocusInput()],
+          [UnlockScroll, CompletedUnlockScroll()],
+          [RestoreInert, CompletedRestoreInert()],
+        ),
+        Story.message(Closed({ restingInputValue: 'Stale' })),
+        Story.Command.expectNone(),
+        Story.model(model => {
+          expect(model.isOpen).toBe(false)
+          expect(model.inputValue).toBe('')
         }),
       )
     })
@@ -1005,7 +1040,7 @@ describe('Combobox', () => {
           expect(model.isOpen).toBe(true)
         }),
         Story.message(Closed({ restingInputValue: '' })),
-        Story.Command.resolve(FocusInput, CompletedFocusInput()),
+        Story.Command.resolveAllExact([FocusInput, CompletedFocusInput()]),
         Story.model(model => {
           expect(model.isOpen).toBe(false)
         }),

--- a/packages/ui/src/combobox/single.ts
+++ b/packages/ui/src/combobox/single.ts
@@ -1,4 +1,4 @@
-import { Array, Option, Schema as S, pipe } from 'effect'
+import { Option, Schema as S } from 'effect'
 import type * as Command from 'foldkit/command'
 import { evo } from 'foldkit/struct'
 import { type View as SubmodelView, defineView } from 'foldkit/submodel'
@@ -58,16 +58,12 @@ export const update = makeUpdate<Model>({
   handleSelectedItem: (model, item, displayText, wasSelected, context) => {
     const nullableDeselect = model.nullable && wasSelected
 
-    return [
+    return context.closeWithFocus(
       evo(closedBaseModel(model), {
         inputValue: () => (nullableDeselect ? '' : displayText),
       }),
-      pipe(
-        Array.getSomes([context.maybeUnlockScroll, context.maybeRestoreInert]),
-        Array.prepend(context.focusInput),
-      ),
       Option.some(SharedSelected({ value: item })),
-    ]
+    )
   },
 
   handleImmediateActivation: (model, item) => [

--- a/packages/website/src/page/testingScene.md
+++ b/packages/website/src/page/testingScene.md
@@ -124,18 +124,20 @@ Command tracking has a few semantics worth knowing:
 - Pending Commands accumulate in the order `update` returns them, across as many steps as the test takes.
 - Resolving a Command feeds its result Message through `update`; new Commands produced by that update join the pending list.
 - `Command.resolveAll` walks cascades within the batch. If resolving Command A produces Command B and B’s resolver is in the same call, B resolves without a separate step.
+- `Command.resolveAllExact` walks the same cascades while requiring every listed resolver to match within that call and every actual Command to be resolved.
 - Interactions throw if there are unresolved Commands when they try to dispatch a Message.
 - `scene` throws at the end if any Command remains unresolved.
 
 ::Snippet{name="sceneCommandAssertions" label="command assertions example"}
 
-| Step                                            | Effect                                                                                                                                                                                                                                       |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Command.resolve(Def, ResultMessage)`           | Resolves the first pending Command with the given name by feeding `ResultMessage` through update. For a child Submodel Command, pass the child’s raw result Message; resolve replays the Command’s own `mapMessages` wrapping automatically. |
-| `Command.resolveAll([Def, ResultMessage], ...)` | Resolves a batch of pending Commands, walking cascades. Each entry resolves exactly one matching dispatch in declaration order; compose with Array.makeBy for N identical responses.                                                         |
-| `Command.expectExact(A, B)`                     | The pending Commands are exactly A and B (order-independent).                                                                                                                                                                                |
-| `Command.expectHas(A)`                          | A is among the pending Commands (subset check).                                                                                                                                                                                              |
-| `Command.expectNone()`                          | There are no pending Commands.                                                                                                                                                                                                               |
+| Step                                                 | Effect                                                                                                                                                                                                                                       |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Command.resolve(Def, ResultMessage)`                | Resolves the first pending Command with the given name by feeding `ResultMessage` through update. For a child Submodel Command, pass the child’s raw result Message; resolve replays the Command’s own `mapMessages` wrapping automatically. |
+| `Command.resolveAll([Def, ResultMessage], ...)`      | Resolves a batch of pending Commands, walking cascades. Each entry resolves exactly one matching dispatch in declaration order and unmatched entries carry forward; compose with Array.makeBy for N identical responses.                     |
+| `Command.resolveAllExact([Def, ResultMessage], ...)` | Resolves a batch and throws unless every listed resolver matches within the call and no actual Commands remain unresolved. Repeated Definition entries consume repeated dispatches in declaration order.                                     |
+| `Command.expectExact(A, B)`                          | The pending Commands are exactly A and B (order-independent).                                                                                                                                                                                |
+| `Command.expectHas(A)`                               | A is among the pending Commands (subset check).                                                                                                                                                                                              |
+| `Command.expectNone()`                               | There are no pending Commands.                                                                                                                                                                                                               |
 
 Prefer `Command.expectExact` as the default. It catches bugs where an interaction produces unexpected Commands. Use `Command.expectHas` when you only care about a subset of the pending Commands.
 

--- a/packages/website/src/page/testingStory.md
+++ b/packages/website/src/page/testingStory.md
@@ -8,7 +8,7 @@ The Elm Architecture makes testing straightforward. The update function is pure.
 
 ## The API
 
-Import the steps you need from `foldkit/story`. The top-level steps are `story`, `given`, `message`, `model`, `expectOutMessage`, and `expectNoOutMessage`. Command resolution and assertions live under the `Command` namespace: `Command.resolve`, `Command.resolveAll`, `Command.expectHas`, `Command.expectExact`, and `Command.expectNone`.
+Import the steps you need from `foldkit/story`. The top-level steps are `story`, `given`, `message`, `model`, `expectOutMessage`, and `expectNoOutMessage`. Command resolution and assertions live under the `Command` namespace: `Command.resolve`, `Command.resolveAll`, `Command.resolveAllExact`, `Command.expectHas`, `Command.expectExact`, and `Command.expectNone`.
 
 A test file usually needs only one of the two testing modules, so named imports keep the call sites short. When a single file tests both a story and a scene, import the namespaces instead (`import { Scene, Story } from 'foldkit'`) so `Story.given` and `Scene.given` stay distinguishable.
 
@@ -30,14 +30,18 @@ The test reads as a story. Start from a Model with count 5. Send `ClickedResetAf
 
 ## Multi-Step Flows
 
-Real apps have multi-step user stories. `Command.resolve` and `Command.resolveAll` let you resolve Commands inline at any point in the story. This keeps the resolution next to the step that produced the Command, so the test reads chronologically:
+Real apps have multi-step user stories. `Command.resolve`, `Command.resolveAll`, and `Command.resolveAllExact` let you resolve Commands inline at any point in the story. This keeps the resolution next to the step that produced the Command, so the test reads chronologically:
 
 ::Snippet{name="testingWeatherFlow" label="multi-step test example"}
 
-Every `message` is a user action: “the user submitted the form.” Every `Command.resolve` or `Command.resolveAll` is world-building: “the weather API succeeded.” Every `model` is a scene check: “the weather is showing.”
+Every `message` is a user action: “the user submitted the form.” Every Command resolver is world-building: “the weather API succeeded.” Every `model` is a scene check: “the weather is showing.”
 
 :::Info{label="Resolvers are a queue"}
 Each entry in `resolveAll` resolves exactly one matching dispatch in declaration order. `[FetchCount, m1], [FetchCount, m2], [FetchCount, m3]` reads as three responses to three dispatches. For N identical responses, compose with `Array.makeBy(n, () => [Def, message])`. Resolvers carry across calls: unused entries can match later dispatches, and a new entry replaces any leftover resolvers sharing its Definition or Instance shape (latest wins).
+:::
+
+:::Info{label="Exact resolution"}
+Use `resolveAllExact` when the resolver list is also a claim about which Commands were dispatched. It walks cascades like `resolveAll`, but every listed entry must match one dispatch within that call and no actual Command may remain unresolved. Repeated entries sharing a Definition consume repeated dispatches in declaration order. Supplied resolvers never carry forward.
 :::
 
 :::Info{label="Unresolved Commands"}

--- a/packages/website/src/snippet/sceneCommandAssertions.ts
+++ b/packages/website/src/snippet/sceneCommandAssertions.ts
@@ -17,6 +17,13 @@ Command.resolveAll(
   [TrackSignInAttempt, CompletedTrackSignInAttempt()],
 )
 
+// Resolve the batch while asserting every listed Command was dispatched.
+click(role('button', { name: 'Sign In' }))
+Command.resolveAllExact(
+  [RequestAuthentication, SucceededRequestAuthentication({ session })],
+  [TrackSignInAttempt, CompletedTrackSignInAttempt()],
+)
+
 // Subset assertion. Use when you only care that a particular Command is pending.
 // Definition or instance: instance form locks in the args.
 Command.expectHas(FetchWeather)

--- a/packages/website/src/snippet/testingApi.ts
+++ b/packages/website/src/snippet/testingApi.ts
@@ -29,6 +29,14 @@ Command.resolveAll(
   [ScrollToTop, CompletedScrollToTop()],
 )
 
+// Resolve and assert a batch. Every listed resolver must match in this call,
+// and no actual Command may remain unresolved.
+message(ClickedSubmit())
+Command.resolveAllExact(
+  [FocusInput, CompletedFocusInput()],
+  [ScrollToTop, CompletedScrollToTop()],
+)
+
 // For N identical responses, compose with Array.makeBy.
 Command.resolveAll(
   ...Array.makeBy(3, () => [AnimationTick, CompletedTick()] as const),


### PR DESCRIPTION
## Summary

- wait for the pending render commit before `Dom.inertOthers` resolves its allow-list, so portaled popup containers are not hidden or made inert
- unwind modal Combobox scroll locks and inert state on close, blur, toggle-button dismissal, and single-select selection while leaving multi-select selection open
- add `Story.Command.resolveAllExact` and `Scene.Command.resolveAllExact` so resolver lists assert that every expected Command was dispatched

These defects formed one lifecycle gap: inerting read the DOM before the popup commit, Combobox close paths did not release the resources acquired on open, and permissive test resolvers could not prove cleanup Commands ran.

## Compatibility

`Command.resolveAll` keeps its existing carry-forward behavior. `Command.resolveAllExact` is an opt-in asserting variant: every supplied resolver must match during the call, repeated Definitions consume repeated dispatches in order, and actual Commands may not remain unresolved.

## Validation

- `pnpm --filter foldkit exec vitest run src/dom/index.test.ts src/test/story.test.ts src/test/scene.test.ts` (660 passed)
- `pnpm --filter @foldkit/ui exec vitest run src/combobox/single.test.ts src/combobox/multi.test.ts` (111 passed)
- `pnpm --filter foldkit typecheck` (passed)
- `pnpm --filter @foldkit/ui typecheck` (passed)
- `pnpm --filter website typecheck` (passed with existing TypeDoc warnings)
- `pnpm lint` (passed)
- `pnpm format:check` (passed)
- `pnpm check:changeset-unwrapped` (passed)
- `pnpm check:changeset-ignore` (passed)
- `pnpm check:no-major-changesets` (passed)
- `pnpm changeset status --since=origin/main` (passed)
- repository pre-push hook from `git push -u origin codex/fix-modal-overlay-lifecycles` (passed, including the workspace build, typecheck, package tests, and Chromium smoke test)

Fixes #933
Fixes #934
Fixes #935


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exact command-resolution tools for stories and scenes, ensuring expected commands match and no commands remain unresolved.
* **Bug Fixes**
  * Improved modal Combobox cleanup, focus restoration, scroll unlocking, and inert-state handling.
  * Ensured portaled modal content remains interactive and canceled outdated inert updates.
* **Documentation**
  * Updated testing guides and examples to explain exact resolution, matching behavior, cascading commands, and resolver lifecycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->