### PR TITLE
fix(ui): stop emitting aria-disabled from Input, Select, and Textarea

### DIFF
--- a/.changeset/drop-redundant-aria-disabled.md
+++ b/.changeset/drop-redundant-aria-disabled.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': minor
+---
+
+Stop emitting `aria-disabled` from Input, Select, and Textarea
+
+These three set the native `disabled` attribute, which already carries the state, so the extra `aria-disabled` restated native semantics in ARIA. The native attribute and `data-disabled` are unchanged. If you select on `[aria-disabled]` in CSS for one of these three, switch to `[data-disabled]`.

--- a/packages/ui/src/input/index.ts
+++ b/packages/ui/src/input/index.ts
@@ -48,7 +48,7 @@ export const view = <Message>(
   } = config
 
   const disabledAttributes = isDisabled
-    ? [h.AriaDisabled(true), h.Disabled(true), h.DataAttribute('disabled', '')]
+    ? [h.Disabled(true), h.DataAttribute('disabled', '')]
     : []
 
   const readOnlyAttributes = isReadOnly

--- a/packages/ui/src/input/scene.test.ts
+++ b/packages/ui/src/input/scene.test.ts
@@ -65,6 +65,15 @@ describe('Input controlled view', () => {
     )
   })
 
+  it('carries the disabled state natively, without aria-disabled', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).toBeDisabled(),
+      Scene.expect(field).not.toHaveAttr('aria-disabled'),
+    )
+  })
+
   it('emits read-only attributes without disabled attributes', () => {
     Scene.scene(
       { update, view: testView({ isReadOnly: true }) },

--- a/packages/ui/src/select/index.ts
+++ b/packages/ui/src/select/index.ts
@@ -42,7 +42,7 @@ export const view = <Message>(
   } = config
 
   const disabledAttributes = isDisabled
-    ? [h.AriaDisabled(true), h.Disabled(true), h.DataAttribute('disabled', '')]
+    ? [h.Disabled(true), h.DataAttribute('disabled', '')]
     : []
 
   const invalidAttributes = isInvalid

--- a/packages/ui/src/select/scene.test.ts
+++ b/packages/ui/src/select/scene.test.ts
@@ -1,0 +1,69 @@
+import { Match as M, Schema as S } from 'effect'
+import type { HtmlBuilder } from 'foldkit/html'
+import { m } from 'foldkit/message'
+import * as Scene from 'foldkit/scene'
+import { evo } from 'foldkit/struct'
+
+import { describe, it } from '@effect/vitest'
+
+import { view } from './index.js'
+
+const Changed = m('Changed', { value: S.String })
+const Message = S.Union([Changed])
+type Message = typeof Message.Type
+
+type Model = Readonly<{ value: string }>
+
+type UpdateReturn = readonly [Model, ReadonlyArray<never>]
+
+const update = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    M.withReturnType<UpdateReturn>(),
+    M.tagsExhaustive({
+      Changed: ({ value }) => [evo(model, { value: () => value }), []],
+    }),
+  )
+
+const testView =
+  ({ isDisabled = false }: { isDisabled?: boolean } = {}) =>
+  (model: Model, h: HtmlBuilder<Message>) =>
+    view(
+      {
+        id: 'test',
+        value: model.value,
+        onChange: value => Changed({ value }),
+        isDisabled,
+        toView: ({ select, label }) =>
+          h.div(
+            [],
+            [
+              h.select([...select], [h.option([h.Value('a')], ['A'])]),
+              h.label([...label], ['Choice']),
+            ],
+          ),
+      },
+      h,
+    )
+
+const field = Scene.role('combobox')
+
+describe('Select controlled view', () => {
+  it('is not interactive when disabled', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true }) },
+      Scene.given({ value: 'a' }),
+      Scene.expect(field).toBeDisabled(),
+      Scene.expect(field).toHaveAttr('data-disabled', ''),
+      Scene.expect(field).not.toHaveHandler('change'),
+    )
+  })
+
+  it('carries the disabled state natively, without aria-disabled', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true }) },
+      Scene.given({ value: 'a' }),
+      Scene.expect(field).toBeDisabled(),
+      Scene.expect(field).not.toHaveAttr('aria-disabled'),
+    )
+  })
+})

