### PR TITLE
fix(website): align doc heading ids with their heading text

### DIFF
--- a/packages/website/src/markdown/demoLabel.ts
+++ b/packages/website/src/markdown/demoLabel.ts
@@ -1,0 +1,72 @@
+import { Array, Match as M, Option, Record as Record_ } from 'effect'
+
+import type { Island, MarkdownDocument } from '@foldkit/markdown'
+
+import type { HeadingIds } from './tableOfContents'
+
+// DEMO LABEL
+
+/** The id of the heading each `::Demo` island sits under, by the demo's name. */
+export type DemoLabels = ReadonlyMap<string, string>
+
+type DemoLabelEntry = readonly [demoName: string, headingId: string]
+
+type DemoLabelWalk = Readonly<{
+  maybeHeadingId: Option.Option<string>
+  entries: ReadonlyArray<DemoLabelEntry>
+}>
+
+const DEMO_ISLAND_NAME = 'Demo'
+
+const demoLabelEntry = (
+  island: Island,
+  maybeHeadingId: Option.Option<string>,
+): Option.Option<DemoLabelEntry> => {
+  if (island.name === DEMO_ISLAND_NAME) {
+    return Option.map(
+      Option.all([Record_.get(island.attributes, 'name'), maybeHeadingId]),
+      ([demoName, headingId]) => [demoName, headingId],
+    )
+  } else {
+    return Option.none()
+  }
+}
+
+/**
+ * Pairs every `::Demo` island with the heading it sits under, so the island view
+ * can render the demo as a region labelled by that heading. Ids come from the map
+ * {@link collectHeadings} already assigned rather than a second slug pass, so a
+ * demo's label cannot drift from the heading it points at. A demo with no heading
+ * above it is absent from the map and renders unlabelled.
+ */
+export const collectDemoLabels = (
+  document: MarkdownDocument,
+  idByHeading: HeadingIds,
+): DemoLabels =>
+  new Map(
+    Array.reduce(
+      document.blocks,
+      {
+        maybeHeadingId: Option.none<string>(),
+        entries: Array.empty<DemoLabelEntry>(),
+      },
+      (walk: DemoLabelWalk, block) =>
+        M.value(block).pipe(
+          M.withReturnType<DemoLabelWalk>(),
+          M.tag('Heading', heading => ({
+            maybeHeadingId: Option.fromNullishOr(idByHeading.get(heading)),
+            entries: walk.entries,
+          })),
+          M.tag('Island', island =>
+            Option.match(demoLabelEntry(island, walk.maybeHeadingId), {
+              onNone: () => walk,
+              onSome: entry => ({
+                maybeHeadingId: walk.maybeHeadingId,
+                entries: Array.append(walk.entries, entry),
+              }),
+            }),
+          ),
+          M.orElse(() => walk),
+        ),
+    ).entries,
+  )

--- a/packages/website/src/markdown/docPage.test.ts
+++ b/packages/website/src/markdown/docPage.test.ts
@@ -1,21 +1,30 @@
-import { Array, Option, Result, String as String_ } from 'effect'
+import { Array, Match as M, Option, Result, String as String_ } from 'effect'
 import { inertHtml as ih } from 'foldkit/html'
 import { describe, expect, test } from 'vitest'
 
 import { parseMarkdown } from '@foldkit/markdown/vite'
 
+import { PostFrontmatter } from '../page/blog/frontmatter'
 import comingFromReactSource from '../page/comingFromReact/comingFromReact.md?raw'
 import { FAQ_IDS } from '../page/comingFromReact/faq'
 import commandsSource from '../page/core/commands.md?raw'
 import submodelSource from '../page/core/submodel.md?raw'
 import manifestoSource from '../page/manifesto.md?raw'
+import comboboxPageSource from '../page/ui/comboboxPage.md?raw'
+import { collectDemoLabels } from './demoLabel'
 import { islandAttributes } from './islandAttributes'
-import { slugify, stripHeadingIdMarker } from './slug'
+import { parseHeadingId, slugify, stripHeadingIdMarker } from './slug'
 import { collectHeadings } from './tableOfContents'
 
+// NOTE: mirrors the options the website's markdown plugin runs with, so a check
+// over every page's source reads the same documents the site builds.
+const markdownOptions = {
+  islands: islandAttributes,
+  frontmatter: PostFrontmatter,
+}
+
 const tocOf = (source: string) =>
