### PR TITLE
refactor(foldkit,typing-game): name the joined-room fold for the fact it applies

### DIFF
--- a/.changeset/tidy-rooms-enter.md
+++ b/.changeset/tidy-rooms-enter.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Rename the `Update.foldChild` TSDoc example's step from `joinRoom` to `enterJoinedRoom` and the child helper it calls from `Room.join` to `Room.informJoined`. The step runs after the join has already succeeded, so the old names read as initiating a join the example is actually reporting.

--- a/packages/foldkit/src/update/update.ts
+++ b/packages/foldkit/src/update/update.ts
@@ -334,12 +334,12 @@ export type FoldWithOutMessage<
  *  of the child's:
  *
  *  ```ts
- *  const joinRoom = (roomId: string, player: Player): UpdateStep =>
+ *  const enterJoinedRoom = (roomId: string, player: Player): UpdateStep =>
  *    Update.combine([
  *      model => [model, [NavigateToRoom({ roomId })]],
  *      Update.foldChild({
- *        update: (room: Room.Model, player: Player) =>
- *          Room.join(room, player, { roomId }),
+ *        update: (room: Room.Model, joinedPlayer: Player) =>
+ *          Room.informJoined(room, joinedPlayer, { roomId }),
  *        read: readRoom,
  *        write: writeRoom,
  *        toParentMessage: toGotRoomMessage,

--- a/packages/typing-game/client/src/page/room/update/update.ts
+++ b/packages/typing-game/client/src/page/room/update/update.ts
@@ -289,7 +289,7 @@ const handleStartGame = (model: Model, room: Shared.Room) => (): UpdateReturn =>
     onNone: () => [model, []],
   })
 
-export const join = (
+export const informJoined = (
   model: Model,
   player: Shared.Player,
   context: Context,

--- a/packages/typing-game/client/src/update.ts
+++ b/packages/typing-game/client/src/update.ts
@@ -61,12 +61,12 @@ const navigateToRoom =
   (roomId: string): UpdateStep =>
   model => [model, [NavigateToRoom({ roomId })]]
 
-const joinRoom = (roomId: string, player: Shared.Player): UpdateStep =>
+const enterJoinedRoom = (roomId: string, player: Shared.Player): UpdateStep =>
   Update.combine([
     navigateToRoom(roomId),
     Update.foldChild({
-      update: (roomModel: Room.Model.Model, joiningPlayer: Shared.Player) =>
-        Room.join(roomModel, joiningPlayer, { roomId }),
+      update: (roomModel: Room.Model.Model, joinedPlayer: Shared.Player) =>
+        Room.informJoined(roomModel, joinedPlayer, { roomId }),
       read: readRoom,
       write: writeRoom,
       toParentMessage: toGotRoomMessage,
@@ -78,7 +78,7 @@ const foldHomeOutMessage: (outMessage: Home.Message.OutMessage) => UpdateStep =
     M.value(outMessage).pipe(
       withUpdateReturn,
       M.tag('SucceededCreateRoom', 'SucceededJoinRoom', ({ roomId, player }) =>
-        joinRoom(roomId, player)(model),
+        enterJoinedRoom(roomId, player)(model),
       ),
       M.exhaustive,
     )


### PR DESCRIPTION
Renames the typing game's join handoff so both names report the fact they apply instead of a join they perform, and carries the same rename into the `Update.foldChild` TSDoc example that was lifted from this code.

## What changed

- `joinRoom` to `enterJoinedRoom` in `packages/typing-game/client/src/update.ts`. The step runs after the Home child reports `SucceededCreateRoom` or `SucceededJoinRoom`, so the join has already succeeded; the step navigates and seeds the Room submodel.
- `Room.join` to `Room.informJoined` in `page/room/update/update.ts`. The body applies `SucceededJoinRoom` via `update`, matching the `inform*` prefix of its sibling `informPressedKey`.
- The inner `joiningPlayer` binding follows to `joinedPlayer`.
- The `Update.foldChild` TSDoc example in `packages/foldkit/src/update/update.ts` gets the same rename, since it renders on the API reference page. Patch changeset for `foldkit` included.

Deliberately kept: the `joinRoom` RPC, its server handler, and the `client.joinRoom(...)` call sites, which genuinely perform the join.

Pure rename, no behavior change.

## Verification

Typing-game client typecheck and tests (13), foldkit typecheck and tests (1777), root lint, prettier. Exhaustive search confirms no remaining references to the old names outside the RPC/server surfaces that keep them.

Fixes #969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WinpmwSSdwtBZ2KpqJ4tMv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WinpmwSSdwtBZ2KpqJ4tMv)_