--- a/packages/ui/src/textarea/index.ts
+++ b/packages/ui/src/textarea/index.ts
@@ -48,7 +48,7 @@ export const view = <Message>(
   } = config
 
   const disabledAttributes = isDisabled
-    ? [h.AriaDisabled(true), h.Disabled(true), h.DataAttribute('disabled', '')]
+    ? [h.Disabled(true), h.DataAttribute('disabled', '')]
     : []
 
   const readOnlyAttributes = isReadOnly

--- a/packages/ui/src/textarea/scene.test.ts
+++ b/packages/ui/src/textarea/scene.test.ts
@@ -68,6 +68,15 @@ describe('Textarea controlled view', () => {
     )
   })
 
+  it('carries the disabled state natively, without aria-disabled', () => {
+    Scene.scene(
+      { update, view: testView({ isDisabled: true }) },
+      Scene.given({ value: '' }),
+      Scene.expect(field).toBeDisabled(),
+      Scene.expect(field).not.toHaveAttr('aria-disabled'),
+    )
+  })
+
   it('emits read-only attributes without disabled attributes', () => {
     Scene.scene(
       { update, view: testView({ isReadOnly: true }) },

--- a/packages/website/src/page/ui/inputPage.md
+++ b/packages/website/src/page/ui/inputPage.md
@@ -20,7 +20,7 @@ Pass an `id`, an `onInput` handler, and a `toView` callback. The callback receiv
 
 ### Disabled
 
-Set `isDisabled: true` to disable the input. Unlike Button, Input uses the native `disabled` attribute in addition to `aria-disabled`, so the browser prevents interaction entirely.
+Set `isDisabled: true` to disable the input. Unlike Button, Input uses the native `disabled` attribute, so the browser prevents interaction entirely.
 
 ::Demo{name="disabled"}
 
@@ -70,7 +70,7 @@ Configuration object passed to `Input.view()`.
 | `toView`      | `(attributes: InputAttributes) => Html`     | —        | Callback that receives attribute groups for the input, label, and description elements.                                                                         |
 | `onInput`     | `((value: string) => Message) \| undefined` | —        | Optional function that maps the current input value to a Message on each input event. Omit for a read-only display.                                             |
 | `value`       | `string`                                    | —        | The current value of the input.                                                                                                                                 |
-| `isDisabled`  | `boolean`                                   | `false`  | Whether the input is disabled. Sets both the native disabled attribute and aria-disabled.                                                                       |
+| `isDisabled`  | `boolean`                                   | `false`  | Whether the input is disabled. Sets the native disabled attribute.                                                                                              |
 | `isReadOnly`  | `boolean`                                   | `false`  | Whether the input is readable but not editable. Sets the native readonly attribute and adds a data-readonly attribute for styling. Independent of `isDisabled`. |
 | `isInvalid`   | `boolean`                                   | `false`  | Whether the input is in an invalid state. Sets aria-invalid and adds a data-invalid attribute for styling.                                                      |
 | `isAutofocus` | `boolean`                                   | `false`  | Whether the input receives focus when the page loads.                                                                                                           |

--- a/packages/website/src/page/ui/selectPage.md
+++ b/packages/website/src/page/ui/selectPage.md
@@ -61,7 +61,7 @@ Configuration object passed to `Select.view()`.
 | `toView`      | `(attributes: SelectAttributes) => Html` | —       | Callback that receives attribute groups for the select, label, and description elements.                    |
 | `onChange`    | `(value: string) => Message`             | —       | Function that maps the selected value to a Message when the selection changes.                              |
 | `value`       | `string`                                 | —       | The currently selected value.                                                                               |
-| `isDisabled`  | `boolean`                                | `false` | Whether the select is disabled. Sets both the native disabled attribute and aria-disabled.                  |
+| `isDisabled`  | `boolean`                                | `false` | Whether the select is disabled. Sets the native disabled attribute.                                         |
 | `isInvalid`   | `boolean`                                | `false` | Whether the select is in an invalid state. Sets aria-invalid and adds a data-invalid attribute for styling. |
 | `isAutofocus` | `boolean`                                | `false` | Whether the select receives focus when the page loads.                                                      |
 | `name`        | `string`                                 | —       | The form field name for native form submission.                                                             |

--- a/packages/website/src/page/ui/textareaPage.md
+++ b/packages/website/src/page/ui/textareaPage.md
@@ -20,7 +20,7 @@ The `toView` callback receives attribute groups for the label, description, and 
 
 ### Disabled
 
-Set `isDisabled: true` to disable the textarea. Like Input, this sets both the native `disabled` attribute and `aria-disabled`.
+Set `isDisabled: true` to disable the textarea. Like Input, this sets the native `disabled` attribute.
 
 ::Demo{name="disabled"}
 
@@ -70,7 +70,7 @@ Configuration object passed to `Textarea.view()`.
 | `toView`      | `(attributes: TextareaAttributes) => Html` | —       | Callback that receives attribute groups for the textarea, label, and description elements.                                                                         |
 | `onInput`     | `(value: string) => Message`               | —       | Function that maps the current textarea value to a Message on each input event.                                                                                    |
 | `value`       | `string`                                   | —       | The current value of the textarea.                                                                                                                                 |
-| `isDisabled`  | `boolean`                                  | `false` | Whether the textarea is disabled. Sets both the native disabled attribute and aria-disabled.                                                                       |
+| `isDisabled`  | `boolean`                                  | `false` | Whether the textarea is disabled. Sets the native disabled attribute.                                                                                              |
 | `isReadOnly`  | `boolean`                                  | `false` | Whether the textarea is readable but not editable. Sets the native readonly attribute and adds a data-readonly attribute for styling. Independent of `isDisabled`. |
 | `isInvalid`   | `boolean`                                  | `false` | Whether the textarea is in an invalid state. Sets aria-invalid and adds a data-invalid attribute for styling.                                                      |
 | `isAutofocus` | `boolean`                                  | `false` | Whether the textarea receives focus when the page loads.                                                                                                           |


### PR DESCRIPTION
Follow-up to #953, which argued that Input and Textarea should not emit `aria-readonly` because the native `readonly` attribute already carries the state. The same reasoning applies to `disabled`, where the older code did the thing #953 correctly declined to do.

## What was wrong

Input, Select, and Textarea render a native `<input>`, `<select>`, and `<textarea>`, and already set the native `disabled` attribute. The browser puts that into the accessibility tree on its own. Emitting `aria-disabled` alongside it restated native semantics in ARIA, against the first rule of ARIA, and left two sources of truth that could drift.

```
- ? [h.AriaDisabled(true), h.Disabled(true), h.DataAttribute('disabled', '')]
+ ? [h.Disabled(true), h.DataAttribute('disabled', '')]
```

Select was not in the original observation but has the identical pattern, so it's included. Everything else in `packages/ui` that emits `aria-disabled` is correct and untouched: Button, Checkbox, Switch, Disclosure, Menu, Popover, RadioGroup, Slider, Tabs, and Calendar all render an element with an explicit role and no native disabled state.

## What is unchanged

The native `disabled` attribute and the `data-disabled` styling hook. Native interaction blocking and `data-[disabled]` styling behave exactly as before.

## Tests

Each component gets a scene test pinning the absence, and Select gets the scene test file it never had.

I verified these fail against the old behavior rather than assuming they were meaningful. Restoring `h.AriaDisabled(true)` in Input produces:

```
× carries the disabled state natively, without aria-disabled
Error: Expected element matching textbox not to have attribute "aria-disabled" but it does.
```

`toBeDisabled()` keeps passing throughout, because `isElementDisabled` in `scene.ts` already matches the native `disabled` prop independently of the ARIA attribute.

## Breaking-ish

The changeset is `minor` and spells this out: anyone selecting on `[aria-disabled]` in CSS for these three components should switch to `[data-disabled]`, which is the documented styling hook. `inputPage.md` had documented the old behavior explicitly, so this is a visible change rather than a purely internal one.

## Verification

- `format:check`, `lint`, `check:dead-code`: pass
- changeset gates: pass
- `pnpm -r typecheck`, `build:website`: pass
- `pnpm test`: pass, with `@foldkit/ui` at 909 across 39 files, up from 905 across 38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014L5XBC6Uj7XAW2c4dWFc4N

---
_Generated by [Claude Code](https://claude.ai/code/session_014L5XBC6Uj7XAW2c4dWFc4N)_