### PR TITLE
refactor: extract the fieldset, dialog, and listbox demo views

### DIFF
--- a/examples/ui-showcase/src/ui/view/calendar.ts
+++ b/examples/ui-showcase/src/ui/view/calendar.ts
@@ -23,12 +23,10 @@ const navButtonClassName =
 
 const gridClassName = 'flex flex-col gap-1 outline-none'
 
-const headerRowClassName = 'grid grid-cols-7 gap-1'
+const rowClassName = 'grid grid-cols-7 gap-1'
 
 const columnHeaderClassName =
   'text-center text-xs font-medium uppercase tracking-wide text-gray-500 py-1'
-
-const weekRowClassName = 'grid grid-cols-7 gap-1'
 
 const cellClassName = 'group flex items-center justify-center'
 
@@ -61,7 +59,7 @@ const headingButton = (
 
 const weekRow = (week: Calendar.Week, h: HtmlBuilder<UiMessage>): Html =>
   h.div(
-    [...week.attributes, h.Class(weekRowClassName)],
+    [...week.attributes, h.Class(rowClassName)],
     week.cells.map(cell =>
       h.div(
         [...cell.cellAttributes, h.Class(cellClassName)],
@@ -96,7 +94,7 @@ const daysView = (
         [...days.grid, h.Class(gridClassName)],
         [
           h.div(
-            [...days.headerRow, h.Class(headerRowClassName)],
+            [...days.headerRow, h.Class(rowClassName)],
             days.columnHeaders.map(header =>
               h.div(
                 [...header.attributes, h.Class(columnHeaderClassName)],

--- a/examples/ui-showcase/src/ui/view/datePicker.ts
+++ b/examples/ui-showcase/src/ui/view/datePicker.ts
@@ -38,12 +38,10 @@ const navButtonClassName =
 
 const gridClassName = 'flex flex-col gap-1 outline-none'
 
-const headerRowClassName = 'grid grid-cols-7 gap-1'
+const rowClassName = 'grid grid-cols-7 gap-1'
 
 const columnHeaderClassName =
   'text-center text-xs font-medium uppercase tracking-wide text-gray-500 py-1'
-
-const weekRowClassName = 'grid grid-cols-7 gap-1'
 
 const cellClassName = 'group flex items-center justify-center'
 
@@ -75,7 +73,7 @@ const headingButton = (
 
 const weekRow = (week: Calendar.Week, h: HtmlBuilder<UiMessage>): Html =>
   h.div(
-    [...week.attributes, h.Class(weekRowClassName)],
+    [...week.attributes, h.Class(rowClassName)],
     week.cells.map(cell =>
       h.div(
         [...cell.cellAttributes, h.Class(cellClassName)],
@@ -110,7 +108,7 @@ const daysView = (
         [...days.grid, h.Class(gridClassName)],
         [
           h.div(
-            [...days.headerRow, h.Class(headerRowClassName)],
+            [...days.headerRow, h.Class(rowClassName)],
             days.columnHeaders.map(header =>
               h.div(
                 [...header.attributes, h.Class(columnHeaderClassName)],

--- a/examples/ui-showcase/src/ui/view/dialog.ts
+++ b/examples/ui-showcase/src/ui/view/dialog.ts
@@ -43,8 +43,16 @@ const animatedPanelClassName =
 
 const titleClassName = 'text-lg font-normal text-gray-900 mb-2'
 
+const descriptionClassName = 'text-gray-600 mb-4'
+
 const dialogClassName =
   'bg-transparent p-0 open:flex items-center justify-center'
+
+const actionsClassName = 'flex gap-2 justify-end'
+
+const triggerRowClassName = 'flex gap-3'
+
+const sectionHeadingClassName = 'text-lg font-semibold text-gray-900 mt-8 mb-4'
 
 const cancelButtonClassName =
   'px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-100'
@@ -62,24 +70,36 @@ const OVERLAY_COMBOBOX_ANCHOR = {
   portal: false,
 }
 
-const dialogPanel = (
+// PANEL CONTENT
+
+const trigger = (
+  label: string,
+  message: UiMessage,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.div(
+    [h.Class(triggerRowClassName)],
+    [h.button([h.Class(triggerClassName), h.OnClick(message)], [label])],
+  )
+
+const confirmContent = (
   closeButton: Dialog.RenderInfo['closeButton'],
   title: Dialog.RenderInfo['title'],
   description: Dialog.RenderInfo['description'],
   h: HtmlBuilder<UiMessage>,
-): Html => {
-  return h.div(
+): Html =>
+  h.div(
     [],
     [
       h.h2([...title, h.Class(titleClassName)], ['Confirm Action']),
       h.p(
-        [...description, h.Class('text-gray-600 mb-4')],
+        [...description, h.Class(descriptionClassName)],
         [
           'Are you sure you want to proceed? This action demonstrates the Dialog component with focus trapping, backdrop click, and Escape key handling.',
         ],
       ),
       h.div(
-        [h.Class('flex gap-2 justify-end')],
+        [h.Class(actionsClassName)],
         [
           h.button(
             [...closeButton, h.Class(cancelButtonClassName)],
@@ -93,26 +113,168 @@ const dialogPanel = (
       ),
     ],
   )
-}
+
+const editFiltersContent = (
+  title: Dialog.RenderInfo['title'],
+  description: Dialog.RenderInfo['description'],
+  comboboxModel: Combobox.Model,
+  maybeSelectedCity: Option.Option<City>,
+  h: HtmlBuilder<UiMessage>,
+): ReadonlyArray<Html> => [
+  h.h2([...title, h.Class(titleClassName)], ['Edit filters']),
+  h.p(
+    [...description, h.Class(descriptionClassName)],
+    [
+      'With portal: false, the combobox panel stays inside the dialog instead of rendering behind it.',
+    ],
+  ),
+  h.submodel({
+    slotId: comboboxModel.id,
+    model: comboboxModel,
+    view: CityCombobox.view,
+    viewInputs: {
+      ...comboboxInputs(
+        {
+          inputValue: comboboxModel.inputValue,
+          restingInputValue: Option.getOrElse(maybeSelectedCity, () => ''),
+          anchor: OVERLAY_COMBOBOX_ANCHOR,
+          wrapperClass: 'relative w-full',
+        },
+        h,
+      ),
+      maybeSelectedValue: maybeSelectedCity,
+    },
+    toParentMessage: message => GotOverlayComboboxDemoMessage({ message }),
+  }),
+]
+
+const projectSettingsContent = (
+  closeButton: Dialog.RenderInfo['closeButton'],
+  title: Dialog.RenderInfo['title'],
+  description: Dialog.RenderInfo['description'],
+  h: HtmlBuilder<UiMessage>,
+): ReadonlyArray<Html> => [
+  h.h2([...title, h.Class(titleClassName)], ['Project settings']),
+  h.p(
+    [...description, h.Class(descriptionClassName)],
+    [
+      'Deleting the project removes all of its data. The confirmation opens as a second dialog stacked on top of this one.',
+    ],
+  ),
+  h.div(
+    [h.Class(actionsClassName)],
+    [
+      h.button([...closeButton, h.Class(cancelButtonClassName)], ['Close']),
+      h.button(
+        [h.Class(dangerButtonClassName), h.OnClick(ClickedDeleteProject())],
+        ['Delete project'],
+      ),
+    ],
+  ),
+]
+
+const deleteProjectContent = (
+  closeButton: Dialog.RenderInfo['closeButton'],
+  title: Dialog.RenderInfo['title'],
+  description: Dialog.RenderInfo['description'],
+  h: HtmlBuilder<UiMessage>,
+): ReadonlyArray<Html> => [
+  h.h2([...title, h.Class(titleClassName)], ['Delete project?']),
+  h.p(
+    [...description, h.Class(descriptionClassName)],
+    [
+      'This permanently deletes the project and cannot be undone. Escape closes this confirmation first, then the settings dialog.',
+    ],
+  ),
+  h.div(
+    [h.Class(actionsClassName)],
+    [
+      h.button([...closeButton, h.Class(cancelButtonClassName)], ['Cancel']),
+      h.button([...closeButton, h.Class(dangerButtonClassName)], ['Delete']),
+    ],
+  ),
+]
+
+// DEMOS
+
+const basicDemo = (
+  dialogModel: Dialog.Model,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.submodel({
+    slotId: dialogModel.id,
+    model: dialogModel,
+    view: Dialog.view,
+    viewInputs: {
+      toView: ({
+        dialog,
+        backdrop,
+        panel,
+        closeButton,
+        title,
+        description,
+        isVisible,
+      }) =>
+        h.dialog(
+          [...dialog, h.Class(dialogClassName)],
+          isVisible
+            ? [
+                h.div([...backdrop, h.Class(backdropClassName)]),
+                h.div(
+                  [...panel, h.Class(panelClassName)],
+                  [confirmContent(closeButton, title, description, h)],
+                ),
+              ]
+            : [],
+        ),
+    },
+    toParentMessage: message => GotDialogDemoMessage({ message }),
+  })
+
+const animatedDemo = (
+  dialogModel: Dialog.Model,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.submodel({
+    slotId: dialogModel.id,
+    model: dialogModel,
+    view: Dialog.view,
+    viewInputs: {
+      toView: ({
+        dialog,
+        backdrop,
+        panel,
+        closeButton,
+        title,
+        description,
+        isVisible,
+      }) =>
+        h.dialog(
+          [...dialog, h.Class(dialogClassName)],
+          isVisible
+            ? [
+                h.div([...backdrop, h.Class(animatedBackdropClassName)]),
+                h.div(
+                  [...panel, h.Class(animatedPanelClassName)],
+                  [confirmContent(closeButton, title, description, h)],
+                ),
+              ]
+            : [],
+        ),
+    },
+    toParentMessage: message => GotDialogAnimatedDemoMessage({ message }),
+  })
 
 const overlayDemo = (
   dialogModel: Dialog.Model,
   comboboxModel: Combobox.Model,
   maybeSelectedCity: Option.Option<City>,
   h: HtmlBuilder<UiMessage>,
-): Html => {
-  return h.div(
+): Html =>
+  h.div(
     [],
     [
-      h.div(
-        [h.Class('flex gap-3')],
-        [
-          h.button(
-            [h.Class(triggerClassName), h.OnClick(ClickedEditFilters())],
-            ['Edit filters'],
-          ),
-        ],
-      ),
+      trigger('Edit filters', ClickedEditFilters(), h),
       h.submodel({
         slotId: dialogModel.id,
         model: dialogModel,
@@ -133,40 +295,13 @@ const overlayDemo = (
                     h.div([...backdrop, h.Class(backdropClassName)]),
                     h.div(
                       [...panel, h.Class(panelClassName)],
-                      [
-                        h.h2(
-                          [...title, h.Class(titleClassName)],
-                          ['Edit filters'],
-                        ),
-                        h.p(
-                          [...description, h.Class('text-gray-600 mb-4')],
-                          [
-                            'With portal: false, the combobox panel stays inside the dialog instead of rendering behind it.',
-                          ],
-                        ),
-                        h.submodel({
-                          slotId: comboboxModel.id,
-                          model: comboboxModel,
-                          view: CityCombobox.view,
-                          viewInputs: {
-                            ...comboboxInputs(
-                              {
-                                inputValue: comboboxModel.inputValue,
-                                restingInputValue: Option.getOrElse(
-                                  maybeSelectedCity,
-                                  () => '',
-                                ),
-                                anchor: OVERLAY_COMBOBOX_ANCHOR,
-                                wrapperClass: 'relative w-full',
-                              },
-                              h,
-                            ),
-                            maybeSelectedValue: maybeSelectedCity,
-                          },
-                          toParentMessage: message =>
-                            GotOverlayComboboxDemoMessage({ message }),
-                        }),
-                      ],
+                      editFiltersContent(
+                        title,
+                        description,
+                        comboboxModel,
+                        maybeSelectedCity,
+                        h,
+                      ),
                     ),
                   ]
                 : [],
@@ -176,28 +311,16 @@ const overlayDemo = (
       }),
     ],
   )
-}
 
 const nestedDemo = (
   parentDialogModel: Dialog.Model,
   childDialogModel: Dialog.Model,
   h: HtmlBuilder<UiMessage>,
-): Html => {
-  return h.div(
+): Html =>
+  h.div(
     [],
     [
-      h.div(
-        [h.Class('flex gap-3')],
-        [
-          h.button(
-            [
-              h.Class(triggerClassName),
-              h.OnClick(ClickedOpenProjectSettings()),
-            ],
-            ['Open project settings'],
-          ),
-        ],
-      ),
+      trigger('Open project settings', ClickedOpenProjectSettings(), h),
       h.submodel({
         slotId: parentDialogModel.id,
         model: parentDialogModel,
@@ -219,34 +342,12 @@ const nestedDemo = (
                     h.div([...backdrop, h.Class(backdropClassName)]),
                     h.div(
                       [...panel, h.Class(settingsPanelClassName)],
-                      [
-                        h.h2(
-                          [...title, h.Class(titleClassName)],
-                          ['Project settings'],
-                        ),
-                        h.p(
-                          [...description, h.Class('text-gray-600 mb-4')],
-                          [
-                            'Deleting the project removes all of its data. The confirmation opens as a second dialog stacked on top of this one.',
-                          ],
-                        ),
-                        h.div(
-                          [h.Class('flex gap-2 justify-end')],
-                          [
-                            h.button(
-                              [...closeButton, h.Class(cancelButtonClassName)],
-                              ['Close'],
-                            ),
-                            h.button(
-                              [
-                                h.Class(dangerButtonClassName),
-                                h.OnClick(ClickedDeleteProject()),
-                              ],
-                              ['Delete project'],
-                            ),
-                          ],
-                        ),
-                      ],
+                      projectSettingsContent(
+                        closeButton,
+                        title,
+                        description,
+                        h,
+                      ),
                     ),
                   ]
                 : [],
@@ -276,31 +377,7 @@ const nestedDemo = (
                     h.div([...backdrop, h.Class(backdropClassName)]),
                     h.div(
                       [...panel, h.Class(confirmPanelClassName)],
-                      [
-                        h.h2(
-                          [...title, h.Class(titleClassName)],
-                          ['Delete project?'],
-                        ),
-                        h.p(
-                          [...description, h.Class('text-gray-600 mb-4')],
-                          [
-                            'This permanently deletes the project and cannot be undone. Escape closes this confirmation first, then the settings dialog.',
-                          ],
-                        ),
-                        h.div(
-                          [h.Class('flex gap-2 justify-end')],
-                          [
-                            h.button(
-                              [...closeButton, h.Class(cancelButtonClassName)],
-                              ['Cancel'],
-                            ),
-                            h.button(
-                              [...closeButton, h.Class(dangerButtonClassName)],
-                              ['Delete'],
-                            ),
-                          ],
-                        ),
-                      ],
+                      deleteProjectContent(closeButton, title, description, h),
                     ),
                   ]
                 : [],
@@ -311,7 +388,8 @@ const nestedDemo = (
       }),
     ],
   )
-}
+
+// VIEW
 
 export const view = Submodel.defineView<UiModel, UiMessage>(
   (model, h): Html => {
@@ -320,99 +398,15 @@ export const view = Submodel.defineView<UiModel, UiMessage>(
       [
         h.h2([h.Class('text-2xl font-bold text-gray-900 mb-6')], ['Dialog']),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Basic'],
-        ),
-        h.div(
-          [h.Class('flex gap-3')],
-          [
-            h.button(
-              [h.Class(triggerClassName), h.OnClick(ClickedOpenDialog())],
-              ['Open Dialog'],
-            ),
-          ],
-        ),
-        h.submodel({
-          slotId: model.dialogDemo.id,
-          model: model.dialogDemo,
-          view: Dialog.view,
-          viewInputs: {
-            toView: ({
-              dialog,
-              backdrop,
-              panel,
-              closeButton,
-              title,
-              description,
-              isVisible,
-            }) =>
-              h.dialog(
-                [...dialog, h.Class(dialogClassName)],
-                isVisible
-                  ? [
-                      h.div([...backdrop, h.Class(backdropClassName)]),
-                      h.div(
-                        [...panel, h.Class(panelClassName)],
-                        [dialogPanel(closeButton, title, description, h)],
-                      ),
-                    ]
-                  : [],
-              ),
-          },
-          toParentMessage: message => GotDialogDemoMessage({ message }),
-        }),
+        h.h3([h.Class(sectionHeadingClassName)], ['Basic']),
+        trigger('Open Dialog', ClickedOpenDialog(), h),
+        basicDemo(model.dialogDemo, h),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Animated'],
-        ),
-        h.div(
-          [h.Class('flex gap-3')],
-          [
-            h.button(
-              [
-                h.Class(triggerClassName),
-                h.OnClick(ClickedOpenAnimatedDialog()),
-              ],
-              ['Open Animated Dialog'],
-            ),
-          ],
-        ),
-        h.submodel({
-          slotId: model.dialogAnimatedDemo.id,
-          model: model.dialogAnimatedDemo,
-          view: Dialog.view,
-          viewInputs: {
-            toView: ({
-              dialog,
-              backdrop,
-              panel,
-              closeButton,
-              title,
-              description,
-              isVisible,
-            }) =>
-              h.dialog(
-                [...dialog, h.Class(dialogClassName)],
-                isVisible
-                  ? [
-                      h.div([...backdrop, h.Class(animatedBackdropClassName)]),
-                      h.div(
-                        [...panel, h.Class(animatedPanelClassName)],
-                        [dialogPanel(closeButton, title, description, h)],
-                      ),
-                    ]
-                  : [],
-              ),
-          },
-          toParentMessage: message => GotDialogAnimatedDemoMessage({ message }),
-        }),
+        h.h3([h.Class(sectionHeadingClassName)], ['Animated']),
+        trigger('Open Animated Dialog', ClickedOpenAnimatedDialog(), h),
+        animatedDemo(model.dialogAnimatedDemo, h),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Field'],
-        ),
+        h.h3([h.Class(sectionHeadingClassName)], ['Field']),
         overlayDemo(
           model.overlayDialogDemo,
           model.overlayComboboxDemo,
@@ -420,10 +414,7 @@ export const view = Submodel.defineView<UiModel, UiMessage>(
           h,
         ),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Stacked'],
-        ),
+        h.h3([h.Class(sectionHeadingClassName)], ['Stacked']),
         nestedDemo(
           model.nestedDialogParentDemo,
           model.nestedDialogChildDemo,

--- a/examples/ui-showcase/src/ui/view/fieldset.ts
+++ b/examples/ui-showcase/src/ui/view/fieldset.ts
@@ -1,5 +1,5 @@
 import { Submodel } from 'foldkit'
-import type { Html } from 'foldkit/html'
+import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Checkbox, Fieldset, Input, Textarea } from '@foldkit/ui'
 
@@ -37,279 +37,250 @@ const checkboxLabelClassName =
 
 const checkboxDescriptionClassName = 'text-sm text-gray-500'
 
+const fieldClassName = 'flex flex-col gap-1.5'
+
+const fieldsClassName = 'mt-4 flex flex-col gap-4'
+
+const sectionHeadingClassName = 'text-lg font-semibold text-gray-900 mt-8 mb-4'
+
+// FIELDS
+
+const checkmark = (h: HtmlBuilder<UiMessage>): Html =>
+  h.span([h.Class('text-white text-xs')], ['✓'])
+
+const nameInput = (value: string, h: HtmlBuilder<UiMessage>): Html =>
+  Input.view(
+    {
+      id: 'fieldset-name-input',
+      value,
+      onInput: inputValue => UpdatedFieldsetInputValue({ value: inputValue }),
+      placeholder: 'Enter your full name',
+      toView: attributes =>
+        h.div(
+          [h.Class(fieldClassName)],
+          [
+            h.label([...attributes.label, h.Class(labelClassName)], ['Name']),
+            h.input([...attributes.input, h.Class(inputClassName)]),
+            h.span(
+              [...attributes.description, h.Class(descriptionClassName)],
+              ['As it appears on your government-issued ID.'],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+const bioTextarea = (value: string, h: HtmlBuilder<UiMessage>): Html =>
+  Textarea.view(
+    {
+      id: 'fieldset-bio-textarea',
+      value,
+      onInput: textareaValue =>
+        UpdatedFieldsetTextareaValue({ value: textareaValue }),
+      placeholder: 'Tell us about yourself...',
+      rows: 3,
+      toView: attributes =>
+        h.div(
+          [h.Class(fieldClassName)],
+          [
+            h.label([...attributes.label, h.Class(labelClassName)], ['Bio']),
+            h.textarea([...attributes.textarea, h.Class(textareaClassName)]),
+            h.span(
+              [...attributes.description, h.Class(descriptionClassName)],
+              ['A brief introduction about yourself.'],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+const termsCheckbox = (isChecked: boolean, h: HtmlBuilder<UiMessage>): Html =>
+  Checkbox.view(
+    {
+      id: FIELDSET_CHECKBOX_DEMO_ID,
+      isChecked,
+      onToggle: nextIsChecked =>
+        ToggledFieldsetCheckboxDemo({ isChecked: nextIsChecked }),
+      toView: attributes =>
+        h.div(
+          [h.Class('flex flex-col gap-1')],
+          [
+            h.div(
+              [h.Class('flex items-center gap-2')],
+              [
+                h.button(
+                  [...attributes.checkbox, h.Class(checkboxClassName)],
+                  isChecked ? [checkmark(h)] : [],
+                ),
+                h.label(
+                  [...attributes.label, h.Class(checkboxLabelClassName)],
+                  ['I agree to the terms and conditions'],
+                ),
+              ],
+            ),
+            h.p(
+              [
+                ...attributes.description,
+                h.Class(checkboxDescriptionClassName),
+              ],
+              ['You agree to our Terms of Service and Privacy Policy.'],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+// DISABLED FIELDS
+
+const disabledNameInput = (h: HtmlBuilder<UiMessage>): Html =>
+  Input.view(
+    {
+      id: 'fieldset-disabled-name-input',
+      isDisabled: true,
+      value: 'Ada Lovelace',
+      toView: attributes =>
+        h.div(
+          [h.Class(fieldClassName)],
+          [
+            h.label([...attributes.label, h.Class(labelClassName)], ['Name']),
+            h.input([...attributes.input, h.Class(inputClassName)]),
+          ],
+        ),
+    },
+    h,
+  )
+
+const disabledBioTextarea = (h: HtmlBuilder<UiMessage>): Html =>
+  Textarea.view(
+    {
+      id: 'fieldset-disabled-bio-textarea',
+      isDisabled: true,
+      value:
+        "Mathematician and writer, known for work on Charles Babbage's Analytical Engine.",
+      rows: 3,
+      toView: attributes =>
+        h.div(
+          [h.Class(fieldClassName)],
+          [
+            h.label([...attributes.label, h.Class(labelClassName)], ['Bio']),
+            h.textarea([...attributes.textarea, h.Class(textareaClassName)]),
+          ],
+        ),
+    },
+    h,
+  )
+
+const disabledTermsCheckbox = (h: HtmlBuilder<UiMessage>): Html =>
+  Checkbox.view(
+    {
+      id: FIELDSET_DISABLED_CHECKBOX_ID,
+      isChecked: true,
+      isDisabled: true,
+      onToggle: isChecked => ToggledFieldsetCheckboxDemo({ isChecked }),
+      toView: attributes =>
+        h.div(
+          [h.Class('flex items-center gap-2')],
+          [
+            h.button(
+              [...attributes.checkbox, h.Class(checkboxClassName)],
+              [checkmark(h)],
+            ),
+            h.label(
+              [...attributes.label, h.Class(checkboxLabelClassName)],
+              ['I agree to the terms and conditions'],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+// DEMOS
+
+const basicDemo = (model: UiModel, h: HtmlBuilder<UiMessage>): Html =>
+  Fieldset.view(
+    {
+      id: 'fieldset-basic-demo',
+      toView: attributes =>
+        h.fieldset(
+          [...attributes.fieldset, h.Class(fieldsetClassName)],
+          [
+            h.legend(
+              [...attributes.legend, h.Class(legendClassName)],
+              ['Personal Information'],
+            ),
+            h.span(
+              [
+                ...attributes.description,
+                h.Class(`${descriptionClassName} mt-1`),
+              ],
+              ['We just need a few details.'],
+            ),
+            h.div(
+              [h.Class(fieldsClassName)],
+              [
+                nameInput(model.fieldsetInputValue, h),
+                bioTextarea(model.fieldsetTextareaValue, h),
+                termsCheckbox(model.isFieldsetCheckboxDemoChecked, h),
+              ],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+const disabledDemo = (h: HtmlBuilder<UiMessage>): Html =>
+  Fieldset.view(
+    {
+      id: 'fieldset-disabled-demo',
+      isDisabled: true,
+      toView: attributes =>
+        h.fieldset(
+          [...attributes.fieldset, h.Class(fieldsetClassName)],
+          [
+            h.legend(
+              [...attributes.legend, h.Class(legendClassName)],
+              ['Personal Information'],
+            ),
+            h.span(
+              [
+                ...attributes.description,
+                h.Class(`${descriptionClassName} mt-1`),
+              ],
+              ['This fieldset is disabled.'],
+            ),
+            h.div(
+              [h.Class(fieldsClassName)],
+              [
+                disabledNameInput(h),
+                disabledBioTextarea(h),
+                disabledTermsCheckbox(h),
+              ],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+// VIEW
+
 export const view = Submodel.defineView<UiModel, UiMessage>(
   (model, h): Html => {
-    const checkmark = h.span([h.Class('text-white text-xs')], ['✓'])
-
     return h.div(
       [],
       [
         h.h2([h.Class('text-2xl font-bold text-gray-900 mb-6')], ['Fieldset']),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Basic'],
-        ),
-        Fieldset.view(
-          {
-            id: 'fieldset-basic-demo',
-            toView: attributes =>
-              h.fieldset(
-                [...attributes.fieldset, h.Class(fieldsetClassName)],
-                [
-                  h.legend(
-                    [...attributes.legend, h.Class(legendClassName)],
-                    ['Personal Information'],
-                  ),
-                  h.span(
-                    [
-                      ...attributes.description,
-                      h.Class(`${descriptionClassName} mt-1`),
-                    ],
-                    ['We just need a few details.'],
-                  ),
-                  h.div(
-                    [h.Class('mt-4 flex flex-col gap-4')],
-                    [
-                      Input.view(
-                        {
-                          id: 'fieldset-name-input',
-                          value: model.fieldsetInputValue,
-                          onInput: value =>
-                            UpdatedFieldsetInputValue({ value }),
-                          placeholder: 'Enter your full name',
-                          toView: inputAttributes =>
-                            h.div(
-                              [h.Class('flex flex-col gap-1.5')],
-                              [
-                                h.label(
-                                  [
-                                    ...inputAttributes.label,
-                                    h.Class(labelClassName),
-                                  ],
-                                  ['Name'],
-                                ),
-                                h.input([
-                                  ...inputAttributes.input,
-                                  h.Class(inputClassName),
-                                ]),
-                                h.span(
-                                  [
-                                    ...inputAttributes.description,
-                                    h.Class(descriptionClassName),
-                                  ],
-                                  [
-                                    'As it appears on your government-issued ID.',
-                                  ],
-                                ),
-                              ],
-                            ),
-                        },
-                        h,
-                      ),
-                      Textarea.view(
-                        {
-                          id: 'fieldset-bio-textarea',
-                          value: model.fieldsetTextareaValue,
-                          onInput: value =>
-                            UpdatedFieldsetTextareaValue({ value }),
-                          placeholder: 'Tell us about yourself...',
-                          rows: 3,
-                          toView: textareaAttributes =>
-                            h.div(
-                              [h.Class('flex flex-col gap-1.5')],
-                              [
-                                h.label(
-                                  [
-                                    ...textareaAttributes.label,
-                                    h.Class(labelClassName),
-                                  ],
-                                  ['Bio'],
-                                ),
-                                h.textarea([
-                                  ...textareaAttributes.textarea,
-                                  h.Class(textareaClassName),
-                                ]),
-                                h.span(
-                                  [
-                                    ...textareaAttributes.description,
-                                    h.Class(descriptionClassName),
-                                  ],
-                                  ['A brief introduction about yourself.'],
-                                ),
-                              ],
-                            ),
-                        },
-                        h,
-                      ),
-                      Checkbox.view(
-                        {
-                          id: FIELDSET_CHECKBOX_DEMO_ID,
-                          isChecked: model.isFieldsetCheckboxDemoChecked,
-                          onToggle: isChecked =>
-                            ToggledFieldsetCheckboxDemo({ isChecked }),
-                          toView: checkboxAttributes =>
-                            h.div(
-                              [h.Class('flex flex-col gap-1')],
-                              [
-                                h.div(
-                                  [h.Class('flex items-center gap-2')],
-                                  [
-                                    h.button(
-                                      [
-                                        ...checkboxAttributes.checkbox,
-                                        h.Class(checkboxClassName),
-                                      ],
-                                      model.isFieldsetCheckboxDemoChecked
-                                        ? [checkmark]
-                                        : [],
-                                    ),
-                                    h.label(
-                                      [
-                                        ...checkboxAttributes.label,
-                                        h.Class(checkboxLabelClassName),
-                                      ],
-                                      ['I agree to the terms and conditions'],
-                                    ),
-                                  ],
-                                ),
-                                h.p(
-                                  [
-                                    ...checkboxAttributes.description,
-                                    h.Class(checkboxDescriptionClassName),
-                                  ],
-                                  [
-                                    'You agree to our Terms of Service and Privacy Policy.',
-                                  ],
-                                ),
-                              ],
-                            ),
-                        },
-                        h,
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-          },
-          h,
-        ),
+        h.h3([h.Class(sectionHeadingClassName)], ['Basic']),
+        basicDemo(model, h),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Disabled'],
-        ),
-        Fieldset.view(
-          {
-            id: 'fieldset-disabled-demo',
-            isDisabled: true,
-            toView: attributes =>
-              h.fieldset(
-                [...attributes.fieldset, h.Class(fieldsetClassName)],
-                [
-                  h.legend(
-                    [...attributes.legend, h.Class(legendClassName)],
-                    ['Personal Information'],
-                  ),
-                  h.span(
-                    [
-                      ...attributes.description,
-                      h.Class(`${descriptionClassName} mt-1`),
-                    ],
-                    ['This fieldset is disabled.'],
-                  ),
-                  h.div(
-                    [h.Class('mt-4 flex flex-col gap-4')],
-                    [
-                      Input.view(
-                        {
-                          id: 'fieldset-disabled-name-input',
-                          isDisabled: true,
-                          value: 'Ada Lovelace',
-                          toView: inputAttributes =>
-                            h.div(
-                              [h.Class('flex flex-col gap-1.5')],
-                              [
-                                h.label(
-                                  [
-                                    ...inputAttributes.label,
-                                    h.Class(labelClassName),
-                                  ],
-                                  ['Name'],
-                                ),
-                                h.input([
-                                  ...inputAttributes.input,
-                                  h.Class(inputClassName),
-                                ]),
-                              ],
-                            ),
-                        },
-                        h,
-                      ),
-                      Textarea.view(
-                        {
-                          id: 'fieldset-disabled-bio-textarea',
-                          isDisabled: true,
-                          value:
-                            "Mathematician and writer, known for work on Charles Babbage's Analytical Engine.",
-                          rows: 3,
-                          toView: textareaAttributes =>
-                            h.div(
-                              [h.Class('flex flex-col gap-1.5')],
-                              [
-                                h.label(
-                                  [
-                                    ...textareaAttributes.label,
-                                    h.Class(labelClassName),
-                                  ],
-                                  ['Bio'],
-                                ),
-                                h.textarea([
-                                  ...textareaAttributes.textarea,
-                                  h.Class(textareaClassName),
-                                ]),
-                              ],
-                            ),
-                        },
-                        h,
-                      ),
-                      Checkbox.view(
-                        {
-                          id: FIELDSET_DISABLED_CHECKBOX_ID,
-                          isChecked: true,
-                          isDisabled: true,
-                          onToggle: isChecked =>
-                            ToggledFieldsetCheckboxDemo({ isChecked }),
-                          toView: checkboxAttributes =>
-                            h.div(
-                              [h.Class('flex items-center gap-2')],
-                              [
-                                h.button(
-                                  [
-                                    ...checkboxAttributes.checkbox,
-                                    h.Class(checkboxClassName),
-                                  ],
-                                  [checkmark],
-                                ),
-                                h.label(
-                                  [
-                                    ...checkboxAttributes.label,
-                                    h.Class(checkboxLabelClassName),
-                                  ],
-                                  ['I agree to the terms and conditions'],
-                                ),
-                              ],
-                            ),
-                        },
-                        h,
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-          },
-          h,
-        ),
+        h.h3([h.Class(sectionHeadingClassName)], ['Disabled']),
+        disabledDemo(h),
       ],
     )
   },

--- a/examples/ui-showcase/src/ui/view/listbox.ts
+++ b/examples/ui-showcase/src/ui/view/listbox.ts
@@ -1,6 +1,6 @@
 import { Array, Option } from 'effect'
 import { Submodel } from 'foldkit'
-import { type Html, childAttributes } from 'foldkit/html'
+import { type Html, type HtmlBuilder, childAttributes } from 'foldkit/html'
 
 import { Listbox } from '@foldkit/ui'
 
@@ -69,240 +69,196 @@ const labelClassName = 'block text-sm font-medium text-gray-700'
 
 const fieldClassName = 'flex flex-col gap-1.5 items-start'
 
+const checkIconClassName =
+  'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900'
+
+const buttonContentClassName = 'flex w-full items-center justify-between gap-4'
+
+const sectionHeadingClassName = 'text-lg font-semibold text-gray-900 mt-8 mb-4'
+
 const LISTBOX_ANCHOR = {
   placement: 'bottom-start' as const,
   gap: 4,
   padding: 8,
 }
 
+// PIECES
+
+const itemContent = (label: string, h: HtmlBuilder<UiMessage>): Html =>
+  h.div(
+    [h.Class('flex items-center gap-2')],
+    [Icon.check(checkIconClassName), h.span([], [label])],
+  )
+
+const buttonContent = (label: string, h: HtmlBuilder<UiMessage>): Html =>
+  h.div(
+    [h.Class(buttonContentClassName)],
+    [h.span([], [label]), Icon.chevronDown('w-4 h-4')],
+  )
+
+const chromeAttributes = (h: HtmlBuilder<UiMessage>) => ({
+  buttonAttributes: childAttributes([h.Class(triggerClassName)]),
+  itemsAttributes: childAttributes([h.Class(itemsClassName)]),
+  backdropAttributes: childAttributes([h.Class(backdropClassName)]),
+  attributes: childAttributes([h.Class(wrapperClassName)]),
+})
+
+const field = (
+  buttonId: string,
+  label: string,
+  listbox: Html,
+  h: HtmlBuilder<UiMessage>,
+): Html =>
+  h.div(
+    [h.Class(fieldClassName)],
+    [
+      h.label([h.For(buttonId), h.Class(labelClassName)], [label]),
+      h.div([h.Class('relative')], [listbox]),
+    ],
+  )
+
+// DEMOS
+
+const singleSelectDemo = (
+  listboxModel: Listbox.Model,
+  maybeSelectedItem: Option.Option<ListboxItem>,
+  h: HtmlBuilder<UiMessage>,
+): Html => {
+  const buttonLabel = Option.getOrElse(
+    maybeSelectedItem,
+    () => 'Select a Bluth',
+  )
+
+  return field(
+    Listbox.buttonId(listboxModel.id),
+    'Family member',
+    h.submodel({
+      slotId: 'listbox-single',
+      model: listboxModel,
+      view: ItemListbox.view,
+      viewInputs: {
+        anchor: LISTBOX_ANCHOR,
+        items: LISTBOX_ITEMS,
+        maybeSelectedValue: maybeSelectedItem,
+        itemToConfig: item => ({
+          className: itemClassName,
+          content: itemContent(item, h),
+        }),
+        buttonContent: buttonContent(buttonLabel, h),
+        ...chromeAttributes(h),
+      },
+      toParentMessage: message => GotListboxDemoMessage({ message }),
+    }),
+    h,
+  )
+}
+
+const multiSelectDemo = (
+  listboxModel: Listbox.Multi.Model,
+  selectedItems: ReadonlyArray<ListboxItem>,
+  h: HtmlBuilder<UiMessage>,
+): Html => {
+  const buttonLabel = Array.match(selectedItems, {
+    onEmpty: () => 'Select Bluths',
+    onNonEmpty: items =>
+      items.length === 1
+        ? Array.headNonEmpty(items)
+        : `${items.length} selected`,
+  })
+
+  return field(
+    Listbox.Multi.buttonId(listboxModel.id),
+    'Family members',
+    h.submodel({
+      slotId: 'listbox-multi',
+      model: listboxModel,
+      view: ItemMultiListbox.view,
+      viewInputs: {
+        anchor: LISTBOX_ANCHOR,
+        items: LISTBOX_ITEMS,
+        selectedValues: selectedItems,
+        itemToConfig: item => ({
+          className: itemClassName,
+          content: itemContent(item, h),
+        }),
+        buttonContent: buttonContent(buttonLabel, h),
+        ...chromeAttributes(h),
+      },
+      toParentMessage: message => GotListboxMultiDemoMessage({ message }),
+    }),
+    h,
+  )
+}
+
+const groupedDemo = (
+  listboxModel: Listbox.Model,
+  maybeSelectedItem: Option.Option<string>,
+  h: HtmlBuilder<UiMessage>,
+): Html => {
+  const buttonLabel = Option.getOrElse(
+    maybeSelectedItem,
+    () => 'Select a character',
+  )
+
+  return field(
+    Listbox.buttonId(listboxModel.id),
+    'Character',
+    h.submodel({
+      slotId: 'listbox-grouped',
+      model: listboxModel,
+      view: CharacterListbox.view,
+      viewInputs: {
+        anchor: LISTBOX_ANCHOR,
+        items: GROUPED_CHARACTERS,
+        maybeSelectedValue: maybeSelectedItem,
+        itemToValue: characterName,
+        itemGroupKey: character => character.lastName,
+        groupToHeading: lastName => ({
+          content: h.span([], [`${lastName}s`]),
+          className: groupHeadingClassName,
+        }),
+        separatorAttributes: childAttributes([h.Class(separatorClassName)]),
+        itemToConfig: character => ({
+          className: itemClassName,
+          content: itemContent(characterName(character), h),
+        }),
+        buttonContent: buttonContent(buttonLabel, h),
+        ...chromeAttributes(h),
+      },
+      toParentMessage: message => GotListboxGroupedDemoMessage({ message }),
+    }),
+    h,
+  )
+}
+
+// VIEW
+
 export const view = Submodel.defineView<UiModel, UiMessage>(
   (model, h): Html => {
-    const singleButtonLabel = Option.getOrElse(
-      model.maybeListboxDemoSelectedItem,
-      () => 'Select a Bluth',
-    )
-
-    const multiButtonLabel = Array.match(model.listboxMultiDemoSelectedItems, {
-      onEmpty: () => 'Select Bluths',
-      onNonEmpty: items =>
-        items.length === 1
-          ? Array.headNonEmpty(items)
-          : `${items.length} selected`,
-    })
-
-    const groupedButtonLabel = Option.getOrElse(
-      model.maybeListboxGroupedDemoSelectedItem,
-      () => 'Select a character',
-    )
-
     return h.div(
       [],
       [
         h.h2([h.Class('text-2xl font-bold text-gray-900 mb-6')], ['Listbox']),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Single-Select'],
-        ),
-        h.div(
-          [h.Class(fieldClassName)],
-          [
-            h.label(
-              [
-                h.For(Listbox.buttonId(model.listboxDemo.id)),
-                h.Class(labelClassName),
-              ],
-              ['Family member'],
-            ),
-            h.div(
-              [h.Class('relative')],
-              [
-                h.submodel({
-                  slotId: 'listbox-single',
-                  model: model.listboxDemo,
-                  view: ItemListbox.view,
-                  viewInputs: {
-                    anchor: LISTBOX_ANCHOR,
-                    items: LISTBOX_ITEMS,
-                    maybeSelectedValue: model.maybeListboxDemoSelectedItem,
-                    itemToConfig: item => ({
-                      className: itemClassName,
-                      content: h.div(
-                        [h.Class('flex items-center gap-2')],
-                        [
-                          Icon.check(
-                            'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900',
-                          ),
-                          h.span([], [item]),
-                        ],
-                      ),
-                    }),
-                    buttonContent: h.div(
-                      [
-                        h.Class(
-                          'flex w-full items-center justify-between gap-4',
-                        ),
-                      ],
-                      [
-                        h.span([], [singleButtonLabel]),
-                        Icon.chevronDown('w-4 h-4'),
-                      ],
-                    ),
-                    buttonAttributes: childAttributes([
-                      h.Class(triggerClassName),
-                    ]),
-                    itemsAttributes: childAttributes([h.Class(itemsClassName)]),
-                    backdropAttributes: childAttributes([
-                      h.Class(backdropClassName),
-                    ]),
-                    attributes: childAttributes([h.Class(wrapperClassName)]),
-                  },
-                  toParentMessage: message =>
-                    GotListboxDemoMessage({ message }),
-                }),
-              ],
-            ),
-          ],
+        h.h3([h.Class(sectionHeadingClassName)], ['Single-Select']),
+        singleSelectDemo(
+          model.listboxDemo,
+          model.maybeListboxDemoSelectedItem,
+          h,
         ),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Multi-Select'],
-        ),
-        h.div(
-          [h.Class(fieldClassName)],
-          [
-            h.label(
-              [
-                h.For(Listbox.Multi.buttonId(model.listboxMultiDemo.id)),
-                h.Class(labelClassName),
-              ],
-              ['Family members'],
-            ),
-            h.div(
-              [h.Class('relative')],
-              [
-                h.submodel({
-                  slotId: 'listbox-multi',
-                  model: model.listboxMultiDemo,
-                  view: ItemMultiListbox.view,
-                  viewInputs: {
-                    anchor: LISTBOX_ANCHOR,
-                    items: LISTBOX_ITEMS,
-                    selectedValues: model.listboxMultiDemoSelectedItems,
-                    itemToConfig: item => ({
-                      className: itemClassName,
-                      content: h.div(
-                        [h.Class('flex items-center gap-2')],
-                        [
-                          Icon.check(
-                            'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900',
-                          ),
-                          h.span([], [item]),
-                        ],
-                      ),
-                    }),
-                    buttonContent: h.div(
-                      [
-                        h.Class(
-                          'flex w-full items-center justify-between gap-4',
-                        ),
-                      ],
-                      [
-                        h.span([], [multiButtonLabel]),
-                        Icon.chevronDown('w-4 h-4'),
-                      ],
-                    ),
-                    buttonAttributes: childAttributes([
-                      h.Class(triggerClassName),
-                    ]),
-                    itemsAttributes: childAttributes([h.Class(itemsClassName)]),
-                    backdropAttributes: childAttributes([
-                      h.Class(backdropClassName),
-                    ]),
-                    attributes: childAttributes([h.Class(wrapperClassName)]),
-                  },
-                  toParentMessage: message =>
-                    GotListboxMultiDemoMessage({ message }),
-                }),
-              ],
-            ),
-          ],
+        h.h3([h.Class(sectionHeadingClassName)], ['Multi-Select']),
+        multiSelectDemo(
+          model.listboxMultiDemo,
+          model.listboxMultiDemoSelectedItems,
+          h,
         ),
 
-        h.h3(
-          [h.Class('text-lg font-semibold text-gray-900 mt-8 mb-4')],
-          ['Grouped'],
-        ),
-        h.div(
-          [h.Class(fieldClassName)],
-          [
-            h.label(
-              [
-                h.For(Listbox.buttonId(model.listboxGroupedDemo.id)),
-                h.Class(labelClassName),
-              ],
-              ['Character'],
-            ),
-            h.div(
-              [h.Class('relative')],
-              [
-                h.submodel({
-                  slotId: 'listbox-grouped',
-                  model: model.listboxGroupedDemo,
-                  view: CharacterListbox.view,
-                  viewInputs: {
-                    anchor: LISTBOX_ANCHOR,
-                    items: GROUPED_CHARACTERS,
-                    maybeSelectedValue:
-                      model.maybeListboxGroupedDemoSelectedItem,
-                    itemToValue: characterName,
-                    itemGroupKey: character => character.lastName,
-                    groupToHeading: lastName => ({
-                      content: h.span([], [`${lastName}s`]),
-                      className: groupHeadingClassName,
-                    }),
-                    separatorAttributes: childAttributes([
-                      h.Class(separatorClassName),
-                    ]),
-                    itemToConfig: character => ({
-                      className: itemClassName,
-                      content: h.div(
-                        [h.Class('flex items-center gap-2')],
-                        [
-                          Icon.check(
-                            'w-4 h-4 shrink-0 invisible group-data-[selected]:visible text-gray-900',
-                          ),
-                          h.span([], [characterName(character)]),
-                        ],
-                      ),
-                    }),
-                    buttonContent: h.div(
-                      [
-                        h.Class(
-                          'flex w-full items-center justify-between gap-4',
-                        ),
-                      ],
-                      [
-                        h.span([], [groupedButtonLabel]),
-                        Icon.chevronDown('w-4 h-4'),
-                      ],
-                    ),
-                    buttonAttributes: childAttributes([
-                      h.Class(triggerClassName),
-                    ]),
-                    itemsAttributes: childAttributes([h.Class(itemsClassName)]),
-                    backdropAttributes: childAttributes([
-                      h.Class(backdropClassName),
-                    ]),
-                    attributes: childAttributes([h.Class(wrapperClassName)]),
-                  },
-                  toParentMessage: message =>
-                    GotListboxGroupedDemoMessage({ message }),
-                }),
-              ],
-            ),
-          ],
+        h.h3([h.Class(sectionHeadingClassName)], ['Grouped']),
+        groupedDemo(
+          model.listboxGroupedDemo,
+          model.maybeListboxGroupedDemoSelectedItem,
+          h,
         ),
       ],
     )

--- a/packages/website/src/page/ui/calendar.ts
+++ b/packages/website/src/page/ui/calendar.ts
@@ -25,12 +25,10 @@ const navButtonClassName =
 
 const gridClassName = 'flex flex-col gap-1 outline-none'
 
-const headerRowClassName = 'grid grid-cols-7 gap-1'
+const rowClassName = 'grid grid-cols-7 gap-1'
 
 const columnHeaderClassName =
   'text-center text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 py-1'
-
-const weekRowClassName = 'grid grid-cols-7 gap-1'
 
 const cellClassName = 'group flex items-center justify-center'
 
@@ -63,7 +61,7 @@ const headingButton = (
 
 const weekRow = (week: Calendar.Week, h: HtmlBuilder<Message>): Html =>
   h.div(
-    [...week.attributes, h.Class(weekRowClassName)],
+    [...week.attributes, h.Class(rowClassName)],
     week.cells.map(cell =>
       h.div(
         [...cell.cellAttributes, h.Class(cellClassName)],
@@ -98,7 +96,7 @@ const daysView = (
         [...days.grid, h.Class(gridClassName)],
         [
           h.div(
-            [...days.headerRow, h.Class(headerRowClassName)],
+            [...days.headerRow, h.Class(rowClassName)],
             days.columnHeaders.map(header =>
               h.div(
                 [...header.attributes, h.Class(columnHeaderClassName)],

--- a/packages/website/src/page/ui/datePicker.ts
+++ b/packages/website/src/page/ui/datePicker.ts
@@ -40,12 +40,10 @@ const navButtonClassName =
 
 const gridClassName = 'flex flex-col gap-1 outline-none'
 
-const headerRowClassName = 'grid grid-cols-7 gap-1'
+const rowClassName = 'grid grid-cols-7 gap-1'
 
 const columnHeaderClassName =
   'text-center text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 py-1'
-
-const weekRowClassName = 'grid grid-cols-7 gap-1'
 
 const cellClassName = 'group flex items-center justify-center'
 
@@ -78,7 +76,7 @@ const headingButton = (
 
 const weekRow = (week: Calendar.Week, h: HtmlBuilder<Message>): Html =>
   h.div(
-    [...week.attributes, h.Class(weekRowClassName)],
+    [...week.attributes, h.Class(rowClassName)],
     week.cells.map(cell =>
       h.div(
         [...cell.cellAttributes, h.Class(cellClassName)],
@@ -113,7 +111,7 @@ const daysView = (
         [...days.grid, h.Class(gridClassName)],
         [
           h.div(
-            [...days.headerRow, h.Class(headerRowClassName)],
+            [...days.headerRow, h.Class(rowClassName)],
             days.columnHeaders.map(header =>
               h.div(
                 [...header.attributes, h.Class(columnHeaderClassName)],

--- a/packages/website/src/page/ui/dialog.ts
+++ b/packages/website/src/page/ui/dialog.ts
@@ -1,5 +1,5 @@
 import { Option } from 'effect'
-import type { HtmlBuilder } from 'foldkit/html'
+import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Combobox, Dialog } from '@foldkit/ui'
 
@@ -44,8 +44,12 @@ const confirmPanelClassName =
 
 const titleClassName = 'text-lg font-normal text-gray-900 dark:text-white mb-2'
 
+const descriptionClassName = 'text-gray-600 dark:text-gray-300 mb-4'
+
 const dialogClassName =
   'bg-transparent p-0 open:flex items-center justify-center'
+
+const actionsClassName = 'flex gap-2 justify-end'
 
 const cancelButtonClassName =
   'px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
@@ -63,6 +67,138 @@ const OVERLAY_COMBOBOX_ANCHOR = {
   portal: false,
 }
 
+// PANEL CONTENT
+
+const trigger = (label: string, message: Message, h: HtmlBuilder<Message>) =>
+  h.div(
+    [h.Class('flex gap-3')],
+    [h.button([h.Class(triggerClassName), h.OnClick(message)], [label])],
+  )
+
+const confirmContent = (
+  title: Dialog.RenderInfo['title'],
+  description: Dialog.RenderInfo['description'],
+  closeButton: Dialog.RenderInfo['closeButton'],
+  descriptionText: string,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [],
+    [
+      h.h2([...title, h.Class(titleClassName)], ['Confirm Action']),
+      h.p([...description, h.Class(descriptionClassName)], [descriptionText]),
+      h.div(
+        [h.Class(actionsClassName)],
+        [
+          h.button(
+            [...closeButton, h.Class(cancelButtonClassName)],
+            ['Cancel'],
+          ),
+          h.button(
+            [...closeButton, h.Class(confirmButtonClassName)],
+            ['Confirm'],
+          ),
+        ],
+      ),
+    ],
+  )
+
+const editFiltersContent = (
+  title: Dialog.RenderInfo['title'],
+  description: Dialog.RenderInfo['description'],
+  comboboxModel: Combobox.Model,
+  maybeSelectedCity: Option.Option<City>,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [],
+    [
+      h.h2([...title, h.Class(titleClassName)], ['Edit filters']),
+      h.p(
+        [...description, h.Class(descriptionClassName)],
+        [
+          'With portal: false, the combobox panel stays inside the dialog instead of rendering behind it.',
+        ],
+      ),
+      h.submodel({
+        slotId: comboboxModel.id,
+        model: comboboxModel,
+        view: CityCombobox.view,
+        viewInputs: {
+          ...comboboxViewInputs({
+            inputValue: comboboxModel.inputValue,
+            restingInputValue: Option.getOrElse(maybeSelectedCity, () => ''),
+            anchor: OVERLAY_COMBOBOX_ANCHOR,
+            wrapperClass: 'relative w-full',
+          }),
+          maybeSelectedValue: maybeSelectedCity,
+        },
+        toParentMessage: message => GotOverlayComboboxDemoMessage({ message }),
+      }),
+    ],
+  )
+
+const projectSettingsContent = (
+  title: Dialog.RenderInfo['title'],
+  description: Dialog.RenderInfo['description'],
+  closeButton: Dialog.RenderInfo['closeButton'],
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [],
+    [
+      h.h2([...title, h.Class(titleClassName)], ['Project settings']),
+      h.p(
+        [...description, h.Class(descriptionClassName)],
+        [
+          'Deleting the project removes all of its data. The confirmation opens as a second dialog stacked on top of this one.',
+        ],
+      ),
+      h.div(
+        [h.Class(actionsClassName)],
+        [
+          h.button([...closeButton, h.Class(cancelButtonClassName)], ['Close']),
+          h.button(
+            [h.Class(dangerButtonClassName), h.OnClick(ClickedDeleteProject())],
+            ['Delete project'],
+          ),
+        ],
+      ),
+    ],
+  )
+
+const deleteProjectContent = (
+  title: Dialog.RenderInfo['title'],
+  description: Dialog.RenderInfo['description'],
+  closeButton: Dialog.RenderInfo['closeButton'],
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [],
+    [
+      h.h2([...title, h.Class(titleClassName)], ['Delete project?']),
+      h.p(
+        [...description, h.Class(descriptionClassName)],
+        [
+          'This permanently deletes the project and cannot be undone. Escape closes this confirmation first, then the settings dialog.',
+        ],
+      ),
+      h.div(
+        [h.Class(actionsClassName)],
+        [
+          h.button(
+            [...closeButton, h.Class(cancelButtonClassName)],
+            ['Cancel'],
+          ),
+          h.button(
+            [...closeButton, h.Class(dangerButtonClassName)],
+            ['Delete'],
+          ),
+        ],
+      ),
+    ],
+  )
+
 // VIEW
 
 export const dialogDemo = (
@@ -70,15 +206,7 @@ export const dialogDemo = (
   h: HtmlBuilder<Message>,
 ) => {
   return [
-    h.div(
-      [h.Class('flex gap-3')],
-      [
-        h.button(
-          [h.Class(triggerClassName), h.OnClick(ClickedOpenDialog())],
-          ['Open Dialog'],
-        ),
-      ],
-    ),
+    trigger('Open Dialog', ClickedOpenDialog(), h),
     h.submodel({
       slotId: dialogModel.id,
       model: dialogModel,
@@ -101,42 +229,12 @@ export const dialogDemo = (
                   h.div(
                     [...panel, h.Class(panelClassName)],
                     [
-                      h.div(
-                        [],
-                        [
-                          h.h2(
-                            [...title, h.Class(titleClassName)],
-                            ['Confirm Action'],
-                          ),
-                          h.p(
-                            [
-                              ...description,
-                              h.Class('text-gray-600 dark:text-gray-300 mb-4'),
-                            ],
-                            [
-                              'Are you sure you want to proceed? This action demonstrates the Dialog component with focus trapping, backdrop click, and Escape key handling.',
-                            ],
-                          ),
-                          h.div(
-                            [h.Class('flex gap-2 justify-end')],
-                            [
-                              h.button(
-                                [
-                                  ...closeButton,
-                                  h.Class(cancelButtonClassName),
-                                ],
-                                ['Cancel'],
-                              ),
-                              h.button(
-                                [
-                                  ...closeButton,
-                                  h.Class(confirmButtonClassName),
-                                ],
-                                ['Confirm'],
-                              ),
-                            ],
-                          ),
-                        ],
+                      confirmContent(
+                        title,
+                        description,
+                        closeButton,
+                        'Are you sure you want to proceed? This action demonstrates the Dialog component with focus trapping, backdrop click, and Escape key handling.',
+                        h,
                       ),
                     ],
                   ),
@@ -156,15 +254,7 @@ export const overlayDialogDemo = (
   h: HtmlBuilder<Message>,
 ) => {
   return [
-    h.div(
-      [h.Class('flex gap-3')],
-      [
-        h.button(
-          [h.Class(triggerClassName), h.OnClick(ClickedEditFilters())],
-          ['Edit filters'],
-        ),
-      ],
-    ),
+    trigger('Edit filters', ClickedEditFilters(), h),
     h.submodel({
       slotId: dialogModel.id,
       model: dialogModel,
@@ -179,42 +269,12 @@ export const overlayDialogDemo = (
                   h.div(
                     [...panel, h.Class(panelClassName)],
                     [
-                      h.div(
-                        [],
-                        [
-                          h.h2(
-                            [...title, h.Class(titleClassName)],
-                            ['Edit filters'],
-                          ),
-                          h.p(
-                            [
-                              ...description,
-                              h.Class('text-gray-600 dark:text-gray-300 mb-4'),
-                            ],
-                            [
-                              'With portal: false, the combobox panel stays inside the dialog instead of rendering behind it.',
-                            ],
-                          ),
-                          h.submodel({
-                            slotId: comboboxModel.id,
-                            model: comboboxModel,
-                            view: CityCombobox.view,
-                            viewInputs: {
-                              ...comboboxViewInputs({
-                                inputValue: comboboxModel.inputValue,
-                                restingInputValue: Option.getOrElse(
-                                  maybeSelectedCity,
-                                  () => '',
-                                ),
-                                anchor: OVERLAY_COMBOBOX_ANCHOR,
-                                wrapperClass: 'relative w-full',
-                              }),
-                              maybeSelectedValue: maybeSelectedCity,
-                            },
-                            toParentMessage: message =>
-                              GotOverlayComboboxDemoMessage({ message }),
-                          }),
-                        ],
+                      editFiltersContent(
+                        title,
+                        description,
+                        comboboxModel,
+                        maybeSelectedCity,
+                        h,
                       ),
                     ],
                   ),
@@ -233,15 +293,7 @@ export const nestedDialogDemo = (
   h: HtmlBuilder<Message>,
 ) => {
   return [
-    h.div(
-      [h.Class('flex gap-3')],
-      [
-        h.button(
-          [h.Class(triggerClassName), h.OnClick(ClickedOpenProjectSettings())],
-          ['Open project settings'],
-        ),
-      ],
-    ),
+    trigger('Open project settings', ClickedOpenProjectSettings(), h),
     h.submodel({
       slotId: parentDialogModel.id,
       model: parentDialogModel,
@@ -264,42 +316,11 @@ export const nestedDialogDemo = (
                   h.div(
                     [...panel, h.Class(settingsPanelClassName)],
                     [
-                      h.div(
-                        [],
-                        [
-                          h.h2(
-                            [...title, h.Class(titleClassName)],
-                            ['Project settings'],
-                          ),
-                          h.p(
-                            [
-                              ...description,
-                              h.Class('text-gray-600 dark:text-gray-300 mb-4'),
-                            ],
-                            [
-                              'Deleting the project removes all of its data. The confirmation opens as a second dialog stacked on top of this one.',
-                            ],
-                          ),
-                          h.div(
-                            [h.Class('flex gap-2 justify-end')],
-                            [
-                              h.button(
-                                [
-                                  ...closeButton,
-                                  h.Class(cancelButtonClassName),
-                                ],
-                                ['Close'],
-                              ),
-                              h.button(
-                                [
-                                  h.Class(dangerButtonClassName),
-                                  h.OnClick(ClickedDeleteProject()),
-                                ],
-                                ['Delete project'],
-                              ),
-                            ],
-                          ),
-                        ],
+                      projectSettingsContent(
+                        title,
+                        description,
+                        closeButton,
+                        h,
                       ),
                     ],
                   ),
@@ -330,45 +351,7 @@ export const nestedDialogDemo = (
                   h.div([...backdrop, h.Class(backdropClassName)]),
                   h.div(
                     [...panel, h.Class(confirmPanelClassName)],
-                    [
-                      h.div(
-                        [],
-                        [
-                          h.h2(
-                            [...title, h.Class(titleClassName)],
-                            ['Delete project?'],
-                          ),
-                          h.p(
-                            [
-                              ...description,
-                              h.Class('text-gray-600 dark:text-gray-300 mb-4'),
-                            ],
-                            [
-                              'This permanently deletes the project and cannot be undone. Escape closes this confirmation first, then the settings dialog.',
-                            ],
-                          ),
-                          h.div(
-                            [h.Class('flex gap-2 justify-end')],
-                            [
-                              h.button(
-                                [
-                                  ...closeButton,
-                                  h.Class(cancelButtonClassName),
-                                ],
-                                ['Cancel'],
-                              ),
-                              h.button(
-                                [
-                                  ...closeButton,
-                                  h.Class(dangerButtonClassName),
-                                ],
-                                ['Delete'],
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ],
+                    [deleteProjectContent(title, description, closeButton, h)],
                   ),
                 ]
               : [],
@@ -384,15 +367,7 @@ export const dialogAnimatedDemo = (
   h: HtmlBuilder<Message>,
 ) => {
   return [
-    h.div(
-      [h.Class('flex gap-3')],
-      [
-        h.button(
-          [h.Class(triggerClassName), h.OnClick(ClickedOpenAnimatedDialog())],
-          ['Open Animated Dialog'],
-        ),
-      ],
-    ),
+    trigger('Open Animated Dialog', ClickedOpenAnimatedDialog(), h),
     h.submodel({
       slotId: dialogModel.id,
       model: dialogModel,
@@ -415,42 +390,12 @@ export const dialogAnimatedDemo = (
                   h.div(
                     [...panel, h.Class(animatedPanelClassName)],
                     [
-                      h.div(
-                        [],
-                        [
-                          h.h2(
-                            [...title, h.Class(titleClassName)],
-                            ['Confirm Action'],
-                          ),
-                          h.p(
-                            [
-                              ...description,
-                              h.Class('text-gray-600 dark:text-gray-300 mb-4'),
-                            ],
-                            [
-                              'This dialog uses CSS transitions coordinated by the TransitionState machine: a fade on the backdrop and a scale-up on the panel. Content stays mounted during exit so both enter and leave transitions play smoothly.',
-                            ],
-                          ),
-                          h.div(
-                            [h.Class('flex gap-2 justify-end')],
-                            [
-                              h.button(
-                                [
-                                  ...closeButton,
-                                  h.Class(cancelButtonClassName),
-                                ],
-                                ['Cancel'],
-                              ),
-                              h.button(
-                                [
-                                  ...closeButton,
-                                  h.Class(confirmButtonClassName),
-                                ],
-                                ['Confirm'],
-                              ),
-                            ],
-                          ),
-                        ],
+                      confirmContent(
+                        title,
+                        description,
+                        closeButton,
+                        'This dialog uses CSS transitions coordinated by the TransitionState machine: a fade on the backdrop and a scale-up on the panel. Content stays mounted during exit so both enter and leave transitions play smoothly.',
+                        h,
                       ),
                     ],
                   ),

--- a/packages/website/src/page/ui/fieldset.ts
+++ b/packages/website/src/page/ui/fieldset.ts
@@ -1,4 +1,4 @@
-import type { HtmlBuilder } from 'foldkit/html'
+import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Checkbox, Fieldset, Input, Textarea } from '@foldkit/ui'
 
@@ -39,11 +39,168 @@ const checkboxLabelClassName =
 
 const checkboxDescriptionClassName = 'text-sm text-gray-500 dark:text-gray-400'
 
+const fieldClassName = 'flex flex-col gap-1.5'
+
+const fieldsClassName = 'mt-4 flex flex-col gap-4'
+
+// FIELDS
+
+const checkmark = (h: HtmlBuilder<Message>): Html =>
+  h.span([h.Class('text-white text-xs')], ['✓'])
+
+const nameInput = (value: string, h: HtmlBuilder<Message>): Html =>
+  Input.view(
+    {
+      id: 'fieldset-name-input',
+      value,
+      onInput: inputValue => UpdatedFieldsetInputValue({ value: inputValue }),
+      placeholder: 'Enter your full name',
+      toView: attributes =>
+        h.div(
+          [h.Class(fieldClassName)],
+          [
+            h.label([...attributes.label, h.Class(labelClassName)], ['Name']),
+            h.input([...attributes.input, h.Class(inputClassName)]),
+            h.span(
+              [...attributes.description, h.Class(descriptionClassName)],
+              ['As it appears on your government-issued ID.'],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+const bioTextarea = (value: string, h: HtmlBuilder<Message>): Html =>
+  Textarea.view(
+    {
+      id: 'fieldset-bio-textarea',
+      value,
+      onInput: textareaValue =>
+        UpdatedFieldsetTextareaValue({ value: textareaValue }),
+      placeholder: 'Tell us about yourself...',
+      rows: 3,
+      toView: attributes =>
+        h.div(
+          [h.Class(fieldClassName)],
+          [
+            h.label([...attributes.label, h.Class(labelClassName)], ['Bio']),
+            h.textarea([...attributes.textarea, h.Class(textareaClassName)]),
+            h.span(
+              [...attributes.description, h.Class(descriptionClassName)],
+              ['A brief introduction about yourself.'],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+const termsCheckbox = (isChecked: boolean, h: HtmlBuilder<Message>): Html =>
+  Checkbox.view(
+    {
+      id: FIELDSET_CHECKBOX_DEMO_ID,
+      isChecked,
+      onToggle: nextIsChecked =>
+        ToggledFieldsetCheckboxDemo({ isChecked: nextIsChecked }),
+      toView: attributes =>
+        h.div(
+          [h.Class('flex flex-col gap-1')],
+          [
+            h.div(
+              [h.Class('flex items-center gap-2')],
+              [
+                h.button(
+                  [...attributes.checkbox, h.Class(checkboxClassName)],
+                  isChecked ? [checkmark(h)] : [],
+                ),
+                h.label(
+                  [...attributes.label, h.Class(checkboxLabelClassName)],
+                  ['I agree to the terms and conditions'],
+                ),
+              ],
+            ),
+            h.p(
+              [
+                ...attributes.description,
+                h.Class(checkboxDescriptionClassName),
+              ],
+              ['You agree to our Terms of Service and Privacy Policy.'],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
+// DISABLED FIELDS
+
+const disabledNameInput = (h: HtmlBuilder<Message>): Html =>
+  Input.view(
+    {
+      id: 'fieldset-disabled-name-input',
+      isDisabled: true,
+      value: 'Ada Lovelace',
+      toView: attributes =>
+        h.div(
+          [h.Class(fieldClassName)],
+          [
+            h.label([...attributes.label, h.Class(labelClassName)], ['Name']),
+            h.input([...attributes.input, h.Class(inputClassName)]),
+          ],
+        ),
+    },
+    h,
+  )
+
+const disabledBioTextarea = (h: HtmlBuilder<Message>): Html =>
+  Textarea.view(
+    {
+      id: 'fieldset-disabled-bio-textarea',
+      isDisabled: true,
+      value:
+        'Mathematician and writer, known for work on Charles Babbage’s Analytical Engine.',
+      rows: 3,
+      toView: attributes =>
+        h.div(
+          [h.Class(fieldClassName)],
+          [
+            h.label([...attributes.label, h.Class(labelClassName)], ['Bio']),
+            h.textarea([...attributes.textarea, h.Class(textareaClassName)]),
+          ],
+        ),
+    },
+    h,
+  )
+
+const disabledTermsCheckbox = (h: HtmlBuilder<Message>): Html =>
+  Checkbox.view(
+    {
+      id: FIELDSET_DISABLED_CHECKBOX_ID,
+      isChecked: true,
+      isDisabled: true,
+      onToggle: isChecked => ToggledFieldsetCheckboxDemo({ isChecked }),
+      toView: attributes =>
+        h.div(
+          [h.Class('flex items-center gap-2')],
+          [
+            h.button(
+              [...attributes.checkbox, h.Class(checkboxClassName)],
+              [checkmark(h)],
+            ),
+            h.label(
+              [...attributes.label, h.Class(checkboxLabelClassName)],
+              ['I agree to the terms and conditions'],
+            ),
+          ],
+        ),
+    },
+    h,
+  )
+
 // VIEW
 
 export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
-  const checkmark = h.span([h.Class('text-white text-xs')], ['✓'])
-
   return [
     Fieldset.view(
       {
@@ -64,120 +221,11 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
                 ['We just need a few details.'],
               ),
               h.div(
-                [h.Class('mt-4 flex flex-col gap-4')],
+                [h.Class(fieldsClassName)],
                 [
-                  Input.view(
-                    {
-                      id: 'fieldset-name-input',
-                      value: model.fieldsetInputValue,
-                      onInput: value => UpdatedFieldsetInputValue({ value }),
-                      placeholder: 'Enter your full name',
-                      toView: inputAttributes =>
-                        h.div(
-                          [h.Class('flex flex-col gap-1.5')],
-                          [
-                            h.label(
-                              [
-                                ...inputAttributes.label,
-                                h.Class(labelClassName),
-                              ],
-                              ['Name'],
-                            ),
-                            h.input([
-                              ...inputAttributes.input,
-                              h.Class(inputClassName),
-                            ]),
-                            h.span(
-                              [
-                                ...inputAttributes.description,
-                                h.Class(descriptionClassName),
-                              ],
-                              ['As it appears on your government-issued ID.'],
-                            ),
-                          ],
-                        ),
-                    },
-                    h,
-                  ),
-                  Textarea.view(
-                    {
-                      id: 'fieldset-bio-textarea',
-                      value: model.fieldsetTextareaValue,
-                      onInput: value => UpdatedFieldsetTextareaValue({ value }),
-                      placeholder: 'Tell us about yourself...',
-                      rows: 3,
-                      toView: textareaAttributes =>
-                        h.div(
-                          [h.Class('flex flex-col gap-1.5')],
-                          [
-                            h.label(
-                              [
-                                ...textareaAttributes.label,
-                                h.Class(labelClassName),
-                              ],
-                              ['Bio'],
-                            ),
-                            h.textarea([
-                              ...textareaAttributes.textarea,
-                              h.Class(textareaClassName),
-                            ]),
-                            h.span(
-                              [
-                                ...textareaAttributes.description,
-                                h.Class(descriptionClassName),
-                              ],
-                              ['A brief introduction about yourself.'],
-                            ),
-                          ],
-                        ),
-                    },
-                    h,
-                  ),
-                  Checkbox.view(
-                    {
-                      id: FIELDSET_CHECKBOX_DEMO_ID,
-                      isChecked: model.isFieldsetCheckboxDemoChecked,
-                      onToggle: isChecked =>
-                        ToggledFieldsetCheckboxDemo({ isChecked }),
-                      toView: checkboxAttributes =>
-                        h.div(
-                          [h.Class('flex flex-col gap-1')],
-                          [
-                            h.div(
-                              [h.Class('flex items-center gap-2')],
-                              [
-                                h.button(
-                                  [
-                                    ...checkboxAttributes.checkbox,
-                                    h.Class(checkboxClassName),
-                                  ],
-                                  model.isFieldsetCheckboxDemoChecked
-                                    ? [checkmark]
-                                    : [],
-                                ),
-                                h.label(
-                                  [
-                                    ...checkboxAttributes.label,
-                                    h.Class(checkboxLabelClassName),
-                                  ],
-                                  ['I agree to the terms and conditions'],
-                                ),
-                              ],
-                            ),
-                            h.p(
-                              [
-                                ...checkboxAttributes.description,
-                                h.Class(checkboxDescriptionClassName),
-                              ],
-                              [
-                                'You agree to our Terms of Service and Privacy Policy.',
-                              ],
-                            ),
-                          ],
-                        ),
-                    },
-                    h,
-                  ),
+                  nameInput(model.fieldsetInputValue, h),
+                  bioTextarea(model.fieldsetTextareaValue, h),
+                  termsCheckbox(model.isFieldsetCheckboxDemoChecked, h),
                 ],
               ),
             ],
@@ -189,8 +237,6 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
 }
 
 export const disabledDemo = (_model: Model, h: HtmlBuilder<Message>) => {
-  const checkmark = h.span([h.Class('text-white text-xs')], ['✓'])
-
   return [
     Fieldset.view(
       {
@@ -212,90 +258,11 @@ export const disabledDemo = (_model: Model, h: HtmlBuilder<Message>) => {
                 ['This fieldset is disabled.'],
               ),
               h.div(
-                [h.Class('mt-4 flex flex-col gap-4')],
+                [h.Class(fieldsClassName)],
                 [
-                  Input.view(
-                    {
-                      id: 'fieldset-disabled-name-input',
-                      isDisabled: true,
-                      value: 'Ada Lovelace',
-                      toView: inputAttributes =>
-                        h.div(
-                          [h.Class('flex flex-col gap-1.5')],
-                          [
-                            h.label(
-                              [
-                                ...inputAttributes.label,
-                                h.Class(labelClassName),
-                              ],
-                              ['Name'],
-                            ),
-                            h.input([
-                              ...inputAttributes.input,
-                              h.Class(inputClassName),
-                            ]),
-                          ],
-                        ),
-                    },
-                    h,
-                  ),
-                  Textarea.view(
-                    {
-                      id: 'fieldset-disabled-bio-textarea',
-                      isDisabled: true,
-                      value:
-                        'Mathematician and writer, known for work on Charles Babbage’s Analytical Engine.',
-                      rows: 3,
-                      toView: textareaAttributes =>
-                        h.div(
-                          [h.Class('flex flex-col gap-1.5')],
-                          [
-                            h.label(
-                              [
-                                ...textareaAttributes.label,
-                                h.Class(labelClassName),
-                              ],
-                              ['Bio'],
-                            ),
-                            h.textarea([
-                              ...textareaAttributes.textarea,
-                              h.Class(textareaClassName),
-                            ]),
-                          ],
-                        ),
-                    },
-                    h,
-                  ),
-                  Checkbox.view(
-                    {
-                      id: FIELDSET_DISABLED_CHECKBOX_ID,
-                      isChecked: true,
-                      isDisabled: true,
-                      onToggle: isChecked =>
-                        ToggledFieldsetCheckboxDemo({ isChecked }),
-                      toView: checkboxAttributes =>
-                        h.div(
-                          [h.Class('flex items-center gap-2')],
-                          [
-                            h.button(
-                              [
-                                ...checkboxAttributes.checkbox,
-                                h.Class(checkboxClassName),
-                              ],
-                              [checkmark],
-                            ),
-                            h.label(
-                              [
-                                ...checkboxAttributes.label,
-                                h.Class(checkboxLabelClassName),
-                              ],
-                              ['I agree to the terms and conditions'],
-                            ),
-                          ],
-                        ),
-                    },
-                    h,
-                  ),
+                  disabledNameInput(h),
+                  disabledBioTextarea(h),
+                  disabledTermsCheckbox(h),
                 ],
               ),
             ],


### PR DESCRIPTION
Follow-up to #1048, applying the same treatment to the demo sources that sit deepest.

### Scoping

Ranked by how much code actually lives in the deep zone (lines indented ten levels or more) rather than by max nesting alone, which separates genuinely tangled files from ones that are merely long. There is a clear gap after the top five (218, 200, 182, 115, 111, then 67), and those five are what this PR touches.

Notably, no docs snippet ranked, so the highest-visibility surface was already fine for these components. `popover.ts` scored 52 and is already half-factored behind its shared `popoverDemo`, so it is out. `combobox.ts` is 389 lines but flat: thirteen small demos, no deep expression.

| File | Max nesting | Deep lines | Lines |
| --- | --- | --- | --- |
| `showcase/fieldset.ts` | 20 → 9 | 218 → 0 | 300 → 256 |
| `website/dialog.ts` | 17 → 12 | 200 → 41 | 443 → 380 |
| `website/fieldset.ts` | 18 → 9 | 182 → 0 | 289 → 247 |
| `showcase/listbox.ts` | 14 → 5 | 115 → 0 | 286 → 231 |
| `showcase/dialog.ts` | 17 → 12 | 111 → 26 | 412 → 390 |

### Fieldset

The depth came from nesting one component's `toView` inside another's, four deep: the name input, bio textarea, and terms checkbox each lived inside the fieldset expression that rendered them. Each field is now its own view function.

The disabled variants stay separate functions rather than merging behind flags. The two demos differ in id, value, disabled state, and whether a description renders, so a shared field would be a parameter bag defined by what varies.

### Dialog

Each panel's contents moved out of `toView` into `confirmContent`, `editFiltersContent`, `projectSettingsContent`, and `deleteProjectContent`, and the repeated trigger button became `trigger`.

Each `toView` keeps its own dialog shell. A shared shell would need six parameters to cover the backdrop and panel class names the demos vary, which is the same trade this project declined for `gridCell` in #1048. The showcase file's `dialogPanel` is renamed `confirmContent`, matching what it builds and what the website file calls it.

### Listbox

All three demos were inline in one `view`. They are now `singleSelectDemo`, `multiSelectDemo`, and `groupedDemo`, sharing `field`, `itemContent`, `buttonContent`, and a `chromeAttributes` bundle. That bundle is identical across all three demos rather than parameterized by them, which is what makes it worth sharing.

### Class names

`headerRowClassName` and `weekRowClassName` held the same string in the four calendar and date picker views, so both call sites now use one `rowClassName`, matching what the docs snippets already do. Class names these files repeated inline are named: descriptions, action rows, trigger rows, check icons, and section headings.

Short single-use constants are left as they are. Every UI demo file uses the same styles-at-top block, and inlining only the short ones would leave a reader wondering why some classes are named and some are not.

### Verification

Typecheck, lint, prettier, 368 website tests, 11 ui-showcase tests, and `pnpm build` all pass. Driven in Chromium against the built site:

- Fieldset renders both legends, two inputs, one of them disabled, with descriptions intact.
- Dialog opens with title "Confirm Action" and Cancel/Confirm buttons; Escape closes it.
- Stacked dialogs open together, showing "Project settings" behind "Delete project?".
- The calendar day grid still renders its seven rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aRS14YUe1ePFStmMH9WDh


---
_Generated by [Claude Code](https://claude.ai/code/session_018aRS14YUe1ePFStmMH9WDh)_