### PR TITLE
feat(foldkit,ui): add Scene.expectHandled and Scene.expectIgnored

### DIFF
--- a/.changeset/scene-expect-handled.md
+++ b/.changeset/scene-expect-handled.md
@@ -1,0 +1,13 @@
+---
+'foldkit': minor
+---
+
+Add `Scene.expectHandled()` and `Scene.expectIgnored()`, which assert whether the preceding interaction's event handler produced a Message.
+
+Scene had no way to express this and silently tolerated the negative case. `captureFromElement` resolved a handler that produced nothing back to the unchanged simulation, so an interaction whose handler ran and chose to return `Option.none()` left no trace. An element with no handler at all has always thrown; this is the narrower case of a handler that ran and let the event fall through.
+
+That made a whole class of test vacuous. Any test of the shape "pressing this does nothing" passed whether the interaction was correctly inert or the handler had been deleted outright. In `@foldkit/ui` this was not hypothetical: replacing a read-only Listbox's commit branch with `Option.none()` left every listbox test passing, because the read-only tests asserted only the absence of an OutMessage and of Commands, and both hold when nothing is dispatched at all.
+
+`expectHandled()` is the assertion behind "the key is consumed here". A handler that returns a Message is what makes `h.OnKeyDownPreventDefault` call `preventDefault()`, so a handled keydown is one whose browser default is suppressed: `Space` does not scroll the page and `Enter` does not submit a surrounding form. Reach for it rather than asserting the Message's tag, which couples the test to a name that is only the mechanism.
+
+`expectIgnored()` is its complement, for where falling through is the intended behavior, so the intent is stated rather than left as the absence of any assertion.

--- a/.changeset/ui-expect-handled-tests.md
+++ b/.changeset/ui-expect-handled-tests.md
@@ -1,0 +1,11 @@
+---
+'@foldkit/ui': patch
+---
+
+Assert the read-only commit suppression through `Scene.expectHandled()` instead of a hand-rolled `update` wrapper, and harden three tests that asserted nothing.
+
+Listbox and Combobox recorded dispatched Messages by wrapping `update` and matching on the `SuppressedItemCommit` tag, because Scene could not express what the component actually promises. It promises the keypress is consumed, so the browser default is suppressed; the Message tag is the mechanism. Those four sites now use `expectHandled()` and `expectIgnored()` and drop the wrapper.
+
+Three tests elsewhere asserted inertness with no assertion behind it, and now say so: RadioGroup's read-only Space, and Calendar's disabled-month and disabled-year Enter. Each held whether the key was correctly ignored or its handler had started producing a Message with no visible effect, which is the regression they exist to catch. Removing the handler outright has always thrown from the interaction step.
+
+Test-only change. No API or behavior change.

--- a/packages/foldkit/src/test/apps/selectiveKeys.ts
+++ b/packages/foldkit/src/test/apps/selectiveKeys.ts
@@ -1,0 +1,51 @@
+import { Match as M, Number, Option, Schema as S } from 'effect'
+
+import type { Html, HtmlBuilder } from '../../html/index.js'
+import { m } from '../../message/index.js'
+import { evo } from '../../struct/index.js'
+
+// MODEL
+
+export const Model = S.Struct({
+  commits: S.Number,
+})
+export type Model = typeof Model.Type
+
+// MESSAGE
+
+const Committed = m('Committed')
+
+export const Message = S.Union([Committed])
+export type Message = typeof Message.Type
+
+// INIT
+
+export const initialModel: Model = { commits: 0 }
+
+// UPDATE
+
+export const update = (
+  model: Model,
+  message: Message,
+): readonly [Model, ReadonlyArray<never>] =>
+  M.value(message).pipe(
+    M.withReturnType<readonly [Model, ReadonlyArray<never>]>(),
+    M.tagsExhaustive({
+      Committed: () => [evo(model, { commits: Number.increment }), []],
+    }),
+  )
+
+// VIEW
+
+export const appId = 'selective-keys'
+
+export const view = (model: Model, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [
+      h.Id(appId),
+      h.OnKeyDownPreventDefault(key =>
+        key === 'Enter' ? Option.some(Committed()) : Option.none(),
+      ),
+    ],
+    [h.span([h.Class('commits')], [`${model.commits}`])],
+  )

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -132,6 +132,12 @@ import {
   view as scorePanelView,
 } from './apps/scorePanel.js'
 import {
+  appId as selectiveKeysAppId,
+  initialModel as selectiveKeysInitialModel,
+  update as selectiveKeysUpdate,
+  view as selectiveKeysView,
+} from './apps/selectiveKeys.js'
+import {
   SucceededUploadFile,
   UploadFile,
   initialModel as initialUploadsModel,
@@ -5173,4 +5179,87 @@ describe('attribute builders map to DOM names', () => {
       )
     },
   )
