### PR TITLE
refactor(website): move apiReference module lookup into domain

### DIFF
--- a/packages/website/src/page/apiReference/domain.ts
+++ b/packages/website/src/page/apiReference/domain.ts
@@ -4,6 +4,7 @@ import {
   Option,
   Order,
   Predicate,
+  Record,
   Schema as S,
   String,
   flow,
@@ -487,3 +488,14 @@ export const moduleNameToSlug = (name: string): string =>
 
 export const slugToModuleName = (slug: string): string =>
   pipe(slug, String.split('-'), Array.map(String.capitalize), Array.join(''))
+
+const modulesBySlug = (
+  modules: ReadonlyArray<ApiModule>,
+): Record<string, ApiModule> =>
+  Record.fromIterableBy(modules, module => moduleNameToSlug(module.name))
+
+export const resolveModule = (
+  parsedApi: ParsedApiReference,
+  slug: string,
+): Option.Option<ApiModule> =>
+  Record.get(modulesBySlug(parsedApi.modules), slug)

--- a/packages/website/src/page/apiReference/index.ts
+++ b/packages/website/src/page/apiReference/index.ts
@@ -1,11 +1,3 @@
-import { Array, Option, Record, pipe } from 'effect'
-
-import {
-  type ApiModule,
-  type ParsedApiReference,
-  moduleNameToSlug,
-} from './domain'
-
 export * from './domain'
 export { ApiData, ApiDataAsyncData, Model } from './model'
 export type { Disclosures } from './model'
@@ -13,18 +5,3 @@ export { Message } from './message'
 export { boot, init } from './init'
 export { informRouteChanged, update } from './update'
 export { failureView, skeletonView, view } from './view'
-
-const modulesBySlug = (
-  modules: ReadonlyArray<ApiModule>,
-): Record<string, ApiModule> =>
-  pipe(
-    modules,
-    Array.map(module => [moduleNameToSlug(module.name), module] as const),
-    Record.fromEntries,
-  )
-
-export const resolveModule = (
-  parsedApi: ParsedApiReference,
-  slug: string,
-): Option.Option<ApiModule> =>
-  Record.get(modulesBySlug(parsedApi.modules), slug)


### PR DESCRIPTION
Extracts the one application-code fix from #926 so it can land on its own.

`modulesBySlug` and `resolveModule` were defined in `page/apiReference/index.ts` beside its re-exports. That barrel already re-exports `domain.ts` with `export *`, so moving them there keeps `resolveModule` resolving the same way and leaves all three call sites unchanged:

- `packages/website/src/main.ts`
- `packages/website/src/view/docs.ts`
- `packages/website/src/subscription/activeSection.ts`

The move is @artile's work. Their commit in #926 bundles it with the lint rules, so it could not be cherry-picked cleanly, and the commit here is authored to them.

One change on top of the extraction, not theirs: `modulesBySlug` now builds the record with `Record.fromIterableBy` rather than mapping to tuples and folding them with `Record.fromEntries`, which drops the intermediate array, the `as const`, and the `pipe`.

No changeset, since `website` is in the changesets ignore list.

`pnpm format:check`, `pnpm lint`, website `tsc --noEmit`, and the website suite (282 tests) all pass. Website e2e was skipped locally because the pinned Playwright browsers are unavailable in this environment; CI runs it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Apfo2EJAS3fAyMzW3sZovJ