### PR TITLE
refactor(ui): fold component children with Update.foldChild

### DIFF
--- a/.changeset/ui-internals-fold-child.md
+++ b/.changeset/ui-internals-fold-child.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/ui': patch
+---
+
+Fold child Submodels inside component internals with `Update.foldChild`. Dialog, Popover, Menu, DatePicker, Listbox, Combobox, and Toast now build their child folds from the helper instead of hand-writing `Command.mapMessages` plus an OutMessage match. The Dialog and Toast leave-animation folds take the fold's `Update.FoldContext` and lift the overridable leave Command with `liftCommand`. Internal refactor with no API or behavior change.

--- a/packages/ui/src/combobox/shared.ts
+++ b/packages/ui/src/combobox/shared.ts
@@ -14,6 +14,7 @@ import { m } from 'foldkit/message'
 import * as Mount from 'foldkit/mount'
 import { makeConstrainedEvo } from 'foldkit/struct'
 import { type View as SubmodelView, defineView } from 'foldkit/submodel'
+import * as Update from 'foldkit/update'
 
 import { AnchorConfig, anchorSetup, portalToContainingRoot } from '../anchor.js'
 // NOTE: Animation imports are split across schema + update to avoid a circular
@@ -390,42 +391,6 @@ export const DetectMovementOrAnimationEnd = Command.define(
   },
 )
 
