### PR TITLE
feat(ui): add isReadOnly to Input and Textarea

### DIFF
--- a/.changeset/input-textarea-read-only.md
+++ b/.changeset/input-textarea-read-only.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': minor
+---
+
+Add `isReadOnly` to Input's and Textarea's `ViewConfig`.
+
+A read-only field sets the native `readonly` attribute plus `data-readonly`, stays focusable and selectable, and omits its input handler. `isReadOnly` and `isDisabled` are independent, and either one removes the input handler.

--- a/packages/ui/src/input/index.ts
+++ b/packages/ui/src/input/index.ts
@@ -17,6 +17,7 @@ export type ViewConfig<Message> = Readonly<{
   onInput?: (value: string) => Message
   value?: string
   isDisabled?: boolean
+  isReadOnly?: boolean
   isInvalid?: boolean
   isAutofocus?: boolean
   name?: string
@@ -38,6 +39,7 @@ export const view = <Message>(
     onInput,
     value,
     isDisabled = false,
+    isReadOnly = false,
     isInvalid = false,
     isAutofocus = false,
     name,
@@ -49,12 +51,20 @@ export const view = <Message>(
     ? [h.AriaDisabled(true), h.Disabled(true), h.DataAttribute('disabled', '')]
     : []
 
+  const readOnlyAttributes = isReadOnly
+    ? [h.Readonly(true), h.DataAttribute('readonly', '')]
+    : []
+
   const invalidAttributes = isInvalid
     ? [h.AriaInvalid(true), h.DataAttribute('invalid', '')]
     : []
 
+  const isInteractive = !isDisabled && !isReadOnly
+
   const inputAttributes =
-    Predicate.isNotUndefined(onInput) && !isDisabled ? [h.OnInput(onInput)] : []
+    Predicate.isNotUndefined(onInput) && isInteractive
+      ? [h.OnInput(onInput)]
+      : []
 
   const valueAttributes = Predicate.isNotUndefined(value)
     ? [h.Value(value)]
@@ -73,6 +83,7 @@ export const view = <Message>(
     h.Type(type),
     h.AriaDescribedBy(descriptionId(id)),
     ...disabledAttributes,
+    ...readOnlyAttributes,
     ...invalidAttributes,
     ...inputAttributes,
     ...valueAttributes,

--- a/packages/ui/src/input/scene.test.ts
+++ b/packages/ui/src/input/scene.test.ts
@@ -1,0 +1,97 @@
+import { Match as M, Schema as S } from 'effect'
+import type { HtmlBuilder } from 'foldkit/html'
+import { m } from 'foldkit/message'
+import * as Scene from 'foldkit/scene'
+import { evo } from 'foldkit/struct'
+
+import { describe, it } from '@effect/vitest'
+
+import { view } from './index.js'
+
+const Changed = m('Changed', { value: S.String })
+const Message = S.Union([Changed])
+type Message = typeof Message.Type
+
+type Model = Readonly<{ value: string }>
+
+type UpdateReturn = readonly [Model, ReadonlyArray<never>]
+
+const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    M.withReturnType<UpdateReturn>(),
+    M.tagsExhaustive({
+      Changed: ({ value }) => [evo(model, { value: () => value }), []],
+    }),
+  )
+
+const testView =
+  ({
+    isDisabled = false,
+    isReadOnly = false,
+  }: { isDisabled?: boolean; isReadOnly?: boolean } = {}) =>
+  (model: Model, h: HtmlBuilder<Message>) =>
+    view(
+      {
+        id: 'test',
+        value: model.value,
+        onInput: value => Changed({ value }),
+        isDisabled,
+        isReadOnly,
+        toView: ({ input, label }) =>
+          h.div([], [h.input([...input]), h.label([...label], ['Email'])]),
+      },
+      h,
+    )
+
+const field = Scene.role('textbox')
+
+describe('Input controlled view', () => {
+  it('dispatches the typed value', () => {
+    Scene.scene(
+      { update, view: testView() },
+      Scene.given({ value: '' }),
+      Scene.type(field, 'hello'),
+      Scene.expect(field).toHaveValue('hello'),
+    )
+  })
+
+  it('is not interactive when disabled', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).toBeDisabled(),
+      Scene.expect(field).toHaveAttr('data-disabled', ''),
+      Scene.expect(field).not.toHaveHandler('input'),
+    )
+  })
+
+  it('emits read-only attributes without disabled attributes', () => {
+    Scene.scene(
+      { update, view: testView({ isReadOnly: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).toHaveAttr('readOnly', 'true'),
+      Scene.expect(field).toHaveAttr('data-readonly', ''),
+      Scene.expect(field).not.toBeDisabled(),
+      Scene.expect(field).not.toHaveAttr('data-disabled'),
+    )
+  })
+
+  it('drops the input handler when read-only', () => {
+    Scene.scene(
+      { update, view: testView({ isReadOnly: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).not.toHaveHandler('input'),
+    )
+  })
+
+  it('emits both attribute sets when disabled and read-only are combined', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true, isReadOnly: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).toBeDisabled(),
+      Scene.expect(field).toHaveAttr('data-disabled', ''),
+      Scene.expect(field).toHaveAttr('readOnly', 'true'),
+      Scene.expect(field).toHaveAttr('data-readonly', ''),
+    )
+  })
+})

--- a/packages/ui/src/textarea/index.ts
+++ b/packages/ui/src/textarea/index.ts
@@ -17,6 +17,7 @@ export type ViewConfig<Message> = Readonly<{
   onInput?: (value: string) => Message
   value?: string
   isDisabled?: boolean
+  isReadOnly?: boolean
   isInvalid?: boolean
   isAutofocus?: boolean
   name?: string
@@ -38,6 +39,7 @@ export const view = <Message>(
     onInput,
     value,
     isDisabled = false,
+    isReadOnly = false,
     isInvalid = false,
     isAutofocus = false,
     name,
@@ -49,12 +51,20 @@ export const view = <Message>(
     ? [h.AriaDisabled(true), h.Disabled(true), h.DataAttribute('disabled', '')]
     : []
 
+  const readOnlyAttributes = isReadOnly
+    ? [h.Readonly(true), h.DataAttribute('readonly', '')]
+    : []
+
   const invalidAttributes = isInvalid
     ? [h.AriaInvalid(true), h.DataAttribute('invalid', '')]
     : []
 
+  const isInteractive = !isDisabled && !isReadOnly
+
   const inputAttributes =
-    Predicate.isNotUndefined(onInput) && !isDisabled ? [h.OnInput(onInput)] : []
+    Predicate.isNotUndefined(onInput) && isInteractive
+      ? [h.OnInput(onInput)]
+      : []
 
   const valueAttributes = Predicate.isNotUndefined(value)
     ? [h.Value(value)]
@@ -74,6 +84,7 @@ export const view = <Message>(
     h.Id(id),
     h.AriaDescribedBy(descriptionId(id)),
     ...disabledAttributes,
+    ...readOnlyAttributes,
     ...invalidAttributes,
     ...inputAttributes,
     ...valueAttributes,

--- a/packages/ui/src/textarea/scene.test.ts
+++ b/packages/ui/src/textarea/scene.test.ts
@@ -1,0 +1,100 @@
+import { Match as M, Schema as S } from 'effect'
+import type { HtmlBuilder } from 'foldkit/html'
+import { m } from 'foldkit/message'
+import * as Scene from 'foldkit/scene'
+import { evo } from 'foldkit/struct'
+
+import { describe, it } from '@effect/vitest'
+
+import { view } from './index.js'
+
+const Changed = m('Changed', { value: S.String })
+const Message = S.Union([Changed])
+type Message = typeof Message.Type
+
+type Model = Readonly<{ value: string }>
+
+type UpdateReturn = readonly [Model, ReadonlyArray<never>]
+
+const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    M.withReturnType<UpdateReturn>(),
+    M.tagsExhaustive({
+      Changed: ({ value }) => [evo(model, { value: () => value }), []],
+    }),
+  )
+
+const testView =
+  ({
+    isDisabled = false,
+    isReadOnly = false,
+  }: { isDisabled?: boolean; isReadOnly?: boolean } = {}) =>
+  (model: Model, h: HtmlBuilder<Message>) =>
+    view(
+      {
+        id: 'test',
+        value: model.value,
+        onInput: value => Changed({ value }),
+        isDisabled,
+        isReadOnly,
+        toView: ({ textarea, label }) =>
+          h.div(
+            [],
+            [h.textarea([...textarea]), h.label([...label], ['Message'])],
+          ),
+      },
+      h,
+    )
+
+const field = Scene.role('textbox')
+
+describe('Textarea controlled view', () => {
+  it('dispatches the typed value', () => {
+    Scene.scene(
+      { update, view: testView() },
+      Scene.given({ value: '' }),
+      Scene.type(field, 'hello'),
+      Scene.expect(field).toHaveValue('hello'),
+    )
+  })
+
+  it('is not interactive when disabled', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).toBeDisabled(),
+      Scene.expect(field).toHaveAttr('data-disabled', ''),
+      Scene.expect(field).not.toHaveHandler('input'),
+    )
+  })
+
+  it('emits read-only attributes without disabled attributes', () => {
+    Scene.scene(
+      { update, view: testView({ isReadOnly: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).toHaveAttr('readOnly', 'true'),
+      Scene.expect(field).toHaveAttr('data-readonly', ''),
+      Scene.expect(field).not.toBeDisabled(),
+      Scene.expect(field).not.toHaveAttr('data-disabled'),
+    )
+  })
+
+  it('drops the input handler when read-only', () => {
+    Scene.scene(
+      { update, view: testView({ isReadOnly: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).not.toHaveHandler('input'),
+    )
+  })
+
+  it('emits both attribute sets when disabled and read-only are combined', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true, isReadOnly: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).toBeDisabled(),
+      Scene.expect(field).toHaveAttr('data-disabled', ''),
+      Scene.expect(field).toHaveAttr('readOnly', 'true'),
+      Scene.expect(field).toHaveAttr('data-readonly', ''),
+    )
+  })
+})

--- a/packages/website/src/page/ui/inputPage.md
+++ b/packages/website/src/page/ui/inputPage.md
@@ -28,11 +28,12 @@ Set `isDisabled: true` to disable the input. Unlike Button, Input uses the nativ
 
 ## Styling
 
-Input is headless. Your `toView` callback controls all markup and styling. Use the data attributes below to style different states. For validation, set `isInvalid: true` and style with `data-[invalid]` in your CSS.
+Input is headless. Your `toView` callback controls all markup and styling. Use the data attributes below to style disabled, read-only, and invalid states. For validation, set `isInvalid: true` and style with `data-[invalid]` in your CSS.
 
 | Attribute       | Condition                        |
 | --------------- | -------------------------------- |
 | `data-disabled` | Present when isDisabled is true. |
+| `data-readonly` | Present when isReadOnly is true. |
 | `data-invalid`  | Present when isInvalid is true.  |
 
 ## Keyboard Interaction
@@ -43,11 +44,19 @@ Input uses the native `<input>` element, so all keyboard interaction is handled 
 | ----- | -------------------------------------- |
 | `Tab` | Moves focus to or away from the input. |
 
+A read-only input still takes focus and allows selection and copying. Typing does not change the value.
+
 ## Accessibility
 
 The three attribute groups wire up ARIA relationships automatically. The `label` group includes `for` pointing to the input `id`. The `description` group includes an `id` that the input references via `aria-describedby`. You can access this description ID directly with `Input.descriptionId(id)` if you need to reference it outside the `toView` callback.
 
 When `isInvalid` is true, `aria-invalid="true"` is set on the input element so screen readers announce the error state.
+
+`isReadOnly` sets the native `readonly` attribute, so the browser exposes the read-only state to assistive technology without any extra ARIA. The value stays focusable, selectable, and copyable, and the field is still submitted with its form.
+
+`isDisabled` sets the native `disabled` attribute instead. A disabled input is not focusable and is left out of form submission. Use `isReadOnly` when the value still matters to the user and only editing is blocked, and `isDisabled` when the field is unavailable.
+
+The two flags are independent. Setting both emits both attribute sets, and either one on its own removes the input handler. Browsers give `disabled` precedence when both are present.
 
 ## API Reference
 
@@ -55,18 +64,19 @@ When `isInvalid` is true, `aria-invalid="true"` is set on the input element so s
 
 Configuration object passed to `Input.view()`.
 
-| Name          | Type                                        | Default  | Description                                                                                                         |
-| ------------- | ------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `id`          | `string`                                    | —        | Unique ID for the input element. Used to link the label and description via ARIA attributes.                        |
-| `toView`      | `(attributes: InputAttributes) => Html`     | —        | Callback that receives attribute groups for the input, label, and description elements.                             |
-| `onInput`     | `((value: string) => Message) \| undefined` | —        | Optional function that maps the current input value to a Message on each input event. Omit for a read-only display. |
-| `value`       | `string`                                    | —        | The current value of the input.                                                                                     |
-| `isDisabled`  | `boolean`                                   | `false`  | Whether the input is disabled. Sets both the native disabled attribute and aria-disabled.                           |
-| `isInvalid`   | `boolean`                                   | `false`  | Whether the input is in an invalid state. Sets aria-invalid and adds a data-invalid attribute for styling.          |
-| `isAutofocus` | `boolean`                                   | `false`  | Whether the input receives focus when the page loads.                                                               |
-| `name`        | `string`                                    | —        | The form field name for native form submission.                                                                     |
-| `type`        | `string`                                    | `'text'` | The HTML input type (text, email, password, number, etc.).                                                          |
-| `placeholder` | `string`                                    | —        | Placeholder text shown when the input is empty.                                                                     |
+| Name          | Type                                        | Default  | Description                                                                                                                                                     |
+| ------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`          | `string`                                    | —        | Unique ID for the input element. Used to link the label and description via ARIA attributes.                                                                    |
+| `toView`      | `(attributes: InputAttributes) => Html`     | —        | Callback that receives attribute groups for the input, label, and description elements.                                                                         |
+| `onInput`     | `((value: string) => Message) \| undefined` | —        | Optional function that maps the current input value to a Message on each input event. Omit for a read-only display.                                             |
+| `value`       | `string`                                    | —        | The current value of the input.                                                                                                                                 |
+| `isDisabled`  | `boolean`                                   | `false`  | Whether the input is disabled. Sets both the native disabled attribute and aria-disabled.                                                                       |
+| `isReadOnly`  | `boolean`                                   | `false`  | Whether the input is readable but not editable. Sets the native readonly attribute and adds a data-readonly attribute for styling. Independent of `isDisabled`. |
+| `isInvalid`   | `boolean`                                   | `false`  | Whether the input is in an invalid state. Sets aria-invalid and adds a data-invalid attribute for styling.                                                      |
+| `isAutofocus` | `boolean`                                   | `false`  | Whether the input receives focus when the page loads.                                                                                                           |
+| `name`        | `string`                                    | —        | The form field name for native form submission.                                                                                                                 |
+| `type`        | `string`                                    | `'text'` | The HTML input type (text, email, password, number, etc.).                                                                                                      |
+| `placeholder` | `string`                                    | —        | Placeholder text shown when the input is empty.                                                                                                                 |
 
 ### InputAttributes {#input-attributes}
 

--- a/packages/website/src/page/ui/textareaPage.md
+++ b/packages/website/src/page/ui/textareaPage.md
@@ -28,11 +28,12 @@ Set `isDisabled: true` to disable the textarea. Like Input, this sets both the n
 
 ## Styling
 
-Textarea is headless. Your `toView` callback controls all markup and styling. Use the data attributes below to style different states.
+Textarea is headless. Your `toView` callback controls all markup and styling. Use the data attributes below to style disabled, read-only, and invalid states.
 
 | Attribute       | Condition                        |
 | --------------- | -------------------------------- |
 | `data-disabled` | Present when isDisabled is true. |
+| `data-readonly` | Present when isReadOnly is true. |
 | `data-invalid`  | Present when isInvalid is true.  |
 
 ## Keyboard Interaction
@@ -43,11 +44,19 @@ Textarea uses the native `<textarea>` element, so all keyboard interaction is ha
 | ----- | ----------------------------------------- |
 | `Tab` | Moves focus to or away from the textarea. |
 
+A read-only textarea still takes focus and allows selection and copying. Typing does not change the value.
+
 ## Accessibility
 
 Textarea provides the same ARIA wiring as Input. The `label` group links via `for`, and the `description` group is referenced by `aria-describedby` on the textarea. You can access the description ID directly with `Textarea.descriptionId(id)`.
 
 When `isInvalid` is true, `aria-invalid="true"` is set on the textarea element.
+
+`isReadOnly` sets the native `readonly` attribute, so the browser exposes the read-only state to assistive technology without any extra ARIA. The value stays focusable, selectable, and copyable, and the field is still submitted with its form.
+
+`isDisabled` sets the native `disabled` attribute instead. A disabled textarea is not focusable and is left out of form submission. Use `isReadOnly` when the value still matters to the user and only editing is blocked, and `isDisabled` when the field is unavailable.
+
+The two flags are independent. Setting both emits both attribute sets, and either one on its own removes the input handler. Browsers give `disabled` precedence when both are present.
 
 ## API Reference
 
@@ -55,18 +64,19 @@ When `isInvalid` is true, `aria-invalid="true"` is set on the textarea element.
 
 Configuration object passed to `Textarea.view()`.
 
-| Name          | Type                                       | Default | Description                                                                                                   |
-| ------------- | ------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------- |
-| `id`          | `string`                                   | —       | Unique ID for the textarea element. Used to link the label and description via ARIA attributes.               |
-| `toView`      | `(attributes: TextareaAttributes) => Html` | —       | Callback that receives attribute groups for the textarea, label, and description elements.                    |
-| `onInput`     | `(value: string) => Message`               | —       | Function that maps the current textarea value to a Message on each input event.                               |
-| `value`       | `string`                                   | —       | The current value of the textarea.                                                                            |
-| `isDisabled`  | `boolean`                                  | `false` | Whether the textarea is disabled. Sets both the native disabled attribute and aria-disabled.                  |
-| `isInvalid`   | `boolean`                                  | `false` | Whether the textarea is in an invalid state. Sets aria-invalid and adds a data-invalid attribute for styling. |
-| `isAutofocus` | `boolean`                                  | `false` | Whether the textarea receives focus when the page loads.                                                      |
-| `name`        | `string`                                   | —       | The form field name for native form submission.                                                               |
-| `rows`        | `number`                                   | —       | The visible number of text lines.                                                                             |
-| `placeholder` | `string`                                   | —       | Placeholder text shown when the textarea is empty.                                                            |
+| Name          | Type                                       | Default | Description                                                                                                                                                        |
+| ------------- | ------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`          | `string`                                   | —       | Unique ID for the textarea element. Used to link the label and description via ARIA attributes.                                                                    |
+| `toView`      | `(attributes: TextareaAttributes) => Html` | —       | Callback that receives attribute groups for the textarea, label, and description elements.                                                                         |
+| `onInput`     | `(value: string) => Message`               | —       | Function that maps the current textarea value to a Message on each input event.                                                                                    |
+| `value`       | `string`                                   | —       | The current value of the textarea.                                                                                                                                 |
+| `isDisabled`  | `boolean`                                  | `false` | Whether the textarea is disabled. Sets both the native disabled attribute and aria-disabled.                                                                       |
+| `isReadOnly`  | `boolean`                                  | `false` | Whether the textarea is readable but not editable. Sets the native readonly attribute and adds a data-readonly attribute for styling. Independent of `isDisabled`. |
+| `isInvalid`   | `boolean`                                  | `false` | Whether the textarea is in an invalid state. Sets aria-invalid and adds a data-invalid attribute for styling.                                                      |
+| `isAutofocus` | `boolean`                                  | `false` | Whether the textarea receives focus when the page loads.                                                                                                           |
+| `name`        | `string`                                   | —       | The form field name for native form submission.                                                                                                                    |
+| `rows`        | `number`                                   | —       | The visible number of text lines.                                                                                                                                  |
+| `placeholder` | `string`                                   | —       | Placeholder text shown when the textarea is empty.                                                                                                                 |
 
 ### TextareaAttributes {#textarea-attributes}
 


### PR DESCRIPTION
Part of #925, the Input and Textarea slice. Follows #912 (Checkbox) and #950 (Switch).

## What it does

Both components get an `isReadOnly?: boolean` option, default `false`. When it is
`true`, the field:

- gets the native `readonly` attribute and a `data-readonly` attribute for styling
- drops its `h.OnInput` handler, so no Message can change the value
- stays focusable, selectable, and copyable, and is still sent with its form

`isReadOnly` and `isDisabled` are independent. If you set both, you get both sets
of attributes, and either one alone removes the input handler.

## Why native `readonly` and not `aria-readonly`

Checkbox and Switch render a `<button>` with an explicit `role`. That element has
no native read-only state, so those components must emit `aria-readonly="true"`
themselves.

Input and Textarea render a native `<input>` and `<textarea>`. Those elements have
a real `readonly` attribute, and the browser already puts it into the
accessibility tree. Adding `aria-readonly` on top would repeat native semantics in
ARIA, which the first rule of ARIA tells you not to do, and would leave two
sources of truth that can drift apart.

Native `readonly` also gives us "keeps focus, selection, and copying" for free, so
no `tabindex` handling is needed here, unlike in Switch.

## Two deliberate differences from the earlier slices

**No assistive technology caveat.** #912 and #950 both warn that support for
`aria-readonly` is uneven on the `checkbox` and `switch` roles. Native `readonly`
on a textbox is well supported, so repeating that warning here would be wrong. The
acceptance criterion in #925 is written around the ARIA mechanism, so I am
mentioning this instead of leaving you to wonder whether it was missed.

**No new `::Demo` block.** Both pages have a Demo and a Snippet for Basic and
Disabled. #912 added no demo for the Checkbox read-only state either, and demos
live in `examples/ui-showcase`, which would make the diff much larger. Happy to
add them in a follow-up if you want them.

## Tests

Neither component had a `scene.test.ts` before, so this adds both, modeled on
`packages/ui/src/switch/scene.test.ts`. Five tests each:

- dispatches the typed value
- is not interactive when disabled
- emits read-only attributes without disabled attributes
- drops the input handler when read-only
- emits both attribute sets when disabled and read-only are combined

Two notes on the assertions. `h.Readonly` sets the DOM **prop** `readOnly`, not an
HTML attribute, so the tests use `toHaveAttr('readOnly', 'true')`. That is the same
trap as `tabIndex` in the Switch tests. And the steps that must not fire are
checked with `not.toHaveHandler('input')` rather than by calling `Scene.type` and
expecting nothing, because `maybeCaptureFromElement` throws when the element has no
handler for the event.

## Docs

`inputPage.md` and `textareaPage.md` each get four changes: the `data-readonly` row
in the styling table, a sentence in Keyboard Interaction, an Accessibility block
comparing `isReadOnly` and `isDisabled`, and the `isReadOnly` row in the ViewConfig
table.

## Checks

`pnpm lint`, `pnpm test`, `pnpm build`, and `pnpm format:check` all pass.
