### PR TITLE
perf(markdown): memoize decodeDocument on the wire object

### DIFF
--- a/.changeset/eighty-poems-repeat.md
+++ b/.changeset/eighty-poems-repeat.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/markdown': patch
+---
+
+Memoize `decodeDocument` on a `WeakMap` keyed by the wire object, so decoding the same compiled markdown module again returns the document from the first decode. A module's wire object is immutable build output and the decode is deterministic, so a cached document can never disagree with a fresh one, and each entry is collected along with the module holding its key. Calling `decodeDocument` from a view no longer re-decodes on every render, and consumers no longer need a cache of their own.

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -54,6 +54,8 @@ const view = (h: HtmlBuilder<Message>): Html =>
   h.div([], [Markdown.view(about)])
 ```
 
+`decodeDocument` memoizes on the wire object, so calling it inside a view decodes each module once rather than once per render.
+
 `Markdown.view` renders every node through unstyled semantic defaults. Restyle any node by overriding its view:
 
 ```typescript

--- a/packages/markdown/src/ast/ast.test.ts
+++ b/packages/markdown/src/ast/ast.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeDocument } from './ast.js'
+
+const wireDocument = (): unknown => ({
+  blocks: [
+    {
+      _tag: 'Heading',
+      level: 1,
+      content: [{ _tag: 'Text', value: 'Title' }],
+    },
+    {
+      _tag: 'Paragraph',
+      content: [{ _tag: 'Text', value: 'Prose.' }],
+    },
+  ],
+})
+
+describe('decodeDocument', () => {
+  it('returns the first document when one wire object is decoded again', () => {
+    const wire = wireDocument()
+
+    expect(decodeDocument(wire)).toBe(decodeDocument(wire))
+  })
+
+  it('decodes distinct wire objects independently', () => {
+    const first = decodeDocument(wireDocument())
+    const second = decodeDocument(wireDocument())
+
+    expect(first).not.toBe(second)
+    expect(first).toStrictEqual(second)
+  })
+
+  it('throws on a block outside the markdown vocabulary, every time', () => {
+    const wire = { blocks: [{ _tag: 'Marquee' }] }
+
+    expect(() => decodeDocument(wire)).toThrowError('at ["blocks"][0]')
+    expect(() => decodeDocument(wire)).toThrowError('at ["blocks"][0]')
+  })
+
+  it('throws on input that is not an object', () => {
+    expect(() => decodeDocument('not a document')).toThrowError(
+      'Expected object',
+    )
+  })
+
+  it('bypasses the cache when override options are passed', () => {
+    const wire = wireDocument()
+    const cached = decodeDocument(wire)
+    const overridden = decodeDocument(wire, {})
+
+    expect(overridden).not.toBe(cached)
+    expect(overridden).toStrictEqual(cached)
+    expect(decodeDocument(wire)).toBe(cached)
+  })
+})

--- a/packages/markdown/src/ast/ast.ts
+++ b/packages/markdown/src/ast/ast.ts
@@ -1,5 +1,5 @@
-import { Option, Schema as S } from 'effect'
-import type { Array } from 'effect'
+import { Function, Option, Predicate, Schema as S } from 'effect'
+import type { Array, SchemaAST } from 'effect'
 import { ts } from 'foldkit/schema'
 
 // INLINE
@@ -362,11 +362,42 @@ export type MarkdownDocument = typeof MarkdownDocument.Type
 /** The wire form of {@link MarkdownDocument}. */
 export type MarkdownDocumentEncoded = typeof MarkdownDocument.Encoded
 
+const decodeDocumentUncached = S.decodeUnknownSync(MarkdownDocument)
+
+const documentByWire = new WeakMap<object, MarkdownDocument>()
+
 /**
  * Decodes the default export of a compiled markdown module into a typed
  * {@link MarkdownDocument}. Throws on input outside the markdown vocabulary.
+ *
+ * Results are memoized on a `WeakMap` keyed by the wire object, so decoding the
+ * same compiled module again returns the document from the first decode. A
+ * module's wire object is immutable build output and the decode is
+ * deterministic, so a cached document can never disagree with a fresh one, and
+ * each entry is collected along with the module holding its key. Calling this
+ * from a view costs one decode per module rather than one per render.
+ *
+ * Passing `overrideOptions` bypasses the cache both ways: the decode ignores
+ * cached entries and its result is not stored, since a document decoded under
+ * one set of options cannot answer for another.
  */
-export const decodeDocument = S.decodeUnknownSync(MarkdownDocument)
+export const decodeDocument = (
+  wire: unknown,
+  overrideOptions?: SchemaAST.ParseOptions,
+): MarkdownDocument => {
+  if (overrideOptions === undefined && Predicate.isObject(wire)) {
+    return Option.match(Option.fromNullishOr(documentByWire.get(wire)), {
+      onNone: () => {
+        const document = decodeDocumentUncached(wire)
+        documentByWire.set(wire, document)
+        return document
+      },
+      onSome: Function.identity,
+    })
+  } else {
+    return decodeDocumentUncached(wire, overrideOptions)
+  }
+}
 
 /** Encodes a {@link MarkdownDocument} into its JSON-safe wire form. */
 export const encodeDocument = S.encodeSync(MarkdownDocument)


### PR DESCRIPTION
`decodeDocument` re-decoded a compiled module's wire object on every call, so a consumer calling it inside `view` paid a full Schema decode per render. Consumers worked around it in ways that re-prove invariants only this package can guarantee: the website's docs pages decode at module load, and the blog hand-rolled a slug-keyed cache (whose deletion is #970's PR).

## What changed

- Results are memoized on a `WeakMap<object, MarkdownDocument>` keyed by the wire object itself. The safety argument lives in the TSDoc: the wire object is immutable build output and the decode is deterministic, so a cached document can never disagree with a fresh one, and entries are garbage-collected with the module holding their key.
- A failed decode is never cached, and non-object input decodes uncached exactly as before.
- The public signature keeps its optional `ParseOptions` parameter. Passing it bypasses the cache both ways (no read, no store), since a document decoded under one set of options cannot answer for another.
- New `src/ast/ast.test.ts`: identical reference on repeat decode, independent documents for distinct wire objects, errors rethrown on every call, non-object input unchanged, and the options bypass leaving the cache intact.
- One README sentence noting the cost model: one decode per module, not one per render.
- Patch changeset for `@foldkit/markdown`.

## Verification

Package build, typecheck, and tests (57); website typecheck and tests against the rebuilt package; prettier; root lint.

Fixes #971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WinpmwSSdwtBZ2KpqJ4tMv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WinpmwSSdwtBZ2KpqJ4tMv)_