### PR TITLE
feat(ui): add isReadOnly to Switch

### DIFF
--- a/.changeset/switch-read-only.md
+++ b/.changeset/switch-read-only.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': minor
+---
+
+Add `isReadOnly` to Switch's `ViewConfig`.
+
+A read-only Switch emits `aria-readonly="true"` and `data-readonly`, remains focusable, and omits its click and Space handlers. `isReadOnly` and `isDisabled` are independent, and either one removes the interaction handlers.

--- a/packages/ui/src/switch/index.ts
+++ b/packages/ui/src/switch/index.ts
@@ -24,13 +24,18 @@ export type SwitchAttributes<Message> = Readonly<{
  *    the switch or its label, or presses Space. Handle it in the parent's
  *    `update` by storing the value.
  *  - `toView`: receives the {@link SwitchAttributes} and lays out the
- *    switch. */
+ *    switch.
+ *  - `isReadOnly`: prevents toggling while exposing read-only semantics with
+ *    `aria-readonly="true"` and `data-readonly`. The switch remains
+ *    focusable. Independent of `isDisabled`: setting both emits both
+ *    attribute sets, and either one removes the interaction handlers. */
 export type ViewConfig<Message> = Readonly<{
   id: string
   isChecked: boolean
   onToggle: (isChecked: boolean) => Message
   toView: (attributes: SwitchAttributes<Message>) => Html
   isDisabled?: boolean
+  isReadOnly?: boolean
   name?: string
   value?: string
 }>
@@ -70,6 +75,7 @@ export const view = <Message>(
     onToggle,
     toView,
     isDisabled = false,
+    isReadOnly = false,
     name,
     value: formValue = 'on',
   } = config
@@ -88,6 +94,12 @@ export const view = <Message>(
     ? [h.AriaDisabled(true), h.DataAttribute('disabled', '')]
     : []
 
+  const readOnlyAttributes = isReadOnly
+    ? [h.AriaReadonly(true), h.DataAttribute('readonly', '')]
+    : []
+
+  const isInteractive = !isDisabled && !isReadOnly
+
   const buttonAttributes = [
     h.Role('switch'),
     h.AriaChecked(isChecked),
@@ -96,17 +108,15 @@ export const view = <Message>(
     h.Tabindex(0),
     ...checkedAttributes,
     ...disabledAttributes,
-    ...(isDisabled
-      ? []
-      : [
-          h.OnClick(onToggle(nextChecked)),
-          h.OnKeyUpPreventDefault(handleKeyUp),
-        ]),
+    ...readOnlyAttributes,
+    ...(isInteractive
+      ? [h.OnClick(onToggle(nextChecked)), h.OnKeyUpPreventDefault(handleKeyUp)]
+      : []),
   ]
 
   const labelAttributes = [
     h.Id(labelId(id)),
-    ...(isDisabled ? [] : [h.OnClick(onToggle(nextChecked))]),
+    ...(isInteractive ? [h.OnClick(onToggle(nextChecked))] : []),
   ]
 
   const descriptionAttributes = [h.Id(descriptionId(id))]

--- a/packages/ui/src/switch/scene.test.ts
+++ b/packages/ui/src/switch/scene.test.ts
@@ -28,7 +28,10 @@ const update = (model: Model, message: Message): UpdateReturn =>
   )
 
 const testView =
-  ({ isDisabled = false }: { isDisabled?: boolean } = {}) =>
+  ({
+    isDisabled = false,
+    isReadOnly = false,
+  }: { isDisabled?: boolean; isReadOnly?: boolean } = {}) =>
   (model: Model, h: HtmlBuilder<Message>) =>
     view(
       {
@@ -36,6 +39,7 @@ const testView =
         isChecked: model.isChecked,
         onToggle: isChecked => Toggled({ isChecked }),
         isDisabled,
+        isReadOnly,
         toView: ({ button, label }) =>
           h.div(
             [],
@@ -84,6 +88,39 @@ describe('Switch controlled view', () => {
       Scene.given({ isChecked: false }),
       Scene.expect(toggle).toBeDisabled(),
       Scene.expect(toggle).toHaveAttr('data-disabled', ''),
+    )
+  })
+
+  it('emits read-only attributes without disabled attributes', () => {
+    Scene.scene(
+      { update, view: testView({ isReadOnly: true }) },
+      Scene.given({ isChecked: false }),
+      Scene.expect(toggle).toHaveAttr('aria-readonly', 'true'),
+      Scene.expect(toggle).toHaveAttr('data-readonly', ''),
+      Scene.expect(toggle).not.toBeDisabled(),
+      Scene.expect(toggle).not.toHaveAttr('data-disabled'),
+    )
+  })
+
+  it('stays focusable but drops every handler when read-only', () => {
+    Scene.scene(
+      { update, view: testView({ isReadOnly: true }) },
+      Scene.given({ isChecked: false }),
+      Scene.expect(toggle).toHaveAttr('tabIndex', '0'),
+      Scene.expect(toggle).not.toHaveHandler('click'),
+      Scene.expect(toggle).not.toHaveHandler('keyup'),
+      Scene.expect(label).not.toHaveHandler('click'),
+    )
+  })
+
+  it('emits both attribute sets when disabled and read-only are combined', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true, isReadOnly: true }) },
+      Scene.given({ isChecked: false }),
+      Scene.expect(toggle).toBeDisabled(),
+      Scene.expect(toggle).toHaveAttr('data-disabled', ''),
+      Scene.expect(toggle).toHaveAttr('aria-readonly', 'true'),
+      Scene.expect(toggle).toHaveAttr('data-readonly', ''),
     )
   })
 })

