### PR TITLE
feat(ui,website): add per-side anchor padding, clear landing header

### DIFF
--- a/.changeset/ui-anchor-per-side-padding.md
+++ b/.changeset/ui-anchor-per-side-padding.md
@@ -1,0 +1,7 @@
+---
+'@foldkit/ui': minor
+---
+
+Widen `AnchorConfig.padding` to accept a partial per-side object alongside the existing scalar, mirroring `@floating-ui/dom`'s `Padding` type. A number still pads every side uniformly; `{ top: 88, right: 16, bottom: 16, left: 16 }` bounds each side independently. The value is forwarded unchanged to the `flip`, `shift`, and `size` middleware.
+
+With a single scalar, a panel that `flip` moves above its button can slide to within that scalar of the viewport top, under fixed chrome such as a sticky site header, which then paints over the panel. Per-side padding gives the top the extra clearance the header needs while the other sides keep the tighter viewport bound.

--- a/packages/ui/src/anchor.padding.test.ts
+++ b/packages/ui/src/anchor.padding.test.ts
@@ -1,0 +1,142 @@
+import { Array, Option, pipe } from 'effect'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ComputePositionConfig,
+  Placement as FloatingPlacement,
+} from '@floating-ui/dom'
+
+import { type AnchorConfig, anchorSetup } from './anchor.js'
+
+type MockComputePositionReturn = {
+  x: number
+  y: number
+  placement: FloatingPlacement
+}
+
+const BUTTON_ID = 'btn'
+
+const computePositionMock =
+  vi.fn<
+    (
+      reference: Element,
+      floating: Element,
+      options: Partial<ComputePositionConfig>,
+    ) => Promise<MockComputePositionReturn>
+  >()
+
+// NOTE: `actual` is spread so the real offset/flip/shift/size factories survive
+// and their middleware objects keep the `.name` and `.options` values the
+// assertions match on. Stubbing those factories too would make every padding
+// assertion pass vacuously. `autoUpdate` invokes its callback once on setup,
+// as the real one does.
+vi.mock('@floating-ui/dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('@floating-ui/dom')>()
+  return {
+    ...actual,
+    computePosition: (
+      reference: Element,
+      floating: Element,
+      options: Partial<ComputePositionConfig>,
+    ) => computePositionMock(reference, floating, options),
+    autoUpdate: (
+      _reference: unknown,
+      _floating: unknown,
+      update: () => void,
+    ) => {
+      update()
+      return () => {}
+    },
+  }
+})
+
+describe('anchorSetup padding', () => {
+  afterEach(() => {
+    computePositionMock.mockReset()
+    document.body.replaceChildren()
+  })
+
+  const optionsOfCall = (callIndex: number): Partial<ComputePositionConfig> =>
+    pipe(
+      Array.get(computePositionMock.mock.calls, callIndex),
+      Option.map(([, , options]) => options),
+      Option.getOrThrowWith(
+        () =>
+          new Error(`Expected a computePosition call at index ${callIndex}`),
+      ),
+    )
+
+  const paddingOfMiddleware = (
+    callIndex: number,
+    middlewareName: string,
+  ): unknown => {
+    const middleware = pipe(
+      optionsOfCall(callIndex).middleware ?? [],
+      Array.flatMap(middleware => (middleware ? [middleware] : [])),
+      Array.findFirst(({ name }) => name === middlewareName),
+      Option.getOrThrowWith(
+        () =>
+          new Error(
+            `Expected ${middlewareName} middleware at call index ${callIndex}`,
+          ),
+      ),
+    )
+    const padding: unknown = middleware.options?.padding
+    return padding
+  }
+
+  const mountAnchor = (
+    anchor: AnchorConfig,
+  ): Readonly<{ element: HTMLElement; cleanup: () => void }> => {
+    const button = document.createElement('button')
+    button.id = BUTTON_ID
+    const element = document.createElement('div')
+    document.body.append(button, element)
+    const cleanup = anchorSetup({ buttonId: BUTTON_ID, anchor })(element)
+    return { element, cleanup }
+  }
+
+  it('forwards a per-side padding object to flip, shift, and size', () => {
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: 'bottom-start',
+    })
+    mountAnchor({
+      placement: 'bottom-start',
+      padding: { top: 88, right: 16, bottom: 16, left: 16 },
+      portal: false,
+    })
+
+    const perSidePadding = { top: 88, right: 16, bottom: 16, left: 16 }
+    expect(paddingOfMiddleware(0, 'flip')).toEqual(perSidePadding)
+    expect(paddingOfMiddleware(0, 'shift')).toEqual(perSidePadding)
+    expect(paddingOfMiddleware(0, 'size')).toEqual(perSidePadding)
+  })
+
+  it('forwards a scalar padding unchanged', () => {
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: 'bottom-start',
+    })
+    mountAnchor({ placement: 'bottom-start', padding: 16, portal: false })
+
+    expect(paddingOfMiddleware(0, 'flip')).toBe(16)
+    expect(paddingOfMiddleware(0, 'shift')).toBe(16)
+    expect(paddingOfMiddleware(0, 'size')).toBe(16)
+  })
+
+  it('forwards zero when padding is omitted', () => {
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: 'bottom-start',
+    })
+    mountAnchor({ placement: 'bottom-start', portal: false })
+
+    expect(paddingOfMiddleware(0, 'flip')).toBe(0)
+    expect(paddingOfMiddleware(0, 'shift')).toBe(0)
+    expect(paddingOfMiddleware(0, 'size')).toBe(0)
+  })
+})

