### PR TITLE
test(examples-e2e): cover the listbox, fieldset, and dialog demos

### DIFF
--- a/packages/examples-e2e/e2e/ui-showcase.spec.ts
+++ b/packages/examples-e2e/e2e/ui-showcase.spec.ts
@@ -33,6 +33,171 @@ test.describe('ui-showcase example', () => {
     await expect(trigger).toHaveAttribute('aria-expanded', 'true')
   })
 
+  test('opens the multi-select listbox when its external label is clicked', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Listbox', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/listbox$/)
+
+    const trigger = page.locator('#listbox-multi-demo-button')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(trigger).toHaveText('Select Bluths')
+
+    await page.locator('label[for="listbox-multi-demo-button"]').click()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+    const items = page.locator('#listbox-multi-demo-items')
+    await items.getByRole('option', { name: 'Gob Bluth', exact: true }).click()
+    await expect(trigger).toHaveText('Gob Bluth')
+
+    await items
+      .getByRole('option', { name: 'Buster Bluth', exact: true })
+      .click()
+    await expect(trigger).toHaveText('2 selected')
+  })
+
+  test('opens the grouped listbox and renders its group headings', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Listbox', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/listbox$/)
+
+    const trigger = page.locator('#listbox-grouped-demo-button')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await expect(trigger).toHaveText('Select a character')
+
+    await page.locator('label[for="listbox-grouped-demo-button"]').click()
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+    const items = page.locator('#listbox-grouped-demo-items')
+    await expect(items.getByText('Bluths', { exact: true })).toBeVisible()
+    await expect(items.getByText('Funkes', { exact: true })).toBeVisible()
+
+    await items
+      .getByRole('option', { name: 'Maeby Funke', exact: true })
+      .click()
+    await expect(trigger).toHaveText('Maeby Funke')
+  })
+
+  test('renders the fieldset demos with their descriptions and disabled state', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Fieldset', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/fieldset$/)
+
+    const basicFieldset = page.locator('#fieldset-basic-demo')
+    const disabledFieldset = page.locator('#fieldset-disabled-demo')
+    const nameDescription = 'As it appears on your government-issued ID.'
+
+    const nameInput = basicFieldset.locator('#fieldset-name-input')
+    await expect(nameInput).toBeEnabled()
+    await expect(
+      basicFieldset.getByText(nameDescription, { exact: true }),
+    ).toBeVisible()
+    await expect(
+      basicFieldset.getByText('A brief introduction about yourself.', {
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    const termsCheckbox = basicFieldset.getByRole('checkbox')
+    await expect(termsCheckbox).toHaveAttribute('aria-checked', 'false')
+    await termsCheckbox.click()
+    await expect(termsCheckbox).toHaveAttribute('aria-checked', 'true')
+
+    await expect(
+      disabledFieldset.locator('#fieldset-disabled-name-input'),
+    ).toBeDisabled()
+    await expect(
+      disabledFieldset.locator('#fieldset-disabled-bio-textarea'),
+    ).toBeDisabled()
+    await expect(
+      disabledFieldset.getByText(nameDescription, { exact: true }),
+    ).toHaveCount(0)
+  })
+
+  test('opens each dialog demo with its own panel content', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Dialog', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/dialog$/)
+
+    const openAndClose = async (
+      triggerName: string,
+      dialogId: string,
+      title: string,
+    ): Promise<void> => {
+      const heading = page
+        .locator(dialogId)
+        .getByRole('heading', { name: title, exact: true })
+
+      await page.getByRole('button', { name: triggerName, exact: true }).click()
+      await expect(heading).toBeVisible()
+      await page.keyboard.press('Escape')
+      await expect(heading).toBeHidden()
+    }
+
+    await openAndClose('Open Dialog', '#dialog-demo', 'Confirm Action')
+    await openAndClose(
+      'Open Animated Dialog',
+      '#dialog-animated-demo',
+      'Confirm Action',
+    )
+    await openAndClose('Edit filters', '#overlay-dialog-demo', 'Edit filters')
+  })
+
+  test('stacks the nested dialogs and dismisses them one at a time', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page
+      .getByRole('link', { name: 'Dialog', exact: true })
+      .first()
+      .click()
+    await expect(page).toHaveURL(/\/dialog$/)
+
+    const settingsTitle = page
+      .locator('#nested-dialog-parent-demo')
+      .getByRole('heading', { name: 'Project settings', exact: true })
+    const deleteTitle = page
+      .locator('#nested-dialog-child-demo')
+      .getByRole('heading', { name: 'Delete project?', exact: true })
+
+    await page
+      .getByRole('button', { name: 'Open project settings', exact: true })
+      .click()
+    await expect(settingsTitle).toBeVisible()
+
+    await page
+      .getByRole('button', { name: 'Delete project', exact: true })
+      .click()
+    await expect(deleteTitle).toBeVisible()
+    await expect(settingsTitle).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(deleteTitle).toBeHidden()
+    await expect(settingsTitle).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(settingsTitle).toBeHidden()
+  })
+
   test('opens the menu when its external label is clicked', async ({
     page,
   }) => {


### PR DESCRIPTION
Closes the coverage gap surfaced while verifying #1053.

The ui-showcase suite exercised the single-select listbox and one dialog scroll-lock case. The multi-select and grouped listboxes, the fieldset page, and three of the four dialog demos had no browser coverage at all, which is why restructuring those views could be reviewed but not verified.

### What is now covered

| Test | Asserts |
| --- | --- |
| multi-select listbox | External label opens it; trigger label goes `Select Bluths` → `Gob Bluth` → `2 selected` as selections accumulate |
| grouped listbox | External label opens it; both locale group headings (`Bluths`, `Funkes`) render; selecting commits the full character name |
| fieldset | Both field descriptions render; the checkbox toggles through the Model; the disabled variants are disabled and omit descriptions |
| dialog demos | Basic, Animated, and Field each open their own panel content and dismiss on Escape |
| stacked dialogs | Both titles visible together, then Escape dismisses one level at a time |

The multi-select and grouped cases pin the distinction between `Listbox.Multi.buttonId` and `Listbox.buttonId`. That one typechecks either way and would silently break the external-label association, and it was the specific risk the #1053 review called out as invisible to the existing suite.

Assertions are on rendered behavior (trigger text, heading visibility, aria state) rather than on structure, so they survive future refactors of these views while still catching a dropped attribute or mis-wired id.

### Two traps avoided

Every dialog heading is scoped to its own demo's id. The basic and animated dialogs both render a `Confirm Action` title, so a page-wide heading lookup would pass even with the animated trigger wired to the basic dialog.

The fieldset asserts the checkbox's `aria-checked` rather than an input's value. A typed value survives a re-render whether or not `onInput` reached the Model, because the vnode value is unchanged and snabbdom never rewrites the DOM property, so a `toHaveValue` assertion there cannot fail. Verified by mutation: deleting `onInput` leaves the value assertion green, while breaking `onToggle` turns the `aria-checked` assertion red.

### Verification

`EXAMPLE_SLUG=ui-showcase playwright test` with `retries: 0`: **16 passed** in 13.9s, the 11 existing plus these 5, all first attempt. Prettier, lint, and typecheck pass.

Note on the container: this environment has Playwright browser revision 1194 while the repo's version wants 1228, so the run used a local config override pointing at the installed Chromium. No repo config was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aRS14YUe1ePFStmMH9WDh
