### PR TITLE
refactor: give each calendar view mode its own view function

### DIFF
--- a/examples/ui-showcase/src/ui/view/calendar.ts
+++ b/examples/ui-showcase/src/ui/view/calendar.ts
@@ -1,6 +1,6 @@
 import { Match as M } from 'effect'
 import { Submodel } from 'foldkit'
-import type { Html } from 'foldkit/html'
+import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
 
 import { Calendar } from '@foldkit/ui'
 
@@ -38,10 +38,142 @@ const dayButtonClassName =
 const monthYearGridClassName =
   'grid grid-cols-3 grid-rows-4 gap-1 outline-none flex-1'
 
-const monthYearCellClassName = 'group flex items-center justify-center'
-
 const monthYearButtonClassName =
   'flex h-full w-full items-center justify-center rounded-md text-sm text-gray-900 tabular-nums cursor-pointer hover:bg-gray-100 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white! group-data-[selected]:hover:bg-accent-600 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-500 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
+
+// PIECES
+
+const navButton = (
+  attributes: ReadonlyArray<ChildAttribute>,
+  icon: Html,
+  h: HtmlBuilder<UiMessage>,
+): Html => h.button([...attributes, h.Class(navButtonClassName)], [icon])
+
+const headingButton = (
+  heading: Calendar.DaysModeAttributes['heading'],
+  attributes: ReadonlyArray<ChildAttribute>,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.button(
+    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
+    [heading.text, Icon.chevronDown('w-3 h-3')],
+  )
+
+const weekRow = (week: Calendar.Week, h: HtmlBuilder<UiMessage>): Html =>
+  h.div(
+    [...week.attributes, h.Class(weekRowClassName)],
+    week.cells.map(cell =>
+      h.div(
+        [...cell.cellAttributes, h.Class(cellClassName)],
+        [
+          h.button(
+            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
+            [cell.label],
+          ),
+        ],
+      ),
+    ),
+  )
+
+// MODES
+
+const daysView = (
+  days: Calendar.DaysModeAttributes,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.div(
+    [...days.root, h.Class(containerClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(days.previousMonthButton, Icon.chevronLeft('w-5 h-5'), h),
+          headingButton(days.heading, days.headingButton, h),
+          navButton(days.nextMonthButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...days.grid, h.Class(gridClassName)],
+        [
+          h.div(
+            [...days.headerRow, h.Class(headerRowClassName)],
+            days.columnHeaders.map(header =>
+              h.div(
+                [...header.attributes, h.Class(columnHeaderClassName)],
+                [header.name],
+              ),
+            ),
+          ),
+          ...days.weeks.map(week => weekRow(week, h)),
+        ],
+      ),
+    ],
+  )
+
+const monthsView = (
+  months: Calendar.MonthsModeAttributes,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.div(
+    [...months.root, h.Class(containerClassName)],
+    [
+      h.div(
+        [h.Class(`${headerClassName} justify-center`)],
+        [headingButton(months.heading, months.headingButton, h)],
+      ),
+      h.div(
+        [...months.grid, h.Class(monthYearGridClassName)],
+        months.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.shortLabel],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+const yearsView = (
+  years: Calendar.YearsModeAttributes,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.div(
+    [...years.root, h.Class(containerClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(years.previousPageButton, Icon.chevronLeft('w-5 h-5'), h),
+          h.h2(
+            [h.Id(years.heading.id), h.Class(headingTextClassName)],
+            [years.heading.text],
+          ),
+          navButton(years.nextPageButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...years.grid, h.Class(monthYearGridClassName)],
+        years.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.label],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+// VIEW
 
 export const view = Submodel.defineView<UiModel, UiMessage>(
   (model, h): Html => {
@@ -55,177 +187,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>(
           view: Calendar.view,
           viewInputs: {
             maybeSelectedDate: model.maybeCalendarBasicDemoSelectedDate,
-            toView: attributes =>
-              M.value(attributes).pipe(
-                M.tagsExhaustive({
-                  Days: days =>
-                    h.div(
-                      [...days.root, h.Class(containerClassName)],
-                      [
-                        h.div(
-                          [h.Class(headerClassName)],
-                          [
-                            h.button(
-                              [
-                                ...days.previousMonthButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronLeft('w-5 h-5')],
-                            ),
-                            h.button(
-                              [
-                                h.Id(days.heading.id),
-                                ...days.headingButton,
-                                h.Class(headingButtonClassName),
-                              ],
-                              [days.heading.text, Icon.chevronDown('w-3 h-3')],
-                            ),
-                            h.button(
-                              [
-                                ...days.nextMonthButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronRight('w-5 h-5')],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...days.grid, h.Class(gridClassName)],
-                          [
-                            h.div(
-                              [...days.headerRow, h.Class(headerRowClassName)],
-                              days.columnHeaders.map(header =>
-                                h.div(
-                                  [
-                                    ...header.attributes,
-                                    h.Class(columnHeaderClassName),
-                                  ],
-                                  [header.name],
-                                ),
-                              ),
-                            ),
-                            ...days.weeks.map(week =>
-                              h.div(
-                                [...week.attributes, h.Class(weekRowClassName)],
-                                week.cells.map(cell =>
-                                  h.div(
-                                    [
-                                      ...cell.cellAttributes,
-                                      h.Class(cellClassName),
-                                    ],
-                                    [
-                                      h.button(
-                                        [
-                                          ...cell.buttonAttributes,
-                                          h.Class(dayButtonClassName),
-                                        ],
-                                        [cell.label],
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  Months: months =>
-                    h.div(
-                      [...months.root, h.Class(containerClassName)],
-                      [
-                        h.div(
-                          [h.Class(`${headerClassName} justify-center`)],
-                          [
-                            h.button(
-                              [
-                                h.Id(months.heading.id),
-                                ...months.headingButton,
-                                h.Class(headingButtonClassName),
-                              ],
-                              [
-                                months.heading.text,
-                                Icon.chevronDown('w-3 h-3'),
-                              ],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...months.grid, h.Class(monthYearGridClassName)],
-                          months.cells.map(cell =>
-                            h.div(
-                              [
-                                ...cell.cellAttributes,
-                                h.Class(monthYearCellClassName),
-                              ],
-                              [
-                                h.button(
-                                  [
-                                    ...cell.buttonAttributes,
-                                    h.Class(monthYearButtonClassName),
-                                  ],
-                                  [cell.shortLabel],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  Years: years =>
-                    h.div(
-                      [...years.root, h.Class(containerClassName)],
-                      [
-                        h.div(
-                          [h.Class(headerClassName)],
-                          [
-                            h.button(
-                              [
-                                ...years.previousPageButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronLeft('w-5 h-5')],
-                            ),
-                            h.h2(
-                              [
-                                h.Id(years.heading.id),
-                                h.Class(headingTextClassName),
-                              ],
-                              [years.heading.text],
-                            ),
-                            h.button(
-                              [
-                                ...years.nextPageButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronRight('w-5 h-5')],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...years.grid, h.Class(monthYearGridClassName)],
-                          years.cells.map(cell =>
-                            h.div(
-                              [
-                                ...cell.cellAttributes,
-                                h.Class(monthYearCellClassName),
-                              ],
-                              [
-                                h.button(
-                                  [
-                                    ...cell.buttonAttributes,
-                                    h.Class(monthYearButtonClassName),
-                                  ],
-                                  [cell.label],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                }),
-              ),
+            toView: M.type<Calendar.CalendarAttributes>().pipe(
+              M.tagsExhaustive({
+                Days: days => daysView(days, h),
+                Months: months => monthsView(months, h),
+                Years: years => yearsView(years, h),
+              }),
+            ),
           },
           toParentMessage: message => GotCalendarBasicDemoMessage({ message }),
         }),

--- a/examples/ui-showcase/src/ui/view/datePicker.ts
+++ b/examples/ui-showcase/src/ui/view/datePicker.ts
@@ -1,8 +1,8 @@
 import { Match as M, Option } from 'effect'
 import { Submodel } from 'foldkit'
-import type { Html, HtmlBuilder } from 'foldkit/html'
+import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
 
-import { DatePicker } from '@foldkit/ui'
+import { Calendar, DatePicker } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/popover'
 
 import * as Icon from '../../icon'
@@ -53,10 +53,141 @@ const dayButtonClassName =
 const monthYearGridClassName =
   'grid grid-cols-3 grid-rows-4 gap-1 outline-none flex-1'
 
-const monthYearCellClassName = 'group flex items-center justify-center'
-
 const monthYearButtonClassName =
   'flex h-full w-full items-center justify-center rounded-md text-sm text-gray-900 tabular-nums cursor-pointer hover:bg-gray-100 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white! group-data-[selected]:hover:bg-accent-600 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-500 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
+// PIECES
+
+const navButton = (
+  attributes: ReadonlyArray<ChildAttribute>,
+  icon: Html,
+  h: HtmlBuilder<UiMessage>,
+): Html => h.button([...attributes, h.Class(navButtonClassName)], [icon])
+
+const headingButton = (
+  heading: Calendar.DaysModeAttributes['heading'],
+  attributes: ReadonlyArray<ChildAttribute>,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.button(
+    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
+    [heading.text, Icon.chevronDown('w-3 h-3')],
+  )
+
+const weekRow = (week: Calendar.Week, h: HtmlBuilder<UiMessage>): Html =>
+  h.div(
+    [...week.attributes, h.Class(weekRowClassName)],
+    week.cells.map(cell =>
+      h.div(
+        [...cell.cellAttributes, h.Class(cellClassName)],
+        [
+          h.button(
+            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
+            [cell.label],
+          ),
+        ],
+      ),
+    ),
+  )
+
+// MODES
+
+const daysView = (
+  days: Calendar.DaysModeAttributes,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.div(
+    [...days.root, h.Class(calendarWrapperClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(days.previousMonthButton, Icon.chevronLeft('w-5 h-5'), h),
+          headingButton(days.heading, days.headingButton, h),
+          navButton(days.nextMonthButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...days.grid, h.Class(gridClassName)],
+        [
+          h.div(
+            [...days.headerRow, h.Class(headerRowClassName)],
+            days.columnHeaders.map(header =>
+              h.div(
+                [...header.attributes, h.Class(columnHeaderClassName)],
+                [header.name],
+              ),
+            ),
+          ),
+          ...days.weeks.map(week => weekRow(week, h)),
+        ],
+      ),
+    ],
+  )
+
+const monthsView = (
+  months: Calendar.MonthsModeAttributes,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.div(
+    [...months.root, h.Class(calendarWrapperClassName)],
+    [
+      h.div(
+        [h.Class(`${headerClassName} justify-center`)],
+        [headingButton(months.heading, months.headingButton, h)],
+      ),
+      h.div(
+        [...months.grid, h.Class(monthYearGridClassName)],
+        months.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.shortLabel],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+const yearsView = (
+  years: Calendar.YearsModeAttributes,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.div(
+    [...years.root, h.Class(calendarWrapperClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(years.previousPageButton, Icon.chevronLeft('w-5 h-5'), h),
+          h.h2(
+            [h.Id(years.heading.id), h.Class(headingTextClassName)],
+            [years.heading.text],
+          ),
+          navButton(years.nextPageButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...years.grid, h.Class(monthYearGridClassName)],
+        years.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.label],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+// TRIGGER
 
 const DATE_PICKER_ANCHOR: AnchorConfig = {
   placement: 'bottom-start',
@@ -87,6 +218,8 @@ const triggerContent = (
   )
 }
 
+// VIEW
+
 export const view = Submodel.defineView<UiModel, UiMessage>(
   (model, h): Html => {
     return h.div(
@@ -115,177 +248,13 @@ export const view = Submodel.defineView<UiModel, UiMessage>(
             panelClassName,
             backdropClassName,
             className: wrapperClassName,
-            toCalendarView: attributes =>
-              M.value(attributes).pipe(
-                M.tagsExhaustive({
-                  Days: days =>
-                    h.div(
-                      [...days.root, h.Class(calendarWrapperClassName)],
-                      [
-                        h.div(
-                          [h.Class(headerClassName)],
-                          [
-                            h.button(
-                              [
-                                ...days.previousMonthButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronLeft('w-5 h-5')],
-                            ),
-                            h.button(
-                              [
-                                h.Id(days.heading.id),
-                                ...days.headingButton,
-                                h.Class(headingButtonClassName),
-                              ],
-                              [days.heading.text, Icon.chevronDown('w-3 h-3')],
-                            ),
-                            h.button(
-                              [
-                                ...days.nextMonthButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronRight('w-5 h-5')],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...days.grid, h.Class(gridClassName)],
-                          [
-                            h.div(
-                              [...days.headerRow, h.Class(headerRowClassName)],
-                              days.columnHeaders.map(header =>
-                                h.div(
-                                  [
-                                    ...header.attributes,
-                                    h.Class(columnHeaderClassName),
-                                  ],
-                                  [header.name],
-                                ),
-                              ),
-                            ),
-                            ...days.weeks.map(week =>
-                              h.div(
-                                [...week.attributes, h.Class(weekRowClassName)],
-                                week.cells.map(cell =>
-                                  h.div(
-                                    [
-                                      ...cell.cellAttributes,
-                                      h.Class(cellClassName),
-                                    ],
-                                    [
-                                      h.button(
-                                        [
-                                          ...cell.buttonAttributes,
-                                          h.Class(dayButtonClassName),
-                                        ],
-                                        [cell.label],
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  Months: months =>
-                    h.div(
-                      [...months.root, h.Class(calendarWrapperClassName)],
-                      [
-                        h.div(
-                          [h.Class(`${headerClassName} justify-center`)],
-                          [
-                            h.button(
-                              [
-                                h.Id(months.heading.id),
-                                ...months.headingButton,
-                                h.Class(headingButtonClassName),
-                              ],
-                              [
-                                months.heading.text,
-                                Icon.chevronDown('w-3 h-3'),
-                              ],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...months.grid, h.Class(monthYearGridClassName)],
-                          months.cells.map(cell =>
-                            h.div(
-                              [
-                                ...cell.cellAttributes,
-                                h.Class(monthYearCellClassName),
-                              ],
-                              [
-                                h.button(
-                                  [
-                                    ...cell.buttonAttributes,
-                                    h.Class(monthYearButtonClassName),
-                                  ],
-                                  [cell.shortLabel],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  Years: years =>
-                    h.div(
-                      [...years.root, h.Class(calendarWrapperClassName)],
-                      [
-                        h.div(
-                          [h.Class(headerClassName)],
-                          [
-                            h.button(
-                              [
-                                ...years.previousPageButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronLeft('w-5 h-5')],
-                            ),
-                            h.h2(
-                              [
-                                h.Id(years.heading.id),
-                                h.Class(headingTextClassName),
-                              ],
-                              [years.heading.text],
-                            ),
-                            h.button(
-                              [
-                                ...years.nextPageButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronRight('w-5 h-5')],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...years.grid, h.Class(monthYearGridClassName)],
-                          years.cells.map(cell =>
-                            h.div(
-                              [
-                                ...cell.cellAttributes,
-                                h.Class(monthYearCellClassName),
-                              ],
-                              [
-                                h.button(
-                                  [
-                                    ...cell.buttonAttributes,
-                                    h.Class(monthYearButtonClassName),
-                                  ],
-                                  [cell.label],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                }),
-              ),
+            toCalendarView: M.type<Calendar.CalendarAttributes>().pipe(
+              M.tagsExhaustive({
+                Days: days => daysView(days, h),
+                Months: months => monthsView(months, h),
+                Years: years => yearsView(years, h),
+              }),
+            ),
           },
           toParentMessage: message =>
             GotDatePickerBasicDemoMessage({ message }),

--- a/packages/website/src/page/ui/calendar.ts
+++ b/packages/website/src/page/ui/calendar.ts
@@ -1,5 +1,5 @@
 import { Match as M } from 'effect'
-import type { HtmlBuilder } from 'foldkit/html'
+import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
 
 import { Calendar } from '@foldkit/ui'
 
@@ -40,10 +40,140 @@ const dayButtonClassName =
 const monthYearGridClassName =
   'grid grid-cols-3 grid-rows-4 gap-1 outline-none flex-1'
 
-const monthYearCellClassName = 'group flex items-center justify-center'
-
 const monthYearButtonClassName =
   'flex h-full w-full items-center justify-center rounded-md text-sm text-gray-900 dark:text-gray-100 tabular-nums cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 dark:group-data-[today]:ring-gray-500 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white! group-data-[selected]:hover:bg-accent-600 group-data-[selected]:dark:hover:bg-accent-600 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-500 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
+
+// PIECES
+
+const navButton = (
+  attributes: ReadonlyArray<ChildAttribute>,
+  icon: Html,
+  h: HtmlBuilder<Message>,
+): Html => h.button([...attributes, h.Class(navButtonClassName)], [icon])
+
+const headingButton = (
+  heading: Calendar.DaysModeAttributes['heading'],
+  attributes: ReadonlyArray<ChildAttribute>,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.button(
+    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
+    [heading.text, Icon.chevronDown('w-3 h-3')],
+  )
+
+const weekRow = (week: Calendar.Week, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [...week.attributes, h.Class(weekRowClassName)],
+    week.cells.map(cell =>
+      h.div(
+        [...cell.cellAttributes, h.Class(cellClassName)],
+        [
+          h.button(
+            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
+            [cell.label],
+          ),
+        ],
+      ),
+    ),
+  )
+
+// MODES
+
+const daysView = (
+  days: Calendar.DaysModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...days.root, h.Class(containerClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(days.previousMonthButton, Icon.chevronLeft('w-5 h-5'), h),
+          headingButton(days.heading, days.headingButton, h),
+          navButton(days.nextMonthButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...days.grid, h.Class(gridClassName)],
+        [
+          h.div(
+            [...days.headerRow, h.Class(headerRowClassName)],
+            days.columnHeaders.map(header =>
+              h.div(
+                [...header.attributes, h.Class(columnHeaderClassName)],
+                [header.name],
+              ),
+            ),
+          ),
+          ...days.weeks.map(week => weekRow(week, h)),
+        ],
+      ),
+    ],
+  )
+
+const monthsView = (
+  months: Calendar.MonthsModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...months.root, h.Class(containerClassName)],
+    [
+      h.div(
+        [h.Class(`${headerClassName} justify-center`)],
+        [headingButton(months.heading, months.headingButton, h)],
+      ),
+      h.div(
+        [...months.grid, h.Class(monthYearGridClassName)],
+        months.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.shortLabel],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+const yearsView = (
+  years: Calendar.YearsModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...years.root, h.Class(containerClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(years.previousPageButton, Icon.chevronLeft('w-5 h-5'), h),
+          h.h2(
+            [h.Id(years.heading.id), h.Class(headingTextClassName)],
+            [years.heading.text],
+          ),
+          navButton(years.nextPageButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...years.grid, h.Class(monthYearGridClassName)],
+        years.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.label],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
 
 // VIEW
 
@@ -55,174 +185,13 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
       view: Calendar.view,
       viewInputs: {
         maybeSelectedDate: model.maybeCalendarBasicDemoSelectedDate,
-        toView: attributes =>
-          M.value(attributes).pipe(
-            M.tagsExhaustive({
-              Days: days =>
-                h.div(
-                  [...days.root, h.Class(containerClassName)],
-                  [
-                    h.div(
-                      [h.Class(headerClassName)],
-                      [
-                        h.button(
-                          [
-                            ...days.previousMonthButton,
-                            h.Class(navButtonClassName),
-                          ],
-                          [Icon.chevronLeft('w-5 h-5')],
-                        ),
-                        h.button(
-                          [
-                            h.Id(days.heading.id),
-                            ...days.headingButton,
-                            h.Class(headingButtonClassName),
-                          ],
-                          [days.heading.text, Icon.chevronDown('w-3 h-3')],
-                        ),
-                        h.button(
-                          [
-                            ...days.nextMonthButton,
-                            h.Class(navButtonClassName),
-                          ],
-                          [Icon.chevronRight('w-5 h-5')],
-                        ),
-                      ],
-                    ),
-                    h.div(
-                      [...days.grid, h.Class(gridClassName)],
-                      [
-                        h.div(
-                          [...days.headerRow, h.Class(headerRowClassName)],
-                          days.columnHeaders.map(header =>
-                            h.div(
-                              [
-                                ...header.attributes,
-                                h.Class(columnHeaderClassName),
-                              ],
-                              [header.name],
-                            ),
-                          ),
-                        ),
-                        ...days.weeks.map(week =>
-                          h.div(
-                            [...week.attributes, h.Class(weekRowClassName)],
-                            week.cells.map(cell =>
-                              h.div(
-                                [
-                                  ...cell.cellAttributes,
-                                  h.Class(cellClassName),
-                                ],
-                                [
-                                  h.button(
-                                    [
-                                      ...cell.buttonAttributes,
-                                      h.Class(dayButtonClassName),
-                                    ],
-                                    [cell.label],
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              Months: months =>
-                h.div(
-                  [...months.root, h.Class(containerClassName)],
-                  [
-                    h.div(
-                      [h.Class(`${headerClassName} justify-center`)],
-                      [
-                        h.button(
-                          [
-                            h.Id(months.heading.id),
-                            ...months.headingButton,
-                            h.Class(headingButtonClassName),
-                          ],
-                          [months.heading.text, Icon.chevronDown('w-3 h-3')],
-                        ),
-                      ],
-                    ),
-                    h.div(
-                      [...months.grid, h.Class(monthYearGridClassName)],
-                      months.cells.map(cell =>
-                        h.div(
-                          [
-                            ...cell.cellAttributes,
-                            h.Class(monthYearCellClassName),
-                          ],
-                          [
-                            h.button(
-                              [
-                                ...cell.buttonAttributes,
-                                h.Class(monthYearButtonClassName),
-                              ],
-                              [cell.shortLabel],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              Years: years =>
-                h.div(
-                  [...years.root, h.Class(containerClassName)],
-                  [
-                    h.div(
-                      [h.Class(headerClassName)],
-                      [
-                        h.button(
-                          [
-                            ...years.previousPageButton,
-                            h.Class(navButtonClassName),
-                          ],
-                          [Icon.chevronLeft('w-5 h-5')],
-                        ),
-                        h.h2(
-                          [
-                            h.Id(years.heading.id),
-                            h.Class(headingTextClassName),
-                          ],
-                          [years.heading.text],
-                        ),
-                        h.button(
-                          [
-                            ...years.nextPageButton,
-                            h.Class(navButtonClassName),
-                          ],
-                          [Icon.chevronRight('w-5 h-5')],
-                        ),
-                      ],
-                    ),
-                    h.div(
-                      [...years.grid, h.Class(monthYearGridClassName)],
-                      years.cells.map(cell =>
-                        h.div(
-                          [
-                            ...cell.cellAttributes,
-                            h.Class(monthYearCellClassName),
-                          ],
-                          [
-                            h.button(
-                              [
-                                ...cell.buttonAttributes,
-                                h.Class(monthYearButtonClassName),
-                              ],
-                              [cell.label],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-            }),
-          ),
+        toView: M.type<Calendar.CalendarAttributes>().pipe(
+          M.tagsExhaustive({
+            Days: days => daysView(days, h),
+            Months: months => monthsView(months, h),
+            Years: years => yearsView(years, h),
+          }),
+        ),
       },
       toParentMessage: message => GotCalendarBasicDemoMessage({ message }),
     }),

--- a/packages/website/src/page/ui/datePicker.ts
+++ b/packages/website/src/page/ui/datePicker.ts
@@ -1,7 +1,7 @@
 import { Match as M, Option } from 'effect'
-import type { HtmlBuilder } from 'foldkit/html'
+import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
 
-import { DatePicker } from '@foldkit/ui'
+import { Calendar, DatePicker } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/popover'
 
 import { Icon } from '../../icon'
@@ -55,10 +55,140 @@ const dayButtonClassName =
 const monthYearGridClassName =
   'grid grid-cols-3 grid-rows-4 gap-1 outline-none flex-1'
 
-const monthYearCellClassName = 'group flex items-center justify-center'
-
 const monthYearButtonClassName =
   'flex h-full w-full items-center justify-center rounded-md text-sm text-gray-900 dark:text-gray-100 tabular-nums cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 dark:group-data-[today]:ring-gray-500 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white! group-data-[selected]:hover:bg-accent-600 group-data-[selected]:dark:hover:bg-accent-600 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-500 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
+
+// PIECES
+
+const navButton = (
+  attributes: ReadonlyArray<ChildAttribute>,
+  icon: Html,
+  h: HtmlBuilder<Message>,
+): Html => h.button([...attributes, h.Class(navButtonClassName)], [icon])
+
+const headingButton = (
+  heading: Calendar.DaysModeAttributes['heading'],
+  attributes: ReadonlyArray<ChildAttribute>,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.button(
+    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
+    [heading.text, Icon.chevronDown('w-3 h-3')],
+  )
+
+const weekRow = (week: Calendar.Week, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [...week.attributes, h.Class(weekRowClassName)],
+    week.cells.map(cell =>
+      h.div(
+        [...cell.cellAttributes, h.Class(cellClassName)],
+        [
+          h.button(
+            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
+            [cell.label],
+          ),
+        ],
+      ),
+    ),
+  )
+
+// MODES
+
+const daysView = (
+  days: Calendar.DaysModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...days.root, h.Class(calendarWrapperClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(days.previousMonthButton, Icon.chevronLeft('w-5 h-5'), h),
+          headingButton(days.heading, days.headingButton, h),
+          navButton(days.nextMonthButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...days.grid, h.Class(gridClassName)],
+        [
+          h.div(
+            [...days.headerRow, h.Class(headerRowClassName)],
+            days.columnHeaders.map(header =>
+              h.div(
+                [...header.attributes, h.Class(columnHeaderClassName)],
+                [header.name],
+              ),
+            ),
+          ),
+          ...days.weeks.map(week => weekRow(week, h)),
+        ],
+      ),
+    ],
+  )
+
+const monthsView = (
+  months: Calendar.MonthsModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...months.root, h.Class(calendarWrapperClassName)],
+    [
+      h.div(
+        [h.Class(`${headerClassName} justify-center`)],
+        [headingButton(months.heading, months.headingButton, h)],
+      ),
+      h.div(
+        [...months.grid, h.Class(monthYearGridClassName)],
+        months.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.shortLabel],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+const yearsView = (
+  years: Calendar.YearsModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...years.root, h.Class(calendarWrapperClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(years.previousPageButton, Icon.chevronLeft('w-5 h-5'), h),
+          h.h2(
+            [h.Id(years.heading.id), h.Class(headingTextClassName)],
+            [years.heading.text],
+          ),
+          navButton(years.nextPageButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...years.grid, h.Class(monthYearGridClassName)],
+        years.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.label],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
 
 // VIEW
 
@@ -114,177 +244,13 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
             panelClassName,
             backdropClassName,
             className: wrapperClassName,
-            toCalendarView: attributes =>
-              M.value(attributes).pipe(
-                M.tagsExhaustive({
-                  Days: days =>
-                    h.div(
-                      [...days.root, h.Class(calendarWrapperClassName)],
-                      [
-                        h.div(
-                          [h.Class(headerClassName)],
-                          [
-                            h.button(
-                              [
-                                ...days.previousMonthButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronLeft('w-5 h-5')],
-                            ),
-                            h.button(
-                              [
-                                h.Id(days.heading.id),
-                                ...days.headingButton,
-                                h.Class(headingButtonClassName),
-                              ],
-                              [days.heading.text, Icon.chevronDown('w-3 h-3')],
-                            ),
-                            h.button(
-                              [
-                                ...days.nextMonthButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronRight('w-5 h-5')],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...days.grid, h.Class(gridClassName)],
-                          [
-                            h.div(
-                              [...days.headerRow, h.Class(headerRowClassName)],
-                              days.columnHeaders.map(header =>
-                                h.div(
-                                  [
-                                    ...header.attributes,
-                                    h.Class(columnHeaderClassName),
-                                  ],
-                                  [header.name],
-                                ),
-                              ),
-                            ),
-                            ...days.weeks.map(week =>
-                              h.div(
-                                [...week.attributes, h.Class(weekRowClassName)],
-                                week.cells.map(cell =>
-                                  h.div(
-                                    [
-                                      ...cell.cellAttributes,
-                                      h.Class(cellClassName),
-                                    ],
-                                    [
-                                      h.button(
-                                        [
-                                          ...cell.buttonAttributes,
-                                          h.Class(dayButtonClassName),
-                                        ],
-                                        [cell.label],
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  Months: months =>
-                    h.div(
-                      [...months.root, h.Class(calendarWrapperClassName)],
-                      [
-                        h.div(
-                          [h.Class(`${headerClassName} justify-center`)],
-                          [
-                            h.button(
-                              [
-                                h.Id(months.heading.id),
-                                ...months.headingButton,
-                                h.Class(headingButtonClassName),
-                              ],
-                              [
-                                months.heading.text,
-                                Icon.chevronDown('w-3 h-3'),
-                              ],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...months.grid, h.Class(monthYearGridClassName)],
-                          months.cells.map(cell =>
-                            h.div(
-                              [
-                                ...cell.cellAttributes,
-                                h.Class(monthYearCellClassName),
-                              ],
-                              [
-                                h.button(
-                                  [
-                                    ...cell.buttonAttributes,
-                                    h.Class(monthYearButtonClassName),
-                                  ],
-                                  [cell.shortLabel],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  Years: years =>
-                    h.div(
-                      [...years.root, h.Class(calendarWrapperClassName)],
-                      [
-                        h.div(
-                          [h.Class(headerClassName)],
-                          [
-                            h.button(
-                              [
-                                ...years.previousPageButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronLeft('w-5 h-5')],
-                            ),
-                            h.h2(
-                              [
-                                h.Id(years.heading.id),
-                                h.Class(headingTextClassName),
-                              ],
-                              [years.heading.text],
-                            ),
-                            h.button(
-                              [
-                                ...years.nextPageButton,
-                                h.Class(navButtonClassName),
-                              ],
-                              [Icon.chevronRight('w-5 h-5')],
-                            ),
-                          ],
-                        ),
-                        h.div(
-                          [...years.grid, h.Class(monthYearGridClassName)],
-                          years.cells.map(cell =>
-                            h.div(
-                              [
-                                ...cell.cellAttributes,
-                                h.Class(monthYearCellClassName),
-                              ],
-                              [
-                                h.button(
-                                  [
-                                    ...cell.buttonAttributes,
-                                    h.Class(monthYearButtonClassName),
-                                  ],
-                                  [cell.label],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                }),
-              ),
+            toCalendarView: M.type<Calendar.CalendarAttributes>().pipe(
+              M.tagsExhaustive({
+                Days: days => daysView(days, h),
+                Months: months => monthsView(months, h),
+                Years: years => yearsView(years, h),
+              }),
+            ),
           },
           toParentMessage: message =>
             GotDatePickerBasicDemoMessage({ message }),

--- a/packages/website/src/snippet/uiCalendarBasic.ts
+++ b/packages/website/src/snippet/uiCalendarBasic.ts
@@ -3,7 +3,7 @@
 // update, and view definitions.
 import { Effect, Match as M, Option } from 'effect'
 import { Calendar, Update } from 'foldkit'
-import type { HtmlBuilder } from 'foldkit/html'
+import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
@@ -89,10 +89,182 @@ const foldCalendar = Update.foldChild({
 // Inside your update function's M.tagsExhaustive({...}), call the fold:
 GotCalendarMessage: ({ message }) => foldCalendar(model, message)
 
+// Class names live at module scope, and each view mode gets its own view
+// function below.
+const panelClassName = 'flex flex-col gap-3 rounded-xl border p-4'
+
+const headerClassName = 'flex items-center justify-between'
+
+const navButtonClassName = 'rounded px-2'
+
+const headingButtonClassName =
+  'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold'
+
+const headingTextClassName = 'text-sm font-semibold'
+
+const gridClassName = 'flex flex-col gap-1 outline-none'
+
+const rowClassName = 'grid grid-cols-7 gap-1'
+
+const columnHeaderClassName = 'text-center text-xs uppercase'
+
+// `group` lets the button inside style itself from the cell's data attributes.
+const cellClassName = 'group flex items-center justify-center'
+
+const dayButtonClassName =
+  'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40'
+
+const monthYearGridClassName = 'grid grid-cols-3 gap-1 outline-none'
+
+const monthYearButtonClassName =
+  'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40'
+
+// `ChildAttribute` is the type of the attributes a Submodel publishes to its
+// consumer. Spread them onto whichever element you want to carry them.
+const navButton = (
+  attributes: ReadonlyArray<ChildAttribute>,
+  label: string,
+  h: HtmlBuilder<Message>,
+): Html => h.button([...attributes, h.Class(navButtonClassName)], [label])
+
+// The heading is a button: clicking it drills one level deeper (Days into
+// Months, Months into Years). Pair the text with a chevron so the button reads
+// as interactive at rest.
+const headingButton = (
+  heading: UiCalendar.DaysModeAttributes['heading'],
+  attributes: ReadonlyArray<ChildAttribute>,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.button(
+    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
+    [heading.text, ' ▾'],
+  )
+
+// Each Week carries its own row attributes and seven day cells, and each cell
+// is a gridcell wrapping a button.
+const weekRow = (week: UiCalendar.Week, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [...week.attributes, h.Class(rowClassName)],
+    week.cells.map(cell =>
+      h.div(
+        [...cell.cellAttributes, h.Class(cellClassName)],
+        [
+          h.button(
+            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
+            [cell.label],
+          ),
+        ],
+      ),
+    ),
+  )
+
+// One view function per view mode. Each receives the attribute group for its
+// own grid, so the fields it reads are exactly the fields that exist.
+const daysView = (
+  days: UiCalendar.DaysModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...days.root, h.Class(panelClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(days.previousMonthButton, '‹', h),
+          headingButton(days.heading, days.headingButton, h),
+          navButton(days.nextMonthButton, '›', h),
+        ],
+      ),
+      h.div(
+        [...days.grid, h.Class(gridClassName)],
+        [
+          h.div(
+            [...days.headerRow, h.Class(rowClassName)],
+            days.columnHeaders.map(header =>
+              h.div(
+                [...header.attributes, h.Class(columnHeaderClassName)],
+                [header.name],
+              ),
+            ),
+          ),
+          ...days.weeks.map(week => weekRow(week, h)),
+        ],
+      ),
+    ],
+  )
+
+// The months grid renders 12 cells (one per month). Clicking the heading again
+// drills further into the years grid.
+const monthsView = (
+  months: UiCalendar.MonthsModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...months.root, h.Class(panelClassName)],
+    [
+      h.div(
+        [h.Class('flex items-center justify-center')],
+        [headingButton(months.heading, months.headingButton, h)],
+      ),
+      h.div(
+        [...months.grid, h.Class(monthYearGridClassName)],
+        months.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.shortLabel],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+// The years grid renders 12 cells (one paged window). Prev/next page through
+// 12-year windows; clicking a year drills back to the months grid for that
+// year. Years is terminal, so its heading is text rather than a button.
+const yearsView = (
+  years: UiCalendar.YearsModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...years.root, h.Class(panelClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(years.previousPageButton, '‹', h),
+          h.h2(
+            [h.Id(years.heading.id), h.Class(headingTextClassName)],
+            [years.heading.text],
+          ),
+          navButton(years.nextPageButton, '›', h),
+        ],
+      ),
+      h.div(
+        [...years.grid, h.Class(monthYearGridClassName)],
+        years.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.label],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
 // Inside your view function, render the calendar. The `toView` callback
 // receives a discriminated `CalendarAttributes` whose variant matches the
-// calendar's current `viewMode`. Pattern-match on `_tag` to render the
-// day grid, the months grid, or the years grid:
+// calendar's current `viewMode`, so the match hands each grid to its own view
+// function:
 const view = (model: Model, h: HtmlBuilder<Message>) =>
   h.submodel({
     slotId: model.calendarDemo.id,
@@ -101,203 +273,13 @@ const view = (model: Model, h: HtmlBuilder<Message>) =>
     viewInputs: {
       // The parent-owned selection. The selected-day marker derives from it.
       maybeSelectedDate: model.maybeSelectedDate,
-      toView: attributes =>
-        M.value(attributes).pipe(
-          M.tagsExhaustive({
-            Days: days =>
-              h.div(
-                [
-                  ...days.root,
-                  h.Class('flex flex-col gap-3 rounded-xl border p-4'),
-                ],
-                [
-                  h.div(
-                    [h.Class('flex items-center justify-between')],
-                    [
-                      h.button(
-                        [...days.previousMonthButton, h.Class('rounded px-2')],
-                        ['‹'],
-                      ),
-                      // The heading is a button: clicking it switches to the
-                      // months grid for fast navigation. Pair the text with a
-                      // chevron so the button reads as interactive at rest.
-                      h.button(
-                        [
-                          h.Id(days.heading.id),
-                          ...days.headingButton,
-                          h.Class(
-                            'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                          ),
-                        ],
-                        [days.heading.text, ' ▾'],
-                      ),
-                      h.button(
-                        [...days.nextMonthButton, h.Class('rounded px-2')],
-                        ['›'],
-                      ),
-                    ],
-                  ),
-                  h.div(
-                    [...days.grid, h.Class('flex flex-col gap-1 outline-none')],
-                    [
-                      h.div(
-                        [...days.headerRow, h.Class('grid grid-cols-7 gap-1')],
-                        days.columnHeaders.map(header =>
-                          h.div(
-                            [
-                              ...header.attributes,
-                              h.Class('text-center text-xs uppercase'),
-                            ],
-                            [header.name],
-                          ),
-                        ),
-                      ),
-                      ...days.weeks.map(week =>
-                        h.div(
-                          [
-                            ...week.attributes,
-                            h.Class('grid grid-cols-7 gap-1'),
-                          ],
-                          week.cells.map(cell =>
-                            h.div(
-                              // `group` lets day buttons style themselves from
-                              // parent state via group-data-[today],
-                              // group-data-[selected], etc.
-                              [
-                                ...cell.cellAttributes,
-                                h.Class(
-                                  'group flex items-center justify-center',
-                                ),
-                              ],
-                              [
-                                h.button(
-                                  [
-                                    ...cell.buttonAttributes,
-                                    h.Class(
-                                      'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40',
-                                    ),
-                                  ],
-                                  [cell.label],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            // The months grid renders 12 cells (one per month). Clicking the
-            // heading again drills further into the years grid.
-            Months: months =>
-              h.div(
-                [
-                  ...months.root,
-                  h.Class('flex flex-col gap-3 rounded-xl border p-4'),
-                ],
-                [
-                  h.div(
-                    [h.Class('flex items-center justify-center')],
-                    [
-                      h.button(
-                        [
-                          h.Id(months.heading.id),
-                          ...months.headingButton,
-                          h.Class(
-                            'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                          ),
-                        ],
-                        [months.heading.text, ' ▾'],
-                      ),
-                    ],
-                  ),
-                  h.div(
-                    [
-                      ...months.grid,
-                      h.Class('grid grid-cols-3 gap-1 outline-none'),
-                    ],
-                    months.cells.map(cell =>
-                      h.div(
-                        [
-                          ...cell.cellAttributes,
-                          h.Class('group flex items-center justify-center'),
-                        ],
-                        [
-                          h.button(
-                            [
-                              ...cell.buttonAttributes,
-                              h.Class(
-                                'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
-                              ),
-                            ],
-                            [cell.shortLabel],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            // The years grid renders 12 cells (one paged window). Prev/next
-            // page through 12-year windows; clicking a year drills back to
-            // the months grid for that year.
-            Years: years =>
-              h.div(
-                [
-                  ...years.root,
-                  h.Class('flex flex-col gap-3 rounded-xl border p-4'),
-                ],
-                [
-                  h.div(
-                    [h.Class('flex items-center justify-between')],
-                    [
-                      h.button(
-                        [...years.previousPageButton, h.Class('rounded px-2')],
-                        ['‹'],
-                      ),
-                      h.h2(
-                        [
-                          h.Id(years.heading.id),
-                          h.Class('text-sm font-semibold'),
-                        ],
-                        [years.heading.text],
-                      ),
-                      h.button(
-                        [...years.nextPageButton, h.Class('rounded px-2')],
-                        ['›'],
-                      ),
-                    ],
-                  ),
-                  h.div(
-                    [
-                      ...years.grid,
-                      h.Class('grid grid-cols-3 gap-1 outline-none'),
-                    ],
-                    years.cells.map(cell =>
-                      h.div(
-                        [
-                          ...cell.cellAttributes,
-                          h.Class('group flex items-center justify-center'),
-                        ],
-                        [
-                          h.button(
-                            [
-                              ...cell.buttonAttributes,
-                              h.Class(
-                                'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
-                              ),
-                            ],
-                            [cell.label],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-          }),
-        ),
+      toView: M.type<UiCalendar.CalendarAttributes>().pipe(
+        M.tagsExhaustive({
+          Days: days => daysView(days, h),
+          Months: months => monthsView(months, h),
+          Years: years => yearsView(years, h),
+        }),
+      ),
     },
     toParentMessage: message => GotCalendarMessage({ message }),
   })

--- a/packages/website/src/snippet/uiDatePickerBasic.ts
+++ b/packages/website/src/snippet/uiDatePickerBasic.ts
@@ -3,11 +3,11 @@
 // update, and view definitions.
 import { Effect, Match as M, Option } from 'effect'
 import { Calendar, Update } from 'foldkit'
-import type { HtmlBuilder } from 'foldkit/html'
+import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
 import { m } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 
-import { DatePicker } from '@foldkit/ui'
+import { DatePicker, Calendar as UiCalendar } from '@foldkit/ui'
 
 // Add a field to your Model for the DatePicker Submodel, plus a field the
 // parent owns for the selected date. The picker no longer stores the
@@ -96,10 +96,183 @@ const foldDatePicker = Update.foldChild({
 // Inside your update function's M.tagsExhaustive({...}), call the fold:
 GotDatePickerMessage: ({ message }) => foldDatePicker(model, message)
 
+// Class names live at module scope, and each view mode gets its own view
+// function below. The calendar panel has no border of its own: the
+// DatePicker's popover panel provides it.
+const panelClassName = 'flex flex-col gap-3 p-4'
+
+const headerClassName = 'flex items-center justify-between'
+
+const navButtonClassName = 'rounded px-2'
+
+const headingButtonClassName =
+  'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold'
+
+const headingTextClassName = 'text-sm font-semibold'
+
+const gridClassName = 'flex flex-col gap-1 outline-none'
+
+const rowClassName = 'grid grid-cols-7 gap-1'
+
+const columnHeaderClassName = 'text-center text-xs uppercase'
+
+// `group` lets the button inside style itself from the cell's data attributes.
+const cellClassName = 'group flex items-center justify-center'
+
+const dayButtonClassName =
+  'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40'
+
+const monthYearGridClassName = 'grid grid-cols-3 gap-1 outline-none'
+
+const monthYearButtonClassName =
+  'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40'
+
+// `ChildAttribute` is the type of the attributes a Submodel publishes to its
+// consumer. Spread them onto whichever element you want to carry them.
+const navButton = (
+  attributes: ReadonlyArray<ChildAttribute>,
+  label: string,
+  h: HtmlBuilder<Message>,
+): Html => h.button([...attributes, h.Class(navButtonClassName)], [label])
+
+// The heading is a button: clicking it drills one level deeper (Days into
+// Months, Months into Years). Pair the text with a chevron so the button reads
+// as interactive at rest.
+const headingButton = (
+  heading: UiCalendar.DaysModeAttributes['heading'],
+  attributes: ReadonlyArray<ChildAttribute>,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.button(
+    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
+    [heading.text, ' ▾'],
+  )
+
+// Each Week carries its own row attributes and seven day cells, and each cell
+// is a gridcell wrapping a button.
+const weekRow = (week: UiCalendar.Week, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [...week.attributes, h.Class(rowClassName)],
+    week.cells.map(cell =>
+      h.div(
+        [...cell.cellAttributes, h.Class(cellClassName)],
+        [
+          h.button(
+            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
+            [cell.label],
+          ),
+        ],
+      ),
+    ),
+  )
+
+// One view function per view mode. Each receives the attribute group for its
+// own grid, so the fields it reads are exactly the fields that exist.
+const daysView = (
+  days: UiCalendar.DaysModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...days.root, h.Class(panelClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(days.previousMonthButton, '‹', h),
+          headingButton(days.heading, days.headingButton, h),
+          navButton(days.nextMonthButton, '›', h),
+        ],
+      ),
+      h.div(
+        [...days.grid, h.Class(gridClassName)],
+        [
+          h.div(
+            [...days.headerRow, h.Class(rowClassName)],
+            days.columnHeaders.map(header =>
+              h.div(
+                [...header.attributes, h.Class(columnHeaderClassName)],
+                [header.name],
+              ),
+            ),
+          ),
+          ...days.weeks.map(week => weekRow(week, h)),
+        ],
+      ),
+    ],
+  )
+
+// The months grid renders 12 cells (one per month). Clicking the heading again
+// drills further into the years grid.
+const monthsView = (
+  months: UiCalendar.MonthsModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...months.root, h.Class(panelClassName)],
+    [
+      h.div(
+        [h.Class('flex items-center justify-center')],
+        [headingButton(months.heading, months.headingButton, h)],
+      ),
+      h.div(
+        [...months.grid, h.Class(monthYearGridClassName)],
+        months.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.shortLabel],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+// The years grid renders 12 cells (one paged window). Prev/next page through
+// 12-year windows; clicking a year drills back to the months grid for that
+// year. Years is terminal, so its heading is text rather than a button.
+const yearsView = (
+  years: UiCalendar.YearsModeAttributes,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...years.root, h.Class(panelClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(years.previousPageButton, '‹', h),
+          h.h2(
+            [h.Id(years.heading.id), h.Class(headingTextClassName)],
+            [years.heading.text],
+          ),
+          navButton(years.nextPageButton, '›', h),
+        ],
+      ),
+      h.div(
+        [...years.grid, h.Class(monthYearGridClassName)],
+        years.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.label],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
 // Inside your view function, embed the DatePicker via h.submodel. The
 // `toCalendarView` callback receives a discriminated `CalendarAttributes`
-// whose variant matches the calendar's current `viewMode`. Pattern-match
-// on `_tag` to render the day grid, the months grid, or the years grid.
+// whose variant matches the calendar's current `viewMode`, so the match hands
+// each grid to its own view function.
 //
 // The trigger is a form field, so give it an accessible name. Pass
 // `ariaLabelledBy` with the id of a visible label element, and render that
@@ -133,200 +306,13 @@ const view = (model: Model, h: HtmlBuilder<Message>) => {
               onSome: date =>
                 h.span([], [`${date.year}-${date.month}-${date.day}`]),
             }),
-          toCalendarView: attributes =>
-            M.value(attributes).pipe(
-              M.tagsExhaustive({
-                Days: days =>
-                  h.div(
-                    [...days.root, h.Class('flex flex-col gap-3 p-4')],
-                    [
-                      h.div(
-                        [h.Class('flex items-center justify-between')],
-                        [
-                          h.button(
-                            [
-                              ...days.previousMonthButton,
-                              h.Class('rounded px-2'),
-                            ],
-                            ['‹'],
-                          ),
-                          h.button(
-                            [
-                              h.Id(days.heading.id),
-                              ...days.headingButton,
-                              h.Class(
-                                'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                              ),
-                            ],
-                            [days.heading.text, ' ▾'],
-                          ),
-                          h.button(
-                            [...days.nextMonthButton, h.Class('rounded px-2')],
-                            ['›'],
-                          ),
-                        ],
-                      ),
-                      h.div(
-                        [
-                          ...days.grid,
-                          h.Class('flex flex-col gap-1 outline-none'),
-                        ],
-                        [
-                          h.div(
-                            [
-                              ...days.headerRow,
-                              h.Class('grid grid-cols-7 gap-1'),
-                            ],
-                            days.columnHeaders.map(header =>
-                              h.div(
-                                [
-                                  ...header.attributes,
-                                  h.Class('text-center text-xs uppercase'),
-                                ],
-                                [header.name],
-                              ),
-                            ),
-                          ),
-                          ...days.weeks.map(week =>
-                            h.div(
-                              [
-                                ...week.attributes,
-                                h.Class('grid grid-cols-7 gap-1'),
-                              ],
-                              week.cells.map(cell =>
-                                h.div(
-                                  [
-                                    ...cell.cellAttributes,
-                                    h.Class(
-                                      'group flex items-center justify-center',
-                                    ),
-                                  ],
-                                  [
-                                    h.button(
-                                      [
-                                        ...cell.buttonAttributes,
-                                        h.Class(
-                                          'h-9 w-9 rounded-full text-sm group-data-[today]:ring-1 group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[outside-month]:text-gray-400 group-data-[disabled]:opacity-40',
-                                        ),
-                                      ],
-                                      [cell.label],
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                // The months grid renders 12 cells (one per month). Clicking the
-                // heading again drills further into the years grid.
-                Months: months =>
-                  h.div(
-                    [...months.root, h.Class('flex flex-col gap-3 p-4')],
-                    [
-                      h.div(
-                        [h.Class('flex items-center justify-center')],
-                        [
-                          h.button(
-                            [
-                              h.Id(months.heading.id),
-                              ...months.headingButton,
-                              h.Class(
-                                'inline-flex items-center gap-2 rounded px-2 text-sm font-semibold',
-                              ),
-                            ],
-                            [months.heading.text, ' ▾'],
-                          ),
-                        ],
-                      ),
-                      h.div(
-                        [
-                          ...months.grid,
-                          h.Class('grid grid-cols-3 gap-1 outline-none'),
-                        ],
-                        months.cells.map(cell =>
-                          h.div(
-                            [
-                              ...cell.cellAttributes,
-                              h.Class('group flex items-center justify-center'),
-                            ],
-                            [
-                              h.button(
-                                [
-                                  ...cell.buttonAttributes,
-                                  h.Class(
-                                    'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
-                                  ),
-                                ],
-                                [cell.shortLabel],
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                // The years grid renders 12 cells (one paged window). Prev/next
-                // page through 12-year windows; clicking a year drills back to
-                // the months grid for that year.
-                Years: years =>
-                  h.div(
-                    [...years.root, h.Class('flex flex-col gap-3 p-4')],
-                    [
-                      h.div(
-                        [h.Class('flex items-center justify-between')],
-                        [
-                          h.button(
-                            [
-                              ...years.previousPageButton,
-                              h.Class('rounded px-2'),
-                            ],
-                            ['‹'],
-                          ),
-                          h.h2(
-                            [
-                              h.Id(years.heading.id),
-                              h.Class('text-sm font-semibold'),
-                            ],
-                            [years.heading.text],
-                          ),
-                          h.button(
-                            [...years.nextPageButton, h.Class('rounded px-2')],
-                            ['›'],
-                          ),
-                        ],
-                      ),
-                      h.div(
-                        [
-                          ...years.grid,
-                          h.Class('grid grid-cols-3 gap-1 outline-none'),
-                        ],
-                        years.cells.map(cell =>
-                          h.div(
-                            [
-                              ...cell.cellAttributes,
-                              h.Class('group flex items-center justify-center'),
-                            ],
-                            [
-                              h.button(
-                                [
-                                  ...cell.buttonAttributes,
-                                  h.Class(
-                                    'h-12 w-full rounded-md text-sm group-data-[selected]:bg-accent-600 group-data-[selected]:text-white group-data-[disabled]:opacity-40',
-                                  ),
-                                ],
-                                [cell.label],
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-              }),
-            ),
+          toCalendarView: M.type<UiCalendar.CalendarAttributes>().pipe(
+            M.tagsExhaustive({
+              Days: days => daysView(days, h),
+              Months: months => monthsView(months, h),
+              Years: years => yearsView(years, h),
+            }),
+          ),
           // Optional: enable hidden form input for native <form> submission:
           name: 'appointment-date',
         },


### PR DESCRIPTION
The Calendar and DatePicker demos, and the snippets the docs pages show, rendered all three calendar view modes inline inside one `toView` callback. Both pages led with a single expression nested 19 to 21 levels deep, which is the first thing a reader sees on the Calendar page.

Each mode now has its own view function, so `toView` and `toCalendarView` read as a three-line match:

```ts
toView: M.type<Calendar.CalendarAttributes>().pipe(
  M.tagsExhaustive({
    Days: days => daysView(days, h),
    Months: months => monthsView(months, h),
    Years: years => yearsView(years, h),
  }),
),
```

Alongside the mode views, `navButton` (four call sites), `headingButton` (its body is `Id` plus the published attributes plus a chevron), and `weekRow` (the map-inside-a-map that nests deepest) carry the markup the modes repeat.

Max nesting per file, before and after:

| File | Before | After |
| --- | --- | --- |
| `page/ui/calendar.ts` | 19 levels / 231 lines | 8 / 200 |
| `page/ui/datePicker.ts` | 21 levels / 296 lines | 8 / 262 |
| `snippet/uiCalendarBasic.ts` | 19 levels / 304 lines | 8 / 286 |
| `snippet/uiDatePickerBasic.ts` | 21 levels / 338 lines | 8 / 324 |

`examples/ui-showcase/src/ui/view/calendar.ts` and `datePicker.ts` get the same shape, so the "See it in an app" links land on what the pages teach.

### What is deliberately not shared

The cell markup stays inline in each mode rather than collapsing into a shared `gridCell` helper. Day, month, and year cells coincide only because the three grids are styled alike today, and a helper parameterized by the button class name is defined by what varies rather than named for what it is. The docs snippets are copied into codebases where those grids will diverge, so each mode spells out the element shape it renders: five lines, twice.

`monthYearCellClassName` was character-identical to `cellClassName` in all four app files, so the cells now share the one constant.

### No behavior change

Every `M.tagsExhaustive` arm was already its own branded function (`viewIdentity.ts` collects every function node and brands its returns; an arm written as `Days: days => ...` is named from its property key), so the three modes already had three distinct identities and a mode switch already replaced the subtree. This is a legibility change only.

### Verification

Typecheck, lint, prettier, 366 website tests, 11 ui-showcase tests, and `pnpm build` all pass. Driven in Chromium against the built site:

- Calendar days, months, and years grids render correctly.
- Focus stays on `role="grid"` across mode switches (`aria-label="Month picker, 2026"`), and ArrowRight in the years grid moves `aria-activedescendant` to `cell-year-2027`.
- The date picker opens, and picking a cell updates the trigger to `2026-08-15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aRS14YUe1ePFStmMH9WDh


---
_Generated by [Claude Code](https://claude.ai/code/session_018aRS14YUe1ePFStmMH9WDh)_