### PR TITLE
fix(ui): report and gate the anchor positioning tick

### DIFF
--- a/.changeset/anchor-position-tick-gate.md
+++ b/.changeset/anchor-position-tick-gate.md
@@ -1,0 +1,13 @@
+---
+'@foldkit/ui': patch
+---
+
+Report a failed anchor positioning tick through `console.error` instead of letting it escape as an unhandled rejection, and apply the tick gate to every panel rather than only to placement-locked ones.
+
+`anchorSetup` positions through a promise chain that had no rejection handler. `computePosition` awaits platform measurement and every middleware, so a throw in any of them rejects the tick, and that rejection reached the window unhandled.
+
+It is now reported, rather than either escaping or being swallowed silently. A panel that never appears with nothing logged is the hard case to debug, since the caller renders `visibility: hidden` and only a successful tick clears it. A run of consecutive failures is reported once, because the panel repositions on every scroll and resize and a persistent failure would otherwise repeat on each one. A fresh failure after a recovery is reported again.
+
+The gate that keeps at most one tick in flight, so the last write always wins, was conditional on `isPlacementLocked`. That tied a concurrency guard to an unrelated positioning flag. It now applies to every anchored panel. This part changes no behavior: with the current `@floating-ui/dom` a tick settles inside a microtask chain, and each `autoUpdate` callback returns through a microtask checkpoint, so two ticks are never in flight together and the gate does not engage. It makes the invariant hold by construction rather than by coincidence.
+
+Placement locking is unchanged.

--- a/packages/ui/src/anchor/anchor.isPlacementLocked.test.ts
+++ b/packages/ui/src/anchor/anchor.isPlacementLocked.test.ts
@@ -80,11 +80,12 @@ vi.mock('@floating-ui/dom', async importOriginal => {
   }
 })
 
