### PR TITLE
feat(foldkit)!: distinguish Machine ignored-step reasons

### DIFF
--- a/.changeset/machine-ignored-reason.md
+++ b/.changeset/machine-ignored-reason.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+The experimental Machine's `Ignored` result now carries a required `reason` field, typed as the new `IgnoredReason` export, so a step that matched no Edge says why. `OutOfAlphabet` means the Message tag appears in no state's `on` record anywhere in the table. `NotApplicable` means the tag is in the Machine's alphabet but no Edge for it exists from the current state. `GuardsFellThrough` means an Edge entry exists for this state and Message but every guard declined and no `otherwise` was present, which previously looked identical to a Message the Machine never handles.

--- a/.changeset/machine-ignored-reason.md
+++ b/.changeset/machine-ignored-reason.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+The experimental Machine's `Ignored` result now carries a required `reason` field, typed as the new `IgnoredReason` export, so a step that matched no Edge says why. `OutOfAlphabet` means the Message tag appears in no state's `on` record anywhere in the table. `NotApplicable` means the tag is in the Machine's alphabet but no Edge for it exists from the current state. `GuardsFellThrough` means an Edge entry exists for this state and Message but every guard declined and no `otherwise` was present, which previously looked identical to a Message the Machine never handles. Consumers that construct or assert an `Ignored` result must add its `reason`.

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -740,6 +740,7 @@ describe('remote data machine', () => {
       stateTag: 'Idle',
       messageTag: 'ClickedRetry',
       state: RemoteData.Idle(),
+      reason: 'NotApplicable',
     })
 
     const ignoredRetry = remoteDataMachine.transition(
@@ -884,6 +885,7 @@ describe('connection machine', () => {
       stateTag: 'Disconnected',
       messageTag: 'TimedOutBackoff',
       state: ConnectionState.Disconnected(),
+      reason: 'NotApplicable',
     })
   })
 
@@ -1014,6 +1016,7 @@ describe('guard lists', () => {
       stateTag: 'Connecting',
       messageTag: 'SocketErrored',
       state: atLimit,
+      reason: 'GuardsFellThrough',
     })
 
     const declinedSocketError = guardValueMachine.transition(
@@ -1021,6 +1024,74 @@ describe('guard lists', () => {
       ConnectionMessage.SocketErrored({ reason: 'boom' }),
     )
     expect(declinedSocketError).toEqual({ model: atLimit })
+  })
+})
+
+describe('ignored reasons', () => {
+  it('reports a message that appears in no state entry as OutOfAlphabet', () => {
+    const result = connectionMachine.step(
+      ConnectionState.Disconnected(),
+      ConnectionMessage.CompletedLogTransition(),
+    )
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Disconnected',
+      messageTag: 'CompletedLogTransition',
+      state: ConnectionState.Disconnected(),
+      reason: 'OutOfAlphabet',
+    })
+  })
+
+  it('reports a state with no table entry as NotApplicable when the message is in the alphabet', () => {
+    const result = narrowingMachine.step(
+      ConnectionState.Disconnected(),
+      ConnectionMessage.SocketErrored({ reason: 'boom' }),
+    )
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Disconnected',
+      messageTag: 'SocketErrored',
+      state: ConnectionState.Disconnected(),
+      reason: 'NotApplicable',
+    })
+  })
+
+  it('includes a declared empty guard list in the message alphabet', () => {
+    const emptyGuardListMachine = define({
+      state: ConnectionState,
+      message: ConnectionMessage,
+    })({
+      initial: ConnectionState.Disconnected(),
+      states: {
+        Connecting: {
+          on: { SocketErrored: [] },
+        },
+      },
+    })
+
+    const notApplicable = emptyGuardListMachine.step(
+      ConnectionState.Disconnected(),
+      ConnectionMessage.SocketErrored({ reason: 'boom' }),
+    )
+    expect(notApplicable).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Disconnected',
+      messageTag: 'SocketErrored',
+      state: ConnectionState.Disconnected(),
+      reason: 'NotApplicable',
+    })
+
+    const guardsFellThrough = emptyGuardListMachine.step(
+      ConnectionState.Connecting({ attemptCount: 1 }),
+      ConnectionMessage.SocketErrored({ reason: 'boom' }),
+    )
+    expect(guardsFellThrough).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Connecting',
+      messageTag: 'SocketErrored',
+      state: ConnectionState.Connecting({ attemptCount: 1 }),
+      reason: 'GuardsFellThrough',
+    })
   })
 })
 

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -717,6 +717,7 @@ describe('remote data machine', () => {
       stateTag: 'Idle',
       messageTag: 'ClickedRetry',
       state: Idle(),
+      reason: 'NotApplicable',
     })
 
     const [unchanged, commands] = remoteDataMachine.transition(
@@ -848,6 +849,7 @@ describe('connection machine', () => {
       stateTag: 'Disconnected',
       messageTag: 'TimedOutBackoff',
       state: Disconnected(),
+      reason: 'NotApplicable',
     })
   })
 