-const delegateToAnimation = <Model extends BaseModel>(
-  model: Model,
-  animationMessage: AnimationMessage,
-): readonly [
-  Model,
-  ReadonlyArray<Command.Command<Message>>,
-  Option.Option<OutMessage>,
-] => {
-  const [nextAnimation, animationCommands, maybeOutMessage] = animationUpdate(
-    model.animation,
-    animationMessage,
-  )
-
-  const mappedCommands = Command.mapMessages(animationCommands, message =>
-    GotAnimationMessage({ message }),
-  )
-
-  const additionalCommands = Option.match(maybeOutMessage, {
-    onNone: () => [],
-    onSome: M.type<AnimationOutMessage>().pipe(
-      M.tagsExhaustive({
-        StartedLeaveAnimating: () => [
-          DetectMovementOrAnimationEnd({ id: model.id }),
-        ],
-        TransitionedOut: () => [],
-      }),
-    ),
-  })
-
-  return [
-    constrainedEvo(model, { animation: () => nextAnimation }),
-    [...mappedCommands, ...additionalCommands],
-    Option.none(),
-  ]
-}
-
 /** Creates a combobox update function from variant-specific handlers. Shared logic (open, close, activate, transition) is handled internally; only close, selection, and immediate-activation behavior varies by variant. */
 export const makeUpdate = <Model extends BaseModel>(
   handlers: Readonly<{
@@ -456,6 +421,29 @@ export const makeUpdate = <Model extends BaseModel>(
     Option.Option<OutMessage>,
   ]
   const withUpdateReturn = M.withReturnType<UpdateReturn>()
+
+  const foldAnimationOutMessage: (
+    outMessage: AnimationOutMessage,
+  ) => Update.Step<Model, Message> = M.type<AnimationOutMessage>().pipe(
+    M.withReturnType<Update.Step<Model, Message>>(),
+    M.tagsExhaustive({
+      StartedLeaveAnimating: () => model => [
+        model,
+        [DetectMovementOrAnimationEnd({ id: model.id })],
+      ],
+      TransitionedOut: () => model => [model, []],
+    }),
+  )
+
+  const foldAnimation = Update.foldChild({
+    update: animationUpdate,
+    read: (model: Model) => Option.some(model.animation),
+    write: (model, nextAnimation) =>
+      constrainedEvo(model, { animation: () => nextAnimation }),
+    toParentMessage: message => GotAnimationMessage({ message }),
+    toParentOutMessage: () => Option.none(),
+    foldOutMessage: foldAnimationOutMessage,
+  })
 
   const internalUpdate = (model: Model, message: Message): UpdateReturn => {
     const maybeLockScroll = OptionExt.when(model.isModal, LockScroll())
@@ -489,7 +477,7 @@ export const makeUpdate = <Model extends BaseModel>(
       const commands = didClose ? closeWithFocusCommands : [focusInput]
 
       if (didClose && model.isAnimated) {
-        const [transitionedModel, animationCommands] = delegateToAnimation(
+        const [transitionedModel, animationCommands] = foldAnimation(
           nextModel,
           AnimationHid(),
         )
@@ -505,7 +493,7 @@ export const makeUpdate = <Model extends BaseModel>(
 
     const openCombobox = (baseModel: Model): UpdateReturn => {
       if (model.isAnimated) {
-        const [nextModel, animationCommands] = delegateToAnimation(
+        const [nextModel, animationCommands] = foldAnimation(
           baseModel,
           AnimationShowed(),
         )
@@ -537,7 +525,7 @@ export const makeUpdate = <Model extends BaseModel>(
       )
 
       if (model.isAnimated) {
-        const [nextModel, animationCommands] = delegateToAnimation(
+        const [nextModel, animationCommands] = foldAnimation(
           closed,
           AnimationHid(),
         )
@@ -714,7 +702,7 @@ export const makeUpdate = <Model extends BaseModel>(
         },
 
         GotAnimationMessage: ({ message: animationMessage }) =>
-          delegateToAnimation(model, animationMessage),
+          foldAnimation(model, animationMessage),
       }),
     )
   }

--- a/packages/ui/src/datePicker/index.ts
+++ b/packages/ui/src/datePicker/index.ts
@@ -6,6 +6,7 @@ import type { ChildAttribute, Html } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 import { type Reflect, defineView } from 'foldkit/submodel'
+import * as Update from 'foldkit/update'
 
 import type { AnchorConfig } from '../anchor.js'
 import * as UiCalendar from '../calendar/index.js'
@@ -163,72 +164,67 @@ const mapPopoverCommands = (
 ): ReadonlyArray<Command.Command<Message>> =>
   Command.mapMessages(commands, message => GotPopoverMessage({ message }))
 
-const delegateToCalendar = (
-  model: Model,
-  calendarMessage: UiCalendar.Message,
-): UpdateReturn => {
-  const [nextCalendar, calendarCommands, maybeCalendarOutMessage] =
-    UiCalendar.update(model.calendar, calendarMessage)
-
-  const modelWithCalendar = evo(model, { calendar: () => nextCalendar })
-
-  return Option.match(maybeCalendarOutMessage, {
-    onNone: (): UpdateReturn => [
-      modelWithCalendar,
-      mapCalendarCommands(calendarCommands),
-      Option.none(),
-    ],
-    onSome: M.type<UiCalendar.OutMessage>().pipe(
-      M.withReturnType<UpdateReturn>(),
-      M.tagsExhaustive({
-        ChangedViewMonth: ({ year, month }) => [
-          modelWithCalendar,
-          mapCalendarCommands(calendarCommands),
-          Option.some(ChangedViewMonth({ year, month })),
-        ],
-        SelectedDate: ({ date }) => {
-          const [nextPopover, popoverCommands] = Popover.close(model.popover)
-          return [
-            evo(modelWithCalendar, {
-              popover: () => nextPopover,
-            }),
-            [
-              ...mapCalendarCommands(calendarCommands),
-              ...mapPopoverCommands(popoverCommands),
-            ],
-            Option.some(SelectedDate({ date })),
-          ]
-        },
-      }),
-    ),
-  })
+const closePopover: Update.Step<Model, Message> = model => {
+  const [nextPopover, popoverCommands] = Popover.close(model.popover)
+  return [
+    evo(model, { popover: () => nextPopover }),
+    mapPopoverCommands(popoverCommands),
+  ]
 }
 
-const delegateToPopover = (
-  model: Model,
-  popoverMessage: Popover.Message,
-): UpdateReturn => {
-  const [nextPopover, popoverCommands, maybePopoverOutMessage] = Popover.update(
-    model.popover,
-    popoverMessage,
-  )
-  const modelWithPopover = evo(model, { popover: () => nextPopover })
+const dropCalendarToDays: Update.Step<Model, Message> = model => [
+  evo(model, { calendar: () => UiCalendar.dropToDays(model.calendar) }),
+  [],
+]
 
-  return Option.match(maybePopoverOutMessage, {
-    onNone: (): UpdateReturn => [
-      modelWithPopover,
-      mapPopoverCommands(popoverCommands),
-      Option.none(),
-    ],
-    onSome: (): UpdateReturn => [
-      evo(modelWithPopover, {
-        calendar: () => UiCalendar.dropToDays(modelWithPopover.calendar),
-      }),
-      mapPopoverCommands(popoverCommands),
-      Option.none(),
-    ],
-  })
-}
+const foldCalendarOutMessage: (
+  outMessage: UiCalendar.OutMessage,
+) => Update.Step<Model, Message> = M.type<UiCalendar.OutMessage>().pipe(
+  M.withReturnType<Update.Step<Model, Message>>(),
+  M.tagsExhaustive({
+    ChangedViewMonth: () => model => [model, []],
+    SelectedDate: () => closePopover,
+  }),
+)
+
+const toDatePickerOutMessage: (
+  outMessage: UiCalendar.OutMessage,
+) => Option.Option<OutMessage> = M.type<UiCalendar.OutMessage>().pipe(
+  M.withReturnType<Option.Option<OutMessage>>(),
+  M.tagsExhaustive({
+    ChangedViewMonth: ({ year, month }) =>
+      Option.some(ChangedViewMonth({ year, month })),
+    SelectedDate: ({ date }) => Option.some(SelectedDate({ date })),
+  }),
+)
+
+const foldCalendar = Update.foldChild({
+  update: UiCalendar.update,
+  read: (model: Model) => Option.some(model.calendar),
+  write: (model, nextCalendar) => evo(model, { calendar: () => nextCalendar }),
+  toParentMessage: message => GotCalendarMessage({ message }),
+  toParentOutMessage: toDatePickerOutMessage,
+  foldOutMessage: foldCalendarOutMessage,
+})
+
+const foldPopoverOutMessage: (
+  outMessage: Popover.OutMessage,
+) => Update.Step<Model, Message> = M.type<Popover.OutMessage>().pipe(
+  M.withReturnType<Update.Step<Model, Message>>(),
+  M.tagsExhaustive({
+    Opened: () => dropCalendarToDays,
+    Closed: () => dropCalendarToDays,
+  }),
+)
+
+const foldPopover = Update.foldChild({
+  update: Popover.update,
+  read: (model: Model) => Option.some(model.popover),
+  write: (model, nextPopover) => evo(model, { popover: () => nextPopover }),
+  toParentMessage: message => GotPopoverMessage({ message }),
+  toParentOutMessage: () => Option.none(),
+  foldOutMessage: foldPopoverOutMessage,
+})
 
 /** Processes a date picker message and returns the next model, commands, and
  * optional OutMessage. */
@@ -237,10 +233,10 @@ export const update = (model: Model, message: Message): UpdateReturn =>
     withUpdateReturn,
     M.tagsExhaustive({
       GotCalendarMessage: ({ message: calendarMessage }) =>
-        delegateToCalendar(model, calendarMessage),
+        foldCalendar(model, calendarMessage),
 
       GotPopoverMessage: ({ message: popoverMessage }) =>
-        delegateToPopover(model, popoverMessage),
+        foldPopover(model, popoverMessage),
 
       Opened: () => {
         const [nextPopover, popoverCommands] = Popover.open(model.popover)

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -5,6 +5,7 @@ import { type ChildAttribute, type Html, childAttributes } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 import { defineView } from 'foldkit/submodel'
+import * as Update from 'foldkit/update'
 
 // NOTE: Animation imports are split across schema + update to avoid a circular
 // dependency: animation → html → runtime → devtools → dialog → animation.
@@ -215,41 +216,30 @@ export const ReleaseDialogResources = Command.define('ReleaseDialogResources', {
 const wrapAnimationMessage = (message: AnimationMessage): Message =>
   GotAnimationMessage({ message })
 
-const delegateToAnimation = (
-  model: Model,
-  animationMessage: AnimationMessage,
-): UpdateReturn => {
-  const [nextAnimation, animationCommands, maybeOutMessage] = animationUpdate(
-    model.animation,
-    animationMessage,
+const foldAnimationOutMessage: (
+  outMessage: AnimationOutMessage,
+  context: Update.FoldContext<AnimationMessage, Message>,
+) => Update.Step<Model, Message> = (outMessage, { liftCommand }) =>
+  M.value(outMessage).pipe(
+    M.withReturnType<Update.Step<Model, Message>>(),
+    M.tagsExhaustive({
+      StartedLeaveAnimating: () => model => [
+        model,
+        [liftCommand(animationDefaultLeaveCommand(model.animation))],
+      ],
+      TransitionedOut: () => model => [model, [CloseDialog({ id: model.id })]],
+    }),
   )
 
-  const mappedCommands = Command.mapMessages(
-    animationCommands,
-    wrapAnimationMessage,
-  )
-
-  const additionalCommands = Option.match(maybeOutMessage, {
-    onNone: () => [],
-    onSome: M.type<AnimationOutMessage>().pipe(
-      M.tagsExhaustive({
-        StartedLeaveAnimating: () => [
-          Command.mapMessage(
-            animationDefaultLeaveCommand(nextAnimation),
-            wrapAnimationMessage,
-          ),
-        ],
-        TransitionedOut: () => [CloseDialog({ id: model.id })],
-      }),
-    ),
-  })
-
-  return [
+const foldAnimation = Update.foldChild({
+  update: animationUpdate,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
     evo(model, { animation: () => nextAnimation }),
-    [...mappedCommands, ...additionalCommands],
-    Option.none(),
-  ]
-}
+  toParentMessage: wrapAnimationMessage,
+  toParentOutMessage: () => Option.none(),
+  foldOutMessage: foldAnimationOutMessage,
+})
 
 /** Processes a dialog message and returns the next model and commands. */
 export const update = (model: Model, message: Message): UpdateReturn =>
@@ -273,7 +263,7 @@ export const update = (model: Model, message: Message): UpdateReturn =>
           : Option.none()
 
         if (model.isAnimated) {
-          const [nextModel, animationCommands] = delegateToAnimation(
+          const [nextModel, animationCommands] = foldAnimation(
             model,
             AnimationShowed(),
           )
@@ -306,7 +296,7 @@ export const update = (model: Model, message: Message): UpdateReturn =>
         const maybeOutMessage = wasOpen ? Option.some(Closed()) : Option.none()
 
         if (model.isAnimated) {
-          const [nextModel, animationCommands] = delegateToAnimation(
+          const [nextModel, animationCommands] = foldAnimation(
             evo(model, { isOpen: () => false }),
             AnimationHid(),
           )
@@ -327,7 +317,7 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       },
 
       GotAnimationMessage: ({ message: animationMessage }) =>
-        delegateToAnimation(model, animationMessage),
+        foldAnimation(model, animationMessage),
 
       Unmounted: () => {
         const isHoldingResources =

--- a/packages/ui/src/listbox/shared.ts
+++ b/packages/ui/src/listbox/shared.ts
@@ -16,6 +16,7 @@ import { m } from 'foldkit/message'
 import * as Mount from 'foldkit/mount'
 import { makeConstrainedEvo } from 'foldkit/struct'
 import { type View as SubmodelView, defineView } from 'foldkit/submodel'
+import * as Update from 'foldkit/update'
 
 import { AnchorConfig, anchorSetup, portalToContainingRoot } from '../anchor.js'
 // NOTE: Animation imports are split across schema + update to avoid a circular
@@ -434,44 +435,35 @@ export const makeUpdate = <Model extends BaseModel>(
   ]
   const withUpdateReturn = M.withReturnType<UpdateReturn>()
 
-  const delegateToAnimation = (
-    model: Model,
-    animationMessage: AnimationMessage,
-  ): UpdateReturn => {
-    const [nextAnimation, animationCommands, maybeOutMessage] = animationUpdate(
-      model.animation,
-      animationMessage,
-    )
+  const foldAnimationOutMessage: (
+    outMessage: AnimationOutMessage,
+  ) => Update.Step<Model, Message> = M.type<AnimationOutMessage>().pipe(
+    M.withReturnType<Update.Step<Model, Message>>(),
+    M.tagsExhaustive({
+      StartedLeaveAnimating: () => model => [
+        model,
+        [DetectMovementOrAnimationEnd({ id: model.id })],
+      ],
+      TransitionedOut: () => model => [model, []],
+    }),
+  )
 
-    const mappedCommands = Command.mapMessages(animationCommands, message =>
-      GotAnimationMessage({ message }),
-    )
-
-    const additionalCommands = Option.match(maybeOutMessage, {
-      onNone: () => [],
-      onSome: M.type<AnimationOutMessage>().pipe(
-        M.tagsExhaustive({
-          StartedLeaveAnimating: () => [
-            DetectMovementOrAnimationEnd({ id: model.id }),
-          ],
-          TransitionedOut: () => [],
-        }),
-      ),
-    })
-
-    return [
+  const foldAnimation = Update.foldChild({
+    update: animationUpdate,
+    read: (model: Model) => Option.some(model.animation),
+    write: (model, nextAnimation) =>
       constrainedEvo(model, { animation: () => nextAnimation }),
-      [...mappedCommands, ...additionalCommands],
-      Option.none(),
-    ]
-  }
+    toParentMessage: message => GotAnimationMessage({ message }),
+    toParentOutMessage: () => Option.none(),
+    foldOutMessage: foldAnimationOutMessage,
+  })
 
   const openListbox = (
     baseModel: Model,
     openCommands: ReadonlyArray<Command.Command<Message>>,
   ): UpdateReturn => {
     if (baseModel.isAnimated) {
-      const [nextModel, animationCommands] = delegateToAnimation(
+      const [nextModel, animationCommands] = foldAnimation(
         baseModel,
         AnimationShowed(),
       )
@@ -501,7 +493,7 @@ export const makeUpdate = <Model extends BaseModel>(
     const closed = closedModel(baseModel)
 
     if (baseModel.isAnimated) {
-      const [nextModel, animationCommands] = delegateToAnimation(
+      const [nextModel, animationCommands] = foldAnimation(
         closed,
         AnimationHid(),
       )
@@ -683,7 +675,7 @@ export const makeUpdate = <Model extends BaseModel>(
         },
 
         GotAnimationMessage: ({ message: animationMessage }) =>
-          delegateToAnimation(model, animationMessage),
+          foldAnimation(model, animationMessage),
 
         PressedPointerOnButton: ({ pointerType, button }) => {
           const withPointerType = constrainedEvo(model, {

--- a/packages/ui/src/menu/index.ts
+++ b/packages/ui/src/menu/index.ts
@@ -16,6 +16,7 @@ import { m } from 'foldkit/message'
 import * as Mount from 'foldkit/mount'
 import { evo } from 'foldkit/struct'
 import { type View as SubmodelView, defineView } from 'foldkit/submodel'
+import * as Update from 'foldkit/update'
 
 import { AnchorConfig, anchorSetup, portalToContainingRoot } from '../anchor.js'
 // NOTE: Animation imports are split across schema + update to avoid a circular
@@ -411,37 +412,28 @@ export const DetectMovementOrAnimationEnd = Command.define(
   },
 )
 
-const delegateToAnimation = (
-  model: Model,
-  animationMessage: AnimationMessage,
-): UpdateReturn => {
-  const [nextAnimation, animationCommands, maybeOutMessage] = animationUpdate(
-    model.animation,
-    animationMessage,
-  )
+const foldAnimationOutMessage: (
+  outMessage: AnimationOutMessage,
+) => Update.Step<Model, Message> = M.type<AnimationOutMessage>().pipe(
+  M.withReturnType<Update.Step<Model, Message>>(),
+  M.tagsExhaustive({
+    StartedLeaveAnimating: () => model => [
+      model,
+      [DetectMovementOrAnimationEnd({ id: model.id })],
+    ],
+    TransitionedOut: () => model => [model, []],
+  }),
+)
 
-  const mappedCommands = Command.mapMessages(animationCommands, message =>
-    GotAnimationMessage({ message }),
-  )
-
-  const additionalCommands = Option.match(maybeOutMessage, {
-    onNone: () => [],
-    onSome: M.type<AnimationOutMessage>().pipe(
-      M.tagsExhaustive({
-        StartedLeaveAnimating: () => [
-          DetectMovementOrAnimationEnd({ id: model.id }),
-        ],
-        TransitionedOut: () => [],
-      }),
-    ),
-  })
-
-  return [
+const foldAnimation = Update.foldChild({
+  update: animationUpdate,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
     evo(model, { animation: () => nextAnimation }),
-    [...mappedCommands, ...additionalCommands],
-    Option.none(),
-  ]
-}
+  toParentMessage: message => GotAnimationMessage({ message }),
+  toParentOutMessage: () => Option.none(),
+  foldOutMessage: foldAnimationOutMessage,
+})
 
 /** Processes a menu message and returns the next model and commands. */
 export const update = (model: Model, message: Message): UpdateReturn => {
@@ -476,7 +468,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
 
   const openMenu = (baseModel: Model): UpdateReturn => {
     if (model.isAnimated) {
-      const [nextModel, animationCommands] = delegateToAnimation(
+      const [nextModel, animationCommands] = foldAnimation(
         baseModel,
         AnimationShowed(),
       )
@@ -502,7 +494,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
     const closed = closedModel(baseModel)
 
     if (model.isAnimated) {
-      const [nextModel, animationCommands] = delegateToAnimation(
+      const [nextModel, animationCommands] = foldAnimation(
         closed,
         AnimationHid(),
       )
@@ -636,7 +628,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
       },
 
       GotAnimationMessage: ({ message: animationMessage }) =>
-        delegateToAnimation(model, animationMessage),
+        foldAnimation(model, animationMessage),
 
       PressedPointerOnButton: ({
         pointerType,

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -14,6 +14,7 @@ import { m } from 'foldkit/message'
 import * as Mount from 'foldkit/mount'
 import { evo } from 'foldkit/struct'
 import { defineView } from 'foldkit/submodel'
+import * as Update from 'foldkit/update'
 
 import { AnchorConfig, anchorSetup, portalToContainingRoot } from '../anchor.js'
 // NOTE: Animation imports are split across schema + update to avoid a circular
@@ -262,37 +263,28 @@ export const DetectMovementOrAnimationEnd = Command.define(
   },
 )
 
-const delegateToAnimation = (
-  model: Model,
-  animationMessage: AnimationMessage,
-): UpdateReturn => {
-  const [nextAnimation, animationCommands, maybeOutMessage] = animationUpdate(
-    model.animation,
-    animationMessage,
-  )
+const foldAnimationOutMessage: (
+  outMessage: AnimationOutMessage,
+) => Update.Step<Model, Message> = M.type<AnimationOutMessage>().pipe(
+  M.withReturnType<Update.Step<Model, Message>>(),
+  M.tagsExhaustive({
+    StartedLeaveAnimating: () => model => [
+      model,
+      [DetectMovementOrAnimationEnd({ id: model.id })],
+    ],
+    TransitionedOut: () => model => [model, []],
+  }),
+)
 
-  const mappedCommands = Command.mapMessages(animationCommands, message =>
-    GotAnimationMessage({ message }),
-  )
-
-  const additionalCommands = Option.match(maybeOutMessage, {
-    onNone: () => [],
-    onSome: M.type<AnimationOutMessage>().pipe(
-      M.tagsExhaustive({
-        StartedLeaveAnimating: () => [
-          DetectMovementOrAnimationEnd({ id: model.id }),
-        ],
-        TransitionedOut: () => [],
-      }),
-    ),
-  })
-
-  return [
+const foldAnimation = Update.foldChild({
+  update: animationUpdate,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
     evo(model, { animation: () => nextAnimation }),
-    [...mappedCommands, ...additionalCommands],
-    Option.none(),
-  ]
-}
+  toParentMessage: message => GotAnimationMessage({ message }),
+  toParentOutMessage: () => Option.none(),
+  foldOutMessage: foldAnimationOutMessage,
+})
 
 /** Processes a popover message and returns the next model, commands, and optional OutMessage. */
 export const update = (model: Model, message: Message): UpdateReturn => {
@@ -323,7 +315,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
 
   const openPopover = (baseModel: Model): UpdateReturn => {
     if (model.isAnimated) {
-      const [nextModel, animationCommands] = delegateToAnimation(
+      const [nextModel, animationCommands] = foldAnimation(
         baseModel,
         AnimationShowed(),
       )
@@ -351,7 +343,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
     const closed = closedModel(baseModel)
 
     if (model.isAnimated) {
-      const [nextModel, animationCommands] = delegateToAnimation(
+      const [nextModel, animationCommands] = foldAnimation(
         closed,
         AnimationHid(),
       )
@@ -409,7 +401,7 @@ export const update = (model: Model, message: Message): UpdateReturn => {
       },
 
       GotAnimationMessage: ({ message: animationMessage }) =>
-        delegateToAnimation(model, animationMessage),
+        foldAnimation(model, animationMessage),
 
       CompletedFocusPanel: () => [model, [], Option.none()],
       CompletedFocusButton: () => [model, [], Option.none()],

--- a/packages/ui/src/test/apps/disabledButton.ts
+++ b/packages/ui/src/test/apps/disabledButton.ts
@@ -1,7 +1,9 @@
-import { Match as M, Schema as S } from 'effect'
+import { Match as M, Option, Schema as S } from 'effect'
 import * as Command from 'foldkit/command'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 import { m } from 'foldkit/message'
+import { evo } from 'foldkit/struct'
+import * as Update from 'foldkit/update'
 
 import * as Dialog from '../../dialog/index.js'
 
@@ -33,6 +35,24 @@ export const initialModel: Model = {
 
 // UPDATE
 
+const foldDialogOutMessage: (
+  outMessage: Dialog.OutMessage,
+) => Update.Step<Model, Message> = M.type<Dialog.OutMessage>().pipe(
+  M.withReturnType<Update.Step<Model, Message>>(),
+  M.tagsExhaustive({
+    Opened: () => model => [model, []],
+    Closed: () => model => [model, []],
+  }),
+)
+
+const foldDialog = Update.foldChild({
+  update: Dialog.update,
+  read: (model: Model) => Option.some(model.dialog),
+  write: (model, nextDialog) => evo(model, { dialog: () => nextDialog }),
+  toParentMessage: message => GotDialogMessage({ message }),
+  foldOutMessage: foldDialogOutMessage,
+})
+
 export const update = (
   model: Model,
   message: Message,
@@ -44,18 +64,8 @@ export const update = (
     M.tagsExhaustive({
       ClickedToggle: () => [{ ...model, isEnabled: !model.isEnabled }, []],
       ClickedSubmit: () => [model, []],
-      GotDialogMessage: ({ message: dialogMessage }) => {
-        const [nextDialog, commands] = Dialog.update(
-          model.dialog,
-          dialogMessage,
-        )
-        return [
-          { ...model, dialog: nextDialog },
-          Command.mapMessages(commands, dialogMessage =>
-            GotDialogMessage({ message: dialogMessage }),
-          ),
-        ]
-      },
+      GotDialogMessage: ({ message: dialogMessage }) =>
+        foldDialog(model, dialogMessage),
     }),
   )
 

--- a/packages/ui/src/toast/update.ts
+++ b/packages/ui/src/toast/update.ts
@@ -6,9 +6,11 @@ import {
   Number,
   Option,
   Schema as S,
+  pipe,
 } from 'effect'
 import * as Command from 'foldkit/command'
 import { evo } from 'foldkit/struct'
+import * as Update from 'foldkit/update'
 
 import {
   Hid as AnimationHid,
@@ -139,62 +141,84 @@ export const makeRuntime = <A, I>(payloadSchema: S.Codec<A, I>) => {
     }
   }
 
+  const readEntryAnimation =
+    (entryId: string) =>
+    (model: Model): Option.Option<Entry['animation']> =>
+      pipe(
+        Array.findFirst(model.entries, ({ id }) => id === entryId),
+        Option.map(({ animation }) => animation),
+      )
+
+  const writeEntryAnimation =
+    (entryId: string) =>
+    (model: Model, nextAnimation: Entry['animation']): Model =>
+      updateEntry(model, entryId, entry =>
+        evo(entry, { animation: () => nextAnimation }),
+      )
+
+  const toGotAnimationMessage =
+    (entryId: string) =>
+    (message: AnimationMessage): Message =>
+      GotAnimationMessage({ entryId, message })
+
+  const toDismissedToastOutMessage: (
+    payload: A,
+  ) => (
+    outMessage: AnimationOutMessage,
+  ) => Option.Option<OutMessage> = payload =>
+    M.type<AnimationOutMessage>().pipe(
+      M.withReturnType<Option.Option<OutMessage>>(),
+      M.tagsExhaustive({
+        StartedLeaveAnimating: () => Option.none(),
+        TransitionedOut: () => Option.some(DismissedToast({ payload })),
+      }),
+    )
+
+  const foldEntryAnimationOutMessage: (
+    entryId: string,
+  ) => (
+    outMessage: AnimationOutMessage,
+    context: Update.FoldContext<AnimationMessage, Message>,
+  ) => Update.Step<Model, Message> =
+    entryId =>
+    (outMessage, { liftCommand }) =>
+      M.value(outMessage).pipe(
+        M.withReturnType<Update.Step<Model, Message>>(),
+        M.tagsExhaustive({
+          StartedLeaveAnimating: () => model =>
+            Option.match(readEntryAnimation(entryId)(model), {
+              onNone: () => [model, []],
+              onSome: animation => [
+                model,
+                [liftCommand(animationDefaultLeaveCommand(animation))],
+              ],
+            }),
+          TransitionedOut: () => model => [removeEntry(model, entryId), []],
+        }),
+      )
+
+  const foldEntryAnimation = (entry: Entry) =>
+    Update.foldChild({
+      update: animationUpdate,
+      read: readEntryAnimation(entry.id),
+      write: writeEntryAnimation(entry.id),
+      toParentMessage: toGotAnimationMessage(entry.id),
+      toParentOutMessage: toDismissedToastOutMessage(entry.payload),
+      foldOutMessage: foldEntryAnimationOutMessage(entry.id),
+    })
+
   const delegateToEntryAnimation = (
     model: Model,
     entryId: string,
     animationMessage: AnimationMessage,
-  ): UpdateReturn => {
-    const maybeEntry = Array.findFirst(
-      model.entries,
-      ({ id }) => id === entryId,
-    )
-
-    return Option.match(maybeEntry, {
-      onNone: (): UpdateReturn => [model, [], Option.none()],
-      onSome: entry => {
-        const [nextAnimation, animationCommands, maybeOutMessage] =
-          animationUpdate(entry.animation, animationMessage)
-
-        const toMessage = (message: AnimationMessage): Message =>
-          GotAnimationMessage({ entryId, message })
-
-        const mappedCommands = Command.mapMessages(animationCommands, toMessage)
-
-        const nextEntry: Entry = evo(entry, {
-          animation: () => nextAnimation,
-        })
-
-        return Option.match(maybeOutMessage, {
-          onNone: (): UpdateReturn => [
-            updateEntry(model, entryId, () => nextEntry),
-            mappedCommands,
-            Option.none(),
-          ],
-          onSome: M.type<AnimationOutMessage>().pipe(
-            withUpdateReturn,
-            M.tagsExhaustive({
-              StartedLeaveAnimating: () => [
-                updateEntry(model, entryId, () => nextEntry),
-                [
-                  ...mappedCommands,
-                  Command.mapMessage(
-                    animationDefaultLeaveCommand(nextAnimation),
-                    toMessage,
-                  ),
-                ],
-                Option.none(),
-              ],
-              TransitionedOut: () => [
-                removeEntry(model, entryId),
-                mappedCommands,
-                Option.some(DismissedToast({ payload: entry.payload })),
-              ],
-            }),
-          ),
-        })
+  ): UpdateReturn =>
+    Option.match(
+      Array.findFirst(model.entries, ({ id }) => id === entryId),
+      {
+        onNone: (): UpdateReturn => [model, [], Option.none()],
+        onSome: entry => foldEntryAnimation(entry)(model, animationMessage),
       },
-    })
-  }
+    )
 
   const createEntry = (model: Model, input: ShowInput<A>): Entry => {
     const entryId = `${model.id}-entry-${model.nextEntryKey}`


### PR DESCRIPTION
Part two of the composition sweep: the `@foldkit/ui` composites no longer hand-fold their children with `Command.mapMessages` plus an OutMessage match. Each internal fold is now an `Update.foldChild` config.

Fixes #964.

## What changed

| File | Child folded | Notes |
| --- | --- | --- |
| `dialog/index.ts` | Animation | `foldOutMessage` reads the written-back `model.animation` for `defaultLeaveCommand`, and emits `CloseDialog` on `TransitionedOut` |
| `popover/index.ts` | Animation | `DetectMovementOrAnimationEnd` on `StartedLeaveAnimating` |
| `menu/index.ts` | Animation | same shape as Popover |
| `datePicker/index.ts` | Calendar, Popover | the Calendar fold lifts `ChangedViewMonth` and `SelectedDate` through `toDatePickerOutMessage`; the Popover fold returns None upward and drops the Calendar to Days |
| `listbox/shared.ts` | Animation | fold built inside `makeUpdate`, so it is generic over the variant Model with no extra type parameters |
| `combobox/shared.ts` | Animation | module-level generic `delegateToAnimation` moved inside `makeUpdate` for the same reason |
| `toast/update.ts` | per-entry Animation | keyed by entry id, every config field a named factory over that id |
| `test/apps/disabledButton.ts` | Dialog | test fixture, now folds through the helper |

Every component that is itself a Submodel passes `toParentOutMessage`, so its fold returns the three-tuple directly. Where a child OutMessage stops at the component (Animation everywhere, Popover inside DatePicker) that is `() =&gt; Option.none()`, which reads as the explicit statement that nothing passes upward.

Every fold config field is a named const rather than an inline lambda, so each config reads as one line per capability. Toast is the case that needed factories: entries are keyed by id, so `readEntryAnimation`, `writeEntryAnimation`, `toGotAnimationMessage`, and `foldEntryAnimationOutMessage` each close over the entry id, and `toDismissedToastOutMessage` closes over the payload the `DismissedToast` OutMessage carries. That mirrors the keyed fold in the job-application example. DatePicker&#39;s Calendar `toParentOutMessage` came out to `toDatePickerOutMessage` for the same reason.

## Design note

Nothing was left hand-written, and no site needed an `as` cast, an `any`, or a lint suppression. Inference landed on the first attempt everywhere, including inside the two generic `makeUpdate` factories, with the annotated standalone `foldOutMessage` consts the conventions call for.

One rough edge worth recording, since the issue asked for friction reports. A parent with no OutMessage channel that folds a child which has one must still supply `foldOutMessage`. `ChildFold` requires a two-tuple `update`, and `ChildFoldWithOutMessage` makes `foldOutMessage` required, so there is no shape for &#34;this child raises OutMessages and the parent ignores all of them.&#34; `test/apps/disabledButton.ts` therefore carries a `foldDialogOutMessage` whose arms both return `[model, []]`. That is correct and explicit, and arguably good pressure to make a parent state its indifference, but `foldOutMessage` could reasonably be optional on `ChildFoldWithOutMessage` the way it already is on `ChildFoldWithParentOutMessage`. Left alone rather than changing the helper&#39;s API inside a behavior-preserving refactor.

Now that #983 has merged, the animation folds use `Update.FoldContext`. Dialog and Toast are the two whose Step returns the overridable leave Command, whose result is the Animation child's Message. Each takes the fold's second parameter, destructures `liftCommand`, and lifts that Command with it, so no hand-written `Command.mapMessage` remains in any fold. The Popover, Menu, Listbox, and Combobox folds return `DetectMovementOrAnimationEnd`, which already produces the component's own Message, so they stay one-parameter functions and take no context.

## Verification

- `pnpm check` green on the final commit, rebased onto latest main (Effect 4.0.0-beta.106).
- `@foldkit/ui` is 924 tests in 39 files, all green, including the Dialog and Menu leave-animation story suites.
- Command ordering specifically: drove Dialog, Menu, Popover, Listbox, DatePicker, and Toast through their open, leave-animation, and close sequences with a throwaway probe that dumped each step's full Model, its Command list in order, and its OutMessage. The probe also replays each Command's message-mapping chain, so a lifted Command's result Message is compared, not just its name and args. Ran it against this branch and against `origin/main`; the two transcripts are byte-identical. That covers the Dialog leave (`WaitForPaint`, `WaitForAnimationSettled`, `CloseDialog`), the Menu and Popover leave (`WaitForPaint`, `DetectMovementOrAnimationEnd`), Toast dismiss-all, hover and un-hover rescheduling, a Toast message for an entry that no longer exists, and the Toast `DismissedToast` payload. Re-run after the `Update.FoldContext` adoption, still identical.
- The full pre-push suite, including the website e2e run, passed on the pre-rebase commit.

`@foldkit/ui` patch changeset. No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)