-describe('anchorSetup isPlacementLocked', () => {
+describe('anchorSetup placement locking and position ticks', () => {
   afterEach(() => {
     computePositionMock.mockReset()
     updateCallbacks.length = 0
     document.body.replaceChildren()
+    vi.restoreAllMocks()
   })
 
   const optionsOfCall = (callIndex: number): Partial<ComputePositionConfig> =>
@@ -287,6 +288,105 @@ describe('anchorSetup isPlacementLocked', () => {
     secondTick.resolve({ x: 30, y: 40, placement: 'top-start' })
     await waitForPosition(element, 30, 40)
     expect(computePositionMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces ticks that arrive while positioning without isPlacementLocked', async () => {
+    const firstTick = deferPosition()
+    const secondTick = deferPosition()
+    computePositionMock
+      .mockReturnValueOnce(firstTick.promise)
+      .mockReturnValueOnce(secondTick.promise)
+    const { element } = mountAnchor({
+      placement: 'bottom-start',
+      portal: false,
+    })
+
+    triggerUpdate(0)
+    triggerUpdate(0)
+
+    expect(computePositionMock).toHaveBeenCalledTimes(1)
+
+    firstTick.resolve({ x: 5, y: 6, placement: 'bottom-start' })
+    await waitForPosition(element, 5, 6)
+
+    await vi.waitFor(() => {
+      expect(computePositionMock).toHaveBeenCalledTimes(2)
+    })
+
+    secondTick.resolve({ x: 30, y: 40, placement: 'bottom-start' })
+    await waitForPosition(element, 30, 40)
+    expect(computePositionMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('lets the coalesced tick win the last write without isPlacementLocked', async () => {
+    const firstTick = deferPosition()
+    const secondTick = deferPosition()
+    computePositionMock
+      .mockReturnValueOnce(firstTick.promise)
+      .mockReturnValueOnce(secondTick.promise)
+    const { element } = mountAnchor({
+      placement: 'bottom-start',
+      portal: false,
+    })
+
+    triggerUpdate(0)
+
+    secondTick.resolve({ x: 99, y: 99, placement: 'bottom-start' })
+    firstTick.resolve({ x: 10, y: 20, placement: 'bottom-start' })
+    await flushPromises()
+
+    expect(element.style.left).toBe('99px')
+    expect(element.style.top).toBe('99px')
+  })
+
+  it('reports once and leaves the panel hidden while ticks reject', async () => {
+    const reportError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(Function.constVoid)
+    computePositionMock
+      .mockRejectedValueOnce(new Error('measurement failed'))
+      .mockRejectedValueOnce(new Error('measurement failed again'))
+      .mockResolvedValueOnce({ x: 10, y: 20, placement: 'bottom-start' })
+    const { element } = mountAnchor({
+      placement: 'bottom-start',
+      portal: false,
+    })
+    element.style.visibility = 'hidden'
+
+    await flushPromises()
+    triggerUpdate(0)
+    await flushPromises()
+
+    expect(reportError).toHaveBeenCalledTimes(1)
+    expect(element.style.visibility).toBe('hidden')
+
+    triggerUpdate(0)
+    await waitForPosition(element, 10, 20)
+
+    expect(reportError).toHaveBeenCalledTimes(1)
+    expect(element.style.visibility).toBe('')
+  })
+
+  it('reports a fresh failure after a tick has recovered', async () => {
+    const reportError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(Function.constVoid)
+    computePositionMock
+      .mockRejectedValueOnce(new Error('measurement failed'))
+      .mockResolvedValueOnce({ x: 10, y: 20, placement: 'bottom-start' })
+      .mockRejectedValueOnce(new Error('measurement failed later'))
+    const { element } = mountAnchor({
+      placement: 'bottom-start',
+      portal: false,
+    })
+
+    await flushPromises()
+    triggerUpdate(0)
+    await waitForPosition(element, 10, 20)
+    triggerUpdate(0)
+    await flushPromises()
+
+    expect(reportError).toHaveBeenCalledTimes(2)
   })
 
   it('exposes a horizontal side, not only top and bottom', async () => {

--- a/packages/ui/src/anchor/anchor.ts
+++ b/packages/ui/src/anchor/anchor.ts
@@ -189,6 +189,7 @@ export const anchorSetup = (
   let isActive = true
   let isPositioning = false
   let isPositioningQueued = false
+  let hasWarnedFailure = false
   let lockedPlacement: FloatingPlacement | undefined
 
   const positionElement = (): void => {
@@ -196,18 +197,23 @@ export const anchorSetup = (
       return
     }
 
-    if (isPlacementLockEnabled && isPositioning) {
+    // NOTE: with the current `@floating-ui/dom` a tick settles inside a
+    // microtask chain and each `autoUpdate` callback returns through a
+    // microtask checkpoint, so this never engages. It holds the invariant by
+    // construction if that changes.
+    if (isPositioning) {
       isPositioningQueued = true
       return
     }
 
-    if (isPlacementLockEnabled) {
-      isPositioning = true
-    }
     const isLocked = isPlacementLockEnabled && lockedPlacement !== undefined
     const requestedPlacement = lockedPlacement ?? placement ?? 'bottom-start'
 
-    computePosition(button, element, {
+    // NOTE: the promise is built before the gate closes, so a synchronous
+    // throw from `computePosition` or a middleware factory cannot leave
+    // `isPositioning` latched with no `finally` attached to release it. That
+    // would wedge every later tick behind the gate.
+    const tick = computePosition(button, element, {
       placement: requestedPlacement,
       strategy,
       middleware: [
@@ -235,47 +241,67 @@ export const anchorSetup = (
         }),
       ],
     })
-      .then(({ x, y, placement: resolvedPlacement }) => {
-        if (!isActive) {
-          return
-        }
 
-        element.style.left = `${x}px`
-        element.style.top = `${y}px`
+    isPositioning = true
 
-        if (isPlacementLockEnabled) {
-          lockedPlacement = lockedPlacement ?? resolvedPlacement
-        }
+    tick
+      .then(
+        ({ x, y, placement: resolvedPlacement }) => {
+          hasWarnedFailure = false
 
-        element.setAttribute(
-          'data-placement',
-          toSide(lockedPlacement ?? resolvedPlacement),
-        )
-
-        if (isFirstUpdate) {
-          isFirstUpdate = false
-          element.style.visibility = ''
-
-          if (config.focusAfterPosition ?? false) {
-            requestAnimationFrame(() => {
-              if (!isActive) {
-                return
-              }
-
-              const target = config.focusSelector
-                ? owner.querySelector(config.focusSelector)
-                : element
-              if (target instanceof HTMLElement) {
-                target.focus()
-              }
-            })
+          if (!isActive) {
+            return
           }
-        }
-      })
+
+          element.style.left = `${x}px`
+          element.style.top = `${y}px`
+
+          if (isPlacementLockEnabled) {
+            lockedPlacement = lockedPlacement ?? resolvedPlacement
+          }
+
+          element.setAttribute(
+            'data-placement',
+            toSide(lockedPlacement ?? resolvedPlacement),
+          )
+
+          if (isFirstUpdate) {
+            isFirstUpdate = false
+            element.style.visibility = ''
+
+            if (config.focusAfterPosition ?? false) {
+              requestAnimationFrame(() => {
+                if (!isActive) {
+                  return
+                }
+
+                const target = config.focusSelector
+                  ? owner.querySelector(config.focusSelector)
+                  : element
+                if (target instanceof HTMLElement) {
+                  target.focus()
+                }
+              })
+            }
+          }
+        },
+        // NOTE: `computePosition` awaits platform measurement and every
+        // middleware, so a throw in any of them rejects the tick. Reported
+        // once per run of consecutive failures, since `autoUpdate` would
+        // otherwise repeat a persistent failure on every scroll and resize,
+        // while a fresh failure after a recovery still gets its own report.
+        (error: unknown) => {
+          if (!hasWarnedFailure) {
+            hasWarnedFailure = true
+            console.error(
+              '[@foldkit/ui] anchorSetup could not position the panel. It keeps the visibility its caller rendered until positioning succeeds.',
+              error,
+            )
+          }
+        },
+      )
       .finally(() => {
-        if (isPlacementLockEnabled) {
-          isPositioning = false
-        }
+        isPositioning = false
 
         if (isActive && isPositioningQueued) {
           isPositioningQueued = false


### PR DESCRIPTION
Follow-up to #1045. Two things about `anchorSetup`'s positioning chain, found while documenting it.

## A failed tick went unreported

The chain had no rejection handler. `computePosition` awaits platform measurement and every middleware, so a throw in any of them rejects the tick, and that rejection reached the window unhandled.

It is now handled on the `then` rejection path rather than through a trailing `.catch`, which keeps the swallow narrow: a future throw in the fulfillment body stays visible instead of disappearing.

**It reports through `console.error`.** Handling the rejection without reporting it would trade an unhandled rejection for a panel that never appears with nothing logged, which is the harder of the two to debug. `error` rather than `warn` because `foldkit` splits them cleanly: `warn` for advisories (missing Vite plugin, duplicate DOM id, slow phase, duplicate sibling key) and `error` for work that failed (`[OnMount x] unhandled failure`, application crash, a port listener throwing). A panel that cannot position is a failure.

**Reported once per run of consecutive failures.** `autoUpdate` fires on scroll, resize, and layout shift, so a persistent failure would repeat on every one. The flag resets on a successful tick, so a fresh failure after a recovery is still reported.

**Not gated to development.** Foldkit does gate some diagnostics on `import.meta.hot` (the duplicate-id scanner, the duplicate-key warning, `schemaSegment` round-trip checks), but the split follows the same line as `warn` versus `error`: diagnostics are dev-only, failures are not. Silencing this in production would hide exactly the case you most need it for, a user reporting that a dropdown will not open with a clean console.

## The tick gate was conditional on an unrelated flag

`anchorSetup` runs at most one `computePosition` at a time and coalesces the ticks that arrive while one is in flight, so the last write always wins. That gate was conditional on `isPlacementLocked`, leaving it off for every panel that does not opt into placement locking, which is all of them by default. Three conditions dropped so it always applies.

The promise is now built before the gate closes. Setting the latch first would mean a synchronous throw from `computePosition` or a middleware factory could leave it latched with no `finally` attached to release it, wedging every later tick behind the gate with nothing logged. Not reachable today, but the gate is being justified as an invariant that holds by construction, so it should not depend on the wrapper happening not to throw.

**The gate change itself alters no behavior.** With the current `@floating-ui/dom` a tick settles inside a microtask chain: `@floating-ui/core@1.7.5` contains no `setTimeout`, `requestAnimationFrame`, or `new Promise` at all, and the three macrotask sources in `@floating-ui/dom@1.7.6` are on the `autoUpdate` / `observeMove` scheduling side rather than in the compute path. Each `autoUpdate` callback returns through a microtask checkpoint, so two ticks are never in flight together and the gate does not engage.

## No docs change

An earlier revision added a paragraph to the Anchor page describing the reporting. It is removed. A reader cannot catch the failure either way, so "reported rather than thrown" is not a decision they make; the page already explains that the panel must start hidden and that only a successful position clears it; and the console message is self-describing. That was release-note content in an API reference, and it lives in the changeset instead.

## Scope

Placement locking is unchanged. It still locks the first resolved side, drops `flip` from later ticks, and holds that side in `data-placement`. All ten existing placement-lock tests pass untouched.

Four tests cover the default path. Each was mutation checked, not just observed passing:

| Test | Mutation | Result |
| --- | --- | --- |
| coalesces ticks that arrive while positioning | gate left conditional | 2 calls, asserts 1 |
| lets the coalesced tick win the last write | gate left conditional | `10px`, asserts `99px` |
| reports once and leaves the panel hidden | rejection path clears visibility | `''`, asserts `'hidden'` |
| reports once and leaves the panel hidden | report every failure | called 2 times, asserts 1 |
| reports a fresh failure after a recovery | reset removed | called 1 time, asserts 2 |

They live in `anchor.isPlacementLocked.test.ts` rather than a new file because the mock harness they need is already there. Splitting that harness out is #1051.

## Considered and rejected

Replacing the gate with a generation counter. A counter guards writes while the gate limits concurrency, so once at most one tick is in flight the counter can never fire and would be dead code. The coalescing is also deliberate, and `computePosition` measures the DOM.

## Follow-ups filed

- #1050, the dead `try`/`catch` around `element.remove()` in `portalToContainingRoot`
- #1051, extracting the shared `@floating-ui/dom` test harness and splitting these files by feature
- #1054, reporting an unresolved `buttonId`, which is the common real cause of a panel that never appears and is still silent

## Checks

`@foldkit/ui` at 991 tests (up from 987), `website` at 368, typecheck, lint, `format:check`, and the changeset checks all pass. Rebased onto `main` at 6fd31988. A `patch` changeset is included.