@@ -935,6 +937,7 @@ describe('guard lists', () => {
       stateTag: 'Connecting',
       messageTag: 'SocketErrored',
       state: atLimit,
+      reason: 'GuardsFellThrough',
     })
 
     const [unchanged, commands] = guardValueMachine.transition(
@@ -943,6 +946,36 @@ describe('guard lists', () => {
     )
     expect(unchanged).toBe(atLimit)
     expect(commands).toEqual([])
+  })
+})
+
+describe('ignored reasons', () => {
+  it('reports a message that appears in no state entry as OutOfAlphabet', () => {
+    const result = connectionMachine.step(
+      Disconnected(),
+      CompletedLogTransition(),
+    )
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Disconnected',
+      messageTag: 'CompletedLogTransition',
+      state: Disconnected(),
+      reason: 'OutOfAlphabet',
+    })
+  })
+
+  it('reports a state with no table entry as NotApplicable when the message is in the alphabet', () => {
+    const result = narrowingMachine.step(
+      Disconnected(),
+      SocketErrored({ reason: 'boom' }),
+    )
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Disconnected',
+      messageTag: 'SocketErrored',
+      state: Disconnected(),
+      reason: 'NotApplicable',
+    })
   })
 })
 

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -1,4 +1,13 @@
-import { Array, Match, Option, Predicate, Record, Schema, pipe } from 'effect'
+import {
+  Array,
+  HashSet,
+  Match,
+  Option,
+  Predicate,
+  Record,
+  Schema,
+  pipe,
+} from 'effect'
 
 import type { Command } from '../../command/index.js'
 import type * as Update from '../../update/index.js'
@@ -311,12 +320,29 @@ export type Transitioned<
   commands: ReadonlyArray<Command<Message, never, R>>
 }>
 
