### PR TITLE
feat(foldkit): add context menu interaction to Scene

### DIFF
--- a/.changeset/calm-context-menus-open.md
+++ b/.changeset/calm-context-menus-open.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add `Scene.contextMenu` so Scene tests can exercise `h.OnContextMenu` behavior with normal event bubbling.

--- a/packages/foldkit/src/test/apps/contextMenu.ts
+++ b/packages/foldkit/src/test/apps/contextMenu.ts
@@ -1,16 +1,17 @@
-import { Match as M, Schema as S } from 'effect'
+import { Match as M, Number, Schema as S } from 'effect'
 
 import type { Html, HtmlBuilder } from '../../html/index.js'
 import { m } from '../../message/index.js'
+import { evo } from '../../struct/index.js'
 
 // MODEL
 
-const ContextMenuState = S.Union([
-  S.TaggedStruct('Closed', {}),
-  S.TaggedStruct('Open', {
-    source: S.Literals(['Direct', 'Inner', 'Outer']),
-  }),
-])
+const Closed = S.TaggedStruct('Closed', {})
+const Open = S.TaggedStruct('Open', {
+  source: S.Literals(['Direct', 'Inner', 'Outer']),
+})
+
+const ContextMenuState = S.Union([Closed, Open])
 type ContextMenuState = typeof ContextMenuState.Type
 
 export const Model = S.Struct({
@@ -31,7 +32,7 @@ type Message = typeof Message.Type
 // INIT
 
 export const initialModel = Model.make({
-  contextMenu: { _tag: 'Closed' },
+  contextMenu: Closed.make({}),
   openCount: 0,
 })
 
@@ -45,10 +46,10 @@ export const update = (
     M.withReturnType<readonly [Model, ReadonlyArray<never>]>(),
     M.tagsExhaustive({
       OpenedContextMenu: ({ source }) => [
-        {
-          contextMenu: { _tag: 'Open', source },
-          openCount: model.openCount + 1,
-        },
+        evo(model, {
+          contextMenu: () => Open.make({ source }),
+          openCount: Number.increment,
+        }),
         [],
       ],
     }),
@@ -57,9 +58,9 @@ export const update = (
 // VIEW
 
 export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
-  const maybeContextMenu = M.value(model.contextMenu).pipe(
+  const contextMenu = M.value(model.contextMenu).pipe(
     M.tagsExhaustive({
-      Closed: () => null,
+      Closed: () => h.empty,
       Open: ({ source }) =>
         h.div(
           [h.Role('menu'), h.AriaLabel(`${source} context menu`)],
@@ -97,7 +98,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
         ],
       ),
       h.span([h.AriaLabel('no handler')], ['No handler']),
-      maybeContextMenu,
+      contextMenu,
     ],
   )
 }

--- a/packages/foldkit/src/test/apps/contextMenu.ts
+++ b/packages/foldkit/src/test/apps/contextMenu.ts
@@ -7,9 +7,11 @@ import { evo } from '../../struct/index.js'
 
 // MODEL
 
+const ContextMenuSource = S.Literals(['Direct', 'Inner', 'Outer'])
+
 const Closed = ts('Closed')
 const Open = ts('Open', {
-  source: S.Literals(['Direct', 'Inner', 'Outer']),
+  source: ContextMenuSource,
 })
 
 const ContextMenuState = S.Union([Closed, Open])
@@ -24,7 +26,7 @@ export type Model = typeof Model.Type
 // MESSAGE
 
 const OpenedContextMenu = m('OpenedContextMenu', {
-  source: S.Literals(['Direct', 'Inner', 'Outer']),
+  source: ContextMenuSource,
 })
 
 const Message = S.Union([OpenedContextMenu])

--- a/packages/foldkit/src/test/apps/contextMenu.ts
+++ b/packages/foldkit/src/test/apps/contextMenu.ts
@@ -2,12 +2,13 @@ import { Match as M, Number, Schema as S } from 'effect'
 
 import type { Html, HtmlBuilder } from '../../html/index.js'
 import { m } from '../../message/index.js'
+import { ts } from '../../schema/index.js'
 import { evo } from '../../struct/index.js'
 
 // MODEL
 
-const Closed = S.TaggedStruct('Closed', {})
-const Open = S.TaggedStruct('Open', {
+const Closed = ts('Closed')
+const Open = ts('Open', {
   source: S.Literals(['Direct', 'Inner', 'Outer']),
 })
 
@@ -32,7 +33,7 @@ type Message = typeof Message.Type
 // INIT
 
 export const initialModel = Model.make({
-  contextMenu: Closed.make({}),
+  contextMenu: Closed(),
   openCount: 0,
 })
 
@@ -47,7 +48,7 @@ export const update = (
     M.tagsExhaustive({
       OpenedContextMenu: ({ source }) => [
         evo(model, {
-          contextMenu: () => Open.make({ source }),
+          contextMenu: () => Open({ source }),
           openCount: Number.increment,
         }),
         [],

--- a/packages/foldkit/src/test/apps/contextMenu.ts
+++ b/packages/foldkit/src/test/apps/contextMenu.ts
@@ -1,0 +1,103 @@
+import { Match as M, Schema as S } from 'effect'
+
+import type { Html, HtmlBuilder } from '../../html/index.js'
+import { m } from '../../message/index.js'
+
+// MODEL
+
+const ContextMenuState = S.Union([
+  S.TaggedStruct('Closed', {}),
+  S.TaggedStruct('Open', {
+    source: S.Literals(['Direct', 'Inner', 'Outer']),
+  }),
+])
+type ContextMenuState = typeof ContextMenuState.Type
+
+export const Model = S.Struct({
+  contextMenu: ContextMenuState,
+  openCount: S.Number,
+})
+export type Model = typeof Model.Type
+
+// MESSAGE
+
+const OpenedContextMenu = m('OpenedContextMenu', {
+  source: S.Literals(['Direct', 'Inner', 'Outer']),
+})
+
+const Message = S.Union([OpenedContextMenu])
+type Message = typeof Message.Type
+
+// INIT
+
+export const initialModel: Model = {
+  contextMenu: { _tag: 'Closed' },
+  openCount: 0,
+}
+
+// UPDATE
+
+export const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<never>] =>
+  M.value(message).pipe(
+    M.withReturnType<readonly [Model, ReadonlyArray<never>]>(),
+    M.tagsExhaustive({
+      OpenedContextMenu: ({ source }) => [
+        {
+          contextMenu: { _tag: 'Open', source },
+          openCount: model.openCount + 1,
+        },
+        [],
+      ],
+    }),
+  )
+
+// VIEW
+
+export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
+  const maybeContextMenu = M.value(model.contextMenu).pipe(
+    M.tagsExhaustive({
+      Closed: () => null,
+      Open: ({ source }) =>
+        h.div(
+          [h.Role('menu'), h.AriaLabel(`${source} context menu`)],
+          [`${source} context menu opens=${model.openCount}`],
+        ),
+    }),
+  )
+
+  return h.div(
+    [],
+    [
+      h.section(
+        [
+          h.AriaLabel('outer context area'),
+          h.OnContextMenu(OpenedContextMenu({ source: 'Outer' })),
+        ],
+        [
+          h.span([h.AriaLabel('outer target')], ['Outer target']),
+          h.div(
+            [
+              h.AriaLabel('inner context area'),
+              h.OnContextMenu(OpenedContextMenu({ source: 'Inner' })),
+            ],
+            [
+              h.span([h.AriaLabel('nearest target')], ['Nearest target']),
+              h.button(
+                [
+                  h.AriaLabel('direct target'),
+                  h.OnContextMenu(OpenedContextMenu({ source: 'Direct' })),
+                ],
+                ['Direct target'],
+              ),
+            ],
+          ),
+        ],
+      ),
+      h.span([h.AriaLabel('no handler')], ['No handler']),
+      maybeContextMenu,
+    ],
+  )
+}

--- a/packages/foldkit/src/test/apps/contextMenu.ts
+++ b/packages/foldkit/src/test/apps/contextMenu.ts
@@ -30,10 +30,10 @@ type Message = typeof Message.Type
 
 // INIT
 
-export const initialModel: Model = {
+export const initialModel = Model.make({
   contextMenu: { _tag: 'Closed' },
   openCount: 0,
-}
+})
 
 // UPDATE
 

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -2096,14 +2096,6 @@ describe('scene with extra interactions', () => {
     )
   })
 
-  test('toHaveHandler recognizes OnContextMenu', () => {
-    Scene.scene(
-      { update: contextMenuUpdate, view: contextMenuView },
-      Scene.given(contextMenuInitialModel),
-      Scene.expect(Scene.label('direct target')).toHaveHandler('contextmenu'),
-    )
-  })
-
   test('hover fires mouseenter handler', () => {
     Scene.scene(
       { update: interactionsUpdate, view: interactionsView },
@@ -3307,6 +3299,28 @@ describe('scene with click bubbling', () => {
     )
   })
 
+  test('click throws when no handler in ancestor chain', () => {
+    expect(() =>
+      Scene.scene(
+        { update: bubblingUpdate, view: bubblingView },
+        Scene.given(bubblingInitialModel),
+        Scene.click(Scene.text('dbl=0')),
+      ),
+    ).toThrow(/neither it nor any ancestor has a click handler/)
+  })
+
+  test('doubleClick throws when no handler in ancestor chain', () => {
+    expect(() =>
+      Scene.scene(
+        { update: bubblingUpdate, view: bubblingView },
+        Scene.given(bubblingInitialModel),
+        Scene.doubleClick(Scene.text('clicks=0')),
+      ),
+    ).toThrow(/neither it nor any ancestor has a dblclick handler/)
+  })
+})
+
+describe('scene with context menu bubbling', () => {
   test('contextMenu bubbles from child to an ancestor with a handler', () => {
     Scene.scene(
       { update: contextMenuUpdate, view: contextMenuView },
@@ -3349,6 +3363,17 @@ describe('scene with click bubbling', () => {
     )
   })
 
+  test('contextMenu resolves an ambiguous target to the first match', () => {
+    Scene.scene(
+      { update: contextMenuUpdate, view: contextMenuView },
+      Scene.given(contextMenuInitialModel),
+      Scene.contextMenu('span'),
+      Scene.expect(
+        Scene.role('menu', { name: 'Outer context menu' }),
+      ).toHaveText('Outer context menu opens=1'),
+    )
+  })
+
   test('contextMenu throws when the target does not exist', () => {
     expect(() =>
       Scene.scene(
@@ -3359,19 +3384,6 @@ describe('scene with click bubbling', () => {
     ).toThrow(
       'I could not find an element matching label "missing target".\n\n' +
         'Check that your selector matches an element in the current view.',
-    )
-  })
-
-  test('contextMenu throws when the target matches multiple elements', () => {
-    expect(() =>
-      Scene.scene(
-        { update: contextMenuUpdate, view: contextMenuView },
-        Scene.given(contextMenuInitialModel),
-        Scene.contextMenu('span'),
-      ),
-    ).toThrow(
-      'I found multiple elements matching "span".\n\n' +
-        'Use a more specific selector or Locator that matches one element.',
     )
   })
 
@@ -3386,26 +3398,6 @@ describe('scene with click bubbling', () => {
       'I found an element matching label "no handler" but neither it nor any ancestor has a contextmenu handler.\n\n' +
         'Make sure the element or a parent has an OnContextMenu attribute.',
     )
-  })
-
-  test('click throws when no handler in ancestor chain', () => {
-    expect(() =>
-      Scene.scene(
-        { update: bubblingUpdate, view: bubblingView },
-        Scene.given(bubblingInitialModel),
-        Scene.click(Scene.text('dbl=0')),
-      ),
-    ).toThrow(/neither it nor any ancestor has a click handler/)
-  })
-
-  test('doubleClick throws when no handler in ancestor chain', () => {
-    expect(() =>
-      Scene.scene(
-        { update: bubblingUpdate, view: bubblingView },
-        Scene.given(bubblingInitialModel),
-        Scene.doubleClick(Scene.text('clicks=0')),
-      ),
-    ).toThrow(/neither it nor any ancestor has a dblclick handler/)
   })
 })
 

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -3362,6 +3362,19 @@ describe('scene with click bubbling', () => {
     )
   })
 
+  test('contextMenu throws when the target matches multiple elements', () => {
+    expect(() =>
+      Scene.scene(
+        { update: contextMenuUpdate, view: contextMenuView },
+        Scene.given(contextMenuInitialModel),
+        Scene.contextMenu('span'),
+      ),
+    ).toThrow(
+      'I found multiple elements matching "span".\n\n' +
+        'Use a more specific selector or Locator that matches one element.',
+    )
+  })
+
   test('contextMenu throws when no handler exists in the ancestor chain', () => {
     expect(() =>
       Scene.scene(

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -31,6 +31,11 @@ import {
   hexColorPicker,
 } from './apps/colorPicker.js'
 import {
+  initialModel as contextMenuInitialModel,
+  update as contextMenuUpdate,
+  view as contextMenuView,
+} from './apps/contextMenu.js'
+import {
   FetchCount,
   FetchCountById,
   PolledCount,
@@ -2080,6 +2085,25 @@ describe('scene with extra interactions', () => {
     )
   })
 
+  test('contextMenu fires a direct handler and renders the resulting menu', () => {
+    Scene.scene(
+      { update: contextMenuUpdate, view: contextMenuView },
+      Scene.given(contextMenuInitialModel),
+      Scene.contextMenu(Scene.label('direct target')),
+      Scene.expect(
+        Scene.role('menu', { name: 'Direct context menu' }),
+      ).toHaveText('Direct context menu opens=1'),
+    )
+  })
+
+  test('toHaveHandler recognizes OnContextMenu', () => {
+    Scene.scene(
+      { update: contextMenuUpdate, view: contextMenuView },
+      Scene.given(contextMenuInitialModel),
+      Scene.expect(Scene.label('direct target')).toHaveHandler('contextmenu'),
+    )
+  })
+
   test('hover fires mouseenter handler', () => {
     Scene.scene(
       { update: interactionsUpdate, view: interactionsView },
@@ -3280,6 +3304,74 @@ describe('scene with click bubbling', () => {
       Scene.given(bubblingInitialModel),
       Scene.doubleClick(Scene.text('dbl=0')),
       Scene.expect(Scene.text('dbl=1')).toExist(),
+    )
+  })
+
+  test('contextMenu bubbles from child to an ancestor with a handler', () => {
+    Scene.scene(
+      { update: contextMenuUpdate, view: contextMenuView },
+      Scene.given(contextMenuInitialModel),
+      Scene.contextMenu(Scene.label('outer target')),
+      Scene.expect(
+        Scene.role('menu', { name: 'Outer context menu' }),
+      ).toHaveText('Outer context menu opens=1'),
+    )
+  })
+
+  test('contextMenu invokes the nearest ancestor handler', () => {
+    Scene.scene(
+      { update: contextMenuUpdate, view: contextMenuView },
+      Scene.given(contextMenuInitialModel),
+      Scene.contextMenu(Scene.label('nearest target')),
+      Scene.expect(
+        Scene.role('menu', { name: 'Inner context menu' }),
+      ).toHaveText('Inner context menu opens=1'),
+      Scene.expect(
+        Scene.role('menu', { name: 'Outer context menu' }),
+      ).toBeAbsent(),
+    )
+  })
+
+  test('a direct contextMenu handler prevents ancestor handlers from firing', () => {
+    Scene.scene(
+      { update: contextMenuUpdate, view: contextMenuView },
+      Scene.given(contextMenuInitialModel),
+      Scene.contextMenu(Scene.label('direct target')),
+      Scene.expect(
+        Scene.role('menu', { name: 'Direct context menu' }),
+      ).toHaveText('Direct context menu opens=1'),
+      Scene.expect(
+        Scene.role('menu', { name: 'Inner context menu' }),
+      ).toBeAbsent(),
+      Scene.expect(
+        Scene.role('menu', { name: 'Outer context menu' }),
+      ).toBeAbsent(),
+    )
+  })
+
+  test('contextMenu throws when the target does not exist', () => {
+    expect(() =>
+      Scene.scene(
+        { update: contextMenuUpdate, view: contextMenuView },
+        Scene.given(contextMenuInitialModel),
+        Scene.contextMenu(Scene.label('missing target')),
+      ),
+    ).toThrow(
+      'I could not find an element matching label "missing target".\n\n' +
+        'Check that your selector matches an element in the current view.',
+    )
+  })
+
+  test('contextMenu throws when no handler exists in the ancestor chain', () => {
+    expect(() =>
+      Scene.scene(
+        { update: contextMenuUpdate, view: contextMenuView },
+        Scene.given(contextMenuInitialModel),
+        Scene.contextMenu(Scene.label('no handler')),
+      ),
+    ).toThrow(
+      'I found an element matching label "no handler" but neither it nor any ancestor has a contextmenu handler.\n\n' +
+        'Make sure the element or a parent has an OnContextMenu attribute.',
     )
   })
 

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -379,6 +379,23 @@ const applyScopeToLocatorAll = (
     },
   })
 
+const hasMultipleTargetMatches = (
+  scope: Option.Option<Locator>,
+  html: VNode,
+  target: string | Locator,
+): boolean => {
+  if (typeof target !== 'string') {
+    return false
+  }
+
+  return pipe(
+    html,
+    applyScopeToLocatorAll(scope, allSelector(target)),
+    Array.drop(1),
+    Array.isArrayNonEmpty,
+  )
+}
+
 // CAPTURING DISPATCH
 
 const createCapturingDispatch = (): CapturingDispatch => {
@@ -1548,6 +1565,14 @@ export const contextMenu =
     simulation: SceneSimulation<Model, Message, OutMessage>,
   ): SceneSimulation<Model, Message, OutMessage> => {
     const internal = toInternal(simulation)
+
+    if (hasMultipleTargetMatches(internal.scope, internal.html, target)) {
+      throw new Error(
+        `I found multiple elements matching "${target}".\n\n` +
+          'Use a more specific selector or Locator that matches one element.',
+      )
+    }
+
     const scopedTarget = applyScopeToTarget(internal.scope, target)
     const { maybeElement, description } = resolveTarget(
       internal.html,

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -379,23 +379,6 @@ const applyScopeToLocatorAll = (
     },
   })
 
-const hasMultipleTargetMatches = (
-  scope: Option.Option<Locator>,
-  html: VNode,
-  target: string | Locator,
-): boolean => {
-  if (!Predicate.isString(target)) {
-    return false
-  }
-
-  return pipe(
-    html,
-    applyScopeToLocatorAll(scope, allSelector(target)),
-    Array.drop(1),
-    Array.isArrayNonEmpty,
-  )
-}
-
 // CAPTURING DISPATCH
 
 const createCapturingDispatch = (): CapturingDispatch => {
@@ -1565,14 +1548,6 @@ export const contextMenu =
     simulation: SceneSimulation<Model, Message, OutMessage>,
   ): SceneSimulation<Model, Message, OutMessage> => {
     const internal = toInternal(simulation)
-
-    if (hasMultipleTargetMatches(internal.scope, internal.html, target)) {
-      throw new Error(
-        `I found multiple elements matching "${target}".\n\n` +
-          'Use a more specific selector or Locator that matches one element.',
-      )
-    }
-
     const scopedTarget = applyScopeToTarget(internal.scope, target)
     const { maybeElement, description } = resolveTarget(
       internal.html,
@@ -1586,7 +1561,7 @@ export const contextMenu =
       )
     }
 
-    const element = maybeElement.value
+    const { value: element } = maybeElement
     const invokeHandler = (handler: Function) => {
       handler({ preventDefault: Function.constVoid })
     }

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -384,7 +384,7 @@ const hasMultipleTargetMatches = (
   html: VNode,
   target: string | Locator,
 ): boolean => {
-  if (typeof target !== 'string') {
+  if (!Predicate.isString(target)) {
     return false
   }
 

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -441,6 +441,7 @@ const isDocument = (value: Html | Document): value is Document =>
 const EVENT_NAMES: Record<string, string> = {
   click: 'OnClick',
   dblclick: 'OnDoubleClick',
+  contextmenu: 'OnContextMenu',
   submit: 'OnSubmit',
   input: 'OnInput',
   change: 'OnChange',
@@ -1534,6 +1535,66 @@ export const doubleClick =
     const attributeName = EVENT_NAMES['dblclick'] ?? 'dblclick'
     throw new Error(
       `I found an element matching ${description} but neither it nor any ancestor has a dblclick handler.\n\n` +
+        `Make sure the element or a parent has an ${attributeName} attribute.`,
+    )
+  }
+
+/** Simulates a contextmenu event on the element matching the target.
+ *  When the element has no contextmenu handler, the event bubbles up to the
+ *  nearest ancestor with one, mirroring browser event propagation. */
+export const contextMenu =
+  (target: string | Locator) =>
+  <Model, Message, OutMessage = undefined>(
+    simulation: SceneSimulation<Model, Message, OutMessage>,
+  ): SceneSimulation<Model, Message, OutMessage> => {
+    const internal = toInternal(simulation)
+    const scopedTarget = applyScopeToTarget(internal.scope, target)
+    const { maybeElement, description } = resolveTarget(
+      internal.html,
+      scopedTarget,
+    )
+
+    if (Option.isNone(maybeElement)) {
+      throw new Error(
+        `I could not find an element matching ${description}.\n\n` +
+          'Check that your selector matches an element in the current view.',
+      )
+    }
+
+    const element = maybeElement.value
+    const invokeHandler = (handler: Function) => {
+      handler({ preventDefault: Function.constVoid })
+    }
+
+    if (element.data?.on?.['contextmenu'] !== undefined) {
+      return captureFromElement(
+        simulation,
+        element,
+        description,
+        'contextmenu',
+        invokeHandler,
+      )
+    }
+
+    const maybeAncestor = findAncestorWithHandler(
+      internal.html,
+      element,
+      'contextmenu',
+    )
+
+    if (Option.isSome(maybeAncestor)) {
+      return captureFromElement(
+        simulation,
+        maybeAncestor.value,
+        `ancestor of ${description}`,
+        'contextmenu',
+        invokeHandler,
+      )
+    }
+
+    const attributeName = EVENT_NAMES['contextmenu'] ?? 'contextmenu'
+    throw new Error(
+      `I found an element matching ${description} but neither it nor any ancestor has a contextmenu handler.\n\n` +
         `Make sure the element or a parent has an ${attributeName} attribute.`,
     )
   }

--- a/packages/website/src/page/testingScene.md
+++ b/packages/website/src/page/testingScene.md
@@ -71,6 +71,7 @@ Interactions exercise the view by invoking event handlers on matched elements. E
 | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `click(target)`                    | `OnClick` (bubbles to ancestors)                                                                 |
 | `doubleClick(target)`              | `OnDoubleClick` (bubbles to ancestors)                                                           |
+| `contextMenu(target)`              | `OnContextMenu` (bubbles to ancestors)                                                           |
 | `pointerDown(target, options?)`    | `OnPointerDown` with optional `{ pointerType, button, screenX, screenY }` (bubbles to ancestors) |
 | `pointerUp(target, options?)`      | `OnPointerUp` with optional `{ pointerType, screenX, screenY }` (bubbles to ancestors)           |
 | `hover(target)`                    | `OnMouseEnter` (falls back to `OnMouseOver`)                                                     |
@@ -80,6 +81,8 @@ Interactions exercise the view by invoking event handlers on matched elements. E
 | `change(target, value)`            | `OnChange` with the given value, for `<select>` and similar                                      |
 | `keydown(target, key, modifiers?)` | `OnKeyDown` or `OnKeyDownPreventDefault` with optional `{ shiftKey, ctrlKey, altKey, metaKey }`  |
 | `submit(target)`                   | `OnSubmit`                                                                                       |
+
+`contextMenu(target)` invokes the target's `OnContextMenu` handler, or the nearest ancestor handler when the target has none. It fails when the target and its ancestors have no matching handler.
 
 `tap(fn)` runs a function for side effects (like ad-hoc assertions on raw VNodes or accumulated Commands) without breaking the step chain.
 

--- a/packages/website/src/page/testingScene.md
+++ b/packages/website/src/page/testingScene.md
@@ -82,8 +82,6 @@ Interactions exercise the view by invoking event handlers on matched elements. E
 | `keydown(target, key, modifiers?)` | `OnKeyDown` or `OnKeyDownPreventDefault` with optional `{ shiftKey, ctrlKey, altKey, metaKey }`  |
 | `submit(target)`                   | `OnSubmit`                                                                                       |
 
-`contextMenu(target)` invokes the target's `OnContextMenu` handler, or the nearest ancestor handler when the target has none. It fails when the target and its ancestors have no matching handler.
-
 `tap(fn)` runs a function for side effects (like ad-hoc assertions on raw VNodes or accumulated Commands) without breaking the step chain.
 
 ## Assertions

--- a/packages/website/src/snippet/sceneApi.ts
+++ b/packages/website/src/snippet/sceneApi.ts
@@ -6,6 +6,7 @@ import {
   blur,
   change,
   click,
+  contextMenu,
   displayValue,
   doubleClick,
   expect,
@@ -73,6 +74,7 @@ pipe(
 // Interactions — exercise the view.
 click(role('button', { name: 'Log out' }))
 doubleClick(role('button', { name: 'Expand' }))
+contextMenu(role('row', { name: 'Quarterly report' }))
 pointerDown(role('button', { name: 'Toggle' }))
 pointerUp(role('button', { name: 'Toggle' }))
 hover(role('menuitem', { name: 'File' }))

--- a/packages/website/src/snippet/sceneInteractions.ts
+++ b/packages/website/src/snippet/sceneInteractions.ts
@@ -2,6 +2,7 @@ import {
   blur,
   change,
   click,
+  contextMenu,
   doubleClick,
   focus,
   hover,
@@ -16,6 +17,7 @@ import {
 
 click(role('button', { name: 'Log out' }))
 doubleClick(role('button', { name: 'Expand' }))
+contextMenu(role('row', { name: 'Quarterly report' }))
 pointerDown(role('button', { name: 'Toggle' }))
 pointerUp(role('button', { name: 'Toggle' }))
 hover(role('menuitem', { name: 'File' }))


### PR DESCRIPTION
## Summary

- add `Scene.contextMenu` for behavior-testing `h.OnContextMenu` handlers
- follow normal event bubbling by invoking the nearest matching handler
- report the standard interaction error when no target or ancestor handler exists
- document the new Scene interaction and add regression coverage

Fixes #937

## Validation

- `pnpm --filter foldkit exec vitest run src/test/scene.test.ts -t contextMenu` passed: 6 tests
- `pnpm --filter foldkit exec vitest run src/test/scene.test.ts` passed: 598 tests
- `pnpm --filter foldkit test` passed: 1,758 tests, 1 skipped
- `pnpm --filter foldkit typecheck` passed
- `pnpm lint` passed
- `pnpm format` passed
- `pnpm format:check` passed
- `pnpm check:changeset-unwrapped` passed
- `pnpm check:changeset-ignore` passed
- `pnpm check:no-major-changesets` passed
- `pnpm check:no-claude-comments` passed
- `pnpm changeset status --since=origin/main` passed with a minor Foldkit bump
- `pnpm test` passed after reconciling workspace artifacts and allowing loopback access for relay tests
- `git push -u origin codex/add-scene-context-menu` passed, including the complete repository pre-push hook with builds, recursive typechecks and tests, dead-code checks, and the Chromium website smoke test