--- a/packages/website/src/page/ui/switchPage.md
+++ b/packages/website/src/page/ui/switchPage.md
@@ -18,22 +18,33 @@ The switch renders as a `<button>` with `role="switch"`. The typical visual is a
 
 ## Styling
 
-Switch is headless. Your `toView` callback controls all markup and styling. Use `data-[checked]` to change the track color and translate the knob.
+Switch is headless. Your `toView` callback controls all markup and styling. Use `data-[checked]` to change the track color and translate the knob, and the data attributes below to style the disabled and read-only states.
 
 | Attribute       | Condition                        |
 | --------------- | -------------------------------- |
 | `data-checked`  | Present when the switch is on.   |
 | `data-disabled` | Present when isDisabled is true. |
+| `data-readonly` | Present when isReadOnly is true. |
 
 ## Keyboard Interaction
 
-| Key     | Description         |
-| ------- | ------------------- |
-| `Space` | Toggles the switch. |
+| Key     | Description                                                             |
+| ------- | ----------------------------------------------------------------------- |
+| `Space` | Toggles the Switch when `isDisabled` and `isReadOnly` are both `false`. |
 
 ## Accessibility
 
 The switch button receives `role="switch"` and `aria-checked`. The label is linked via `aria-labelledby` and the description via `aria-describedby`. Clicking the label toggles the switch.
+
+`isReadOnly` and `isDisabled` both stop the Switch from reacting to clicks and Space. They differ in the semantics exposed to assistive technology, so they are not interchangeable.
+
+`aria-disabled="true"`, which `isDisabled` emits, communicates that the Switch is unavailable. `aria-readonly="true"`, which `isReadOnly` emits, communicates that its value cannot be changed but remains relevant to the user. Both states keep `tabindex="0"`, following Foldkit's convention that unavailable controls remain discoverable by keyboard and assistive technology.
+
+Assistive technology support for `aria-readonly` on switches varies. Pair it with a visible read-only treatment or explanatory text when users must distinguish it from disabled, and test the browser and assistive technology combinations your app supports.
+
+Use `isReadOnly` when the on/off state is still information the user needs, such as a setting controlled elsewhere, and `isDisabled` when the Switch is unavailable.
+
+The two flags are independent. Setting both emits both sets of attributes, and either one on its own removes the click and Space handlers.
 
 ## API Reference
 
@@ -41,15 +52,16 @@ The switch button receives `role="switch"` and `aria-checked`. The label is link
 
 Configuration object passed to `Switch.view()`.
 
-| Name         | Type                                     | Default | Description                                                                                                         |
-| ------------ | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| `id`         | `string`                                 | —       | Unique ID for the switch instance. Used to link the label and description via ARIA.                                 |
-| `isChecked`  | `boolean`                                | —       | The current on/off state, read from your Model. `aria-checked` and the `data-checked` marker derive from it.        |
-| `onToggle`   | `(isChecked: boolean) => Message`        | —       | Maps the new on/off state to a Message when the user toggles the switch. Your update handler just stores the value. |
-| `toView`     | `(attributes: SwitchAttributes) => Html` | —       | Callback that receives attribute groups for the button, label, description, and hidden input elements.              |
-| `isDisabled` | `boolean`                                | `false` | Whether the switch is disabled.                                                                                     |
-| `name`       | `string`                                 | —       | Form field name. When provided, a hidden input is included for native form submission.                              |
-| `value`      | `string`                                 | `'on'`  | Value sent in the form when checked.                                                                                |
+| Name         | Type                                     | Default | Description                                                                                                                          |
+| ------------ | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`         | `string`                                 | —       | Unique ID for the switch instance. Used to link the label and description via ARIA.                                                  |
+| `isChecked`  | `boolean`                                | —       | The current on/off state, read from your Model. `aria-checked` and the `data-checked` marker derive from it.                         |
+| `onToggle`   | `(isChecked: boolean) => Message`        | —       | Maps the new on/off state to a Message when the user toggles the switch. Your update handler just stores the value.                  |
+| `toView`     | `(attributes: SwitchAttributes) => Html` | —       | Callback that receives attribute groups for the button, label, description, and hidden input elements.                               |
+| `isDisabled` | `boolean`                                | `false` | Whether the switch is disabled.                                                                                                      |
+| `isReadOnly` | `boolean`                                | `false` | Whether the switch is readable but not toggleable. Carries `aria-readonly` rather than `aria-disabled`. Independent of `isDisabled`. |
+| `name`       | `string`                                 | —       | Form field name. When provided, a hidden input is included for native form submission.                                               |
+| `value`      | `string`                                 | `'on'`  | Value sent in the form when checked.                                                                                                 |
 
 ### SwitchAttributes {#switch-attributes}
 


### PR DESCRIPTION
`@foldkit/ui` had no way to render a Switch whose on/off state remains
relevant but cannot be changed. `isDisabled` removes interaction, but it
exposes disabled semantics and applies disabled styling.

Add `isReadOnly` to Switch's `ViewConfig`. A read-only Switch emits
`aria-readonly="true"` and `data-readonly`, remains focusable, and omits click
and Space handlers from both the button and label attribute groups.
`isReadOnly` and `isDisabled` are independent. Either removes interaction
handlers, and setting both emits both attribute sets.

Scene tests cover read-only attributes, focusability, handler removal, and the
combined disabled/read-only state. The website documents styling, keyboard
behavior, the accessibility distinction, and the fact that assistive
technology support for read-only switches varies.

Part of #925, following the convention established by #912.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only mode for switches.
  - Read-only switches remain focusable and expose appropriate accessibility attributes.
  - Read-only and disabled states can be configured independently.

- **Documentation**
  - Updated switch configuration and accessibility guidance, including read-only styling and keyboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->