-  collectHeadings(parseMarkdown(source, { islands: islandAttributes }))
-    .tableOfContents
+  collectHeadings(parseMarkdown(source, markdownOptions)).tableOfContents
 
 describe('slugify', () => {
   test('lowercases and dashes non-alphanumeric runs', () => {
@@ -25,6 +34,11 @@ describe('slugify', () => {
     expect(slugify('Build Your Product, Not Your Architecture')).toBe(
       'build-your-product-not-your-architecture',
     )
+  })
+
+  test('drops apostrophes instead of dashing them', () => {
+    expect(slugify('Don’t Compute in Update')).toBe('dont-compute-in-update')
+    expect(slugify("What's in it")).toBe('whats-in-it')
   })
 })
 
@@ -319,6 +333,12 @@ const markdownSources = import.meta.glob('../page/**/*.md', {
   eager: true,
 })
 
+const pageSources = import.meta.glob('../page/**/*.ts', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+})
+
 const COMING_FROM_REACT_PATH = '../page/comingFromReact/comingFromReact.md'
 
 const capturedNames = (
@@ -365,12 +385,6 @@ describe('faq island registration', () => {
 const DEMO_ISLAND_PATTERN = /::Demo\{name="([^"]+)"\}/g
 
 describe('demo island registration', () => {
-  const pageSources = import.meta.glob('../page/**/*.ts', {
-    query: '?raw',
-    import: 'default',
-    eager: true,
-  })
-
   const demoUsages = Array.filterMap(
     Object.entries(markdownSources),
     ([markdownPath, source]) => {
@@ -453,4 +467,107 @@ describe('snippet island registration', () => {
       expect(missing, `${markdownPath} references missing snippets`).toEqual([])
     },
   )
+})
+
+type HeadingOverride = Readonly<{ id: string; text: string }>
+
+const explicitHeadingIds = (source: string): ReadonlyArray<HeadingOverride> =>
+  Array.filterMap(parseMarkdown(source, markdownOptions).blocks, block =>
+    M.value(block).pipe(
+      M.withReturnType<Result.Result<HeadingOverride, void>>(),
+      M.tag('Heading', heading => {
+        const { maybeId, text } = parseHeadingId(heading.content)
+
+        return Result.fromOption(
+          Option.map(maybeId, id => ({ id, text })),
+          () => undefined,
+        )
+      }),
+      M.orElse(() => Result.failVoid),
+    ),
+  )
+
+// NOTE: a `{#id}` marker earns its place only when `slugify` would derive
+// something else, such as kebab-casing an identifier or pinning a short anchor
+// under a long heading. One that repeats the derived id reads as a convention
+// the next heading has to follow, and it silently stops matching the heading the
+// first time that heading is reworded.
+describe('heading id overrides', () => {
+  const overrideUsages = Array.filterMap(
+    Object.entries(markdownSources),
+    ([markdownPath, source]) =>
+      Array.match(explicitHeadingIds(String(source)), {
+        onEmpty: () => Result.failVoid,
+        onNonEmpty: overrides => Result.succeed({ markdownPath, overrides }),
+      }),
+  )
+
+  test('finds heading id overrides to check', () => {
+    expect(Array.isArrayNonEmpty(overrideUsages)).toBe(true)
+  })
+
+  test.each(overrideUsages)(
+    '$markdownPath overrides only the ids slugify would not derive',
+    ({ markdownPath, overrides }) => {
+      const redundant = overrides.filter(({ id, text }) => id === slugify(text))
+
+      expect(
+        redundant,
+        `${markdownPath} repeats the derived id in a {#id} marker`,
+      ).toEqual([])
+    },
+  )
+})
+
+// NOTE: every demo sits under a heading, so each one renders as a region named
+// by that heading. This walks the same documents the site builds and checks the
+// pairing holds, since a demo that drifts above its heading loses its accessible
+// name silently.
+describe('demo section labels', () => {
+  const labelUsages = Array.filterMap(
+    Object.entries(markdownSources),
+    ([markdownPath, source]) => {
+      const names = capturedNames(String(source), DEMO_ISLAND_PATTERN)
+
+      return Array.match(names, {
+        onEmpty: () => Result.failVoid,
+        onNonEmpty: presentNames =>
+          Result.succeed({ markdownPath, names: presentNames, source }),
+      })
+    },
+  )
+
+  test('finds demo islands to check', () => {
+    expect(Array.isArrayNonEmpty(labelUsages)).toBe(true)
+  })
+
+  test.each(labelUsages)(
+    '$markdownPath labels every demo with the heading above it',
+    ({ markdownPath, names, source }) => {
+      const document = parseMarkdown(String(source), markdownOptions)
+      const demoLabels = collectDemoLabels(
+        document,
+        collectHeadings(document).idByHeading,
+      )
+      const unlabeled = names.filter(name => demoLabels.get(name) === undefined)
+
+      expect(unlabeled, `${markdownPath} has demos with no heading`).toEqual([])
+    },
+  )
+
+  test('labels the combobox demos with their own section headings', () => {
+    const document = parseMarkdown(comboboxPageSource, markdownOptions)
+    const demoLabels = collectDemoLabels(
+      document,
+      collectHeadings(document).idByHeading,
+    )
+
+    expect(Object.fromEntries(demoLabels)).toEqual({
+      'single-select': 'single-select',
+      nullable: 'nullable',
+      'select-on-focus': 'select-on-focus',
+      'locked-placement': 'locked-placement',
+      multi: 'multi-select',
+    })
+  })
 })

--- a/packages/website/src/markdown/docPage.ts
+++ b/packages/website/src/markdown/docPage.ts
@@ -7,6 +7,7 @@ import { type TableOfContentsEntry } from '../main'
 import { type Message } from '../message'
 import { defaultRenderHeadingLink } from '../prose'
 import { type CopiedSnippets, defaultRenderCopyButton } from '../view/codeBlock'
+import { type DemoLabels, collectDemoLabels } from './demoLabel'
 import { docIslands } from './islands'
 import { type Slots } from './slots'
 import { type HeadingIds, collectHeadings } from './tableOfContents'
@@ -18,6 +19,7 @@ const renderDocument = (
   document: Markdown.MarkdownDocument,
   pageId: string,
   idByHeading: HeadingIds,
+  demoLabels: DemoLabels,
   slots: Slots<string>,
 ): Html =>
   Markdown.view(document, {
@@ -27,7 +29,7 @@ const renderDocument = (
       renderCopyButton: slots.renderCopyButton,
       renderHeadingLink: slots.renderHeadingLink,
     }),
-    islands: docIslands(slots),
+    islands: docIslands(slots, demoLabels),
   })
 
 /**
@@ -69,10 +71,12 @@ export const slotDocPage = <DemoName extends string = never>(
 ): SlotDocPage<DemoName> => {
   const document = Markdown.decodeDocument(raw)
   const { tableOfContents, idByHeading } = collectHeadings(document)
+  const demoLabels = collectDemoLabels(document, idByHeading)
 
   return {
     tableOfContents,
-    view: slots => renderDocument(document, pageId, idByHeading, slots),
+    view: slots =>
+      renderDocument(document, pageId, idByHeading, demoLabels, slots),
   }
 }
 

--- a/packages/website/src/markdown/islands.ts
+++ b/packages/website/src/markdown/islands.ts
@@ -1,15 +1,28 @@
 import { Option } from 'effect'
-import { inertHtml as ih } from 'foldkit/html'
+import { Html, inertHtml as ih } from 'foldkit/html'
 
 import * as Markdown from '@foldkit/markdown'
 
 import { ctaLinks, infoCalloutBlocks, warningCalloutBlocks } from '../prose'
 import { highlightedCodeBlock } from '../view/codeBlock'
+import type { DemoLabels } from './demoLabel'
 import { islandAttributes } from './islandAttributes'
 import { type Slots, renderFaqSection, resolveDemo } from './slots'
 import { lookupSnippet } from './snippets'
 
 // ISLANDS
+
+/**
+ * Renders a demo as a region labelled by the heading it sits under, so a page of
+ * near-identical demos is navigable: a screen reader user landing on one of the
+ * five comboboxes on the Combobox page hears which example they are in. A demo
+ * the document leaves unlabelled renders bare rather than as an unnamed region.
+ */
+const demoRegion = (demoLabels: DemoLabels, name: string, demo: Html): Html =>
+  Option.match(Option.fromNullishOr(demoLabels.get(name)), {
+    onNone: () => demo,
+    onSome: headingId => ih.section([ih.AriaLabelledBy(headingId)], [demo]),
+  })
 
 /**
  * The site's island views, paired with {@link islandAttributes} so attributes
@@ -25,7 +38,10 @@ import { lookupSnippet } from './snippets'
  * which the snippet registration test is there to catch. The views stay pure, so
  * a missing snippet reports at test time rather than warning from a render.
  */
-export const docIslands = (slots: Slots<string>): Markdown.Islands => {
+export const docIslands = (
+  slots: Slots<string>,
+  demoLabels: DemoLabels,
+): Markdown.Islands => {
   return Markdown.islandsFor(islandAttributes, {
     Snippet: ({ name, label, class: className }) =>
       Option.match(lookupSnippet(name), {
@@ -48,7 +64,7 @@ export const docIslands = (slots: Slots<string>): Markdown.Islands => {
 
     Cta: (_attributes, content) => ctaLinks(content),
 
-    Demo: ({ name }) => resolveDemo(slots, name),
+    Demo: ({ name }) => demoRegion(demoLabels, name, resolveDemo(slots, name)),
 
     Faq: ({ id, question }, content) =>
       renderFaqSection(slots, id, question, content),

--- a/packages/website/src/markdown/slug.ts
+++ b/packages/website/src/markdown/slug.ts
@@ -40,11 +40,15 @@ export const inlineToText = (content: ReadonlyArray<Inline>): string =>
   )
 
 /**
- * Derives a URL fragment id from heading text: lowercased, with every run of
- * non-alphanumeric characters collapsed to a single dash and surrounding dashes
- * trimmed. `"HTTP Requests"` becomes `"http-requests"`.
+ * Derives a URL fragment id from heading text: lowercased, with apostrophes
+ * dropped, every run of non-alphanumeric characters collapsed to a single dash,
+ * and surrounding dashes trimmed. `"HTTP Requests"` becomes `"http-requests"`.
+ * Apostrophes go before the collapse so a contraction stays one word:
+ * `"Don’t Compute in Update"` becomes `"dont-compute-in-update"`, not
+ * `"don-t-compute-in-update"`.
  */
 export const slugify: (text: string) => string = flow(
+  String.replaceAll(/['’]/g, ''),
   String.toLowerCase,
   String.replaceAll(/[^a-z0-9]+/g, '-'),
   String.replaceAll(/^-+|-+$/g, ''),

--- a/packages/website/src/page/bestPractices/sideEffectsAndPurity.md
+++ b/packages/website/src/page/bestPractices/sideEffectsAndPurity.md
@@ -62,7 +62,7 @@ This purity has a practical payoff: testing is trivial. Foldkit ships `foldkit/t
 
 A common mistake is computing random or time-based values directly in `update`. This breaks purity. Calling the function twice with the same inputs would return different results.
 
-### Don’t Compute in Update {#dont-compute-in-update}
+### Don’t Compute in Update
 
 ::Snippet{name="pureUpdateBad" label="bad example"}
 

--- a/packages/website/src/page/typingTerminal.md
+++ b/packages/website/src/page/typingTerminal.md
@@ -20,7 +20,7 @@ The repo splits into three packages.
 
 No new framework concepts are involved. The architecture is the same one [Counter](/example-apps/counter) uses. The interesting part is what falls out when that architecture meets a real backend: shared schemas across the wire, a typed RPC client without runtime decoders, a streaming [Subscription](/core/subscriptions) that owns reconnect logic, and [Commands](/core/commands) that map cleanly to RPC calls.
 
-## What’s in it {#whats-in-it}
+## What’s in it
 
 - Multiplayer rooms with hosts and joiners, joined by a short room code
 - A `Waiting | GetReady | Countdown | Playing | Finished` state machine modelled as a discriminated union on the server, mirrored on the client

--- a/packages/website/src/page/ui/animationPage.md
+++ b/packages/website/src/page/ui/animationPage.md
@@ -118,9 +118,9 @@ Configuration object passed to `Animation.view()`.
 | `attributes`  | `ReadonlyArray<Attribute<Message>>` | —       | Additional attributes for the wrapper.                                                                                                             |
 | `element`     | `TagName`                           | `'div'` | The HTML element for the wrapper.                                                                                                                  |
 
-### OutMessages {#out-messages}
+### OutMessage
 
-OutMessages emitted from `Animation.update()`. Fold these in the `foldOutMessage` of your [`Update.foldChild`](/core/submodel#fold-child) config.
+Messages emitted to the parent through the third element of `[Model, Commands, Option<OutMessage>]`. Fold the OutMessage in the `foldOutMessage` of your [`Update.foldChild`](/core/submodel#fold-child) config.
 
 | Name                    | Type         | Default | Description                                                                                                                                                                     |
 | ----------------------- | ------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/website/src/page/ui/calendarPage.md
+++ b/packages/website/src/page/ui/calendarPage.md
@@ -119,7 +119,7 @@ Attribute groups and derived data provided to the `toView` callback.
 | `weeks`                                 | `ReadonlyArray<Week<Message>>`                                             | —       | (Days only.) Six week rows. Each Week carries its own row attributes (role="row", aria-rowindex) and seven DayCells. DayCells carry cellAttributes (role="gridcell", aria-colindex), buttonAttributes (type="button", aria-label, click), the day label string, and state flags (isToday, isSelected, isFocused, isInViewMonth, isDisabled).                                                                                                                                                                                                             |
 | `cells`                                 | `ReadonlyArray<MonthCell<Message>> \| ReadonlyArray<YearCell<Message>>`    | —       | (Months, Years.) Twelve cells. In Months mode each cell carries the month number (1-12), the full localized name (label, e.g. "September"), and the localized abbreviation (shortLabel, e.g. "Sep"). Render whichever fits, never substring label to abbreviate. In Years mode each cell carries a year from the current 12-year window. Both expose cellAttributes (role="gridcell", aria-selected), buttonAttributes (click dispatches SelectedMonth/SelectedYear), and state flags (isSelected, isFocused, isCurrentMonth/isCurrentYear, isDisabled). |
 
-### OutMessage {#out-messages}
+### OutMessage {#out-message}
 
 Messages emitted to the parent through the third element of `[Model, Commands, Option<OutMessage>]`. Parents fold the OutMessage in the `foldOutMessage` of their [`Update.foldChild`](/core/submodel#fold-child) config.
 

--- a/packages/website/src/page/ui/combobox.ts
+++ b/packages/website/src/page/ui/combobox.ts
@@ -10,7 +10,6 @@ import { Combobox } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/combobox'
 
 import { Icon } from '../../icon'
-import type { TableOfContentsEntry } from '../../main'
 import {
   GotComboboxDemoMessage,
   GotComboboxMultiDemoMessage,
@@ -20,38 +19,6 @@ import {
   type Message,
 } from './message'
 import type { City } from './model'
-
-// TABLE OF CONTENTS
-
-export const singleSelectHeader: TableOfContentsEntry = {
-  level: 'h3',
-  id: 'combobox-single-select',
-  text: 'Single-Select',
-}
-
-export const nullableHeader: TableOfContentsEntry = {
-  level: 'h3',
-  id: 'combobox-nullable',
-  text: 'Nullable',
-}
-
-export const selectOnFocusHeader: TableOfContentsEntry = {
-  level: 'h3',
-  id: 'combobox-select-on-focus',
-  text: 'Select on Focus',
-}
-
-export const placementLockHeader: TableOfContentsEntry = {
-  level: 'h3',
-  id: 'combobox-locked-placement',
-  text: 'Locked Placement',
-}
-
-export const multiHeader: TableOfContentsEntry = {
-  level: 'h3',
-  id: 'combobox-multi',
-  text: 'Multi-Select',
-}
 
 // DEMO CONTENT
 

--- a/packages/website/src/page/ui/comboboxPage.md
+++ b/packages/website/src/page/ui/comboboxPage.md
@@ -16,7 +16,7 @@ Check out how Combobox is wired up in a [real Foldkit app](https://github.com/fo
 
 ## Examples
 
-### Single-Select {#combobox-single-select}
+### Single-Select
 
 Pass `itemToValue` and `itemToDisplayText` to control how items map to values and what text appears in the input on selection. Filter the `items` array yourself based on `model.inputValue`.
 
@@ -24,7 +24,7 @@ Pass `itemToValue` and `itemToDisplayText` to control how items map to values an
 
 ::Snippet{name="uiComboboxBasic" label="combobox example"}
 
-### Nullable {#combobox-nullable}
+### Nullable
 
 Pass `nullable: true` at init to allow clearing the selection by clicking the selected item again, or by emptying the input and closing. Both paths reach the parent as OutMessages (`Selected` toggles, `ClearedSelection` clears), so the parent decides what an empty selection looks like.
 
@@ -32,13 +32,13 @@ Pass `nullable: true` at init to allow clearing the selection by clicking the se
 
 ::Demo{name="nullable"}
 
-### Select on Focus {#combobox-select-on-focus}
+### Select on Focus
 
 Pass `selectInputOnFocus: true` at init to highlight the input text when the combobox receives focus. Typing immediately replaces the current value, making it easy to start a new search.
 
 ::Demo{name="select-on-focus"}
 
-### Locked Placement {#combobox-locked-placement}
+### Locked Placement
 
 Set `anchor.isPlacementLocked` to `true` when a panel should keep the side chosen when it opens, even if its size changes. Focus the input, then type `Zurich`. The tall list initially opens above the input. After filtering, the list is short enough to fit below, but it stays above until it closes.
 
@@ -46,7 +46,7 @@ To make the behavior reproducible at any scroll position, this demo keeps the pa
 
 ::Demo{name="locked-placement"}
 
-### Multi-Select {#combobox-multi}
+### Multi-Select
 
 Use `Combobox.Multi` for multi-selection. The dropdown stays open on selection and items toggle on/off. The parent stores the selected values and folds each `Selected` OutMessage by toggling the value in its array.
 
@@ -54,7 +54,7 @@ Use `Combobox.Multi` for multi-selection. The dropdown stays open on selection a
 
 ::Snippet{name="uiComboboxMulti" label="multi-select combobox example"}
 
-## Read-Only {#read-only}
+## Read-Only
 
 `isReadOnly` keeps the Combobox browsable but not committable. It still opens from `Arrow Down`, `Arrow Up`, the toggle button, and `openOnFocus`, still navigates with `Arrow Down`, `Arrow Up`, `Home`, and `End`, still tracks the active item through `aria-activedescendant` and pointer hover, and still closes on `Escape`, blur, and a backdrop click. The input still takes focus, and its text can still be selected and copied.
 

--- a/packages/website/src/page/ui/comboboxPage.ts
+++ b/packages/website/src/page/ui/comboboxPage.ts
@@ -28,65 +28,40 @@ export const view = Submodel.defineView<Model, Message, ViewInputs>(
   (model, { renderCopyButton, renderHeadingLink }, h): Html =>
     renderPage({
       demos: {
-        'single-select': h.section(
-          [h.AriaLabelledBy(Combobox.singleSelectHeader.id)],
-          [
-            demoContainer(
-              ...Combobox.comboboxDemo(
-                model.comboboxDemo,
-                model.maybeComboboxDemoSelectedCity,
-                h,
-              ),
-            ),
-          ],
+        'single-select': demoContainer(
+          ...Combobox.comboboxDemo(
+            model.comboboxDemo,
+            model.maybeComboboxDemoSelectedCity,
+            h,
+          ),
         ),
-        nullable: h.section(
-          [h.AriaLabelledBy(Combobox.nullableHeader.id)],
-          [
-            demoContainer(
-              ...Combobox.nullableDemo(
-                model.comboboxNullableDemo,
-                model.maybeComboboxNullableDemoSelectedCity,
-                h,
-              ),
-            ),
-          ],
+        nullable: demoContainer(
+          ...Combobox.nullableDemo(
+            model.comboboxNullableDemo,
+            model.maybeComboboxNullableDemoSelectedCity,
+            h,
+          ),
         ),
-        'select-on-focus': h.section(
-          [h.AriaLabelledBy(Combobox.selectOnFocusHeader.id)],
-          [
-            demoContainer(
-              ...Combobox.selectOnFocusDemo(
-                model.comboboxSelectOnFocusDemo,
-                model.maybeComboboxSelectOnFocusDemoSelectedCity,
-                h,
-              ),
-            ),
-          ],
+        'select-on-focus': demoContainer(
+          ...Combobox.selectOnFocusDemo(
+            model.comboboxSelectOnFocusDemo,
+            model.maybeComboboxSelectOnFocusDemoSelectedCity,
+            h,
+          ),
         ),
-        'locked-placement': h.section(
-          [h.AriaLabelledBy(Combobox.placementLockHeader.id)],
-          [
-            demoContainer(
-              ...Combobox.placementLockDemo(
-                model.comboboxPlacementLockDemo,
-                model.maybeComboboxPlacementLockDemoSelectedCity,
-                h,
-              ),
-            ),
-          ],
+        'locked-placement': demoContainer(
+          ...Combobox.placementLockDemo(
+            model.comboboxPlacementLockDemo,
+            model.maybeComboboxPlacementLockDemoSelectedCity,
+            h,
+          ),
         ),
-        multi: h.section(
-          [h.AriaLabelledBy(Combobox.multiHeader.id)],
-          [
-            demoContainer(
-              ...Combobox.multiDemo(
-                model.comboboxMultiDemo,
-                model.comboboxMultiDemoSelectedCities,
-                h,
-              ),
-            ),
-          ],
+        multi: demoContainer(
+          ...Combobox.multiDemo(
+            model.comboboxMultiDemo,
+            model.comboboxMultiDemoSelectedCities,
+            h,
+          ),
         ),
       },
       renderCopyButton,

--- a/packages/website/src/page/ui/datePickerPage.md
+++ b/packages/website/src/page/ui/datePickerPage.md
@@ -109,7 +109,7 @@ Configuration object passed to `DatePicker.view()`.
 
 The discriminated union passed to `toCalendarView`. Pattern-match on `_tag` (`'Days' | 'Months' | 'Years'`) with `M.tagsExhaustive` to render each grid. Each variant exposes a different shape: Days carries weeks plus a headingButton; Months carries 12 month cells plus a headingButton; Years carries 12 year cells plus prev/next page buttons. See [the Calendar page's CalendarAttributes section](/ui/calendar) for the full prop table. The type is the same.
 
-### OutMessage {#out-messages}
+### OutMessage {#out-message}
 
 Messages emitted to the parent through the third element of `[Model, Commands, Option<OutMessage>]`. Fold the OutMessage in the `foldOutMessage` of your [`Update.foldChild`](/core/submodel#fold-child) config.
 

--- a/packages/website/src/page/ui/dialogPage.md
+++ b/packages/website/src/page/ui/dialogPage.md
@@ -10,7 +10,7 @@ Check out how Dialog is wired up in a [real Foldkit app](https://github.com/fold
 
 ## Examples
 
-### Basic {#dialog-basic}
+### Basic
 
 Open the dialog from a trigger by dispatching your own Message and calling `Dialog.open(model)` in your update. Spread the `closeButton` bundle onto a Cancel button to dismiss it, or call `Dialog.close(model)` directly. Both return `[Model, Commands, Option<OutMessage>]`. Spread `...title` onto a heading element so the dialog is labeled for screen readers.
 
@@ -18,7 +18,7 @@ Open the dialog from a trigger by dispatching your own Message and calling `Dial
 
 ::Snippet{name="uiDialogBasic" label="dialog example"}
 
-### Animated {#dialog-animated}
+### Animated
 
 Pass `isAnimated: true` at init to coordinate animations. The component manages an Animation submodel internally. Apply transition classes using `data-closed` (e.g. `data-[closed]:opacity-0 data-[closed]:scale-95`).
 
@@ -26,7 +26,7 @@ Pass `isAnimated: true` at init to coordinate animations. The component manages 
 
 ::Snippet{name="uiDialogAnimated" label="animated dialog example"}
 
-### Field {#dialog-field}
+### Field
 
 A field inside a dialog can open its own overlay, like a Combobox or DatePicker. By default that overlay portals its panel to the document body, where the dialog renders on top of it. Pass `anchor: { portal: false }` so the panel stays inside the dialog and remains visible.
 
@@ -34,7 +34,7 @@ A field inside a dialog can open its own overlay, like a Combobox or DatePicker.
 
 ::Snippet{name="uiDialogOverlay" label="field dialog example"}
 
-### Stacked {#dialog-stacked}
+### Stacked
 
 Use a separate Dialog Model for each level and open the second from a button in the first. The framework stacks them by z-index, traps focus in the topmost, and closes them one at a time: Escape closes the top dialog before the one beneath it.
 

--- a/packages/website/src/page/ui/listboxPage.md
+++ b/packages/website/src/page/ui/listboxPage.md
@@ -16,7 +16,7 @@ Check out how Listbox is wired up in a [real Foldkit app](https://github.com/fol
 
 ## Examples
 
-### Single-Select {#single-select-listbox}
+### Single-Select
 
 Pass an `itemToConfig` callback that maps each item to its content. The context provides `isSelected` and `isActive` for styling the highlighted and selected states.
 
@@ -24,7 +24,7 @@ Pass an `itemToConfig` callback that maps each item to its content. The context 
 
 ::Snippet{name="uiListboxBasic" label="listbox example"}
 
-### Multi-select {#multi-select-listbox}
+### Multi-select
 
 Use `Listbox.Multi` for multi-selection. The dropdown stays open on selection and items toggle on/off. The parent stores the selected values and folds each `Selected` OutMessage by toggling the value in its array.
 
@@ -32,7 +32,7 @@ Use `Listbox.Multi` for multi-selection. The dropdown stays open on selection an
 
 ::Snippet{name="uiListboxMulti" label="multi-select listbox example"}
 
-### Grouped {#grouped-listbox}
+### Grouped
 
 Pass `itemGroupKey` to group contiguous items by key, and `groupToHeading` to render section headers. Groups are separated automatically.
 
@@ -40,7 +40,7 @@ Pass `itemGroupKey` to group contiguous items by key, and `groupToHeading` to re
 
 ::Snippet{name="uiListboxGrouped" label="grouped listbox example"}
 
-## Read-Only {#read-only}
+## Read-Only
 
 `isReadOnly` keeps the Listbox browsable but not committable. It still opens from the button by click, `Enter`, `Space`, `Arrow Down`, and `Arrow Up`, and still closes by `Escape`, a backdrop click, and blur. Arrow, `Home`, `End`, `PageUp`, and `PageDown` navigation, typeahead search, and pointer hover all keep moving the active item. What a read-only Listbox never does is commit: items carry no click handler, and `Enter` or `Space` on the active item inside the items panel reports a `SuppressedItemCommit` Message that leaves the Model unchanged, so no `Selected` OutMessage ever reaches the parent. `Space` still types into a pending typeahead query, because there the key is a search character rather than a commit.
 

--- a/packages/website/src/page/ui/menuPage.md
+++ b/packages/website/src/page/ui/menuPage.md
@@ -14,7 +14,7 @@ Check out how Menu is wired up in a [real Foldkit app](https://github.com/foldki
 
 ## Examples
 
-### Basic {#basic-menu}
+### Basic
 
 Pair `view` and `update` behind `Menu.create<Item>()` at module scope. The factory threads your item union through both, so `Selected({ value, index })` carries the picked value directly. Menu closes automatically after selection.
 
@@ -22,7 +22,7 @@ Pair `view` and `update` behind `Menu.create<Item>()` at module scope. The facto
 
 ::Snippet{name="uiMenuBasic" label="menu example"}
 
-### Animated {#animated-menu}
+### Animated
 
 Pass `isAnimated: true` at init for animation coordination.
 

--- a/packages/website/src/page/ui/popoverPage.md
+++ b/packages/website/src/page/ui/popoverPage.md
@@ -12,7 +12,7 @@ Check out how Popover is wired up in a [real Foldkit app](https://github.com/fol
 
 ## Examples
 
-### Basic {#basic-popover}
+### Basic
 
 Pass `anchor` to position the panel relative to the button. The panel can hold any content: links, forms, or informational text.
 
@@ -20,13 +20,13 @@ Pass `anchor` to position the panel relative to the button. The panel can hold a
 
 ::Snippet{name="uiPopoverBasic" label="popover example"}
 
-### Animated {#animated-popover}
+### Animated
 
 Pass `isAnimated: true` at init for animation coordination.
 
 ::Demo{name="animated"}
 
-### Nested {#nested-popovers}
+### Nested
 
 Use a separate Popover Model for each level. For a parent panel that opens onto another Popover trigger, pass `contentFocus: true` at init and `focusSelector` in the view so focus lands on the nested trigger.
 

--- a/packages/website/src/page/ui/radioGroupPage.md
+++ b/packages/website/src/page/ui/radioGroupPage.md
@@ -30,7 +30,7 @@ Pass `orientation: 'Horizontal'` in the view inputs to switch to left/right arro
 
 ::Demo{name="horizontal"}
 
-## Read-Only {#read-only}
+## Read-Only
 
 `isReadOnly` keeps the group navigable but not selectable. Arrow, `Home`, `End`, `PageUp`, and `PageDown` still move focus, and the group reports each move as a `FocusedOption` Message, so the focused option is stored in the RadioGroup Model rather than left as an untracked DOM detail. `data-active`, `isActive`, and `tabindex` all follow that modeled focus, which means a read-only group's focus ring lands where the keyboard actually is instead of staying pinned to the selection. Space and clicking do nothing, and no `Selected` OutMessage ever reaches the parent.
 

--- a/packages/website/src/page/ui/sliderPage.md
+++ b/packages/website/src/page/ui/sliderPage.md
@@ -103,7 +103,7 @@ Attribute groups provided to the `toView` callback.
 | `label`       | `ReadonlyArray<Attribute<Message>>` | —       | Spread onto the visible label element. Carries the id the thumb’s aria-labelledby points to by default.                                                                                              |
 | `hiddenInput` | `ReadonlyArray<Attribute<Message>>` | —       | Spread onto a hidden `<input>` for form submission. Only populated when the name prop is set.                                                                                                        |
 
-### OutMessage {#out-messages}
+### OutMessage {#out-message}
 
 Messages emitted to the parent through the third element of `[Model, Commands, Option<OutMessage>]`. Parents fold the OutMessage in the `foldOutMessage` of their [`Update.foldChild`](/core/submodel#fold-child) config.
 


### PR DESCRIPTION
A `{#id}` marker on a docs heading earns its place only when `slugify` would derive something else, such as kebab-casing an identifier (`ViewConfig` → `view-config`) or pinning a short anchor under a long heading (`## The Biparser Approach {#biparser}`). Auditing all 837 headings across the 87 page markdown files turned up 262 markers, and several had drifted away from that rule. This keeps the rule and fixes the drift.

## The `OutMessage` sections

Every UI component exports a type named `OutMessage`, and each page's API reference section names that type, sitting in a run alongside `InitConfig`, `ViewConfig`, and `RenderInfo`.

Three of those sections, on the Calendar, Date Picker, and Slider pages, carried a plural `{#out-messages}` id under a singular heading. The Animation page headed the section `OutMessages` outright. All of them now read `OutMessage`, matching both the exported type and the six pages that already did, and the Animation section's prose follows the wording its siblings use. That section drops its marker along with the plural, since a singular heading derives `out-message` on its own.

Variant count is not what these headings name: Popover and Calendar both union two variants and both read singular. `core/submodel.md`'s "Defining OutMessages" heading stays plural, since that one is prose about writing several, not a reference to a type.

## Demo section anchors

These ran three conventions at once:

- prefixed: `dialog-basic`, `combobox-single-select`
- suffixed: `basic-menu`, `single-select-listbox`, `basic-popover`
- bare: `read-only` on the Combobox, Listbox, and Radio Group pages, sitting next to qualified siblings in the same file

Plus pluralization drift inside one file (`basic-popover`, `animated-popover`, `nested-popovers`) and one abbreviation (`combobox-multi` for a `Multi-Select` heading that the Listbox page spells out).

Heading ids are page-scoped, so the page-name qualifier bought nothing: `/ui/menu#basic` says everything `/ui/menu#basic-menu` did. Those 17 markers are gone and the headings derive their own ids.

## Apostrophes in `slugify`

`slugify` turned `’` into a dash, so `Don’t Compute in Update` would derive `don-t-compute-in-update`. Every apostrophe heading in the docs carried a hand-written marker to dodge that. It now drops apostrophes before collapsing runs, and the two markers that only restated the derived id are gone. The two that are real shortenings stayed.

## Demo sections become labelled regions everywhere

Chasing the anchor renames surfaced why the Combobox page was the only one holding heading ids in TypeScript: it wraps each demo in a `<section>` labelled by its heading, so the five near-identical comboboxes are distinguishable. The `e2e` smoke test depends on it (`getByRole('region', { name: 'Single-Select' })`). No other UI page did this, and the ids were a hand-kept copy of ids the markdown already owns.

Rather than copy that duplication to every other page, the label is now derived. `collectDemoLabels` pairs each `::Demo` island with the heading it sits under, reading the ids `collectHeadings` already assigned rather than slugging a second time, and the island view renders every demo as a region labelled by that heading. Every UI page gains the accessible naming only Combobox had, and the change deletes more than it adds: the five `TableOfContentsEntry` constants in `page/ui/combobox.ts` and the five `h.section` wrappers in `comboboxPage.ts` are gone. A demo with no heading above it renders bare, as before.

All demos are top-level with exactly one per heading, so the pairing is one-to-one.

## Guards

- no page markdown overrides an id `slugify` already derives
- every `::Demo` island resolves to the heading above it

Both were verified to fail when the invariant is broken.

## Verification

`pnpm -F website typecheck`, `pnpm -F website test` (445 passing), `pnpm lint`, and `pnpm -F website build` are green, and the full pre-push gate passed. All 78 in-doc anchor links still resolve.

The e2e smoke test was run separately and passes against the derived regions. Note that `scripts/run-website-e2e.sh` skips the suite when the pinned Playwright browser is absent, which is the case in a cloud session, so it was run manually against the installed Chromium via an `executablePath` override. CI installs browsers explicitly and will run it here.

## Note on public anchors

The 17 dropped demo-section markers change public URL fragments (`/ui/listbox#single-select-listbox` becomes `/ui/listbox#single-select`). Nothing in the repo linked them, and the redundancy seemed worse than the risk, but it is a judgment call worth a second opinion.

Separately: `scripts/cloud-session-setup.sh` builds only `foldkit` and `@foldkit/vite-plugin`, so the website typecheck and tests fail in a fresh session until `@foldkit/ui` is built, while the script reports "up to date". Left alone here as out of scope.
