### PR TITLE
feat(ui): add isReadOnly to Slider

### DIFF
--- a/.changeset/slider-read-only.md
+++ b/.changeset/slider-read-only.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': minor
+---
+
+Add `isReadOnly` to Slider's view inputs.
+
+A read-only Slider emits `aria-readonly="true"` on the thumb and `data-readonly` on every attribute group, remains focusable, and omits its pointerdown and keydown handlers. `isReadOnly` and `isDisabled` are independent, and either one removes the interaction handlers.

--- a/packages/ui/src/slider/index.ts
+++ b/packages/ui/src/slider/index.ts
@@ -524,6 +524,16 @@ export type ViewInputs = Readonly<{
   ariaLabelledBy?: string
   formatValue?: (value: number) => string
   isDisabled?: boolean
+  /** Prevents value changes while exposing read-only semantics with
+   *  `aria-readonly="true"` and `data-readonly`. The thumb remains focusable.
+   *  Independent of `isDisabled`: setting both emits both attribute sets, and
+   *  either one removes the pointer and keyboard handlers.
+   *
+   *  A drag already in flight is not interrupted. The handlers this flag
+   *  removes are what start a drag, and the pointermove Subscription runs off
+   *  `dragState` in the Model until pointerup. `isDisabled` behaves the same
+   *  way. */
+  isReadOnly?: boolean
   name?: string
   /** Resolves the root that holds the slider track when looking it up by its
    *  `data-slider-track-id` attribute. Defaults to `document`. Provide a
@@ -543,6 +553,7 @@ export const view = defineView<Model, Message, ViewInputs>(
       value,
       formatValue,
       isDisabled = false,
+      isReadOnly = false,
       name,
       getTrackRoot = () => document,
     } = viewInputs
@@ -590,6 +601,7 @@ export const view = defineView<Model, Message, ViewInputs>(
     const stateAttributes = [
       ...(isDragging ? [h.DataAttribute('dragging', '')] : []),
       ...(isDisabled ? [h.DataAttribute('disabled', '')] : []),
+      ...(isReadOnly ? [h.DataAttribute('readonly', '')] : []),
     ]
 
     const rootAttributes = [
@@ -598,9 +610,11 @@ export const view = defineView<Model, Message, ViewInputs>(
       ...stateAttributes,
     ]
 
-    const trackInteractionAttributes = isDisabled
-      ? []
-      : [h.OnPointerDown(trackPointerHandler)]
+    const isInteractive = !isDisabled && !isReadOnly
+
+    const trackInteractionAttributes = isInteractive
+      ? [h.OnPointerDown(trackPointerHandler)]
+      : []
 
     const trackAttributes = [
       h.DataAttribute('slider-track-id', id),
@@ -635,12 +649,12 @@ export const view = defineView<Model, Message, ViewInputs>(
     const maybeAriaValuetext =
       formatValue !== undefined ? [h.AriaValuetext(formatValue(value))] : []
 
-    const thumbInteractionAttributes = isDisabled
-      ? []
-      : [
+    const thumbInteractionAttributes = isInteractive
+      ? [
           h.OnPointerDown(thumbPointerHandler),
           h.OnKeyDownPreventDefault(handleKeyDown),
         ]
+      : []
 
     const thumbAttributes = [
       h.Id(`${id}-thumb`),
@@ -653,6 +667,7 @@ export const view = defineView<Model, Message, ViewInputs>(
       ...maybeAriaValuetext,
       ...thumbLabelAttributes,
       ...(isDisabled ? [h.AriaDisabled(true)] : []),
+      ...(isReadOnly ? [h.AriaReadonly(true)] : []),
       h.Style({
         position: 'absolute',
         left: percentString(fraction),

--- a/packages/ui/src/slider/scene.test.ts
+++ b/packages/ui/src/slider/scene.test.ts
@@ -143,6 +143,60 @@ describe('Slider', () => {
     })
   })
 
+  describe('read-only', () => {
+    it('marks the root, track, and thumb with data-readonly and the thumb with aria-readonly', () => {
+      Scene.scene(
+        { update, view: sceneView({ isReadOnly: true }) },
+        Scene.given(defaultModel),
+        Scene.expect(root).toHaveAttr('data-readonly', ''),
+        Scene.expect(track).toHaveAttr('data-readonly', ''),
+        Scene.expect(thumb).toHaveAttr('data-readonly', ''),
+        Scene.expect(thumb).toHaveAttr('aria-readonly', 'true'),
+        Scene.expect(thumb).not.toHaveAttr('aria-disabled'),
+        Scene.expect(thumb).not.toHaveAttr('data-disabled'),
+      )
+    })
+
+    it('emits both attribute sets when disabled and read-only are combined', () => {
+      Scene.scene(
+        {
+          update,
+          view: sceneView({ isDisabled: true, isReadOnly: true }),
+        },
+        Scene.given(defaultModel),
+        Scene.expect(thumb).toHaveAttr('aria-disabled', 'true'),
+        Scene.expect(thumb).toHaveAttr('data-disabled', ''),
+        Scene.expect(thumb).toHaveAttr('aria-readonly', 'true'),
+        Scene.expect(thumb).toHaveAttr('data-readonly', ''),
+      )
+    })
+
+    it('drops the track and thumb pointer handlers when read-only', () => {
+      Scene.scene(
+        { update, view: sceneView({ isReadOnly: true }) },
+        Scene.given(defaultModel),
+        Scene.expect(track).not.toHaveHandler('pointerdown'),
+        Scene.expect(thumb).not.toHaveHandler('pointerdown'),
+      )
+    })
+
+    it('drops the keyboard handler when read-only', () => {
+      Scene.scene(
+        { update, view: sceneView({ isReadOnly: true }) },
+        Scene.given(defaultModel),
+        Scene.expect(thumb).not.toHaveHandler('keydown'),
+      )
+    })
+
+    it('keeps the thumb focusable when read-only', () => {
+      Scene.scene(
+        { update, view: sceneView({ isReadOnly: true }) },
+        Scene.given(defaultModel),
+        Scene.expect(thumb).toHaveAttr('tabIndex', '0'),
+      )
+    })
+  })
+
   describe('hidden input', () => {
     it('is absent when no name is provided', () => {
       Scene.scene(

--- a/packages/website/src/page/ui/sliderPage.md
+++ b/packages/website/src/page/ui/sliderPage.md
@@ -22,12 +22,13 @@ Pointer drag needs document-level `pointermove` / `pointerup` tracking (the curs
 
 ## Styling
 
-Slider exposes `data-dragging` while the user is actively dragging, `data-disabled` when disabled, and `data-orientation` on the root. The `filledTrack` attribute group carries an inline width so the filled portion always matches the current value.
+Slider exposes `data-dragging` while the user is actively dragging, `data-disabled` when disabled, `data-readonly` when read-only, and `data-orientation` on the root. The `filledTrack` attribute group carries an inline width so the filled portion always matches the current value.
 
 | Attribute          | Condition                                                                                |
 | ------------------ | ---------------------------------------------------------------------------------------- |
 | `data-dragging`    | Present on the root, track, filled track, and thumb while the user is actively dragging. |
 | `data-disabled`    | Present on all groups when isDisabled is true.                                           |
+| `data-readonly`    | Present on all groups when isReadOnly is true.                                           |
 | `data-orientation` | Present on the root. Always "horizontal" in v1; vertical is planned.                     |
 
 ## Keyboard Interaction
@@ -42,9 +43,17 @@ Slider exposes `data-dragging` while the user is actively dragging, `data-disabl
 | `End`                   | Jumps to the maximum value.                                              |
 | `Escape`                | During a pointer drag, cancels the drag and restores the pre-drag value. |
 
+Every key in this table is inert when `isDisabled` or `isReadOnly` is true, because both remove the thumb's keydown handler. Escape is the exception. It cancels a drag through a Subscription rather than the handler, so a drag that began before the slider became read-only can still be cancelled, and can still run to pointerup on its own. Flipping `isReadOnly` mid-drag does not interrupt the drag in flight. `isDisabled` behaves the same way.
+
 ## Accessibility
 
 The thumb receives `role="slider"`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-orientation`. When `formatValue` is provided, the formatted string is announced via `aria-valuetext`. By default the thumb is labeled via `aria-labelledby` pointing at the id carried on the `label` attribute group; you can override this with an explicit `ariaLabel` or `ariaLabelledBy`.
+
+`aria-disabled="true"`, which `isDisabled` emits, communicates that the Slider is unavailable. `aria-readonly="true"`, which `isReadOnly` emits, communicates that its value cannot be changed but remains relevant to the user. It sits on the thumb, the element carrying `role="slider"`. Both states keep `tabindex="0"`, following Foldkit's convention that unavailable controls remain discoverable by keyboard and assistive technology.
+
+Assistive technology support for `aria-readonly` on sliders varies. Pair it with a visible read-only treatment or explanatory text when users must distinguish it from disabled, and test the browser and assistive technology combinations your app supports.
+
+The two flags are independent. Setting both emits both sets of attributes, and either one on its own removes the pointer and keyboard handlers.
 
 ## API Reference
 
@@ -73,6 +82,7 @@ Configuration object passed to `Slider.view()`.
 | `ariaLabelledBy`  | `string`                                          | —       | ID of an external element whose text serves as the slider’s accessible name.                                                                                                                                                 |
 | `formatValue`     | `(value: number) => string`                       | —       | Produces the aria-valuetext announced to screen readers. Use it when the numeric value needs a natural-language form (e.g. "3 of 10" or "50 percent").                                                                       |
 | `isDisabled`      | `boolean`                                         | `false` | Whether the slider is disabled. Removes pointer and keyboard interactivity while preserving focusability.                                                                                                                    |
+| `isReadOnly`      | `boolean`                                         | `false` | Whether the slider is readable but not adjustable. Carries `aria-readonly` rather than `aria-disabled`. Independent of `isDisabled`. Removes pointer and keyboard interactivity while preserving focusability.               |
 | `name`            | `string`                                          | —       | Form field name. When provided, a hidden input carrying the current numeric value is included for native form submission.                                                                                                    |
 | `getTrackRoot`    | `(() => Document \| ShadowRoot) \| undefined`     | —       | Optional accessor returning the DOM root that contains the slider track. Defaults to `document`. Override when rendering inside a Shadow DOM so the drag subscription can find the track element to measure cursor position. |
 


### PR DESCRIPTION
Slice five of #925, following #912 (Checkbox), #950 (Switch), #953 (Input and Textarea), and #965 (RadioGroup, open). This one shares no files with #965 and needs no core change, so it can land in either order.

Slider is a stateful Submodel rather than a stateless controlled view, so `isReadOnly` goes in `ViewInputs` beside `isDisabled`. Beyond that it is the Switch pattern exactly: emit the attributes, drop the handlers, keep focus. Its thumb is a single element and every key `keyToDirection` handles changes the value, so there is no navigation to preserve and no need for the focus-only primitive #965 adds.

Three things worth calling out, none of them visible from the diff.

**`data-readonly` goes on all four attribute groups, not the thumb alone.** The issue wording says "on the thumb". Slider puts `data-disabled` on all groups via the shared `stateAttributes` const, and `sliderPage.md` documents it as "Present on all groups", so two state markers behaving differently would be unpredictable for a consumer, and thumb-only would make styling a read-only track impossible without a parent selector. `aria-readonly` is thumb-only, since the thumb is the `role="slider"` element. Happy to narrow it if you would rather match the issue text.

**Focusability is asserted as `tabIndex="0"` rather than real focus.** Scene has no way to observe DOM focus, so this follows the same substitute `switch/scene.test.ts` uses.

**Flipping `isReadOnly` mid-drag does not stop the drag in flight.** The handlers this flag removes are what start a drag, and the pointermove Subscription runs off `dragState` in the Model until pointerup. `isDisabled` has the same behavior today, so this matches existing behavior rather than introducing an inconsistency. Closing it for both flags would be a behavior change to `isDisabled` that #925 did not ask for. Documented in the TSDoc and the Keyboard Interaction section instead.

The interaction consts also flip from `isDisabled ? [] : [...]` to `isInteractive ? [...] : []`, so the branches swap. The pre-existing disabled test covers that.

Verified with `pnpm lint`, `pnpm test`, `pnpm build`, and `pnpm format:check`.
