### PR TITLE
fix(foldkit): make Scene assertions reflect rendered accessibility

### DIFF
--- a/.changeset/calm-scenes-render.md
+++ b/.changeset/calm-scenes-render.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+Make negated Scene property, state, accessible-name, and accessible-description assertions require their target element to exist. Use `toBeAbsent()` or `not.toExist()` when absence is the intended assertion.
+
+Accessible-name and accessible-description queries now exclude descendants hidden with `aria-hidden`, the `hidden` attribute, `display: none`, or `visibility: hidden`. Hidden elements directly referenced by `aria-labelledby` or `aria-describedby` continue to contribute their full subtree text.

--- a/packages/foldkit/src/test/matchers.ts
+++ b/packages/foldkit/src/test/matchers.ts
@@ -1,7 +1,7 @@
 import { Option, String as String_ } from 'effect'
 
 import type { VNode } from '../vdom.js'
-import { attr, textContent } from './query.js'
+import { attr, isHidden, textContent } from './query.js'
 
 type MatcherContext = Readonly<{ isNot: boolean }>
 
@@ -345,21 +345,8 @@ export const sceneMatchers = {
           'Expected element to be visible but the element does not exist.',
       }),
       onSome: vnode => {
-        const hiddenAttr = attr(vnode, 'hidden')
-        const hiddenByAttr =
-          Option.isSome(hiddenAttr) && hiddenAttr.value !== 'false'
-        const ariaHidden = attr(vnode, 'aria-hidden')
-        const hiddenByAria =
-          Option.isSome(ariaHidden) && ariaHidden.value === 'true'
-        const display = vnode.data?.style?.['display']
-        const visibility = vnode.data?.style?.['visibility']
-        const isHidden =
-          hiddenByAttr ||
-          hiddenByAria ||
-          display === 'none' ||
-          visibility === 'hidden'
         return {
-          pass: !isHidden,
+          pass: !isHidden(vnode),
           message: () =>
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             (this as unknown as MatcherContext).isNot

--- a/packages/foldkit/src/test/query.ts
+++ b/packages/foldkit/src/test/query.ts
@@ -196,6 +196,40 @@ const lookupStringAttribute =
   (vnode: VNode): Option.Option<string> =>
     pipe(vnode, lookupAttribute(name), Option.map(String))
 
+/** Returns whether an element is hidden from the accessibility tree. */
+export const isHidden = (vnode: VNode): boolean => {
+  const maybeHiddenProperty = Option.fromNullishOr(
+    vnode.data?.props?.['hidden'],
+  )
+  if (Option.exists(maybeHiddenProperty, Boolean)) {
+    return true
+  }
+  if (Option.isNone(maybeHiddenProperty)) {
+    const maybeHiddenAttribute = Option.fromNullishOr(
+      vnode.data?.attrs?.['hidden'],
+    )
+    if (
+      Option.isSome(maybeHiddenAttribute) &&
+      maybeHiddenAttribute.value !== false
+    ) {
+      return true
+    }
+  }
+  const maybeAriaHidden = lookupStringAttribute('aria-hidden')(vnode)
+  if (Option.isSome(maybeAriaHidden) && maybeAriaHidden.value === 'true') {
+    return true
+  }
+  const display = vnode.data?.style?.['display']
+  if (display === 'none') {
+    return true
+  }
+  const visibility = vnode.data?.style?.['visibility']
+  if (visibility === 'hidden') {
+    return true
+  }
+  return false
+}
+
 const isElement = (node: VNode): boolean => !Predicate.isUndefined(node.sel)
 
 const isVNode = (child: VNode | string): child is VNode =>
@@ -510,6 +544,26 @@ const resolveRoles =
 const nonEmptyString = (value: unknown): Option.Option<string> =>
   Option.filter(Option.some(String(value)), String_.isNonEmpty)
 
+const accessibleTextContent = (vnode: VNode): string => {
+  if (Predicate.isString(vnode.text)) {
+    return vnode.text
+  }
+
+  return pipe(
+    vnode.children ?? [],
+    Array.map(child => {
+      if (Predicate.isString(child)) {
+        return child
+      }
+      return isHidden(child) ? '' : accessibleTextContent(child)
+    }),
+    Array.join(''),
+  )
+}
+
+const referencedTextContent = (vnode: VNode): string =>
+  isHidden(vnode) ? textContent(vnode) : accessibleTextContent(vnode)
+
 const nameFromLabelledBy =
   (root: VNode) =>
   (vnode: VNode): Option.Option<string> =>
@@ -524,7 +578,7 @@ const nameFromLabelledBy =
           Array.filterMap(
             flow(
               findById(root),
-              Option.map(textContent),
+              Option.map(referencedTextContent),
               Result.fromOption(() => undefined),
             ),
           ),
@@ -555,13 +609,13 @@ const nameFromLabelFor =
                 Option.exists(Equal.equals(idString)),
               ),
           ),
