### PR TITLE
docs: name the real root barrel import in the anchor subpath changeset

### DIFF
--- a/.changeset/anchor-public-subpath.md
+++ b/.changeset/anchor-public-subpath.md
@@ -18,7 +18,7 @@ import {
 
 `anchorSetup` and `portalToContainingRoot` are plain DOM functions that return a cleanup, meant to be called inside `Effect.sync` in a Mount and stashed in the Mount result. `AnchorConfig`, `Placement` and `Padding` are now available as Schema values, not only as types.
 
-The module is also reachable as `Ui.Anchor` from the root barrel and appears in the API reference.
+The module is also exported from the root barrel, as `import { Anchor } from '@foldkit/ui'`, and appears in the API reference as `Ui.Anchor`.
 
 Nothing is removed or renamed. `src/anchor.ts` moved to `src/anchor/`, which is internal layout only.
 


### PR DESCRIPTION
Closes #1052.

`.changeset/anchor-public-subpath.md`, still unreleased, said:

> The module is also reachable as `Ui.Anchor` from the root barrel and appears in the API reference.

`Ui.Anchor` is not a form a consumer writes. `packages/ui/src/index.ts:1` is `export * as Anchor from './anchor/public.js'`, so the barrel import is `import { Anchor } from '@foldkit/ui'`. The `Ui.` prefix comes from `packages/ui/typedoc-entry.ts:7`, which wraps the package under a `Ui` namespace so the merged API reference renders it apart from core's own modules.

So the sentence was right about the API reference and wrong about the barrel. It now gives each half its own clause:

> The module is also exported from the root barrel, as `import { Anchor } from '@foldkit/ui'`, and appears in the API reference as `Ui.Anchor`.

Both halves verified against source rather than assumed.

## Why now

The changeset has not shipped. `packages/ui/CHANGELOG.md` still has no mention of the subpath, so this would land verbatim in the published changelog on the next release, and it is the first thing a reader meets about the new subpath. Correcting it here beats correcting the changelog afterwards.

The same wording was corrected on the `/ui/anchor` page in #1045, where it had been copied from this changeset. The changeset was left alone at the time because it is a contributor's text and the fix was outside that PR's scope.

## Scope

One line. No scope on the subject, since `.changeset/` is not a package directory and CLAUDE.md says to omit the scope when none fits the whole change. No changeset of its own: editing a pending changeset is not a package change.

`changeset status`, `check:changeset-unwrapped`, `check:changeset-ignore`, `check:no-major-changesets`, and `format:check` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBVRxz8Bjh52iAhaNBLA4n)_