### PR TITLE
fix(foldkit): flatten nested Machine state unions

### DIFF
--- a/.changeset/nested-state-unions-flatten.md
+++ b/.changeset/nested-state-unions-flatten.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+`Machine.define` now flattens nested state unions when extracting state tags instead of throwing at module load. A state Schema built as a union of unions, such as `S.Union([EnteringPlayers, PlayingState])` where `PlayingState` is itself a union, now works, and `stateTags` lists the tags in depth-first declaration order. Members that are neither a union nor a Struct with a literal `_tag` field still throw the existing error.

--- a/.changeset/nested-state-unions-flatten.md
+++ b/.changeset/nested-state-unions-flatten.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+`Machine.define` now flattens nested state unions when extracting state tags instead of throwing at module load. A state Schema built as a union of unions, such as `Schema.Union([EnteringPlayers, PlayingState])` where `PlayingState` is itself a union, now works, and `stateTags` lists the tags in depth-first declaration order. Members that are neither a union nor a Struct with a literal `_tag` field still throw the existing error.

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -531,6 +531,46 @@ const plainTagMachine = define({
   },
 })
 
+const NestedState = defineTaggedUnion({
+  NestedIdle: {},
+  NestedLoading: {},
+  NestedError: { error: Schema.String },
+  NestedOk: { data: Schema.String },
+})
+const NestedSettled = NestedState.subset(['NestedError', 'NestedOk'])
+const NestedActive = Schema.Union([NestedState.NestedLoading, NestedSettled])
+const NestedStateSchema = Schema.Union([NestedState.NestedIdle, NestedActive])
+type NestedStateSchema = typeof NestedStateSchema.Type
+
+const nestedUnionMachine = define({
+  state: NestedStateSchema,
+  message: RemoteDataMessage,
+})({
+  initial: NestedState.NestedIdle(),
+  states: {
+    NestedIdle: {
+      on: {
+        ClickedFetch: to('NestedLoading', () => NestedState.NestedLoading()),
+      },
+    },
+    NestedLoading: {
+      on: {
+        SucceededFetch: to('NestedOk', ({ message }) =>
+          NestedState.NestedOk({ data: message.data }),
+        ),
+      },
+    },
+    NestedOk: {
+      on: {
+        ClickedRetry: to('NestedIdle', () => NestedState.NestedIdle()),
+      },
+    },
+  },
+})
+
+const UntaggedMember = Schema.Struct({ _tag: Schema.String })
+const UntaggedState = Schema.Union([PlainIdle, UntaggedMember])
+
 // REQUIREMENTS
 
 type UploadsShape = Readonly<{ presign: Effect.Effect<string> }>
@@ -1033,6 +1073,49 @@ describe('state tag extraction', () => {
       RemoteDataMessage.ClickedFetch(),
     )
     expect(fetchClick.model).toStrictEqual({ _tag: 'PlainActive' })
+  })
+
+  it('flattens nested state unions into depth-first tag order', () => {
+    expect(nestedUnionMachine.initial).toStrictEqual(NestedState.NestedIdle())
+    expect(nestedUnionMachine.stateTags).toEqual([
+      'NestedIdle',
+      'NestedLoading',
+      'NestedError',
+      'NestedOk',
+    ])
+  })
+
+  it('transitions into and out of a nested union member', () => {
+    const fetchClick = nestedUnionMachine.transition(
+      NestedState.NestedIdle(),
+      RemoteDataMessage.ClickedFetch(),
+    )
+    expect(fetchClick.model).toStrictEqual(NestedState.NestedLoading())
+
+    const fetchSuccess = nestedUnionMachine.transition(
+      NestedState.NestedLoading(),
+      RemoteDataMessage.SucceededFetch({ data: 'payload' }),
+    )
+    expect(fetchSuccess.model).toStrictEqual(
+      NestedState.NestedOk({ data: 'payload' }),
+    )
+
+    const fetchRetry = nestedUnionMachine.transition(
+      NestedState.NestedOk({ data: 'payload' }),
+      RemoteDataMessage.ClickedRetry(),
+    )
+    expect(fetchRetry.model).toStrictEqual(NestedState.NestedIdle())
+  })
+
+  it('throws when a member is neither a nested union nor a Struct with a literal _tag', () => {
+    expect(() =>
+      define({ state: UntaggedState, message: RemoteDataMessage })({
+        initial: { _tag: 'PlainIdle' },
+        states: {},
+      }),
+    ).toThrow(
+      'Machine.define: every member of the state union Schema must be a Struct with a literal _tag field',
+    )
   })
 })
 

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -515,6 +515,43 @@ const plainTagMachine = define({
   },
 })
 
