### PR TITLE
fix: build ui and devtools in cloud session setup

### DIFF
--- a/scripts/cloud-session-setup.sh
+++ b/scripts/cloud-session-setup.sh
@@ -41,9 +41,17 @@ done
 echo "[setup] reconciling node_modules with pnpm-lock.yaml"
 pnpm install --frozen-lockfile
 
+# Every workspace package another package imports by name, because that import
+# resolves through the dependency's `exports` map into dist/. A package missing
+# from this list is a package the agent has to notice and build by hand, after
+# reading a "Cannot find module" or a wall of `never` and index-signature errors
+# that read like branch breakage. Packages nothing imports, such as the CLIs and
+# the typing game server, stay out: they are built by the tasks that need them.
 prerequisite_packages=(
   'foldkit:packages/foldkit'
   '@foldkit/markdown:packages/markdown'
+  '@foldkit/ui:packages/ui'
+  '@foldkit/devtools:packages/devtools'
   '@foldkit/vite-plugin:packages/vite-plugin-foldkit'
   '@foldkit/oxlint-plugin:packages/oxlint-plugin-foldkit'
   '@typing-game/shared:packages/typing-game/shared'


### PR DESCRIPTION
`scripts/cloud-session-setup.sh` pre-builds the workspace packages whose `exports` maps point at `dist/`, so a cloud snapshot missing those build outputs does not surface as branch breakage. `@foldkit/ui` and `@foldkit/devtools` were absent from that list while being two of the most widely imported packages in the repo.

## The failure

On a clean `main`, with both `dist/` directories removed:

```
$ pnpm -F website typecheck   # 974 errors
$ bash scripts/cloud-session-setup.sh
[setup] prerequisite package dist/ directories present and up to date
```

The errors are exactly the noise the script's own header calls phantom problems: `Cannot find module '@foldkit/ui'`, properties "from an index signature", bindings implicitly `any`, and configs typed `never`. Four figures of them, on a tree nobody touched.

The trap is the second line. An agent sees the error wall, runs the remedy `CLAUDE.md` prescribes for exactly this situation, is told the workspace is fine, and reasonably concludes the branch is broken. `CLAUDE.md` states these errors "are not pre-existing branch failures" and that the script reconciles them, which was not true for these two packages.

With both listed, the same starting state recovers:

```
$ bash scripts/cloud-session-setup.sh
[setup] building prerequisite packages (missing or stale dist/): -F @foldkit/ui -F @foldkit/devtools
$ pnpm -F website typecheck   # 0 errors
```

Re-running afterward reports up to date, so the staleness check still short-circuits.

## Why these two and not the others

Ten workspace packages export `dist/`. A package needs pre-building when another package imports it by name, because that import resolves through the dependency's `exports` map.

| Package | Workspace consumers | In list |
| --- | --- | --- |
| `foldkit`, `@foldkit/markdown`, `@foldkit/vite-plugin`, `@foldkit/oxlint-plugin`, `@typing-game/shared` | yes | already |
| `@foldkit/ui` | website, most examples, devtools | added |
| `@foldkit/devtools` | website, typing game client, most examples | added |
| `create-foldkit-app`, `@foldkit/devtools-mcp`, `@typing-game/server` | none | left out |

`@foldkit/devtools` happened to have a `dist/` in the snapshot I hit, so only `@foldkit/ui` bit me, but it carries the same latent failure with the same breadth of consumers.

The last three are CLIs and a server that nothing imports by name, so no other package's typecheck resolves through their exports maps, and the tasks that need them build them.

A comment above the list now states the rule, so the next package added to the workspace has a criterion to check itself against.

## Verification

Reproduced the failure and confirmed the fix on a clean `main` as shown above, checked the script stays idempotent on a second run, and the full pre-push gate passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_018MHoGhSm2VE1m5tiU7YKzU)_