### PR TITLE
docs(website): retitle and re-slug the server rendering blog post

### DIFF
--- a/packages/website/src/page/blog/post/foldkit-has-server-rendering-now.md
+++ b/packages/website/src/page/blog/post/foldkit-has-server-rendering-now.md
@@ -53,7 +53,7 @@ After hydration, the initial Commands run, and your Foldkit application behaves 
 
 ## What shipped
 
-Check out the [release notes](https://github.com/foldkit/foldkit/blob/main/packages/foldkit/CHANGELOG.md), the new docs page on [Server Rendering](/core/server-rendering), and the runnable [Static Site Generation](/example-apps/ssg) and [Server-Side Rendering](/example-apps/ssr) examples.
+Check out the [release notes](https://github.com/foldkit/foldkit/releases/tag/foldkit%400.147.0), the new docs page on [Server Rendering](/core/server-rendering), and the runnable [Static Site Generation](/example-apps/ssg) and [Server-Side Rendering](/example-apps/ssr) examples.
 
 This website ([foldkit.dev](https://foldkit.dev)) now prerenders every route through the same `renderPage` contract (SSG). The page you are reading hydrated in place.
 


### PR DESCRIPTION
Rename the post to `foldkit-has-server-rendering` and retitle it "Foldkit Has Server Rendering", dropping the dated "now" so the URL and headline stay evergreen. This also gives the launch tweet a fresh canonical URL, so X renders the correct cover card instead of a stale one.

- 308-redirect the old path (and its `.md` form) to the new one.
- Repoint the cover and inline image assets, moved to `public/blog/foldkit-has-server-rendering/`.
- Point the post's release-notes link at the `foldkit@0.147.0` release tag.