+const NestedIdle = ts('NestedIdle')
+const NestedLoading = ts('NestedLoading')
+const NestedOk = ts('NestedOk', { data: S.String })
+
+const NestedActive = S.Union([NestedLoading, NestedOk])
+const NestedState = S.Union([NestedIdle, NestedActive])
+type NestedState = typeof NestedState.Type
+
+const nestedUnionMachine = define({
+  state: NestedState,
+  message: RemoteDataMessage,
+})({
+  initial: NestedIdle(),
+  states: {
+    NestedIdle: {
+      on: {
+        ClickedFetch: to('NestedLoading', () => NestedLoading()),
+      },
+    },
+    NestedLoading: {
+      on: {
+        SucceededFetch: to('NestedOk', ({ message }) =>
+          NestedOk({ data: message.data }),
+        ),
+      },
+    },
+    NestedOk: {
+      on: {
+        ClickedRetry: to('NestedIdle', () => NestedIdle()),
+      },
+    },
+  },
+})
+
+const UntaggedMember = S.Struct({ _tag: S.String })
+const UntaggedState = S.Union([PlainIdle, UntaggedMember])
+
 // REQUIREMENTS
 
 type UploadsShape = Readonly<{ presign: Effect.Effect<string> }>
@@ -955,6 +992,46 @@ describe('state tag extraction', () => {
       ClickedFetch(),
     )
     expect(active).toStrictEqual({ _tag: 'PlainActive' })
+  })
+
+  it('flattens nested state unions into depth-first tag order', () => {
+    expect(nestedUnionMachine.initial).toStrictEqual(NestedIdle())
+    expect(nestedUnionMachine.stateTags).toEqual([
+      'NestedIdle',
+      'NestedLoading',
+      'NestedOk',
+    ])
+  })
+
+  it('transitions into and out of a nested union member', () => {
+    const [loading] = nestedUnionMachine.transition(
+      NestedIdle(),
+      ClickedFetch(),
+    )
+    expect(loading).toStrictEqual(NestedLoading())
+
+    const [ok] = nestedUnionMachine.transition(
+      NestedLoading(),
+      SucceededFetch({ data: 'payload' }),
+    )
+    expect(ok).toStrictEqual(NestedOk({ data: 'payload' }))
+
+    const [idleAgain] = nestedUnionMachine.transition(
+      NestedOk({ data: 'payload' }),
+      ClickedRetry(),
+    )
+    expect(idleAgain).toStrictEqual(NestedIdle())
+  })
+
+  it('throws when a member is neither a nested union nor a Struct with a literal _tag', () => {
+    expect(() =>
+      define({ state: UntaggedState, message: RemoteDataMessage })({
+        initial: { _tag: 'PlainIdle' },
+        states: {},
+      }),
+    ).toThrow(
+      'Machine.define: every member of the state union Schema must be a Struct with a literal _tag field',
+    )
   })
 })
 

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -486,7 +486,7 @@ const isGuardList = <State extends Tagged, Message extends Tagged, R>(
     | LooseEdge<State, Message, R>
     | ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
 ): edgeOrGuardedEdges is ReadonlyArray<LooseGuardedEdge<State, Message, R>> =>