+})
+
+describe('expectHandled and expectIgnored', () => {
+  const app = { update: selectiveKeysUpdate, view: selectiveKeysView }
+  const target = Scene.selector(`#${selectiveKeysAppId}`)
+
+  test('expectHandled passes when the handler produced a Message', () => {
+    Scene.scene(
+      app,
+      Scene.given(selectiveKeysInitialModel),
+      Scene.keydown(target, 'Enter'),
+      Scene.expectHandled(),
+      Scene.expect(Scene.selector('.commits')).toHaveText('1'),
+    )
+  })
+
+  test('expectIgnored passes when the handler let the key fall through', () => {
+    Scene.scene(
+      app,
+      Scene.given(selectiveKeysInitialModel),
+      Scene.keydown(target, 'a'),
+      Scene.expectIgnored(),
+      Scene.expect(Scene.selector('.commits')).toHaveText('0'),
+    )
+  })
+
+  test('expectHandled throws when the handler produced nothing', () => {
+    expect(() =>
+      Scene.scene(
+        app,
+        Scene.given(selectiveKeysInitialModel),
+        Scene.keydown(target, 'a'),
+        Scene.expectHandled(),
+      ),
+    ).toThrow('its handler produced no Message')
+  })
+
+  test('expectIgnored throws when the handler produced a Message', () => {
+    expect(() =>
+      Scene.scene(
+        app,
+        Scene.given(selectiveKeysInitialModel),
+        Scene.keydown(target, 'Enter'),
+        Scene.expectIgnored(),
+      ),
+    ).toThrow('but its handler produced a Message')
+  })
+
+  test('expectIgnored throws when no interaction has run', () => {
+    expect(() =>
+      Scene.scene(
+        app,
+        Scene.given(selectiveKeysInitialModel),
+        Scene.expectIgnored(),
+      ),
+    ).toThrow('no interaction has run yet')
+  })
+
+  test('expectHandled throws when no interaction has run', () => {
+    expect(() =>
+      Scene.scene(
+        app,
+        Scene.given(selectiveKeysInitialModel),
+        Scene.expectHandled(),
+      ),
+    ).toThrow('no interaction has run yet')
+  })
+
+  // NOTE: the reason the pair exists. A read-only widget that stops
+  // committing keeps its handler and returns None, which changes no Model,
+  // no OutMessage, and no DOM. Without expectIgnored the only available
+  // assertions hold just as well against a handler that was deleted, so a
+  // regression to a silently falling-through key would pass.
+  test('an ignored key is indistinguishable without the pair', () => {
+    Scene.scene(
+      app,
+      Scene.given(selectiveKeysInitialModel),
+      Scene.keydown(target, 'a'),
+      Scene.Command.expectNone(),
+      Scene.expect(Scene.selector('.commits')).toHaveText('0'),
+      Scene.expectIgnored(),
+    )
+  })
 })

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -4,6 +4,7 @@ import {
   Effect,
   Equal,
   Function,
+  Match as M,
   Option,
   Predicate,
   type Schema,
@@ -197,6 +198,16 @@ type CapturingDispatch = Readonly<{
   reset: () => void
 }>
 
+/** Whether the most recent interaction step's event handler produced a
+ *  Message. `NotRun` is the seed state, before any interaction has run. */
+type InteractionOutcome = Readonly<
+  { _tag: 'NotRun' } | { _tag: 'Handled' } | { _tag: 'Ignored' }
+>
+
+const NotRun: InteractionOutcome = { _tag: 'NotRun' }
+const Handled: InteractionOutcome = { _tag: 'Handled' }
+const Ignored: InteractionOutcome = { _tag: 'Ignored' }
+
 type UpdateResult<Model, OutMessage> =
   | readonly [Model, ReadonlyArray<AnyCommand>]
   | readonly [Model, ReadonlyArray<AnyCommand>, OutMessage]
@@ -233,6 +244,7 @@ type InternalSceneSimulation<
     capturingDispatch: CapturingDispatch
     scope: Option.Option<Locator>
     mountSlots: ReadonlyArray<MountSlotState>
+    lastInteractionOutcome: InteractionOutcome
   }>
 
 const slotKey = ({ name, occurrence }: PendingMount): string =>