-          Option.map(textContent),
+          Option.map(referencedTextContent),
         ),
       ),
     )
 
 const nameFromTextContent = (vnode: VNode): Option.Option<string> =>
-  Option.filter(Option.some(textContent(vnode)), String_.isNonEmpty)
+  Option.filter(Option.some(accessibleTextContent(vnode)), String_.isNonEmpty)
 
 const nameFromTitle = (vnode: VNode): Option.Option<string> =>
   pipe(vnode, lookupAttribute('title'), Option.flatMap(nonEmptyString))
@@ -577,7 +631,8 @@ const nameFromChildTag =
     pipe(
       vnode,
       findFirstDirectChildWithTag(childTag),
-      Option.map(textContent),
+      Option.filter(child => !isHidden(child)),
+      Option.map(accessibleTextContent),
       Option.flatMap(nonEmptyString),
     )
 
@@ -613,7 +668,7 @@ const nameFromNativeHost = (vnode: VNode): Option.Option<string> =>
 /** Computes the accessible name of an element. Resolves via
  *  `aria-labelledby`, `aria-label`, `<label for>`, native host language
  *  attributes and child elements (img/area alt, input value/alt,
- *  fieldset legend, figure figcaption, table caption), text content,
+ *  fieldset legend, figure figcaption, table caption), accessible text content,
  *  then `title`. */
 export const accessibleName =
   (root: VNode) =>
@@ -645,7 +700,7 @@ export const accessibleDescription =
           Array.filterMap(
             flow(
               findById(root),
-              Option.map(textContent),
+              Option.map(referencedTextContent),
               Result.fromOption(() => undefined),
             ),
           ),

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -135,6 +135,8 @@ import {
 } from './apps/uploads.js'
 import { parseSelector } from './query.js'
 import {
+  accessibleDescription,
+  accessibleName,
   attr,
   find,
   findAll,
@@ -341,6 +343,113 @@ describe('query functions', () => {
       const element = Option.getOrThrow(find(tree, '#email'))
       expect(Option.isNone(attr(element, 'role'))).toBe(true)
     })
+  })
+})
+
+describe('accessible name hidden content', () => {
+  test('ignores an aria-hidden decorative child and retains sibling text', () => {
+    const option = h('div', { attrs: { role: 'option' } }, [
+      h('span', { attrs: { 'aria-hidden': 'true' } }, ['check']),
+      'Triage',
+    ])
+
+    expect(accessibleName(option)(option)).toBe('Triage')
+  })
+
+  test('ignores a hidden descendant subtree and retains visible nested text', () => {
+    const option = h('div', { attrs: { role: 'option' } }, [
+      'Triage ',
+      h('span', { attrs: { hidden: 'true' } }, [
+        h('span', {}, ['hidden subtree']),
+      ]),
+      h('span', {}, ['visible ', h('strong', {}, ['nested text'])]),
+    ])
+
+    expect(accessibleName(option)(option)).toBe('Triage visible nested text')
+  })
+
+  test('ignores a descendant with hidden="false"', () => {
+    const option = h('div', { attrs: { role: 'option' } }, [
+      h('span', { attrs: { hidden: 'false' } }, ['archived']),
+      'Triage',
+    ])
+
+    expect(accessibleName(option)(option)).toBe('Triage')
+  })
+
+  test('includes a descendant with Hidden(false)', () => {
+    const option = Option.getOrThrow(
+      Option.fromNullishOr(
+        inertHtml.div(
+          [inertHtml.Role('option')],
+          ['Triage ', inertHtml.span([inertHtml.Hidden(false)], ['visible'])],
+        ),
+      ),
+    )
+
+    expect(accessibleName(option)(option)).toBe('Triage visible')
+  })
+
+  test('ignores a descendant styled with display none', () => {
+    const option = h('div', { attrs: { role: 'option' } }, [
+      h('span', { style: { display: 'none' } }, ['archived']),
+      'Triage',
+    ])
+
+    expect(accessibleName(option)(option)).toBe('Triage')
+  })
+
+  test('ignores a descendant styled with visibility hidden', () => {
+    const option = h('div', { attrs: { role: 'option' } }, [
+      h('span', { style: { visibility: 'hidden' } }, ['archived']),
+      'Triage',
+    ])
+
+    expect(accessibleName(option)(option)).toBe('Triage')
+  })
+
+  test('includes the full subtree of a hidden aria-labelledby reference', () => {
+    const tree = h('div', {}, [
+      h('span', { attrs: { id: 'hidden-label', 'aria-hidden': 'true' } }, [
+        h('span', { style: { display: 'none' } }, ['Hidden']),
+        ' label',
+      ]),
+      h('button', { attrs: { 'aria-labelledby': 'hidden-label' } }, []),
+    ])
+    const button = Option.getOrThrow(find(tree, 'button'))
+
+    expect(accessibleName(tree)(button)).toBe('Hidden label')
+  })
+
+  test('includes the full subtree of a hidden aria-describedby reference', () => {
+    const tree = h('div', {}, [
+      h('span', { attrs: { id: 'hidden-description', hidden: 'true' } }, [
+        h('span', { style: { visibility: 'hidden' } }, ['Hidden']),
+        ' description',
+      ]),
+      h('button', {
+        attrs: { 'aria-describedby': 'hidden-description' },
+      }),
+    ])
+    const button = Option.getOrThrow(find(tree, 'button'))
+
+    expect(accessibleDescription(tree)(button)).toBe('Hidden description')
+  })
+
+  test('resolves a role by name while literal text still sees hidden content', () => {
+    Scene.scene(
+      {
+        update,
+        view: (_model, html) =>
+          html.div(
+            [html.Role('option')],
+            [html.span([html.AriaHidden(true)], ['check']), 'Triage'],
+          ),
+      },
+      Scene.given(initialModel),
+      Scene.expect(Scene.role('option', { name: 'Triage' })).toExist(),
+      Scene.expect(Scene.text('check')).toExist(),
+    )
   })
 })
 
