### PR TITLE
fix(oxlint-plugin): reserve message payload for submodels

### DIFF
--- a/.changeset/reserved-submodel-message-payload.md
+++ b/.changeset/reserved-submodel-message-payload.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/oxlint-plugin': patch
+---
+
+Reject Got-prefixed Messages that assign an obviously primitive Schema to the reserved `message` payload field. The `message` field identifies a Submodel wrapper, so domain data should use a descriptive field such as `text` instead. Indirect child Message Schemas remain supported.
+
+The `got-submodel-message-name` diagnostic now explains the same reservation when a non-wrapper Message declares a `message` field.

--- a/packages/oxlint-plugin-foldkit/src/message.ts
+++ b/packages/oxlint-plugin-foldkit/src/message.ts
@@ -1,6 +1,28 @@
 import { type ESTree } from 'effect-oxlint'
 
-import { isIdentifier, isObjectExpression, isStringLiteral } from './guards.ts'
+import {
+  isCallExpression,
+  isIdentifier,
+  isMemberExpression,
+  isObjectExpression,
+  isStringLiteral,
+} from './guards.ts'
+
+const primitiveSchemaNames = new Set(['BigInt', 'Boolean', 'Number', 'String'])
+
+const primitiveSchemaFactoryNames = new Set(['Literal', 'Literals'])
+
+const isSchemaMemberNamed = (node: unknown, names: Set<string>): boolean =>
+  isMemberExpression(node) &&
+  !node.computed &&
+  isIdentifier(node.object, 'S') &&
+  isIdentifier(node.property) &&
+  names.has(node.property.name)
+
+const isPrimitiveSchema = (node: unknown): boolean =>
+  isSchemaMemberNamed(node, primitiveSchemaNames) ||
+  (isCallExpression(node) &&
+    isSchemaMemberNamed(node.callee, primitiveSchemaFactoryNames))
 
 export const isMCall = (node: ESTree.CallExpression): boolean =>
   isIdentifier(node.callee, 'm')
@@ -17,5 +39,21 @@ export const hasMessagePayloadProperty = (
       property.type === 'Property' &&
       (isIdentifier(property.key, 'message') ||
         (isStringLiteral(property.key) && property.key.value === 'message')),
+  )
+}
+
+export const hasPrimitiveMessagePayloadProperty = (
+  node: ESTree.CallExpression,
+): boolean => {
+  const [, second] = node.arguments
+  if (!isObjectExpression(second)) {
+    return false
+  }
+  return second.properties.some(
+    property =>
+      property.type === 'Property' &&
+      (isIdentifier(property.key, 'message') ||
+        (isStringLiteral(property.key) && property.key.value === 'message')) &&
+      isPrimitiveSchema(property.value),
   )
 }

--- a/packages/oxlint-plugin-foldkit/src/rules/got-prefix-requires-submodel-payload.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/got-prefix-requires-submodel-payload.ts
@@ -2,7 +2,11 @@ import { Effect } from 'effect'
 import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
 
 import { firstStringArgument, isCallExpression } from '../guards.ts'