-  globalThis.Array.isArray(edgeOrGuardedEdges)
+  Array.isArray(edgeOrGuardedEdges)
 
 const extractLiteralTag = (tagField: unknown): Option.Option<string> => {
   if (
@@ -509,6 +509,20 @@ const extractMemberTag = (member: unknown): Option.Option<string> =>
     Option.filter(Predicate.hasProperty('_tag')),
     Option.flatMap(fields => extractLiteralTag(fields._tag)),
   )
+
+const flattenUnionMembers = (
+  members: ReadonlyArray<unknown>,
+): ReadonlyArray<unknown> =>
+  Array.flatMap(members, member => {
+    if (
+      Predicate.hasProperty(member, 'members') &&
+      Array.isArray(member.members)
+    ) {
+      return flattenUnionMembers(member.members)
+    } else {
+      return [member]
+    }
+  })
 
 /**
  * Compiles a declarative transition table into a {@link Machine}.
@@ -571,6 +585,7 @@ export const define =
 
     const stateTags = pipe(
       schemas.state.members,
+      flattenUnionMembers,
       Array.map(member =>
         Option.getOrThrowWith(
           extractMemberTag(member),

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -1,5 +1,5 @@
 import {
-  Array,
+  Array as Array_,
   Match as M,
   Option,
   Predicate,
@@ -444,7 +444,7 @@ const isGuardList = <State extends Tagged, Message extends Tagged, R>(
     | LooseEdge<State, Message, R>
     | ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
 ): edgeOrGuardedEdges is ReadonlyArray<LooseGuardedEdge<State, Message, R>> =>
-  globalThis.Array.isArray(edgeOrGuardedEdges)
+  Array.isArray(edgeOrGuardedEdges)
 
 const extractLiteralTag = (tagField: unknown): Option.Option<string> => {
   if (
@@ -466,6 +466,15 @@ const extractMemberTag = (member: unknown): Option.Option<string> =>
     Option.map(struct => struct.fields),
     Option.filter(Predicate.hasProperty('_tag')),
     Option.flatMap(fields => extractLiteralTag(fields._tag)),
+  )
+
+const flattenUnionMembers = (
+  members: ReadonlyArray<unknown>,
+): ReadonlyArray<unknown> =>
+  Array_.flatMap(members, member =>
+    Predicate.hasProperty(member, 'members') && Array.isArray(member.members)
+      ? flattenUnionMembers(member.members)
+      : [member],
   )
 
 /**
@@ -527,7 +536,8 @@ export const define =
 
     const stateTags = pipe(
       schemas.state.members,
-      Array.map(member =>
+      flattenUnionMembers,
+      Array_.map(member =>
         Option.getOrThrowWith(
           extractMemberTag(member),
           () =>
@@ -555,7 +565,7 @@ export const define =
         | ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
     ): ReadonlyArray<EdgeSummary<State, Message>> =>
       isGuardList(edgeOrGuardedEdges)
-        ? Array.map(edgeOrGuardedEdges, (guardedEdge, position) =>
+        ? Array_.map(edgeOrGuardedEdges, (guardedEdge, position) =>
             guardedEdge._tag === 'When'
               ? makeEdgeSummary(from, messageTag, guardedEdge.edge.target, {
                   _tag: 'When',
@@ -574,10 +584,10 @@ export const define =
 
     const edges: ReadonlyArray<EdgeSummary<State, Message>> = pipe(
       Record.toEntries(looseStates),
-      Array.flatMap(([sourceTag, stateEntry]) =>
+      Array_.flatMap(([sourceTag, stateEntry]) =>
         pipe(
           Record.toEntries(stateEntry.on),
-          Array.flatMap(([messageTag, edgeOrGuardedEdges]) =>
+          Array_.flatMap(([messageTag, edgeOrGuardedEdges]) =>
             summarizeEntry(sourceTag, messageTag, edgeOrGuardedEdges),
           ),
         ),
@@ -589,7 +599,7 @@ export const define =
       state: State,
       message: Message,
     ): Option.Option<SelectedEdge<State, Message, R>> =>
-      Array.matchLeft(guardedEdges, {
+      Array_.matchLeft(guardedEdges, {
         onEmpty: () => Option.none(),
         onNonEmpty: (guardedEdge, rest) => {
           if (guardedEdge._tag === 'When') {
@@ -691,8 +701,8 @@ export const define =
     const targetsFrom = (tag: TagOf<State>): ReadonlyArray<TagOf<State>> =>
       pipe(
         edges,
-        Array.filter(edgeSummary => edgeSummary.from === tag),
-        Array.map(edgeSummary => edgeSummary.target),
+        Array_.filter(edgeSummary => edgeSummary.from === tag),
+        Array_.map(edgeSummary => edgeSummary.target),
       )
 
     const reachableFrom = (tag: TagOf<State>): ReadonlySet<TagOf<State>> => {
@@ -700,7 +710,7 @@ export const define =
         frontier: ReadonlyArray<TagOf<State>>,
         visited: ReadonlySet<TagOf<State>>,
       ): ReadonlySet<TagOf<State>> =>
-        Array.matchLeft(frontier, {
+        Array_.matchLeft(frontier, {
           onEmpty: () => visited,
           onNonEmpty: (head, tail) =>
             visited.has(head)
@@ -716,7 +726,7 @@ export const define =
 
     const unreachableStates = (): ReadonlyArray<TagOf<State>> => {
       const reachable = reachableFrom(initialTag)
-      return Array.filter(stateTags, stateTag => !reachable.has(stateTag))
+      return Array_.filter(stateTags, stateTag => !reachable.has(stateTag))
     }
 
     const makeDeadTransition = (
@@ -734,14 +744,14 @@ export const define =
     const shadowedEdges = (): ReadonlyArray<DeadTransition<State, Message>> =>
       pipe(
         edges,
-        Array.groupBy(
+        Array_.groupBy(
           edgeSummary => `${edgeSummary.from}|${edgeSummary.messageTag}`,
         ),
         Record.values,
-        Array.flatMap(group => {
+        Array_.flatMap(group => {
           const maybeOtherwisePosition = pipe(
             group,
-            Array.findFirst(
+            Array_.findFirst(
               edgeSummary => edgeSummary.guard._tag === 'Otherwise',
             ),
             Option.flatMap(guardPosition),
@@ -752,13 +762,13 @@ export const define =
             onSome: otherwisePosition =>
               pipe(
                 group,
-                Array.filter(edgeSummary =>
+                Array_.filter(edgeSummary =>
                   Option.match(guardPosition(edgeSummary), {
                     onNone: () => false,
                     onSome: position => position > otherwisePosition,
                   }),
                 ),
-                Array.map(edgeSummary =>
+                Array_.map(edgeSummary =>
                   makeDeadTransition(edgeSummary, 'ShadowedByOtherwise'),
                 ),
               ),
@@ -773,8 +783,8 @@ export const define =
 
       const unreachableSourceEdges = pipe(
         edges,
-        Array.filter(edgeSummary => !reachable.has(edgeSummary.from)),
-        Array.map(edgeSummary =>
+        Array_.filter(edgeSummary => !reachable.has(edgeSummary.from)),
+        Array_.map(edgeSummary =>
           makeDeadTransition(edgeSummary, 'UnreachableSource'),
         ),
       )
@@ -792,15 +802,15 @@ export const define =
           }),
         )
 
-      const stateLines = Array.map(stateTags, stateTag => `  ${stateTag}`)
+      const stateLines = Array_.map(stateTags, stateTag => `  ${stateTag}`)
 
-      const transitionLines = Array.map(
+      const transitionLines = Array_.map(
         edges,
         edgeSummary =>
           `  ${edgeSummary.from} --> ${edgeSummary.target}: ${edgeSummary.messageTag}${guardLabel(edgeSummary.guard)}`,
       )
 
-      return Array.join(
+      return Array_.join(
         [
           'stateDiagram-v2',
           ...stateLines,


### PR DESCRIPTION
Machine.define extracted tags only from the top-level state union members, so a nested union member threw during module initialization even though its variants had valid literal tags.

Flatten nested member lists recursively before extracting tags, preserving depth-first declaration order and the existing error for invalid members.

Part of #851 (finding 3).