--- a/packages/ui/src/anchor.ts
+++ b/packages/ui/src/anchor.ts
@@ -27,12 +27,24 @@ export const Placement = S.Literals([
   'left-end',
 ])
 
+/** Schema mirroring `@floating-ui/dom`'s `Padding` type: a uniform number or a
+ *  partial per-side object (`top`/`right`/`bottom`/`left`). */
+export const Padding = S.Union([
+  S.Number,
+  S.Struct({
+    top: S.optionalKey(S.Number),
+    right: S.optionalKey(S.Number),
+    bottom: S.optionalKey(S.Number),
+    left: S.optionalKey(S.Number),
+  }),
+])
+
 /** Static configuration for anchor-based positioning of a floating element relative to a button. */
 export const AnchorConfig = S.Struct({
   placement: S.optional(Placement),
   gap: S.optional(S.Number),
   offset: S.optional(S.Number),
-  padding: S.optional(S.Number),
+  padding: S.optional(Padding),
   portal: S.optional(S.Boolean),
   isPlacementLocked: S.optional(S.Boolean),
 })

--- a/packages/website/src/view/landing.ts
+++ b/packages/website/src/view/landing.ts
@@ -179,10 +179,23 @@ const lazyNotePlayerDemo = createLazy()
 
 // PLAYGROUND MENU
 
+const VIEWPORT_PADDING = 16
+
+// NOTE: mirrors the md+ CSS --header-height (4.5rem); the variable's
+// env(safe-area-inset-top) term is not readable from static config.
+const MD_HEADER_HEIGHT = 72
+
+const HEADER_CLEARANCE = MD_HEADER_HEIGHT + VIEWPORT_PADDING
+
 const PLAYGROUND_MENU_ANCHOR = {
   placement: 'bottom-start' as const,
   gap: 8,
-  padding: 16,
+  padding: {
+    top: HEADER_CLEARANCE,
+    right: VIEWPORT_PADDING,
+    bottom: VIEWPORT_PADDING,
+    left: VIEWPORT_PADDING,
+  },
 }
 
 const playgroundButtonClassName = 'cta-amber cursor-pointer'


### PR DESCRIPTION
## What and why

On the landing page, opening the Launch Playground menu with limited room below the button lets Floating UI's `flip` place the panel above the button, where `flip`'s best-fit fallback plus `size`'s clamp let it extend to within 16px of the viewport top. The fixed header (`z-50`) paints over the panel (`z-20`), occluding the top of the menu. Floating UI bounds panels by the visual viewport and has no idea the top `--header-height` band is covered by fixed chrome.

## What changed

- `@foldkit/ui`: `AnchorConfig.padding` now accepts a partial per-side object (`{ top, right, bottom, left }`) alongside the existing scalar, via a new `Padding` schema mirroring `@floating-ui/dom`'s `Padding` type. The value is forwarded unchanged to the `flip`, `shift`, and `size` middleware. `S.optionalKey` keeps the per-side fields structurally assignable to Floating UI's `Partial<SideObject>` under `exactOptionalPropertyTypes`.
- Website: the playground menu anchor now passes `{ top: 88, right: 16, bottom: 16, left: 16 }`, where 88 is derived in code as `MD_HEADER_HEIGHT + VIEWPORT_PADDING` (the 4.5rem md+ header plus the shared 16px viewport padding). A flipped panel now stops below the header and scrolls internally instead of sliding under it.
- New `anchor.padding.test.ts` asserting per-side, scalar, and omitted padding are forwarded to all three middleware.
- Changeset: `@foldkit/ui` minor.

## Design decision

Rejected the one-line alternative of raising the panel above the header (`z-[60]`): it trades occlusion for the menu covering the site nav, and leaves every other anchored component with the same latent issue. Per-side padding fixes the class of bug at the positioning layer, matches Floating UI's own API shape, and is additive and non-breaking.

## Accepted tradeoffs

- The clearance is a static constant, so it cannot track `env(safe-area-inset-top)` or the 3.5rem sub-md header. On phones with no top inset it over-clears by 16px; on devices with a large inset the real header can exceed 88px and a flipped panel may still tuck slightly under it. A static `AnchorConfig` cannot read `env()`, and measuring the header at open time was judged disproportionate for this fix.
- `padding.top` is consulted when evaluating top placements. If the menu is already open and the page is scrolled until the button itself slides under the fixed header, the panel keeps `bottom-start` and its top sliver can sit under the header. That is inherent to anchored positioning once the anchor is occluded.

## Verification

- New anchor padding tests plus the existing anchor suites pass (17 tests across 3 files; full ui suite 987 tests).
- Full workspace typecheck, lint, format, and changeset status pass. The pre-push hook runs the complete suite (build, dead-code, all-package typecheck, tests, website e2e) on every push.
- An independent review pass verified the middleware mechanism against the Floating UI source and the schema usage against the vendored Effect source, and confirmed the new tests fail if the padding option is dropped, hardcoded, or a middleware removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)