### PR TITLE
feat(ui): export the switch id derivations

### DIFF
--- a/.changeset/switch-export-id-derivations.md
+++ b/.changeset/switch-export-id-derivations.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': minor
+---
+
+Export `Switch.labelId` and `Switch.descriptionId`
+
+Switch derived `${id}-label` and `${id}-description` from module-private consts, so a consumer that needed to reference the label or description element, to point `aria-details` at it, to style it, or to find it in a test, had to re-declare the convention and hope it did not drift. `Checkbox`, `Fieldset`, `Dialog`, `Select`, `Textarea`, `Input`, and `Popover` already export their equivalents; Switch now matches. No behavior change.

--- a/packages/ui/src/switch/index.ts
+++ b/packages/ui/src/switch/index.ts
@@ -35,8 +35,11 @@ export type ViewConfig<Message> = Readonly<{
   value?: string
 }>
 
-const labelId = (id: string): string => `${id}-label`
-const descriptionId = (id: string): string => `${id}-description`
+/** Generates the label element ID from the switch's base ID. */
+export const labelId = (id: string): string => `${id}-label`
+
+/** Generates the description element ID from the switch's base ID. */
+export const descriptionId = (id: string): string => `${id}-description`
 
 /** Renders an accessible switch as a stateless controlled component. The
  *  parent owns the checked state (`isChecked`) and receives the new state via

--- a/packages/ui/src/switch/public.ts
+++ b/packages/ui/src/switch/public.ts
@@ -1,3 +1,3 @@
-export { view } from './index.js'
+export { view, labelId, descriptionId } from './index.js'
 
 export type { ViewConfig, SwitchAttributes } from './index.js'

--- a/packages/website/src/page/ui/switchPage.md
+++ b/packages/website/src/page/ui/switchPage.md
@@ -35,6 +35,8 @@ Switch is headless. Your `toView` callback controls all markup and styling. Use 
 
 The switch button receives `role="switch"` and `aria-checked`. The label is linked via `aria-labelledby` and the description via `aria-describedby`. Clicking the label toggles the switch.
 
+The `label` attribute group includes an id (accessible via `Switch.labelId(id)`) and the `description` group includes an id (accessible via `Switch.descriptionId(id)`), so a consumer can reference either element without re-declaring the naming convention.
+
 ## API Reference
 
 ### ViewConfig {#view-config}


### PR DESCRIPTION
Closes #899.

## What was wrong

`Switch` derived `${id}-label` and `${id}-description` from module-private consts. A consumer that needed to reference the label or description element, to point `aria-details` at it, to style it, or to find it in a test, had to re-declare the convention and hope it did not drift. `Checkbox`, `Fieldset`, `Dialog`, `Select`, `Textarea`, `Input`, and `Popover` already export their equivalents, so the inconsistency was internal rather than deliberate.

## What changed

The same four files as #881, with `checkbox` swapped for `switch`:

- `packages/ui/src/switch/index.ts`: `export` on both helpers, with the TSDoc wording used for checkbox and fieldset.
- `packages/ui/src/switch/public.ts`: `export { view, labelId, descriptionId }`.
- `packages/website/src/page/ui/switchPage.md`: the Accessibility sentence, matching `checkboxPage.md` and `fieldsetPage.md`.
- A `minor` changeset for `@foldkit/ui`.

No behavior change. The exported functions are the same expressions `view` already calls.

## What I deliberately left alone

- **No test.** #881 added none, and `switch/scene.test.ts` already renders through these expressions indirectly. If you would rather have a pin, the precedent is a test that renders the view and reads the ids back out of the emitted ARIA, guarding the exported helpers against drifting from what `view` emits. Happy to add it, but it is not in the issue so I did not add it pre-emptively.
- **`radioGroup` and `slider`.** Their signatures are not a mechanical copy of #881 and the issue tracks them separately in #900.

## Verification

`pnpm pre-push` passes from a clean worktree, which covers `format:check`, `lint`, the changeset gates, `pnpm -r typecheck`, the full test run, and the website e2e smoke test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported `Switch.labelId` and `Switch.descriptionId` for creating ARIA references.
  * Existing ID generation behavior remains unchanged.

* **Documentation**
  * Updated Switch accessibility guidance to explain the generated ID helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->