-import { hasMessagePayloadProperty, isMCall } from '../message.ts'
+import {
+  hasMessagePayloadProperty,
+  hasPrimitiveMessagePayloadProperty,
+  isMCall,
+} from '../message.ts'
 
 /**
  * Requires Got-prefixed m() Messages to carry a { message: Child.Message }
@@ -19,13 +23,23 @@ export const gotPrefixRequiresSubmodelPayload = Rule.define({
     const ctx = yield* RuleContext
     return {
       CallExpression: (node: ESTree.Node) => {
-        if (!isCallExpression(node) || !isMCall(node)) return Effect.void
+        if (!isCallExpression(node) || !isMCall(node)) {
+          return Effect.void
+        }
         const messageName = firstStringArgument(node)
-        if (
-          messageName === undefined ||
-          !/^Got[A-Z]/.test(messageName.value) ||
-          hasMessagePayloadProperty(node)
-        ) {
+        if (messageName === undefined || !/^Got[A-Z]/.test(messageName.value)) {
+          return Effect.void
+        }
+        if (hasPrimitiveMessagePayloadProperty(node)) {
+          return ctx.report(
+            Diagnostic.make({
+              node: messageName,
+              message:
+                'The reserved message payload field must carry a Submodel Message Schema. Rename the field when it contains domain data.',
+            }),
+          )
+        }
+        if (hasMessagePayloadProperty(node)) {
           return Effect.void
         }
         return ctx.report(

--- a/packages/oxlint-plugin-foldkit/src/rules/got-submodel-message-name.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/got-submodel-message-name.ts
@@ -37,7 +37,7 @@ export const gotSubmodelMessageName = Rule.define({
           Diagnostic.make({
             node: messageName,
             message:
-              'Submodel wrapper Messages should be named Got*Message so Foldkit DevTools can filter them.',
+              'The message payload field is reserved for Submodel wrappers. Name the wrapper Got*Message, or rename the field when it contains domain data.',
           }),
         )
       },

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-prefix-requires-submodel-payload/invalid/message.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-prefix-requires-submodel-payload/invalid/message.ts
@@ -4,3 +4,7 @@ import { m } from 'foldkit/message'
 export const GotWeather = m('GotWeather', {
   temperature: S.Number,
 })
+
+export const GotReceipt = m('GotReceipt', {
+  message: S.String,
+})

--- a/packages/oxlint-plugin-foldkit/test/rules/got-prefix-requires-submodel-payload.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/got-prefix-requires-submodel-payload.test.ts
@@ -43,6 +43,27 @@ describe('got-prefix-requires-submodel-payload', () => {
     expect(suspendedPayload).toHaveLength(0)
   })
 
+  it.each([
+    Testing.memberExpr('S', 'String'),
+    Testing.memberExpr('S', 'Number'),
+    Testing.memberExpr('S', 'Boolean'),
+    Testing.memberExpr('S', 'BigInt'),
+    Testing.callOfMember('S', 'Literal', []),
+    Testing.callOfMember('S', 'Literals', []),
+  ])('rejects a primitive Schema in the reserved message field', schema => {
+    const result = Testing.runRule(
+      gotPrefixRequiresSubmodelPayload,
+      'CallExpression',
+      m('GotReceipt', Testing.objectExpr([{ key: 'message', value: schema }])),
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'reserved message payload field',
+    )
+    expect(result[0]?.diagnostic.message).toContain('Rename the field')
+  })
+
   it('reserves Got-prefixed Messages for Submodel wrappers', () => {
     const result = Testing.runRule(
       gotPrefixRequiresSubmodelPayload,

--- a/packages/oxlint-plugin-foldkit/test/rules/got-submodel-message-name.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/got-submodel-message-name.test.ts
@@ -20,7 +20,11 @@ describe('got-submodel-message-name', () => {
     )
 
     expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'reserved for Submodel wrappers',
+    )
     expect(result[0]?.diagnostic.message).toContain('Got*Message')
+    expect(result[0]?.diagnostic.message).toContain('rename the field')
   })
 
   it('allows Got*Message wrappers around Submodel Messages', () => {

--- a/packages/website/src/page/toolingLinting.md
+++ b/packages/website/src/page/toolingLinting.md
@@ -124,13 +124,13 @@ Flags turning off the freezeModel or slow dev guardrails. Fix the mutation or sl
 
 ### foldkit/got-submodel-message-name {#got-submodel-message-name}
 
-Requires wrapper Messages around Submodel Messages to use the Got\*Message convention.
+Reserves the message payload field for Submodel wrappers and requires those wrappers to use the Got\*Message convention. Rename the field when it contains domain data instead of a child Message.
 
 ::Snippet{name="lintGotSubmodelMessageName" label="foldkit/got-submodel-message-name example"}
 
 ### foldkit/got-prefix-requires-submodel-payload {#got-prefix-requires-submodel-payload}
 
-Reserves the Got\* prefix for Submodel wrappers. Any Got-prefixed Message must include a child Message payload named message.
+Reserves the Got\* prefix for Submodel wrappers. Any Got-prefixed Message must include a child Message payload named message, and an obviously primitive Schema cannot occupy that reserved field.
 
 ::Snippet{name="lintGotPrefixRequiresSubmodelPayload" label="foldkit/got-prefix-requires-submodel-payload example"}
 

--- a/packages/website/src/snippet/lintGotPrefixRequiresSubmodelPayload.ts
+++ b/packages/website/src/snippet/lintGotPrefixRequiresSubmodelPayload.ts
@@ -25,6 +25,13 @@ import * as Child from './child'
 }
 
 {
+  // ❌ Bad: message is reserved for a child Message Schema.
+  const GotReceipt = m('GotReceipt', {
+    message: S.String,
+  })
+}
+
+{
   // ✅ Good: Got wraps a child Message.
   const GotChildMessage = m('GotChildMessage', {
     id: S.String,

--- a/packages/website/src/snippet/lintGotSubmodelMessageName.ts
+++ b/packages/website/src/snippet/lintGotSubmodelMessageName.ts
@@ -1,3 +1,4 @@
+import { Schema as S } from 'effect'
 import { m } from 'foldkit/message'
 
 import * as Child from './child'
@@ -11,3 +12,17 @@ const ChildChanged = m('ChildChanged', {
 const GotChildMessage = m('GotChildMessage', {
   message: Child.Message,
 })
+
+{
+  // ❌ Bad: message is reserved for Submodel wrappers.
+  const ShowedNotice = m('ShowedNotice', {
+    message: S.String,
+  })
+}
+
+{
+  // ✅ Good: name domain data for what it contains.
+  const ShowedNotice = m('ShowedNotice', {
+    text: S.String,
+  })
+}


### PR DESCRIPTION
## Summary

- reject primitive Schemas in the reserved `message` payload field on Got-prefixed Messages
- clarify diagnostics when domain data uses the Submodel wrapper field
- add rule coverage, documentation examples, and a patch changeset

## Why

The lint rules previously treated any `message` property as enough to identify a Submodel wrapper. Domain payloads such as `message: S.String` could therefore bypass the Got-prefix check and blur the wrapper convention.

## Impact

Got-prefixed Messages now report an actionable diagnostic when the reserved field contains an obviously primitive Schema. Indirect child Message Schemas remain supported, and the docs explain how to rename domain payload fields.

## Validation

- `pnpm --filter @foldkit/oxlint-plugin test` (336 tests)
- `pnpm --filter @foldkit/oxlint-plugin typecheck`
- full repository pre-push gate: formatting, changeset validation, lint, dead-code checks, build, workspace typechecks and tests, and website E2E


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linting for `Got*` messages that use a primitive value in the reserved `message` field.
  * Added clearer diagnostics recommending a child Message Schema or renaming the field.
  * Preserved support for indirect child Message Schemas.

* **Documentation**
  * Updated linting guidance and examples to explain Submodel wrapper naming and reserved-field requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->