### PR TITLE
fix(foldkit): type Command mappers against Command so generic combinators unify

### DIFF
--- a/.changeset/command-mappers-nominal-command.md
+++ b/.changeset/command-mappers-nominal-command.md
@@ -1,0 +1,15 @@
+---
+'foldkit': patch
+---
+
+Type `Command.mapEffect`, `Command.mapMessage`, and `Command.mapMessages` against `Command` in argument and result positions instead of structural command shapes. Inside a generic combinator the Message is an open type parameter, so `Command<Message>` stayed a deferred conditional that never unified with the structural shapes. A parent lifting a child Submodel's Commands, generic over the Message types, can now annotate arguments and returns as `Command.Command<Message>` directly:
+
+```ts
+const liftCommands = <ChildMessage, ParentMessage>(
+  commands: ReadonlyArray<Command.Command<ChildMessage>>,
+  toParent: (message: ChildMessage) => ParentMessage,
+): ReadonlyArray<Command.Command<ParentMessage>> =>
+  Command.mapMessages(commands, toParent)
+```
+
+Concrete call sites infer exactly as before.

--- a/packages/foldkit/src/command/index.ts
+++ b/packages/foldkit/src/command/index.ts
@@ -400,29 +400,11 @@ export function define(name: string, config: DefineConfig): unknown {
 export const mapEffect: {
   <A, E1, R1, B, E2, R2>(
     f: (effect: Effect.Effect<A, E1, R1>) => Effect.Effect<B, E2, R2>,
-  ): (
-    command: Readonly<{
-      name: string
-      args?: Record<string, unknown>
-      effect: Effect.Effect<A, E1, R1>
-    }>,
-  ) => Readonly<{
-    name: string
-    args?: Record<string, unknown>
-    effect: Effect.Effect<B, E2, R2>
-  }>
+  ): (command: Command<A, E1, R1>) => Command<B, E2, R2>
   <A, E1, R1, B, E2, R2>(
-    command: Readonly<{
-      name: string
-      args?: Record<string, unknown>
-      effect: Effect.Effect<A, E1, R1>
-    }>,
+    command: Command<A, E1, R1>,
     f: (effect: Effect.Effect<A, E1, R1>) => Effect.Effect<B, E2, R2>,
-  ): Readonly<{
-    name: string
-    args?: Record<string, unknown>
-    effect: Effect.Effect<B, E2, R2>
-  }>
+  ): Command<B, E2, R2>
 } = Function.dual(
   2,
   <A, E1, R1, B, E2, R2>(
@@ -455,33 +437,21 @@ export const mapEffect: {
  *  Preserves the Command's `name` and `args` so traces still attribute
  *  it to the originating Submodel. When you need to transform the
  *  Effect itself (not just the result Message), reach for
- *  {@link mapEffect} instead. */
+ *  {@link mapEffect} instead.
+ *
+ *  Typed against {@link Command} in argument and result positions, so a
+ *  generic combinator over a type-parameter Message unifies with
+ *  `Command.Command<Message>` directly. */
 export const mapMessage: {
   <FromMessage, ToMessage, E = never, R = never>(
-    command: Readonly<{
-      name: string
-      args?: Record<string, unknown>
-      effect: Effect.Effect<FromMessage, E, R>
-    }>,
+    command: Command<FromMessage, E, R>,
     f: (message: FromMessage) => ToMessage,
-  ): Readonly<{
-    name: string
-    args?: Record<string, unknown>
-    effect: Effect.Effect<ToMessage, E, R>
-  }>
+  ): Command<ToMessage, E, R>
   <FromMessage, ToMessage>(
     f: (message: FromMessage) => ToMessage,
   ): <E = never, R = never>(
-    command: Readonly<{
-      name: string
-      args?: Record<string, unknown>
-      effect: Effect.Effect<FromMessage, E, R>
-    }>,
-  ) => Readonly<{
-    name: string
-    args?: Record<string, unknown>
-    effect: Effect.Effect<ToMessage, E, R>
-  }>
+    command: Command<FromMessage, E, R>,
+  ) => Command<ToMessage, E, R>
 } = Function.dual(
   2,
   <FromMessage, ToMessage, E = never, R = never>(
@@ -534,57 +504,26 @@ export const mapMessage: {
  *  from the matched Command.
  *  Preserves each Command's `name` and `args` so traces still attribute the
  *  Command to the originating Submodel. When you need to transform the Effect
- *  itself (not just the result Message), reach for {@link mapEffect} instead. */
+ *  itself (not just the result Message), reach for {@link mapEffect} instead.
+ *
+ *  Typed against {@link Command} in argument and result positions, so a
+ *  generic combinator over a type-parameter Message unifies with
+ *  `Command.Command<Message>` directly. */
 export const mapMessages: {
   <FromMessage, ToMessage, E = never, R = never>(
-    commands: ReadonlyArray<
-      Readonly<{
-        name: string
-        args?: Record<string, unknown>
-        effect: Effect.Effect<FromMessage, E, R>
-      }>
-    >,
+    commands: ReadonlyArray<Command<FromMessage, E, R>>,
     f: (message: FromMessage) => ToMessage,
-  ): ReadonlyArray<
-    Readonly<{
-      name: string
-      args?: Record<string, unknown>
-      effect: Effect.Effect<ToMessage, E, R>
-    }>
-  >
+  ): ReadonlyArray<Command<ToMessage, E, R>>
   <FromMessage, ToMessage>(
     f: (message: FromMessage) => ToMessage,
   ): <E = never, R = never>(
-    commands: ReadonlyArray<
-      Readonly<{
-        name: string
-        args?: Record<string, unknown>
-        effect: Effect.Effect<FromMessage, E, R>
-      }>
-    >,
-  ) => ReadonlyArray<
-    Readonly<{
-      name: string
-      args?: Record<string, unknown>
-      effect: Effect.Effect<ToMessage, E, R>
-    }>
-  >
+    commands: ReadonlyArray<Command<FromMessage, E, R>>,
+  ) => ReadonlyArray<Command<ToMessage, E, R>>
 } = Function.dual(
   2,
   <FromMessage, ToMessage, E = never, R = never>(
-    commands: ReadonlyArray<
-      Readonly<{
-        name: string
-        args?: Record<string, unknown>
-        effect: Effect.Effect<FromMessage, E, R>
-      }>
-    >,
+    commands: ReadonlyArray<Command<FromMessage, E, R>>,
     f: (message: FromMessage) => ToMessage,
-  ): ReadonlyArray<
-    Readonly<{
-      name: string
-      args?: Record<string, unknown>
-      effect: Effect.Effect<ToMessage, E, R>
-    }>
-  > => Array.map(commands, command => mapMessage(command, f)),
+  ): ReadonlyArray<Command<ToMessage, E, R>> =>
+    Array.map(commands, command => mapMessage(command, f)),
 )

--- a/packages/foldkit/src/command/mapMessages.test.ts
+++ b/packages/foldkit/src/command/mapMessages.test.ts
@@ -1,0 +1,93 @@
+import { Array, Effect, Schema as S } from 'effect'
+import { expect, expectTypeOf } from 'vitest'
+
+import { describe, it } from '@effect/vitest'
+
+import { m } from '../message/index.js'
+import * as Command from './index.js'
+
+const CompletedFetchNotes = m('CompletedFetchNotes', { noteCount: S.Number })
+const GotNotesMessage = m('GotNotesMessage', { message: CompletedFetchNotes })
+
+type ChildMessage = typeof CompletedFetchNotes.Type
+type ParentMessage = typeof GotNotesMessage.Type
+
+const FetchNotes = Command.define('FetchNotes', {
+  messages: [CompletedFetchNotes],
+  execute: Effect.succeed(CompletedFetchNotes({ noteCount: 3 })),
+})
+
+const toGotNotesMessage = (message: ChildMessage): ParentMessage =>
+  GotNotesMessage({ message })
+
+// NOTE: These helpers are the regression subjects. Each is generic over the
+// Message types, where Command stays a deferred conditional, so each compiles
+// only while the mappers are typed against Command itself rather than a
+// structural command shape.
+const liftCommands = <FromMessage, ToMessage>(
+  commands: ReadonlyArray<Command.Command<FromMessage>>,
+  toParent: (message: FromMessage) => ToMessage,
+): ReadonlyArray<Command.Command<ToMessage>> =>
+  Command.mapMessages(commands, toParent)
+
+const liftCommand = <FromMessage, ToMessage>(
+  command: Command.Command<FromMessage>,
+  toParent: (message: FromMessage) => ToMessage,
+): Command.Command<ToMessage> => Command.mapMessage(command, toParent)
+
+const withCrashOnFailure = <Message>(
+  command: Command.Command<Message>,
+): Command.Command<Message> => Command.mapEffect(command, Effect.orDie)
+
+describe('Command.mapMessages', () => {
+  it('unifies with Command inside a combinator generic over both Message types', () => {
+    const mappedCommands = liftCommands([FetchNotes()], toGotNotesMessage)
+
+    const dispatchedMessages = Array.map(mappedCommands, command =>
+      Effect.runSync(command.effect),
+    )
+    expect(dispatchedMessages).toEqual([
+      GotNotesMessage({ message: CompletedFetchNotes({ noteCount: 3 }) }),
+    ])
+  })
+
+  it('infers the lifted Message type at a concrete data-first call site', () => {
+    const mappedCommands = Command.mapMessages(
+      [FetchNotes()],
+      toGotNotesMessage,
+    )
+    expectTypeOf(mappedCommands).toEqualTypeOf<
+      ReadonlyArray<Command.Command<ParentMessage>>
+    >()
+  })
+
+  it('infers the lifted Message type through the curried form', () => {
+    const mappedCommands = Command.mapMessages(toGotNotesMessage)([
+      FetchNotes(),
+    ])
+    expectTypeOf(mappedCommands).toEqualTypeOf<
+      ReadonlyArray<Command.Command<ParentMessage>>
+    >()
+  })
+})
+
+describe('Command.mapMessage', () => {
+  it('unifies with Command inside a combinator generic over both Message types', () => {
+    const mappedCommand = liftCommand(FetchNotes(), toGotNotesMessage)
+
+    expect(mappedCommand.name).toBe('FetchNotes')
+    expect(Effect.runSync(mappedCommand.effect)).toEqual(
+      GotNotesMessage({ message: CompletedFetchNotes({ noteCount: 3 }) }),
+    )
+  })
+})
+
+describe('Command.mapEffect', () => {
+  it('unifies with Command inside a combinator generic over the Message type', () => {
+    const mappedCommand = withCrashOnFailure(FetchNotes())
+
+    expect(Effect.runSync(mappedCommand.effect)).toEqual(
+      CompletedFetchNotes({ noteCount: 3 }),
+    )
+  })
+})


### PR DESCRIPTION
## What and why

`Command.mapEffect`, `Command.mapMessage`, and `Command.mapMessages` were typed with structural command shapes (`Readonly<{ name; args?; effect }>`). At concrete call sites those shapes and the conditional `Command<T>` type are mutually assignable, but inside a combinator generic over the Message types, `Command<Message>` stays a deferred conditional and neither the argument nor the result of the mappers unifies with it. A parent lifting a child Submodel's Commands generically could not annotate its arguments and return as `Command.Command<Message>` and had to fall back to capturing the mapped type with `typeof`.

Fixes #654.

## What changed

- Retyped the public signatures of all three mappers (both dual forms each) to use the nominal `Command<T, E, R>` alias in argument and result positions. The `Command` type itself, `define`, and every runtime body are unchanged. The `mapMessages` implementation signature also moved to the nominal alias, which let its internal `mapMessage` call unify without casts.
- Added `packages/foldkit/src/command/mapMessages.test.ts`: generic combinators over `mapMessages`, `mapMessage`, and `mapEffect` whose compilation is the regression assertion (they fail to compile against the old signatures), concrete data-first and curried `expectTypeOf` inference checks, and runtime assertions that mapped Commands dispatch the lifted Message.
- Patch changeset for `foldkit`.

## Design decision

The issue offered two fixes: type the mappers against `Command` nominally, or rework `Command`'s conditional definition. This PR takes the first. It works because TypeScript infers through same-alias instantiations (deferred `Command<ChildMessage>` against `Command<FromMessage>` infers directly from the alias type arguments), while at concrete call sites inference resolves through the conditional's branches, so structural commands from `define` constructors keep inferring exactly as before. Reworking the `Command` conditional was rejected: extracting the Schema decode into the `effect` position still fails contravariant unification with the mapping function's parameter in generic helpers, and dropping the `Command<typeof Schema>` sugar would be a breaking change.

## Verification

The fix was prototyped in a scratch file under the package tsconfig before implementation, covering the issue's generic repro, its curried form, structural commands from `define`, alias-annotated commands, and `Command<typeof Schema>` result annotations, with a consumed `@ts-expect-error` confirming the old signatures fail. The committed regression test keeps the generic combinators compiling. The pre-push suite ran green: format, changeset checks, lint, dead code, build, typecheck for all 48 workspace projects (mapper call sites exist in `@foldkit/ui`, website, and examples), all package tests (1763 passing in `foldkit` including the 5 new ones), and website e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4dHDD7ZMVJkeEGZ3kgT6K)_