### PR TITLE
docs(website): document what the update-side abstractions cost

### DIFF
--- a/packages/website/src/page/core/submodel.md
+++ b/packages/website/src/page/core/submodel.md
@@ -160,6 +160,8 @@ For a dynamic number, hold the instances in an array on the parent Model, iterat
 
 The `slotId` on each `h.submodel` is the per-instance identifier the runtime uses for boundary identity. The same identifier travels with the wrapper Message as `entryId` so the parent’s update can find the matching slice and delegate to `Applicant.update`. See the [job-application example](/example-apps/job-application) for a working version: per-entry education and work-history Submodels, each embedded with its own `entryId`.
 
+An array is the right default, and at the sizes most dynamic collections reach it is not worth thinking about. Both halves of the update are linear in the number of instances: finding the matching slice scans, and writing it back rebuilds the array. If a collection grows large enough for that to show up in a profile, hold the instances in a `HashMap` keyed by the identifier instead. `Update.foldChild` needs no other change, because `read` already returns an `Option` and `HashMap.get` returns one directly.
+
 ## Memoization Across Submodel Boundaries {#memoization}
 
 An `h.submodel` call re-runs the child’s view on every parent render. For a short list of Submodels this is cheap; for a long list (hundreds of rows) or expensive child views, memoize the embed site with `createKeyedLazy` from `foldkit/html`. The keyed lazy compares its deps tuple by `===` and reuses the cached VNode when nothing changed.

--- a/packages/website/src/page/performance.md
+++ b/packages/website/src/page/performance.md
@@ -15,6 +15,16 @@ Every state change in a Foldkit app flows through one pipeline, so the cost mode
 
 The production hot path does no work proportional to Model size. No serialization, no deep comparison, no freezing, no snapshots. Change detection is reference equality, and `evo` preserves unchanged branches by reference, so the cost of a Message is the cost of your `update` logic, and the cost of a frame is the cost of the subtrees that actually changed.
 
+## What the abstractions cost
+
+The cost model above puts the cost of a Message on your `update` logic. What the update-side abstractions add on top of that is small, and worth spelling out, because they are the first thing people suspect when an app feels slow:
+
+- `Update.foldChild` adds a function call and an arity check over the wiring you would otherwise write by hand. Inside, it does exactly what the hand-written handler does: read the child out of the Model, run its update, write it back, and lift the child’s Commands through `toParentMessage`.
+- `evo` is Effect’s `Struct.evolve` at runtime; the wrapper adds key checking at the type level only. It walks the struct’s own enumerable keys once and applies a transform only where you provided one, copying everything else by reference. The cost is proportional to the Model’s top-level field count, the same as an object spread, and that reference preservation is what lets [createLazy](/core/view-memoization) hit its `===` check.
+- `Match.tagsExhaustive` is the one whose cost scales with your app. The handler object and one closure per arm are allocated on every dispatch, and because the arms close over `model` they cannot be hoisted to module scope.
+
+Keep `Match.tagsExhaustive` anyway. Its signature requires a handler for every tag in the union, so adding a Message variant fails to compile in every update that does not handle it. That is a correctness guarantee bought with short-lived allocations a young-generation collector does not notice, and an `if`/`else` chain on `_tag` gives it up. If a profile ever puts a genuinely hot update at the top, that trade is available, but it is the last change to reach for rather than the first.
+
 ## Benchmarks
 
 Foldkit ships a TodoMVC implementation for the [lustre-labs/benchmark](https://github.com/lustre-labs/benchmark) harness, which drives each implementation through the same TodoMVC workload and required selectors (add 100 todos, toggle each one, destroy the first one 100 times). Same-batch timings are comparable because every implementation uses the same driver, runbook, and browser batch. Foldkit registers two slots: an unoptimized view that rebuilds the entire tree on every Message with no memoization, and an optimized view that adds `createLazy` slots for the header, the footer, the filters list, and the toggle-all controls, and `createKeyedLazy` per todo item. The Model and update logic are identical in both. The implementation lives [in the Foldkit repo](https://github.com/foldkit/foldkit/tree/main/internal/lustre-benchmark), so you can run the comparison yourself.


### PR DESCRIPTION
Prompted by a question on the `Update.foldChild` announcement: do the update combinators (`foldChild`, `evo`, `Match`) add up to a perf problem?

The Performance page already covered the pipeline cost model and what to reach for when a phase is slow, but never said what the update-side abstractions themselves add. That is the first thing people suspect when an app feels slow, and there was nowhere on the site that answered it.

## Changes

**`page/performance.md`** adds a `## What the abstractions cost` section between the cost model and the benchmarks. The preceding section ends on "the cost of a Message is the cost of your `update` logic", which is exactly where a reader asks what `foldChild` and `evo` add on top. Three bullets:

- `Update.foldChild` adds a function call and an arity check over the hand-written wiring, and internally does the same read/update/write/map-Commands the manual handler does.
- `evo` is `Struct.evolve` at runtime, walking own enumerable keys once and copying everything else by reference, which is also what lets `createLazy` hit its `===` check.
- `Match.tagsExhaustive` is the only one whose cost scales with the app, allocating the handler object and one closure per arm on every dispatch.

The section closes by keeping `Match.tagsExhaustive` regardless: type-level exhaustiveness is a correctness guarantee, not ergonomics, so dropping to an `if`/`else` chain on the tag is framed as the last change to reach for rather than the first. Without that framing the allocation note reads as permission to give up exhaustiveness.

**`page/core/submodel.md`** adds a paragraph to Multiple Instances noting that an array-backed collection is linear on both halves of the update (the find scans, the write rebuilds), and that a `HashMap` keyed by the identifier drops in once that shows up in a profile. `foldChild` needs no other change, since `read` already returns an `Option` and `HashMap.get` returns one directly.

## Notes

- No changeset: `website` is private and in the changesets ignore list.
- Docs-only, no source changes.

Verified with `pnpm -F website typecheck`, `pnpm -F website build`, `pnpm -F website test` (325 passing), and `pnpm lint`, plus the full pre-push chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmE8csrrjx1so9NyF54NZ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmE8csrrjx1so9NyF54NZ8)_