### PR TITLE
fix(website): throw on metadata registry misses instead of shipping filler

### DIFF
--- a/packages/website/scripts/metadata.test.ts
+++ b/packages/website/scripts/metadata.test.ts
@@ -1,0 +1,100 @@
+import { Array, Option } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { BLOG_SECTION } from '../src/page/blog/meta'
+import { findBySlug } from '../src/page/example/meta'
+import {
+  BlogPostRoute,
+  ExampleDetailRoute,
+  PlaygroundRoute,
+} from '../src/route'
+import { blogPosts } from './blogPosts'
+import { routeToMetadata } from './metadata'
+
+const resolveApiModuleName = (slug: string) => slug
+
+describe('routeToMetadata', () => {
+  describe('BlogPost', () => {
+    it('reports the post frontmatter for a registered slug', () => {
+      const { slug, frontmatter } = Option.getOrThrow(Array.head(blogPosts))
+
+      expect(
+        routeToMetadata(
+          BlogPostRoute({ postSlug: slug }),
+          resolveApiModuleName,
+        ),
+      ).toEqual({
+        title: frontmatter.title,
+        description: frontmatter.description,
+        section: BLOG_SECTION,
+      })
+    })
+
+    it('throws naming the slug and the registry for an unregistered slug', () => {
+      expect(() =>
+        routeToMetadata(
+          BlogPostRoute({ postSlug: 'no-such-post' }),
+          resolveApiModuleName,
+        ),
+      ).toThrow(
+        'Blog post "no-such-post" is missing from the blog post registry.',
+      )
+    })
+  })
+
+  describe('ExampleDetail', () => {
+    it('reports the example title and description for a registered slug', () => {
+      const example = Option.getOrThrow(findBySlug('counter'))
+
+      expect(
+        routeToMetadata(
+          ExampleDetailRoute({ exampleSlug: 'counter' }),
+          resolveApiModuleName,
+        ),
+      ).toEqual({
+        title: example.title,
+        description: example.description,
+        section: 'Examples',
+      })
+    })
+
+    it('throws naming the slug and the registry for an unregistered slug', () => {
+      expect(() =>
+        routeToMetadata(
+          ExampleDetailRoute({ exampleSlug: 'no-such-example' }),
+          resolveApiModuleName,
+        ),
+      ).toThrow(
+        'Example "no-such-example" is missing from the example registry.',
+      )
+    })
+  })
+
+  describe('Playground', () => {
+    it('derives the playground title and description for a registered slug', () => {
+      const example = Option.getOrThrow(findBySlug('counter'))
+
+      expect(
+        routeToMetadata(
+          PlaygroundRoute({ exampleSlug: 'counter' }),
+          resolveApiModuleName,
+        ),
+      ).toEqual({
+        title: `${example.title} playground`,
+        description: `Edit and run the ${example.title} example live in your browser.`,
+        section: 'Playground',
+      })
+    })
+
+    it('throws naming the slug and the registry for an unregistered slug', () => {
+      expect(() =>
+        routeToMetadata(
+          PlaygroundRoute({ exampleSlug: 'no-such-example' }),
+          resolveApiModuleName,
+        ),
+      ).toThrow(
+        'Playground example "no-such-example" is missing from the example registry.',
+      )
+    })
+  })
+})

--- a/packages/website/scripts/metadata.ts
+++ b/packages/website/scripts/metadata.ts
@@ -440,33 +440,39 @@ export const routeToMetadata = (
         'API Reference',
       )
     }),
-    M.tag('BlogPost', ({ postSlug }) =>
-      Option.match(
+    M.tag('BlogPost', ({ postSlug }) => {
+      const { frontmatter } = Option.getOrThrowWith(
         Array.findFirst(blogPosts, ({ slug }) => slug === postSlug),
-        {
-          onNone: () => docs(BLOG_TITLE, 'A Foldkit blog post.', BLOG_SECTION),
-          onSome: ({ frontmatter }) =>
-            docs(frontmatter.title, frontmatter.description, BLOG_SECTION),
-        },
-      ),
-    ),
-    M.tag('ExampleDetail', ({ exampleSlug }) =>
-      Option.match(findBySlug(exampleSlug), {
-        onNone: () =>
-          docs('Example', 'A Foldkit example application.', 'Examples'),
-        onSome: example => docs(example.title, example.description, 'Examples'),
-      }),
-    ),
-    M.tag('Playground', ({ exampleSlug }) =>
-      Option.match(findBySlug(exampleSlug), {
-        onNone: () => docs('Playground', 'Foldkit playground.', 'Playground'),
-        onSome: example =>
-          docs(
-            `${example.title} playground`,
-            `Edit and run the ${example.title} example live in your browser.`,
-            'Playground',
+        () =>
+          new Error(
+            `Blog post "${postSlug}" is missing from the blog post registry.`,
           ),
-      }),
-    ),
+      )
+      return docs(frontmatter.title, frontmatter.description, BLOG_SECTION)
+    }),
+    M.tag('ExampleDetail', ({ exampleSlug }) => {
+      const example = Option.getOrThrowWith(
+        findBySlug(exampleSlug),
+        () =>
+          new Error(
+            `Example "${exampleSlug}" is missing from the example registry.`,
+          ),
+      )
+      return docs(example.title, example.description, 'Examples')
+    }),
+    M.tag('Playground', ({ exampleSlug }) => {
+      const example = Option.getOrThrowWith(
+        findBySlug(exampleSlug),
+        () =>
+          new Error(
+            `Playground example "${exampleSlug}" is missing from the example registry.`,
+          ),
+      )
+      return docs(
+        `${example.title} playground`,
+        `Edit and run the ${example.title} example live in your browser.`,
+        'Playground',
+      )
+    }),
     M.orElse(({ _tag }) => METADATA_BY_TAG[_tag]),
   )


### PR DESCRIPTION
The `BlogPost`, `ExampleDetail`, and `Playground` branches of `routeToMetadata` fell back to generic filler ("A Foldkit blog post.", "A Foldkit example application.", "Foldkit playground.") when a slug lookup missed. None of those arms is reachable on a green build: the prerender enumerates all three route families from the same registries the lookups search, so a miss is a build bug, and the fallback converted it into a page shipped with wrong metadata, OG tags, and sitemap entry.

## What changed

- All three branches now unwrap with `Option.getOrThrowWith` and an error naming the missing slug and the registry it belongs in, matching the stance `scripts/blogPosts.ts` already takes for a post whose frontmatter fails to decode. The `docs(...)` mapping in each branch is unchanged.
- New `packages/website/scripts/metadata.test.ts`: per branch, a happy path asserting the field-to-field mapping against the live registry entry, and a miss asserting the exact throw message.

Accepted consequence, stated in the issue: the script's totality is now coupled to the registries staying in sync. A legitimately dynamic caller added later gets a loud failure as its prompt to design the miss case deliberately.

## Verification

Website typecheck; website tests (325, 6 new); root scripts tests (34); prettier; root lint. No changeset, website is unversioned.

Fixes #972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WinpmwSSdwtBZ2KpqJ4tMv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WinpmwSSdwtBZ2KpqJ4tMv)_