### PR TITLE
docs(ui): document isDisabled on Checkbox, Switch, and Slider

### DIFF
--- a/.changeset/disabled-tsdoc.md
+++ b/.changeset/disabled-tsdoc.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': patch
+---
+
+Document `isDisabled` on Checkbox, Switch, and Slider.
+
+Each component documented `isReadOnly` and left `isDisabled` bare, so the only description of what `isDisabled` emits lived inside its neighbor's comment. Each now describes the attributes it emits, that the control stays focusable, and which of the two flags to reach for. The Slider docs page gains the same guidance.

--- a/packages/ui/src/checkbox/index.ts
+++ b/packages/ui/src/checkbox/index.ts
@@ -40,6 +40,10 @@ export type CheckboxAttributes<Message> = Readonly<{
  *    `update` by storing the value.
  *  - `toView`: receives the {@link CheckboxAttributes} and lays out the
  *    checkbox.
+ *  - `isDisabled`: marks the checkbox unavailable with `aria-disabled="true"`
+ *    and `data-disabled`, keeping it focusable. Use it when the control does
+ *    not apply; use `isReadOnly` when its state is still information the user
+ *    needs.
  *  - `isReadOnly`: prevents toggling while exposing read-only semantics with
  *    `aria-readonly="true"` and `data-readonly`. The checkbox remains
  *    focusable. Independent of `isDisabled`: setting both emits both

--- a/packages/ui/src/slider/index.ts
+++ b/packages/ui/src/slider/index.ts
@@ -523,6 +523,10 @@ export type ViewInputs = Readonly<{
   ariaLabel?: string
   ariaLabelledBy?: string
   formatValue?: (value: number) => string
+  /** Marks the Slider unavailable with `aria-disabled="true"` and
+   *  `data-disabled`. The thumb remains focusable, following Foldkit's
+   *  convention that unavailable controls stay discoverable by keyboard and
+   *  assistive technology. */
   isDisabled?: boolean
   /** Prevents value changes while exposing read-only semantics with
    *  `aria-readonly="true"` and `data-readonly`. The thumb remains focusable.

--- a/packages/ui/src/switch/index.ts
+++ b/packages/ui/src/switch/index.ts
@@ -31,6 +31,10 @@ export type SwitchAttributes<Message> = Readonly<{
  *    `update` by storing the value.
  *  - `toView`: receives the {@link SwitchAttributes} and lays out the
  *    switch.
+ *  - `isDisabled`: marks the switch unavailable with `aria-disabled="true"`
+ *    and `data-disabled`, keeping it focusable. Use it when the control does
+ *    not apply; use `isReadOnly` when its state is still information the user
+ *    needs.
  *  - `isReadOnly`: prevents toggling while exposing read-only semantics with
  *    `aria-readonly="true"` and `data-readonly`. The switch remains
  *    focusable. Independent of `isDisabled`: setting both emits both

--- a/packages/website/src/page/ui/sliderPage.md
+++ b/packages/website/src/page/ui/sliderPage.md
@@ -49,9 +49,13 @@ Every key in this table is inert when `isDisabled` or `isReadOnly` is true, beca
 
 The thumb receives `role="slider"`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-orientation`. When `formatValue` is provided, the formatted string is announced via `aria-valuetext`. By default the thumb is labeled via `aria-labelledby` pointing at the id carried on the `label` attribute group; you can override this with an explicit `ariaLabel` or `ariaLabelledBy`.
 
+`isReadOnly` and `isDisabled` both stop the Slider from reacting to pointer drags and keys. They differ in the semantics exposed to assistive technology, so they are not interchangeable.
+
 `aria-disabled="true"`, which `isDisabled` emits, communicates that the Slider is unavailable. `aria-readonly="true"`, which `isReadOnly` emits, communicates that its value cannot be changed but remains relevant to the user. It sits on the thumb, the element carrying `role="slider"`. Both states keep `tabindex="0"`, following Foldkit's convention that unavailable controls remain discoverable by keyboard and assistive technology.
 
 Assistive technology support for `aria-readonly` on sliders varies. Pair it with a visible read-only treatment or explanatory text when users must distinguish it from disabled, and test the browser and assistive technology combinations your app supports.
+
+Use `isReadOnly` when the value is still information the user needs, such as a level set by another control, and `isDisabled` when the Slider is unavailable.
 
 The two flags are independent. Setting both emits both sets of attributes, and either one on its own removes the pointer and keyboard handlers.
 


### PR DESCRIPTION
Follow-up to #981. No behavior changes, TSDoc and docs prose only.

## What and why

Checkbox, Switch, and Slider each gained an `isReadOnly` flag, and each documented it while leaving `isDisabled` bare. That left the only written description of what `isDisabled` emits sitting inside its neighbor's comment.

On Slider it's plainest, because that file uses per-field TSDoc rather than a bullet list on the type. A nine-line block sits directly against a bare `isDisabled?: boolean`, and the block names `isDisabled` three times and states its contract twice ("either one removes the pointer and keyboard handlers", "`isDisabled` behaves the same way"). Hovering `isDisabled` in an editor gets you nothing.

## What changed

**`isDisabled` documented in all three.** Each entry covers the attributes emitted (`aria-disabled="true"` and `data-disabled`), that the control stays focusable, and which of the two flags to reach for. Checkbox and Switch get a bullet in the existing list on `ViewConfig`; Slider gets a per-field block, matching each file's existing style rather than imposing one.

**Slider docs page.** Two paragraphs in the accessibility section. The page explained what each flag emits but never said when to use either, so a reader learned the mechanics and still had to guess.

## Verification

`pnpm format:check`, `pnpm lint`, `@foldkit/ui` typecheck, and the website build all pass. 924 `@foldkit/ui` tests pass, unchanged, since nothing here is executable.

One `patch` changeset for `@foldkit/ui`. TSDoc ships in the published `.d.ts`, so it is a real change to package consumers.

## Note on scope

The Slider half of this was reviewed and approved against #981 but did not make it into the merge, so it is carried forward here rather than dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NnUsZqp22C79FooWwnA59)_