@@ -487,6 +499,21 @@ const maybeCaptureFromElement = <Model, Message, OutMessage>(
   )
 }
 
+/** Records whether the interaction just run produced a Message, so
+ *  {@link expectHandled} and {@link expectIgnored} can assert on it. An
+ *  interaction whose handler returns no Message leaves the simulation
+ *  otherwise untouched, which is indistinguishable from a correctly inert
+ *  one without this. */
+const withInteractionOutcome = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  outcome: InteractionOutcome,
+): SceneSimulation<Model, Message, OutMessage> =>
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  ({
+    ...simulation,
+    lastInteractionOutcome: outcome,
+  }) as SceneSimulation<Model, Message, OutMessage>
+
 const captureFromElement = <Model, Message, OutMessage>(
   simulation: SceneSimulation<Model, Message, OutMessage>,
   element: VNode,
@@ -494,7 +521,7 @@ const captureFromElement = <Model, Message, OutMessage>(
   eventName: string,
   invokeHandler: (handler: Function) => void,
 ): SceneSimulation<Model, Message, OutMessage> =>
-  Option.getOrElse(
+  Option.match(
     maybeCaptureFromElement(
       simulation,
       element,
@@ -502,7 +529,10 @@ const captureFromElement = <Model, Message, OutMessage>(
       eventName,
       invokeHandler,
     ),
-    () => simulation,
+    {
+      onNone: () => withInteractionOutcome(simulation, Ignored),
+      onSome: next => withInteractionOutcome(next, Handled),
+    },
   )
 
 const invokeAndCapture = <Model, Message, OutMessage>(
@@ -1146,13 +1176,16 @@ const emitCustomElementEvent =
       },
     )
 
-    return Option.getOrThrowWith(
-      maybeNext,
-      () =>
-        new Error(
-          `I dispatched "${eventName}" on the element matching ${description} but its handler produced no Message.\n\n` +
-            "The OnCustomEvent handler only dispatches for CustomEvent instances, so the synthetic event failed the runtime's instanceof check. This points to a CustomEvent realm mismatch in the test environment.",
-        ),
+    return withInteractionOutcome(
+      Option.getOrThrowWith(
+        maybeNext,
+        () =>
+          new Error(
+            `I dispatched "${eventName}" on the element matching ${description} but its handler produced no Message.\n\n` +
+              "The OnCustomEvent handler only dispatches for CustomEvent instances, so the synthetic event failed the runtime's instanceof check. This points to a CustomEvent realm mismatch in the test environment.",
+          ),
+      ),
+      Handled,
     )
   }
 
@@ -1288,6 +1321,84 @@ export const expectNoOutMessage =
 
     return simulation
   }
+
+/** Asserts that the preceding interaction was handled: its event handler
+ *  produced a Message.
+ *
+ *  This is the assertion behind "the key is consumed here". A Foldkit
+ *  handler that returns a Message is what makes `h.OnKeyDownPreventDefault`
+ *  call `preventDefault()`, so a handled keydown is one whose browser
+ *  default is suppressed: `Space` does not scroll the page and `Enter` does
+ *  not submit a surrounding form.
+ *
+ *  Reach for this rather than asserting the Message's tag. The tag is the
+ *  mechanism a component happens to use; being consumed is the contract, and
+ *  it survives renaming the Message.
+ *
+ *  An interaction on an element with no handler at all throws from the
+ *  interaction step itself, so this distinguishes the narrower case of a
+ *  handler that ran and chose to produce nothing.
+ *
+ *  Only interaction steps set the outcome. `Command.resolve`, `Mount.resolve`,
+ *  and plain `expect` leave it alone, so the value is the last *interaction*
+ *  rather than the last step. Keep the assertion next to the interaction it
+ *  covers. */
+export const expectHandled =
+  () =>
+  <Model, Message, OutMessage>(
+    simulation: SceneSimulation<Model, Message, OutMessage>,
+  ): SceneSimulation<Model, Message, OutMessage> =>
+    M.value(toInternal(simulation).lastInteractionOutcome).pipe(
+      M.withReturnType<SceneSimulation<Model, Message, OutMessage>>(),
+      M.tagsExhaustive({
+        NotRun: () => {
+          throw new Error(
+            'I was asked whether the last interaction was handled, but no interaction has run yet.\n\n' +
+              'Put `expectHandled()` after a step like `click`, `keydown`, or `change`.',
+          )
+        },
+        Handled: () => simulation,
+        Ignored: () => {
+          throw new Error(
+            'Expected the last interaction to be handled, but its handler produced no Message.\n\n' +
+              'The handler ran and returned nothing, so the event falls through and the browser default is not prevented.',
+          )
+        },
+      }),
+    )
+
+/** Asserts that the preceding interaction was ignored: its event handler ran
+ *  and produced no Message, so the event falls through and the browser
+ *  default stands.
+ *
+ *  The complement of {@link expectHandled}. Use it where falling through is
+ *  the intended behavior, so the intent is stated rather than left as the
+ *  absence of any assertion.
+ *
+ *  Carries the same adjacency caveat: only interaction steps set the
+ *  outcome, so keep the assertion next to the interaction it covers. */
+export const expectIgnored =
+  () =>
+  <Model, Message, OutMessage>(
+    simulation: SceneSimulation<Model, Message, OutMessage>,
+  ): SceneSimulation<Model, Message, OutMessage> =>
+    M.value(toInternal(simulation).lastInteractionOutcome).pipe(
+      M.withReturnType<SceneSimulation<Model, Message, OutMessage>>(),
+      M.tagsExhaustive({
+        NotRun: () => {
+          throw new Error(
+            'I was asked whether the last interaction was ignored, but no interaction has run yet.\n\n' +
+              'Put `expectIgnored()` after a step like `click`, `keydown`, or `change`.',
+          )
+        },
+        Handled: () => {
+          throw new Error(
+            'Expected the last interaction to be ignored, but its handler produced a Message.',
+          )
+        },
+        Ignored: () => simulation,
+      }),
+    )
 
 /** Runs a function for side effects (e.g. assertions) without breaking the step chain. */
 export const tap =
@@ -2444,6 +2555,7 @@ export const scene: {
     viewFn: config.view,
     capturingDispatch,
     scope: Option.none(),
+    lastInteractionOutcome: NotRun,
   } as unknown as SceneSimulation<Model, Message, OutMessage>
 
   const result = runSteps(seed, steps)

--- a/packages/ui/src/calendar/scene.test.ts
+++ b/packages/ui/src/calendar/scene.test.ts
@@ -683,6 +683,7 @@ describe('Calendar', () => {
         Scene.keydown(grid, 'ArrowDown'),
         Scene.keydown(grid, 'ArrowDown'),
         Scene.keydown(grid, 'Enter'),
+        Scene.expectIgnored(),
         Scene.expect(yearsHeadingButton).toExist(),
       )
     })
