### PR TITLE
Fold DatePicker popover entry points with Update.foldChildStep

### DIFF
--- a/.changeset/date-picker-fold-child-step.md
+++ b/.changeset/date-picker-fold-child-step.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/ui': patch
+---
+
+Fold the DatePicker's Popover entry points with `Update.foldChildStep`. The hand-written `closePopover` Step and the `Opened` and `Closed` handlers now run `Popover.open` and `Popover.close` through the helper instead of calling them directly and lifting their Commands with `Command.mapMessages`, so the Popover's read, write, and Message lift are stated once and shared with the existing `Update.foldChild` config. Internal refactor with no API change.

--- a/packages/ui/src/datePicker/index.ts
+++ b/packages/ui/src/datePicker/index.ts
@@ -164,26 +164,58 @@ const mapPopoverCommands = (
 ): ReadonlyArray<Command.Command<Message>> =>
   Command.mapMessages(commands, message => GotPopoverMessage({ message }))
 
-const closePopover: Update.Step<Model, Message> = model => {
-  const [nextPopover, popoverCommands] = Popover.close(model.popover)
-  return [
-    evo(model, { popover: () => nextPopover }),
-    mapPopoverCommands(popoverCommands),
-  ]
-}
-
 const dropCalendarToDays: Update.Step<Model, Message> = model => [
   evo(model, { calendar: () => UiCalendar.dropToDays(model.calendar) }),
   [],
 ]
 