@@ -1401,6 +1510,20 @@ describe('custom matchers', () => {
     )
   })
 
+  test('toBeVisible fails for hidden="false"', () => {
+    const hidden: VNode = h('div', { attrs: { hidden: 'false' } }, [])
+    expect(() => expect(Option.some(hidden)).toBeVisible()).toThrow(
+      'Expected element to be visible',
+    )
+  })
+
+  test('toBeVisible passes for Hidden(false)', () => {
+    const visible = Option.getOrThrow(
+      Option.fromNullishOr(inertHtml.div([inertHtml.Hidden(false)])),
+    )
+    expect(Option.some(visible)).toBeVisible()
+  })
+
   test('toBeVisible fails for element with aria-hidden="true"', () => {
     const hidden: VNode = h('div', { attrs: { 'aria-hidden': 'true' } }, [])
     expect(() => expect(Option.some(hidden)).toBeVisible()).toThrow(
@@ -1715,6 +1838,62 @@ describe('scene with expect', () => {
       { update, view },
       Scene.given(initialModel),
       Scene.expect(Scene.role('dialog')).toBeAbsent(),
+    )
+  })
+
+  test('not.toBeAbsent passes when element exists', () => {
+    Scene.scene(
+      { update, view },
+      Scene.given(initialModel),
+      Scene.expect(Scene.role('button')).not.toBeAbsent(),
+    )
+  })
+
+  test('positive property assertion throws when the element is missing', () => {
+    expect(() =>
+      Scene.scene(
+        { update, view },
+        Scene.given(initialModel),
+        Scene.expect(Scene.role('dialog')).toHaveText('Settings'),
+      ),
+    ).toThrow(
+      'Expected element matching dialog to have text "Settings" but the element does not exist.',
+    )
+  })
+
+  test('negated property assertion throws when the element is missing', () => {
+    expect(() =>
+      Scene.scene(
+        { update, view },
+        Scene.given(initialModel),
+        Scene.expect(Scene.role('dialog')).not.toHaveAttr('aria-modal'),
+      ),
+    ).toThrow(
+      'Expected element matching dialog not to have attribute "aria-modal" but the element does not exist.',
+    )
+  })
+
+  test('negated state assertion throws when the element is missing', () => {
+    expect(() =>
+      Scene.scene(
+        { update, view },
+        Scene.given(initialModel),
+        Scene.expect(Scene.role('dialog')).not.toBeDisabled(),
+      ),
+    ).toThrow(
+      'Expected element matching dialog not to be disabled but the element does not exist.',
+    )
+  })
+
+  test('negated accessibility assertion throws when the element is missing', () => {
+    expect(() =>
+      Scene.scene(
+        { update, view },
+        Scene.given(initialModel),
+        Scene.expect(Scene.role('dialog')).not.toHaveAccessibleName('Settings'),
+      ),
+    ).toThrow(
+      'Expected element matching dialog not to have accessible name "Settings" but the element does not exist.',
     )
   })
 

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -76,6 +76,7 @@ import {
   accessibleName,
   ancestorsOf,
   attr,
+  isHidden,
   resolveTarget,
   selector,
   textContent,
@@ -1971,12 +1972,10 @@ const assertOnElement =
   ): SceneAssertion =>
   (maybeElement, description, isNot, root) => {
     if (Option.isNone(maybeElement)) {
-      if (!isNot) {
-        throw new Error(
-          `Expected element matching ${description} to ${expectation} but the element does not exist.`,
-        )
-      }
-      return
+      const negation = isNot ? 'not ' : ''
+      throw new Error(
+        `Expected element matching ${description} ${negation}to ${expectation} but the element does not exist.`,
+      )
     }
     const { pass, actual } = check(maybeElement.value, root)
     if (isNot ? pass : !pass) {
@@ -2168,18 +2167,6 @@ const assertIsChecked: SceneAssertion = assertOnElement(vnode => {
     (Option.isSome(ariaChecked) && ariaChecked.value === 'true')
   return { pass, actual: 'it is not checked' }
 }, 'be checked')
-
-const isHidden = (vnode: VNode): boolean => {
-  const hiddenAttr = attr(vnode, 'hidden')
-  if (Option.isSome(hiddenAttr) && hiddenAttr.value !== 'false') return true
-  const ariaHidden = attr(vnode, 'aria-hidden')
-  if (Option.isSome(ariaHidden) && ariaHidden.value === 'true') return true
-  const display = vnode.data?.style?.['display']
-  if (display === 'none') return true
-  const visibility = vnode.data?.style?.['visibility']
-  if (visibility === 'hidden') return true
-  return false
-}
 
 const assertIsVisible: SceneAssertion = assertOnElement(
   vnode => ({ pass: !isHidden(vnode), actual: 'it is hidden' }),

--- a/packages/website/src/page/testingScene.md
+++ b/packages/website/src/page/testingScene.md
@@ -87,26 +87,30 @@ Interactions exercise the view by invoking event handlers on matched elements. E
 
 `expect(locator)` creates an inline assertion step against a single element. Every matcher has a `.not` variant that inverts the assertion.
 
+Property, state, and accessibility matchers require the Locator to match an element, including their `.not` variants. Use `.toBeAbsent()` or `.not.toExist()` when the intended assertion is that no element matches.
+
 ::Snippet{name="sceneAssertions" label="assertion examples"}
 
-| Matcher                                     | Asserts that the element                                                                       |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `.toExist()`                                | Is present in the tree                                                                         |
-| `.toBeAbsent()`                             | Is not present in the tree                                                                     |
-| `.toBeVisible()`                            | Is not hidden via the hidden attribute, aria-hidden, display: none, or visibility: hidden      |
-| `.toBeEmpty()`                              | Has no text content or child elements                                                          |
-| `.toHaveText(value)`                        | Has text content equal to the given string or matching the given regex                         |
-| `.toContainText(value)`                     | Has text content including the given substring or matching the regex                           |
-| `.toHaveAccessibleName(name)`               | Has the given accessible name (resolves aria-labelledby, aria-label, label[for], text content) |
-| `.toHaveAccessibleDescription(description)` | Has the given accessible description (resolves aria-describedby)                               |
-| `.toBeDisabled()`                           | Has aria-disabled or the disabled attribute                                                    |
-| `.toBeEnabled()`                            | Is not disabled                                                                                |
-| `.toBeChecked()`                            | Has aria-checked="true" or the checked attribute                                               |
-| `.toHaveValue(value)`                       | Has the given current form-control value                                                       |
-| `.toHaveAttr(name, value)`                  | Has the given attribute set to the given value                                                 |
-| `.toHaveId(id)`                             | Has the given id                                                                               |
-| `.toHaveClass(name)`                        | Has the given CSS class                                                                        |
-| `.toHaveStyle(name, value)`                 | Has the given inline style property                                                            |
+| Matcher                                     | Asserts that the element                                                                                                                           |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.toExist()`                                | Is present in the tree                                                                                                                             |
+| `.toBeAbsent()`                             | Is not present in the tree                                                                                                                         |
+| `.toBeVisible()`                            | Is not hidden via the hidden attribute, aria-hidden, display: none, or visibility: hidden                                                          |
+| `.toBeEmpty()`                              | Has no text content or child elements                                                                                                              |
+| `.toHaveText(value)`                        | Has text content equal to the given string or matching the given regex                                                                             |
+| `.toContainText(value)`                     | Has text content including the given substring or matching the regex                                                                               |
+| `.toHaveAccessibleName(name)`               | Has the given accessible name (resolves aria-labelledby, aria-label, label[for], native host-language sources, accessible text content, and title) |
+| `.toHaveAccessibleDescription(description)` | Has the given accessible description (resolves aria-describedby)                                                                                   |
+| `.toBeDisabled()`                           | Has aria-disabled or the disabled attribute                                                                                                        |
+| `.toBeEnabled()`                            | Is not disabled                                                                                                                                    |
+| `.toBeChecked()`                            | Has aria-checked="true" or the checked attribute                                                                                                   |
+| `.toHaveValue(value)`                       | Has the given current form-control value                                                                                                           |
+| `.toHaveAttr(name, value)`                  | Has the given attribute set to the given value                                                                                                     |
+| `.toHaveId(id)`                             | Has the given id                                                                                                                                   |
+| `.toHaveClass(name)`                        | Has the given CSS class                                                                                                                            |
+| `.toHaveStyle(name, value)`                 | Has the given inline style property                                                                                                                |
+
+Accessible-name and accessible-description matching excludes hidden descendant content. A hidden node directly referenced by `aria-labelledby` or `aria-describedby` contributes its full subtree text.
 
 For `LocatorAll` (from `all.*`), use `expectAll(locatorAll)` for count-based assertions:
 


### PR DESCRIPTION
## Summary

- Require every single-element Scene property, state, and accessibility assertion to resolve an element, including negated assertions.
- Exclude hidden descendant subtrees from accessible-name content while preserving the Accessible Name rule for directly referenced hidden labels and descriptions.
- Document the absence-assertion migration and add a minor Foldkit changeset.

## Why

Two Scene correctness failures could make tests disagree with rendered browser behavior:

1. A negated property assertion could pass because its Locator matched no element.
2. Accessible-name fallback included descendants excluded from the accessibility tree.

Use `.toBeAbsent()` or `.not.toExist()` when absence is intended. Negated property and state assertions now mean that the element exists and does not have the asserted property or state.

Ordinary hidden descendants are excluded for `aria-hidden="true"`, `hidden`, `display: none`, and `visibility: hidden`. A hidden node directly referenced by `aria-labelledby` or `aria-describedby` still contributes its full subtree.

Fixes #931
Fixes #932

## Validation

- `pnpm --filter foldkit exec vitest run src/test/scene.test.ts --reporter=verbose`: 583 passed.
- `pnpm --filter foldkit test`: 1,734 passed, 1 skipped.
- `pnpm --filter foldkit typecheck`: passed.
- `pnpm lint`: passed.
- `pnpm format:check`: passed.
- `pnpm check:changeset-unwrapped`: passed.
- `pnpm check:changeset-ignore`: passed.
- `pnpm check:no-major-changesets`: passed.
- `pnpm changeset status --since=origin/main`: passed; Foldkit and dependent packages receive minor bumps.
- `pnpm test`: passed across all package and example test suites.
- Repository pre-push hook: passed build, recursive typechecks, full tests, and the Chromium website smoke test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessible-name and accessible-description matching for hidden content.
  * Hidden descendants are excluded from accessibility matching, while explicitly referenced hidden labels and descriptions remain supported.
  * Improved visibility detection, including correct handling of `hidden="false"`.
  * Missing-element assertions now fail consistently, including negated assertions.
  * Role-name matching ignores hidden text while literal text locators can still find it.

* **Documentation**
  * Clarified assertion requirements and accessible-name and accessible-description matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->