-/** A step that matched no Edge: the state is unchanged and the Message is observable as ignored. */
+/**
+ * Why a step matched no Edge. `OutOfAlphabet` means the Message tag appears
+ * in no state's `on` record anywhere in the table, so the Message is outside
+ * the Machine's alphabet. `NotApplicable` means the Message tag is in the
+ * alphabet, but no Edge for it exists from the current state, whether the
+ * state is absent from the table or its `on` record lacks the tag.
+ * `GuardsFellThrough` means an Edge entry exists for this state and Message,
+ * but every guard declined and no {@link otherwise} fallback was present.
+ */
+export type IgnoredReason =
+  'OutOfAlphabet' | 'NotApplicable' | 'GuardsFellThrough'
+
+/**
+ * A step that matched no Edge: the state is unchanged and the Message is
+ * observable as ignored. `reason` distinguishes the three causes, described
+ * on {@link IgnoredReason}.
+ */
 export type Ignored<State extends Tagged, Message extends Tagged> = Readonly<{
   _tag: 'Ignored'
   stateTag: TagOf<State>
   messageTag: TagOf<Message>
   state: State
+  reason: IgnoredReason
 }>
 
 /** The observable outcome of one step: `Transitioned` or `Ignored`.
@@ -628,6 +654,12 @@ export const define =
       ),
     )
 
+    const messageAlphabet: HashSet.HashSet<TagOf<Message>> = pipe(
+      Record.values(looseStates),
+      Array.flatMap(stateEntry => Record.keys(stateEntry.on)),
+      HashSet.fromIterable,
+    )
+
     const selectFromGuardList = (
       guardedEdges: ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
       state: State,
@@ -695,11 +727,13 @@ export const define =
     const makeIgnored = (
       state: State,
       message: Message,
+      reason: IgnoredReason,
     ): Ignored<State, Message> => ({
       _tag: 'Ignored',
       stateTag: state._tag,
       messageTag: message._tag,
       state,
+      reason,
     })
 
     const step = (
@@ -709,13 +743,21 @@ export const define =
       pipe(
         Record.get(looseStates, state._tag),
         Option.flatMap(stateEntry => Record.get(stateEntry.on, message._tag)),
-        Option.flatMap(edgeOrGuardedEdges =>
-          chooseEdge(edgeOrGuardedEdges, state, message),
-        ),
         Option.match({
-          onNone: () => makeIgnored(state, message),
-          onSome: selectedEdge =>
-            makeTransitioned(state, message, selectedEdge),
+          onNone: () =>
+            makeIgnored(
+              state,
+              message,
+              HashSet.has(messageAlphabet, message._tag)
+                ? 'NotApplicable'
+                : 'OutOfAlphabet',
+            ),
+          onSome: edgeOrGuardedEdges =>
+            Option.match(chooseEdge(edgeOrGuardedEdges, state, message), {
+              onNone: () => makeIgnored(state, message, 'GuardsFellThrough'),
+              onSome: selectedEdge =>
+                makeTransitioned(state, message, selectedEdge),
+            }),
         }),
       )
 

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -1,5 +1,6 @@
 import {
   Array,
+  HashSet,
   Match as M,
   Option,
   Predicate,
@@ -312,12 +313,31 @@ export type Transitioned<
   commands: ReadonlyArray<Command<Message, never, R>>
 }>
 
-/** A step that matched no Edge: the state is unchanged and the Message is observable as ignored. */
+/**
+ * Why a step matched no Edge. `OutOfAlphabet` means the Message tag appears
+ * in no state's `on` record anywhere in the table, so the Message is outside
+ * the Machine's alphabet. `NotApplicable` means the Message tag is in the
+ * alphabet, but no Edge for it exists from the current state, whether the
+ * state is absent from the table or its `on` record lacks the tag.
+ * `GuardsFellThrough` means an Edge entry exists for this state and Message,
+ * but every guard declined and no {@link otherwise} fallback was present.
+ */
+export type IgnoredReason =
+  | 'OutOfAlphabet'
+  | 'NotApplicable'
+  | 'GuardsFellThrough'
+
+/**
+ * A step that matched no Edge: the state is unchanged and the Message is
+ * observable as ignored. `reason` distinguishes the three causes, described
+ * on {@link IgnoredReason}.
+ */
 export type Ignored<State extends Tagged, Message extends Tagged> = Readonly<{
   _tag: 'Ignored'
   stateTag: TagOf<State>
   messageTag: TagOf<Message>
   state: State
+  reason: IgnoredReason
 }>
 
 /** The observable outcome of one step: `Transitioned` or `Ignored`. */
@@ -584,6 +604,12 @@ export const define =
       ),
     )
 
+    const messageAlphabet: HashSet.HashSet<TagOf<Message>> = pipe(
+      edges,
+      Array.map(({ messageTag }) => messageTag),
+      HashSet.fromIterable,
+    )
+
     const selectFromGuardList = (
       guardedEdges: ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
       state: State,
@@ -651,11 +677,13 @@ export const define =
     const makeIgnored = (
       state: State,
       message: Message,
+      reason: IgnoredReason,
     ): Ignored<State, Message> => ({
       _tag: 'Ignored',
       stateTag: state._tag,
       messageTag: message._tag,
       state,
+      reason,
     })
 
     const step = (
@@ -665,13 +693,21 @@ export const define =
       pipe(
         Record.get(looseStates, state._tag),
         Option.flatMap(stateEntry => Record.get(stateEntry.on, message._tag)),
-        Option.flatMap(edgeOrGuardedEdges =>
-          chooseEdge(edgeOrGuardedEdges, state, message),
-        ),
         Option.match({
-          onNone: () => makeIgnored(state, message),
-          onSome: selectedEdge =>
-            makeTransitioned(state, message, selectedEdge),
+          onNone: () =>
+            makeIgnored(
+              state,
+              message,
+              HashSet.has(messageAlphabet, message._tag)
+                ? 'NotApplicable'
+                : 'OutOfAlphabet',
+            ),
+          onSome: edgeOrGuardedEdges =>
+            Option.match(chooseEdge(edgeOrGuardedEdges, state, message), {
+              onNone: () => makeIgnored(state, message, 'GuardsFellThrough'),
+              onSome: selectedEdge =>
+                makeTransitioned(state, message, selectedEdge),
+            }),
         }),
       )
 


### PR DESCRIPTION
Machine.step returned the same Ignored result for a Message outside the Machine's alphabet, one not applicable in the current state, and a declared guard list whose guards all declined. Consumers could not distinguish an intentionally unhandled Message from a guard fallthrough worth surfacing.

Add a required reason that names each case and derive alphabet membership once from the declared state `on` records, including empty guard lists. Consumers that construct or assert an Ignored result must add its reason.

Fixes #996.