-const foldCalendarOutMessage: (
-  outMessage: UiCalendar.OutMessage,
-) => Update.Step<Model, Message> = M.type<UiCalendar.OutMessage>().pipe(
+const readPopover = (model: Model): Option.Option<Popover.Model> =>
+  Option.some(model.popover)
+
+const writePopover = (model: Model, nextPopover: Popover.Model): Model =>
+  evo(model, { popover: () => nextPopover })
+
+const toGotPopoverMessage = (message: Popover.Message): Message =>
+  GotPopoverMessage({ message })
+
+const foldPopoverOutMessage = M.type<Popover.OutMessage>().pipe(
+  M.withReturnType<Update.Step<Model, Message>>(),
+  M.tagsExhaustive({
+    Opened: () => dropCalendarToDays,
+    Closed: () => dropCalendarToDays,
+  }),
+)
+
+const foldPopover = Update.foldChild({
+  update: Popover.update,
+  read: readPopover,
+  write: writePopover,
+  toParentMessage: toGotPopoverMessage,
+  toParentOutMessage: () => Option.none(),
+  foldOutMessage: foldPopoverOutMessage,
+})
+
+const foldPopoverOpen = Update.foldChildStep({
+  update: Popover.open,
+  read: readPopover,
+  write: writePopover,
+  toParentMessage: toGotPopoverMessage,
+  foldOutMessage: foldPopoverOutMessage,
+})
+
+const foldPopoverClose = Update.foldChildStep({
+  update: Popover.close,
+  read: readPopover,
+  write: writePopover,
+  toParentMessage: toGotPopoverMessage,
+  foldOutMessage: foldPopoverOutMessage,
+})
+
+const foldCalendarOutMessage = M.type<UiCalendar.OutMessage>().pipe(
   M.withReturnType<Update.Step<Model, Message>>(),
   M.tagsExhaustive({
     ChangedViewMonth: () => model => [model, []],
-    SelectedDate: () => closePopover,
+    SelectedDate: () => foldPopoverClose,
   }),
 )
 
@@ -207,25 +239,6 @@ const foldCalendar = Update.foldChild({
   foldOutMessage: foldCalendarOutMessage,
 })
 
-const foldPopoverOutMessage: (
-  outMessage: Popover.OutMessage,
-) => Update.Step<Model, Message> = M.type<Popover.OutMessage>().pipe(
-  M.withReturnType<Update.Step<Model, Message>>(),
-  M.tagsExhaustive({
-    Opened: () => dropCalendarToDays,
-    Closed: () => dropCalendarToDays,
-  }),
-)
-
-const foldPopover = Update.foldChild({
-  update: Popover.update,
-  read: (model: Model) => Option.some(model.popover),
-  write: (model, nextPopover) => evo(model, { popover: () => nextPopover }),
-  toParentMessage: message => GotPopoverMessage({ message }),
-  toParentOutMessage: () => Option.none(),
-  foldOutMessage: foldPopoverOutMessage,
-})
-
 /** Processes a date picker message and returns the next model, commands, and
  * optional OutMessage. */
 export const update = (model: Model, message: Message): UpdateReturn =>
@@ -238,29 +251,15 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       GotPopoverMessage: ({ message: popoverMessage }) =>
         foldPopover(model, popoverMessage),
 
-      Opened: () => {
-        const [nextPopover, popoverCommands] = Popover.open(model.popover)
-        return [
-          evo(model, {
-            popover: () => nextPopover,
-            calendar: () => UiCalendar.dropToDays(model.calendar),
-          }),
-          mapPopoverCommands(popoverCommands),
-          Option.none(),
-        ]
-      },
+      Opened: () => [
+        ...Update.combine(model, [foldPopoverOpen, dropCalendarToDays]),
+        Option.none(),
+      ],
 
-      Closed: () => {
-        const [nextPopover, popoverCommands] = Popover.close(model.popover)
-        return [
-          evo(model, {
-            popover: () => nextPopover,
-            calendar: () => UiCalendar.dropToDays(model.calendar),
-          }),
-          mapPopoverCommands(popoverCommands),
-          Option.none(),
-        ]
-      },
+      Closed: () => [
+        ...Update.combine(model, [foldPopoverClose, dropCalendarToDays]),
+        Option.none(),
+      ],
 
       RequestedSelectDate: ({ date }) => {
         const [nextCalendar, calendarCommands] = UiCalendar.selectDate(


### PR DESCRIPTION
## What this does

`Update.foldChildStep` (#968) is the `Update.foldChild` variant for a child entry point that takes nothing but the child Model. DatePicker had three such sites, all on its embedded Popover: the `closePopover` Step the Calendar's `SelectedDate` fold runs, and the `Opened` and `Closed` handlers. Each called `Popover.open` or `Popover.close` directly, wrote the popover field back by hand, and lifted the child's Commands with `Command.mapMessages`. All three are now `Update.foldChildStep` configs.

The Popover's three capabilities became named consts (`readPopover`, `writePopover`, `toGotPopoverMessage`) shared by all four popover folds, and the popover fold configs moved above the calendar ones so `foldCalendarOutMessage` names `foldPopoverClose` in its `SelectedDate` arm without a forward reference.

### What converted

| Site | Entry point | Shape |
| --- | --- | --- |
| `foldCalendarOutMessage`, `SelectedDate` arm | `Popover.close` | `foldPopoverClose` replaces the hand-written `closePopover` Step |
| `Opened` | `Popover.open` | `Update.combine(model, [foldPopoverOpen, dropCalendarToDays])` |
| `Closed` | `Popover.close` | `Update.combine(model, [foldPopoverClose, dropCalendarToDays])` |

DatePicker is itself a Submodel, so `Opened` and `Closed` spread the Step's pair and append their own channel, `[...Update.combine(...), Option.none()]`, the idiom the `ChildFoldWithParentOutMessage` TSDoc describes for a child whose OutMessage stops at the parent. No fold in this file returns a Command that produces the child's Message, so none takes the `Update.FoldContext` second parameter.

### Why `Opened` and `Closed` keep the explicit drop

`dropCalendarToDays` stays a step in both handlers rather than leaning on the drop that the Popover's `Opened` and `Closed` OutMessages already trigger through `foldPopoverOutMessage`. `Popover.close` is a no-op when the popover is already closed: same Model, no Commands, no OutMessage. These two handlers reset the calendar unconditionally, and the probe below found that dropping the explicit step changes behavior in a state the rendered tree reaches, since the panel stays mounted through the leave animation and the calendar heading is still clickable there. `UiCalendar.dropToDays` is idempotent, so the explicit step and the OutMessage-driven drop coincide whenever both run.

### What stays hand-written

`RequestedSelectDate`, and with it `mapCalendarCommands` and `mapPopoverCommands`. It calls `UiCalendar.selectDate` and `Popover.close`, discards both children's OutMessages, and hand-builds `Some(SelectedDate({ date }))`. Folding it would route the programmatic path through the Calendar's OutMessage channel, and the Calendar ignores a click on a disabled date: `DatePicker.selectDate(model, disabledDate)` today closes the popover and emits `SelectedDate` anyway, where the folded version would do neither. Folding only the popover half has its own reachable difference, because `Popover.close` through the fold drops the calendar to Days and a programmatic selection taken while the months grid is showing currently does not. Both are behavior changes rather than refactors, so the site is untouched.

### Convention

`foldPopoverOutMessage` and `foldCalendarOutMessage` lose their standalone function-type annotations, per the convention settled on the #989 review. `M.type<Popover.OutMessage>()` piped through `M.withReturnType<Update.Step<Model, Message>>()` supplies the typing on its own; both consts keep their name and their standalone binding. Neither needed an annotation to typecheck, and no fold here takes the fold context.

## Verification

- `pnpm check` green: build, typecheck across every package, lint, dead-code, effect prebundle.
- `pnpm -F @foldkit/ui test`: 39 files, 924 tests passed. Full `pnpm test` green across packages and examples.
- `pnpm format:check` clean. The pre-push suite passed on the pushed commit, with the website e2e skipped for missing playwright browsers as the wrapper allows.

Behavior parity was checked with a throwaway differential probe, deleted before committing. It ran the new update and `origin/main`'s update side by side from the same init Model and compared, after every message, the full Model, the Command list in order (name, args, key, and the replayed message-mapping chain, so a lifted Command's result Message is compared and not just its name), and the returned OutMessage. Three init Models: plain, animated, and animated with min/max plus a disabled date.

- **66 scripted cases.** Open, close, double open, close while already closed, heading zoom-out then close, day click, keyboard commit, disabled-day click, month navigation then commit then reopen, programmatic select while open and while closed, programmatic select of a disabled date, programmatic select from Months mode, clear, pointer toggle, panel blur, and the full animated open and leave sequence. All matched.
- **846,736 exhaustive cases.** Every sequence up to depth 4 over the alphabet the rendered tree can dispatch in the current state: calendar messages only while the panel is mounted, and only the controls the current view mode renders. All matched.
- **141,286 ungated cases.** Every sequence up to depth 3 over the whole alphabet regardless of state, including messages the view cannot produce there. 36 diverge, all one signature: `GotCalendarMessage(ClickedDay)` delivered while the calendar is in Months mode. The Months grid renders month cells rather than day cells, so a `ClickedDay` cannot arrive in that state through the view. A caller who synthesizes one now also gets the calendar reset to Days, because closing the popover through the fold runs the Popover's `Closed` OutMessage. Every view-reachable path is unchanged.

`@foldkit/ui` patch changeset, matching #966. No API change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTKztEadGScoqw1JjXDZFV)_