@@ -700,6 +701,7 @@ describe('Calendar', () => {
         resolveFocusGrid,
         Scene.keydown(grid, 'PageUp'),
         Scene.keydown(grid, 'Enter'),
+        Scene.expectIgnored(),
         Scene.expect(previousYearsPageButton).toExist(),
       )
     })

--- a/packages/ui/src/combobox/multi.test.ts
+++ b/packages/ui/src/combobox/multi.test.ts
@@ -608,22 +608,9 @@ describe('Combobox.Multi', () => {
       })
 
       it('reports Enter on the active item as SuppressedItemCommit', () => {
-        // NOTE: wrapping update to record dispatched Messages stands in for
-        // a missing Scene primitive. What the component promises is that the
-        // keypress is consumed, so OnKeyDownPreventDefault suppresses the
-        // browser default; the Message tag is only the mechanism. Scene
-        // cannot express that today, and silently tolerates an interaction
-        // whose handler produces nothing, so a plain expectNoOutMessage()
-        // here would pass against a handler that was deleted outright (see
-        // issue #1008).
-        const seen: Array<Message> = []
-
         Scene.scene(
           {
-            update: (model: Model, message: Message) => {
-              seen.push(message)
-              return update(model, message)
-            },
+            update,
             view: sceneView({
               isReadOnly: true,
               selectedValues: ['Apple'],
@@ -633,11 +620,7 @@ describe('Combobox.Multi', () => {
           acknowledgeAnchor,
           acknowledgeBackdrop,
           Scene.keydown(input, 'Enter'),
-          Scene.tap(() => {
-            expect(seen.map(message => message._tag)).toContain(
-              'SuppressedItemCommit',
-            )
-          }),
+          Scene.expectHandled(),
           Scene.expectNoOutMessage(),
         )
       })

--- a/packages/ui/src/combobox/single.test.ts
+++ b/packages/ui/src/combobox/single.test.ts
@@ -1773,33 +1773,16 @@ describe('Combobox', () => {
       })
 
       it('reports Enter on the active item as SuppressedItemCommit', () => {
-        // NOTE: wrapping update to record dispatched Messages stands in for
-        // a missing Scene primitive. What the component promises is that the
-        // keypress is consumed, so OnKeyDownPreventDefault suppresses the
-        // browser default; the Message tag is only the mechanism. Scene
-        // cannot express that today, and silently tolerates an interaction
-        // whose handler produces nothing, so a plain expectNoOutMessage()
-        // here would pass against a handler that was deleted outright (see
-        // issue #1008).
-        const seen: Array<Message> = []
-
         Scene.scene(
           {
-            update: (model: Model, message: Message) => {
-              seen.push(message)
-              return update(model, message)
-            },
+            update,
             view: readOnlyView(),
           },
           Scene.given(openModel()),
           acknowledgeAnchor,
           acknowledgeBackdrop,
           Scene.keydown(input, 'Enter'),
-          Scene.tap(() => {
-            expect(seen.map(message => message._tag)).toContain(
-              'SuppressedItemCommit',
-            )
-          }),
+          Scene.expectHandled(),
           Scene.expectNoOutMessage(),
         )
       })
@@ -1972,22 +1955,9 @@ describe('Combobox', () => {
       })
 
       it('does not report SuppressedItemCommit when no item is active', () => {
-        // NOTE: wrapping update to record dispatched Messages stands in for
-        // a missing Scene primitive. What the component promises is that the
-        // keypress is consumed, so OnKeyDownPreventDefault suppresses the
-        // browser default; the Message tag is only the mechanism. Scene
-        // cannot express that today, and silently tolerates an interaction
-        // whose handler produces nothing, so a plain expectNoOutMessage()
-        // here would pass against a handler that was deleted outright (see
-        // issue #1008).
-        const seen: Array<Message> = []
-
         Scene.scene(
           {
-            update: (model: Model, message: Message) => {
-              seen.push(message)
-              return update(model, message)
-            },
+            update,
             view: readOnlyView(),
           },
           Scene.given({
@@ -1997,11 +1967,7 @@ describe('Combobox', () => {
           acknowledgeAnchor,
           acknowledgeBackdrop,
           Scene.keydown(input, 'Enter'),
-          Scene.tap(() => {
-            expect(seen.map(message => message._tag)).not.toContain(
-              'SuppressedItemCommit',
-            )
-          }),
+          Scene.expectIgnored(),
           Scene.expectNoOutMessage(),
         )
       })
@@ -2023,22 +1989,9 @@ describe('Combobox', () => {
       })
 
       it('emits RequestedItemClick on Enter when not read-only', () => {
-        // NOTE: wrapping update to record dispatched Messages stands in for
-        // a missing Scene primitive. What the component promises is that the
-        // keypress is consumed, so OnKeyDownPreventDefault suppresses the
-        // browser default; the Message tag is only the mechanism. Scene
-        // cannot express that today, and silently tolerates an interaction
-        // whose handler produces nothing, so a plain expectNoOutMessage()
-        // here would pass against a handler that was deleted outright (see
-        // issue #1008).
-        const seen: Array<Message> = []
-
         Scene.scene(
           {
-            update: (model: Model, message: Message) => {
-              seen.push(message)
-              return update(model, message)
-            },
+            update,
             view: sceneView({
               maybeSelectedValue: Option.some('Apple'),
               restingInputValue: 'Apple',
@@ -2048,11 +2001,7 @@ describe('Combobox', () => {
           acknowledgeAnchor,
           acknowledgeBackdrop,
           Scene.keydown(input, 'Enter'),
-          Scene.tap(() => {
-            expect(seen.map(message => message._tag)).toContain(
-              'RequestedItemClick',
-            )
-          }),
+          Scene.expectHandled(),
           Scene.Command.resolve(ClickItem, CompletedClickItem()),
         )
       })

--- a/packages/ui/src/listbox/single.test.ts
+++ b/packages/ui/src/listbox/single.test.ts
@@ -1549,49 +1549,35 @@ describe('Listbox', () => {
         )
       })
 
-      it('reports Enter on the active item as SuppressedItemCommit', () => {
-        const seen: Array<Message> = []
-
+      it('consumes Enter on the active item without committing', () => {
         Scene.scene(
           {
-            update: (model: Model, message: Message) => {
-              seen.push(message)
-              return update(model, message)
-            },
+            update,
             view: sceneView({ isReadOnly: true }),
           },
           Scene.given(openModel()),
           acknowledgeAnchor,
           acknowledgeBackdrop,
           Scene.keydown(itemsContainer, 'Enter'),
-          Scene.tap(() => {
-            expect(seen.map(message => message._tag)).toContain(
-              'SuppressedItemCommit',
-            )
-          }),
+          Scene.expectHandled(),
+          Scene.expectNoOutMessage(),
+          Scene.Command.expectNone(),
         )
       })
 
-      it('reports Space on the active item as SuppressedItemCommit', () => {
-        const seen: Array<Message> = []
-
+      it('consumes Space on the active item without committing', () => {
         Scene.scene(
           {
-            update: (model: Model, message: Message) => {
-              seen.push(message)
-              return update(model, message)
-            },
+            update,
             view: sceneView({ isReadOnly: true }),
           },
           Scene.given(openModel()),
           acknowledgeAnchor,
           acknowledgeBackdrop,
           Scene.keydown(itemsContainer, ' '),
-          Scene.tap(() => {
-            expect(seen.map(message => message._tag)).toContain(
-              'SuppressedItemCommit',
-            )
-          }),
+          Scene.expectHandled(),
+          Scene.expectNoOutMessage(),
+          Scene.Command.expectNone(),
         )
       })
 

--- a/packages/ui/src/radioGroup/scene.test.ts
+++ b/packages/ui/src/radioGroup/scene.test.ts
@@ -258,6 +258,7 @@ describe('RadioGroup', () => {
         { update, view: testView({ isReadOnly: true }) },
         Scene.given(nothingSelected),
         Scene.keydown(option(1), ' '),
+        Scene.expectIgnored(),
         Scene.Command.expectNone(),
         Scene.expect(option(1)).toHaveAttr('aria-checked', 'false'),
       )

--- a/packages/website/src/page/testingScene.md
+++ b/packages/website/src/page/testingScene.md
@@ -120,6 +120,16 @@ For `LocatorAll` (from `all.*`), use `expectAll(locatorAll)` for count-based ass
 | `.toHaveCount(n)` | The locator matches exactly n elements |
 | `.toBeEmpty()`    | The locator matches zero elements      |
 
+## Handled and Ignored Interactions
+
+An interaction on an element with no handler for that event throws, so a Scene test cannot silently target the wrong element. A handler that runs and returns `Option.none()` is a different case: the event falls through, nothing changes, and the step is a no-op. `expectHandled()` asserts the preceding interaction's handler produced a Message; `expectIgnored()` asserts it did not.
+
+Reach for these when inertness is the behavior under test. A read-only widget that stops committing changes no Model, emits no OutMessage, and alters no DOM, so `expectNoOutMessage()` and `Command.expectNone()` hold just as well against a build whose handler was deleted. Only `expectIgnored()` distinguishes "correctly inert" from "no longer wired up".
+
+`expectHandled()` is also how to assert that a key is consumed. A handler that returns a Message is what makes `h.OnKeyDownPreventDefault` call `preventDefault()`, so a handled keydown is one whose browser default is suppressed: `Space` does not scroll the page and `Enter` does not submit a surrounding form. Prefer it over asserting which Message was produced. The Message is the mechanism a component happens to use; being consumed is the contract, and the assertion survives renaming the Message.
+
+Only interaction steps set the outcome. `Command.resolve`, `Mount.resolve`, and a plain `expect` leave it alone, so the value is the last interaction rather than the last step. Keep the assertion next to the interaction it covers.
+
 ## Commands
 
 When `update` returns Commands (see [Commands](/core/commands)), Scene tracks each as pending until the test resolves it with the result Message its Effect would resolve to at runtime. `update` declares the Command, the test declares its outcome.


### PR DESCRIPTION
Closes #1008.

## The gap

Scene could not express whether an interaction was handled, and silently tolerated the negative case. `captureFromElement` resolved a handler that produced nothing back to the unchanged simulation:

```ts
Option.getOrElse(maybeCaptureFromElement(...), () => simulation)
```

An element with no handler at all has always thrown, so this is the narrower case: a handler that ran and chose to return `Option.none()`, letting the event fall through.

That made a class of test vacuous. Any test of the shape "pressing this does nothing" passed whether the interaction was correctly inert or the handler had been deleted outright. Not hypothetical: replacing a read-only Listbox's commit branch with `Option.none()` left **all 132 listbox tests passing**, because the read-only tests asserted only the absence of an OutMessage and of Commands, and both hold when nothing is dispatched at all.

## The API

`expectHandled()` is the assertion behind "the key is consumed here". A handler that returns a Message is what makes `h.OnKeyDownPreventDefault` call `preventDefault()`, so a handled keydown is one whose browser default is suppressed: `Space` does not scroll the page, `Enter` does not submit a surrounding form.

It is deliberately not `expectMessage(SuppressedItemCommit())`. Being consumed is the contract; the Message tag is the mechanism a component happens to use, and asserting it couples the test to a name. `expectHandled()` survives renaming the Message or routing suppression through a different one.

`expectIgnored()` is its complement, for where falling through is intended, so the intent is stated rather than left as the absence of any assertion.

Both read an outcome recorded on the simulation by `captureFromElement`, and both throw a distinct error when no interaction has run yet, rather than passing vacuously in exactly the case they exist to prevent.

## What changed in `@foldkit/ui`

Four sites in Listbox and Combobox recorded dispatched Messages by wrapping `update`, then matched on the tag. They now use the steps and drop the wrapper. The same mutation those wrappers caught is still caught by `expectHandled()`, checked against a broken build: replacing the commit branch with `Option.none()` fails exactly those four tests and nothing else.

Three tests elsewhere asserted inertness with nothing behind it, and now say what they mean:

| Test | Was |
| --- | --- |
| RadioGroup, read-only `Space` | passed whether ignored or the handler was gone |
| Calendar, `Enter` on a disabled month | same |
| Calendar, `Enter` on a disabled year | same |

## Measurement, and what this deliberately leaves open

I probed the whole repo by making an unhandled interaction throw, then ran every suite. **Exactly four tests depended on that silence** and they are the four above, one of which already used `expectIgnored()` after the conversion.

So making unhandled interactions loud by default is affordable, and it is the stronger design: it catches future vacuous tests rather than only the ones somebody remembers to annotate. It is not in this PR because it cannot be a throw inside the interaction step. A later `expectIgnored()` cannot opt out of an error already raised, so it needs a deferred check that records the outcome and fails at the end of the scene unless a following step acknowledged it. That is a separate design pass, and #1008 stays open carrying it.

## Verification

- `pnpm check`: pass
- full `pnpm test`: pass, 1804 `foldkit` tests and 984 `@foldkit/ui` tests
- `pnpm format:check`: clean
- The `Option.none()` mutation was run against both Listbox and Combobox and fails only the four `expectHandled()` tests.

One `minor` changeset for `foldkit`, one `patch` for `@foldkit/ui`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NnUsZqp22C79FooWwnA59

---
_Generated by [Claude Code](https://claude.ai/code/session_017NnUsZqp22C79FooWwnA59)_