### PR TITLE
feat(oxlint-plugin): guard server browser globals

### DIFF
--- a/.changeset/oxlint-server-browser-globals.md
+++ b/.changeset/oxlint-server-browser-globals.md
@@ -1,0 +1,11 @@
+---
+'@foldkit/oxlint-plugin': minor
+---
+
+Add `foldkit/no-nonportable-server-globals` to both presets. The rule catches common browser-only globals in `entry.server.ts`, `entry.server.tsx`, TypeScript files under a `server` directory, and `prerender.ts`. Colocated files ending in `.test.ts`, `.test.tsx`, `.spec.ts`, or `.spec.tsx` are excluded.
+
+The curated list covers `document`, `window`, `navigator`, `localStorage`, `sessionStorage`, `history`, `location`, `alert`, `confirm`, `prompt`, `requestAnimationFrame`, `cancelAnimationFrame`, `requestIdleCallback`, `cancelIdleCallback`, `getComputedStyle`, `matchMedia`, `customElements`, `screen`, `IntersectionObserver`, `ResizeObserver`, and `MutationObserver`. The same names are caught when read through a static `globalThis` property or destructured directly from `globalThis`.
+
+Local bindings, parameters, and type-only `typeof` queries remain valid. `Request`, `Response`, `Headers`, `fetch`, and `URL` remain available for host code. The Foldkit-owned rule composes with any `no-restricted-globals` policy in the consuming project instead of replacing it.
+
+This is a portability guardrail, not an exhaustive list of browser APIs or a security boundary. Lint may newly fail when a recognized server file reads one of the listed globals at runtime.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -70,6 +70,24 @@
         "foldkit/selection-submodel-factory-at-module-scope": "error",
         "foldkit/wrap-child-output-in-got-message": "error"
       }
+    },
+    {
+      "files": [
+        "**/entry.server.ts",
+        "**/entry.server.tsx",
+        "**/server/**/*.ts",
+        "**/server/**/*.tsx",
+        "**/prerender.ts"
+      ],
+      "excludeFiles": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx"
+      ],
+      "rules": {
+        "foldkit/no-nonportable-server-globals": "error"
+      }
     }
   ],
   "ignorePatterns": [
@@ -91,6 +109,9 @@
     "packages/website/public/example-apps-embed/",
     "packages/website/playwright-report/",
     "packages/website/test-results/",
-    "packages/website/src/snippet/"
+    "packages/website/src/snippet/",
+    "!packages/website/scripts/prerender.ts",
+    "!examples/*/scripts/prerender.ts",
+    "!packages/vite-plugin-foldkit/test/fixtures/"
   ]
 }

--- a/packages/oxlint-plugin-foldkit/src/index.ts
+++ b/packages/oxlint-plugin-foldkit/src/index.ts
@@ -18,6 +18,7 @@ import { noEmptyObjectTaggedCall } from './rules/no-empty-object-tagged-call.ts'
 import { noHandRolledCommandStruct } from './rules/no-hand-rolled-command-struct.ts'
 import { noHardcodedRouteStrings } from './rules/no-hardcoded-route-strings.ts'
 import { noModuleLevelMutableState } from './rules/no-module-level-mutable-state.ts'
+import { noNonportableServerGlobals } from './rules/no-nonportable-server-globals.ts'
 import { noNoopMessage } from './rules/no-noop-message.ts'
 import { noRawDomEventAttributes } from './rules/no-raw-dom-event-attributes.ts'
 import { noSpreadInEvo } from './rules/no-spread-in-evo.ts'
@@ -48,6 +49,7 @@ const basePlugin = Plugin.define({
     'no-hand-rolled-command-struct': noHandRolledCommandStruct,
     'no-hardcoded-route-strings': noHardcodedRouteStrings,
     'no-module-level-mutable-state': noModuleLevelMutableState,
+    'no-nonportable-server-globals': noNonportableServerGlobals,
     'no-noop-message': noNoopMessage,
     'no-raw-dom-event-attributes': noRawDomEventAttributes,
     'no-spread-in-evo': noSpreadInEvo,
@@ -59,39 +61,67 @@ const basePlugin = Plugin.define({
   },
 })
 
+type Override = Readonly<{
+  files: Array<string>
+  excludeFiles?: Array<string>
+  rules: Record<string, Plugin.RuleSeverity>
+}>
+
 type OverriddenConfig = Plugin.OxlintConfig & {
-  overrides: Array<{
-    files: Array<string>
-    rules: Record<string, Plugin.RuleSeverity>
-  }>
+  overrides: Array<Override>
 }
 
-const testFilePatterns = ['**/*.test.ts', '**/*.test.tsx']
+const testFilePatterns = [
+  '**/*.test.ts',
+  '**/*.test.tsx',
+  '**/*.spec.ts',
+  '**/*.spec.tsx',
+]
+
+const serverFilePatterns = [
+  '**/entry.server.ts',
+  '**/entry.server.tsx',
+  '**/server/**/*.ts',
+  '**/server/**/*.tsx',
+  '**/prerender.ts',
+]
+
+const serverOverride: Override = {
+  files: serverFilePatterns,
+  excludeFiles: testFilePatterns,
+  rules: {
+    'foldkit/no-nonportable-server-globals': 'error',
+  },
+}
 
 // Foldkit rules police application definitions. Tests exercise those
 // definitions rather than write them, so the rules are inert at best and
 // invert at worst (a test may legitimately hardcode a route or hand-roll a
 // Command struct). Scope every foldkit rule off in test files by default; a
 // rule that wants test coverage opts in explicitly.
-const withTestOverride = (config: Plugin.OxlintConfig): OverriddenConfig => ({
+const testOverride = (config: Plugin.OxlintConfig): Override => ({
+  files: testFilePatterns,
+  rules: Object.fromEntries(
+    Object.keys(config.rules).map((id): [string, Plugin.RuleSeverity] => [
+      id,
+      'off',
+    ]),
+  ),
+})
+
+const withOverrides = (config: Plugin.OxlintConfig): OverriddenConfig => ({
   ...config,
-  overrides: [
-    {
-      files: testFilePatterns,
-      rules: Object.fromEntries(
-        Object.keys(config.rules).map((id): [string, Plugin.RuleSeverity] => [
-          id,
-          'off',
-        ]),
-      ),
-    },
-  ],
+  rules: {
+    ...config.rules,
+    'foldkit/no-nonportable-server-globals': 'off',
+  },
+  overrides: [serverOverride, testOverride(config)],
 })
 
 export default {
   ...basePlugin,
   configs: {
-    recommended: withTestOverride(basePlugin.configs.recommended),
-    all: withTestOverride(basePlugin.configs.all),
+    recommended: withOverrides(basePlugin.configs.recommended),
+    all: withOverrides(basePlugin.configs.all),
   },
 }

--- a/packages/oxlint-plugin-foldkit/src/rules/no-nonportable-server-globals.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-nonportable-server-globals.ts
@@ -1,0 +1,209 @@
+import { Array, Effect } from 'effect'
+import {
+  Diagnostic,
+  type ESTree,
+  type OxlintScope,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
+
+const restrictedGlobalNames: ReadonlySet<string> = new Set([
+  'alert',
+  'cancelAnimationFrame',
+  'cancelIdleCallback',
+  'confirm',
+  'customElements',
+  'document',
+  'getComputedStyle',
+  'history',
+  'IntersectionObserver',
+  'localStorage',
+  'location',
+  'matchMedia',
+  'MutationObserver',
+  'navigator',
+  'prompt',
+  'requestAnimationFrame',
+  'requestIdleCallback',
+  'ResizeObserver',
+  'screen',
+  'sessionStorage',
+  'window',
+])
+
+const isInsideTypeQuery = (node: ESTree.Node): boolean => {
+  const parent = node.parent
+
+  if (parent === null) {
+    return false
+  }
+  if (parent.type === 'TSTypeQuery') {
+    return true
+  }
+  if (parent.type === 'TSQualifiedName') {
+    return isInsideTypeQuery(parent)
+  }
+  return false
+}
+
+const staticMemberName = (
+  node: ESTree.MemberExpression,
+): string | undefined => {
+  if (!node.computed && node.property.type === 'Identifier') {
+    return node.property.name
+  }
+  if (
+    node.computed &&
+    node.property.type === 'Literal' &&
+    typeof node.property.value === 'string'
+  ) {
+    return node.property.value
+  }
+  return undefined
+}
+
+const staticPropertyName = (
+  property: Readonly<{ key: ESTree.PropertyKey }>,
+): string | undefined => {
+  if (property.key.type === 'Identifier') {
+    return property.key.name
+  }
+  if (
+    property.key.type === 'Literal' &&
+    typeof property.key.value === 'string'
+  ) {
+    return property.key.value
+  }
+  return undefined
+}
+
+const destructuringSource = (
+  node: ESTree.ObjectPattern | ESTree.ObjectAssignmentTarget,
+): ESTree.Expression | null | undefined => {
+  const parent = node.parent
+
+  if (parent.type === 'VariableDeclarator' && parent.id === node) {
+    return parent.init
+  }
+  if (parent.type === 'AssignmentExpression' && parent.left === node) {
+    return parent.right
+  }
+  return undefined
+}
+
+const destructuredGlobalThis = (
+  node: ESTree.ObjectPattern | ESTree.ObjectAssignmentTarget,
+): ESTree.IdentifierReference | undefined => {
+  const source = destructuringSource(node)
+
+  return source?.type === 'Identifier' && source.name === 'globalThis'
+    ? source
+    : undefined
+}
+
+const restrictedGlobalDiagnostic = (node: ESTree.Node, name: string) =>
+  Diagnostic.make({
+    node,
+    message: `Global \`${name}\` is not portable across Foldkit server targets. Use a server API available everywhere you deploy or pass the value into the entry.`,
+  })
+
+const indexReferences = (
+  scopes: ReadonlyArray<OxlintScope>,
+): WeakMap<ESTree.Node, Reference> => {
+  const references = new WeakMap<ESTree.Node, Reference>()
+
+  for (const scope of scopes) {
+    for (const reference of scope.references) {
+      references.set(reference.identifier, reference)
+    }
+  }
+  return references
+}
+
+const isUnshadowedGlobalReference = (
+  references: WeakMap<ESTree.Node, Reference>,
+  node: ESTree.Node,
+): boolean => {
+  const reference = references.get(node)
+
+  return (
+    reference !== undefined &&
+    (reference.resolved === null || Array.isArrayEmpty(reference.resolved.defs))
+  )
+}
+
+/**
+ * Flags selected browser-only globals in files that run on a server.
+ */
+export const noNonportableServerGlobals = Rule.define({
+  name: 'no-nonportable-server-globals',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Avoid browser-only globals in files that run across Foldkit server targets.',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const references = indexReferences(ctx.sourceCode.scopeManager.scopes)
+    return {
+      Identifier: (node: ESTree.Node) => {
+        if (
+          node.type !== 'Identifier' ||
+          !restrictedGlobalNames.has(node.name) ||
+          isInsideTypeQuery(node)
+        ) {
+          return Effect.void
+        }
+        return isUnshadowedGlobalReference(references, node)
+          ? ctx.report(restrictedGlobalDiagnostic(node, node.name))
+          : Effect.void
+      },
+      MemberExpression: (node: ESTree.Node) => {
+        if (
+          node.type !== 'MemberExpression' ||
+          node.object.type !== 'Identifier' ||
+          node.object.name !== 'globalThis'
+        ) {
+          return Effect.void
+        }
+        const memberName = staticMemberName(node)
+        if (
+          memberName === undefined ||
+          !restrictedGlobalNames.has(memberName)
+        ) {
+          return Effect.void
+        }
+        return isUnshadowedGlobalReference(references, node.object)
+          ? ctx.report(restrictedGlobalDiagnostic(node, memberName))
+          : Effect.void
+      },
+      ObjectPattern: (node: ESTree.Node) => {
+        if (node.type !== 'ObjectPattern') {
+          return Effect.void
+        }
+        const source = destructuredGlobalThis(node)
+        if (source === undefined) {
+          return Effect.void
+        }
+        const restrictedProperties = node.properties.flatMap(property => {
+          if (property.type !== 'Property') {
+            return []
+          }
+          const name = staticPropertyName(property)
+          return name !== undefined && restrictedGlobalNames.has(name)
+            ? [{ name, property }]
+            : []
+        })
+        return isUnshadowedGlobalReference(references, source)
+          ? Effect.forEach(
+              restrictedProperties,
+              ({ name, property }) =>
+                ctx.report(restrictedGlobalDiagnostic(property, name)),
+              { discard: true },
+            )
+          : Effect.void
+      },
+    }
+  },
+})

--- a/packages/oxlint-plugin-foldkit/test/configs.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/configs.test.ts
@@ -2,7 +2,22 @@ import { describe, expect, it } from 'vitest'
 
 import plugin from '../src/index.ts'
 
-const testFilePatterns = ['**/*.test.ts', '**/*.test.tsx']
+const testFilePatterns = [
+  '**/*.test.ts',
+  '**/*.test.tsx',
+  '**/*.spec.ts',
+  '**/*.spec.tsx',
+]
+
+const serverFilePatterns = [
+  '**/entry.server.ts',
+  '**/entry.server.tsx',
+  '**/server/**/*.ts',
+  '**/server/**/*.tsx',
+  '**/prerender.ts',
+]
+
+const serverRuleId = 'foldkit/no-nonportable-server-globals'
 
 const presets = [
   { name: 'recommended', config: plugin.configs.recommended },
@@ -22,15 +37,21 @@ describe('configs', () => {
         )
       })
 
+      it('scopes the server portability rule to recognized server files', () => {
+        const serverOverride = config.overrides[0]
+
+        expect(config.rules[serverRuleId]).toBe('off')
+        expect(serverOverride?.files).toEqual(serverFilePatterns)
+        expect(serverOverride?.excludeFiles).toEqual(testFilePatterns)
+        expect(serverOverride?.rules).toEqual({ [serverRuleId]: 'error' })
+      })
+
       it('turns every foldkit rule off in test files', () => {
-        expect(config.overrides).toBeInstanceOf(Array)
-        expect(config.overrides).toHaveLength(1)
+        const testOverride = config.overrides[1]
 
-        const override = config.overrides[0]
-        expect(override?.files).toEqual(testFilePatterns)
-
+        expect(testOverride?.files).toEqual(testFilePatterns)
         for (const ruleId of Object.keys(config.rules)) {
-          expect(override?.rules[ruleId]).toBe('off')
+          expect(testOverride?.rules[ruleId]).toBe('off')
         }
       })
     })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-nonportable-server-globals/invalid/direct-global.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-nonportable-server-globals/invalid/direct-global.ts
@@ -1,0 +1,1 @@
+export const title = document.title

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-nonportable-server-globals/valid/local-and-type-only.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-nonportable-server-globals/valid/local-and-type-only.ts
@@ -1,0 +1,4 @@
+export type BrowserDocument = typeof document
+export type BrowserGlobalDocument = typeof globalThis.document
+
+export const readTitle = (document: { title: string }): string => document.title

--- a/packages/oxlint-plugin-foldkit/test/integration/real-oxlint.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/real-oxlint.test.ts
@@ -1,10 +1,17 @@
 import { build } from 'esbuild'
-import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { runOxlint } from './run-oxlint.ts'
 
 // Runs every rule through real oxlint against fixtures written in real
 // Foldkit idioms. `invalid/` must produce at least one diagnostic and
@@ -16,14 +23,11 @@ const here = dirname(fileURLToPath(import.meta.url))
 const pluginRoot = join(here, '..', '..')
 const repoRoot = join(pluginRoot, '..', '..')
 const fixturesRoot = join(here, 'fixtures')
-const oxlintBin = join(repoRoot, 'node_modules', '.bin', 'oxlint')
-
-let bundlePath: string
-let workDir: string
+const oxlintBin = join(repoRoot, 'node_modules', 'oxlint', 'bin', 'oxlint')
+const workDir = mkdtempSync(join(tmpdir(), 'foldkit-oxlint-integration-'))
+const bundlePath = join(workDir, 'plugin.mjs')
 
 beforeAll(async () => {
-  workDir = mkdtempSync(join(tmpdir(), 'foldkit-oxlint-integration-'))
-  bundlePath = join(workDir, 'plugin.js')
   await build({
     entryPoints: [join(pluginRoot, 'src', 'index.ts')],
     bundle: true,
@@ -33,28 +37,38 @@ beforeAll(async () => {
   })
 })
 
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true })
+})
+
 type FixtureKind = 'valid' | 'invalid'
 
 const countDiagnostics = (rule: string, kind: FixtureKind): number => {
   const targetDir = join(fixturesRoot, rule, kind)
   const config = {
     plugins: ['typescript'],
-    jsPlugins: [{ name: 'foldkit', specifier: bundlePath }],
+    jsPlugins: [{ name: 'foldkit', specifier: pathToFileURL(bundlePath).href }],
     categories: { correctness: 'off' },
     rules: { [`foldkit/${rule}`]: 'error' },
   }
   const configPath = join(workDir, `${rule}.${kind}.oxlintrc.json`)
   writeFileSync(configPath, JSON.stringify(config))
-  try {
-    execFileSync(oxlintBin, ['--config', configPath, targetDir], {
-      encoding: 'utf8',
-    })
-    return 0
-  } catch (error) {
-    const output = String((error as { stdout?: unknown }).stdout ?? '')
-    const matches = output.match(new RegExp(`foldkit\\(${rule}\\)`, 'g'))
-    return matches === null ? 0 : matches.length
+  const diagnostics = runOxlint({
+    oxlintBin,
+    cwd: workDir,
+    configPath,
+    target: targetDir,
+  })
+  const expectedCode = `foldkit(${rule})`
+
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.code !== expectedCode) {
+      throw new Error(
+        `Expected ${expectedCode}, received ${diagnostic.code} in ${diagnostic.filename}`,
+      )
+    }
   }
+  return diagnostics.length
 }
 
 const ruleFixtures = readdirSync(fixturesRoot, { withFileTypes: true })
@@ -64,7 +78,7 @@ const ruleFixtures = readdirSync(fixturesRoot, { withFileTypes: true })
 
 describe('real-oxlint rule fixtures', () => {
   it('has a fixture directory for every registered rule', async () => {
-    const plugin = await import(bundlePath)
+    const plugin = await import(pathToFileURL(bundlePath).href)
     const registered: ReadonlyArray<string> = Object.keys(
       (plugin.default ?? plugin).rules,
     )

--- a/packages/oxlint-plugin-foldkit/test/integration/run-oxlint.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/run-oxlint.ts
@@ -1,0 +1,75 @@
+import { Array } from 'effect'
+import { spawnSync } from 'node:child_process'
+import { isAbsolute, relative } from 'node:path'
+
+export type LintDiagnostic = Readonly<{
+  code: string
+  filename: string
+}>
+
+const parseDiagnostic = (cwd: string, value: unknown): LintDiagnostic => {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('code' in value) ||
+    typeof value.code !== 'string' ||
+    !('filename' in value) ||
+    typeof value.filename !== 'string'
+  ) {
+    throw new Error('Oxlint returned an invalid diagnostic')
+  }
+  const filename = isAbsolute(value.filename)
+    ? relative(cwd, value.filename)
+    : value.filename
+  return { code: value.code, filename: filename.replaceAll('\\', '/') }
+}
+
+const parseDiagnostics = (
+  cwd: string,
+  output: string,
+): ReadonlyArray<LintDiagnostic> => {
+  const result: unknown = JSON.parse(output)
+
+  if (
+    typeof result !== 'object' ||
+    result === null ||
+    !('diagnostics' in result) ||
+    !globalThis.Array.isArray(result.diagnostics)
+  ) {
+    throw new Error('Oxlint returned invalid JSON output')
+  }
+  return result.diagnostics.map(diagnostic => parseDiagnostic(cwd, diagnostic))
+}
+
+export const runOxlint = ({
+  oxlintBin,
+  cwd,
+  configPath,
+  target,
+}: Readonly<{
+  oxlintBin: string
+  cwd: string
+  configPath: string
+  target: string
+}>): ReadonlyArray<LintDiagnostic> => {
+  const result = spawnSync(
+    process.execPath,
+    [oxlintBin, '--format=json', '--config', configPath, target],
+    { cwd, encoding: 'utf8' },
+  )
+
+  if (result.error !== undefined) {
+    throw result.error
+  }
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(
+      `Oxlint exited with ${String(result.status)}: ${result.stderr}`,
+    )
+  }
+  const diagnostics = parseDiagnostics(cwd, result.stdout)
+
+  if (result.status === 1 && Array.isReadonlyArrayEmpty(diagnostics)) {
+    throw new Error('Oxlint exited with an error but returned no diagnostics')
+  }
+  return diagnostics
+}

--- a/packages/oxlint-plugin-foldkit/test/integration/server-globals.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/server-globals.test.ts
@@ -1,0 +1,186 @@
+import { build } from 'esbuild'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { type LintDiagnostic, runOxlint } from './run-oxlint.ts'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pluginRoot = join(here, '..', '..')
+const repoRoot = join(pluginRoot, '..', '..')
+const oxlintBin = join(repoRoot, 'node_modules', 'oxlint', 'bin', 'oxlint')
+const workDir = mkdtempSync(join(tmpdir(), 'foldkit-server-globals-'))
+const bundlePath = join(workDir, 'plugin.mjs')
+const presetPath = join(workDir, 'recommended.json')
+const configPath = join(workDir, '.oxlintrc.json')
+
+const customRuleCode = 'foldkit(no-nonportable-server-globals)'
+const consumerRuleCode = 'eslint(no-restricted-globals)'
+
+const patternFixtures: Record<string, string> = {
+  'patterns/src/entry.server.ts': `
+export const title = document.title
+`,
+  'patterns/src/entry.server.tsx': `
+export const hasWindow = typeof window !== 'undefined'
+`,
+  'patterns/server/main.ts': `
+export const title = globalThis.document.title
+`,
+  'patterns/server/view.tsx': `
+export const view = <div>{globalThis?.['navigator'].language}</div>
+`,
+  'patterns/scripts/prerender.ts': `
+const { localStorage: storage } = globalThis
+export const theme = storage.getItem('theme')
+`,
+}
+
+const validFixtures: Record<string, string> = {
+  'valid/server/type-only.ts': `
+export type BrowserDocument = typeof document
+export type BrowserGlobalDocument = typeof globalThis.document
+`,
+  'valid/server/local-shadows.ts': `
+const document = { title: 'server document' }
+const globalThis = { document }
+const context = { document }
+
+export const localTitle = document.title
+export const globalTitle = globalThis.document.title
+export const contextTitle = context.document.title
+export const parameterTitle = (window: { title: string }) => window.title
+`,
+  'valid/server/portable.ts': `
+export const fetchPage = async (request: Request): Promise<Response> => {
+  const url = new URL(request.url)
+  const upstream = await fetch(url)
+  const headers = new Headers({ 'content-type': 'text/html' })
+
+  return new Response(await upstream.text(), { headers })
+}
+`,
+  'valid/src/entry.client.ts': `
+export const title = document.title + globalThis.document.title
+`,
+}
+
+const compositionFixtures: Record<string, string> = {
+  'composition/server/policy.ts': `
+export const title = (): string => {
+  console.log('reading title')
+  return document.title
+}
+`,
+  'composition/src/entry.client.ts': `
+console.log(document.title)
+`,
+  'composition/server/policy.test.ts': `
+console.log(document.title)
+`,
+  'composition/server/policy.spec.tsx': `
+console.log(<div>{document.title}</div>)
+`,
+}
+
+const writeFixtures = (fixtures: Record<string, string>): void => {
+  for (const [path, source] of Object.entries(fixtures)) {
+    const fullPath = join(workDir, path)
+    mkdirSync(dirname(fullPath), { recursive: true })
+    writeFileSync(fullPath, source)
+  }
+}
+
+const lint = (target: string): ReadonlyArray<LintDiagnostic> => {
+  return runOxlint({
+    oxlintBin,
+    cwd: workDir,
+    configPath,
+    target,
+  })
+}
+
+const codesFor = (
+  diagnostics: ReadonlyArray<LintDiagnostic>,
+  filename: string,
+): ReadonlyArray<string> => {
+  const codes = diagnostics
+    .filter(diagnostic => diagnostic.filename === filename)
+    .map(diagnostic => diagnostic.code)
+
+  return codes.sort()
+}
+
+beforeAll(async () => {
+  await build({
+    entryPoints: [join(pluginRoot, 'src', 'index.ts')],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: bundlePath,
+  })
+
+  const { default: plugin } = await import(pathToFileURL(bundlePath).href)
+  writeFileSync(
+    presetPath,
+    JSON.stringify({
+      ...plugin.configs.recommended,
+      jsPlugins: [
+        { name: 'foldkit', specifier: pathToFileURL(bundlePath).href },
+      ],
+      categories: { correctness: 'off' },
+    }),
+  )
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      extends: ['./recommended.json'],
+      rules: {
+        'no-restricted-globals': ['error', 'console'],
+      },
+    }),
+  )
+
+  writeFixtures(patternFixtures)
+  writeFixtures(validFixtures)
+  writeFixtures(compositionFixtures)
+})
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true })
+})
+
+describe('recommended preset server portability rule', () => {
+  it('matches every recognized server file pattern', () => {
+    const diagnostics = lint('patterns')
+
+    expect(diagnostics).toHaveLength(Object.keys(patternFixtures).length)
+    for (const filename of Object.keys(patternFixtures)) {
+      expect(codesFor(diagnostics, filename)).toEqual([customRuleCode])
+    }
+  })
+
+  it('allows type-only uses, local bindings, host APIs, and client code', () => {
+    expect(lint('valid')).toEqual([])
+  })
+
+  it('composes with consumer policy and excludes test files', () => {
+    const diagnostics = lint('composition')
+
+    expect(diagnostics).toHaveLength(5)
+    expect(codesFor(diagnostics, 'composition/server/policy.ts')).toEqual(
+      [customRuleCode, consumerRuleCode].sort(),
+    )
+    expect(codesFor(diagnostics, 'composition/src/entry.client.ts')).toEqual([
+      consumerRuleCode,
+    ])
+    expect(codesFor(diagnostics, 'composition/server/policy.test.ts')).toEqual([
+      consumerRuleCode,
+    ])
+    expect(codesFor(diagnostics, 'composition/server/policy.spec.tsx')).toEqual(
+      [consumerRuleCode],
+    )
+  })
+})

--- a/packages/website/src/page/toolingLinting.md
+++ b/packages/website/src/page/toolingLinting.md
@@ -6,11 +6,23 @@ Foldkit projects use `oxlint` for general linting and `@foldkit/oxlint-plugin` f
 
 ## Scaffolded Projects
 
-[Create Foldkit app](/get-started/getting-started) includes `.oxlintrc.json`, a `lint` script, `oxlint`, and `@foldkit/oxlint-plugin`. Generated projects enable a starter set of Foldkit rules:
+[Create Foldkit app](/get-started/getting-started) includes `.oxlintrc.json`, a `lint` script, `oxlint`, and `@foldkit/oxlint-plugin`. Generated projects extend the recommended Foldkit preset:
 
 ::Snippet{name="oxlintConfig" label="oxlint config"}
 
-The rest of the plugin's rules are opt-in. Enable one by adding `"foldkit/<rule-name>": "error"` to the `rules` block. The complete rule set is grouped by the part of the architecture it protects below.
+Override an individual rule in the project's `rules` block when an application needs a narrower policy. The complete rule set is grouped by the part of the architecture it protects below.
+
+## Server Portability
+
+### foldkit/no-nonportable-server-globals {#no-nonportable-server-globals}
+
+The recommended and all presets enable this rule in `entry.server.ts`, `entry.server.tsx`, TypeScript files under a `server` directory, and `prerender.ts`. Files ending in `.test.ts`, `.test.tsx`, `.spec.ts`, or `.spec.tsx` are excluded.
+
+The rule catches direct runtime reads of common browser-only globals: `document`, `window`, `navigator`, `localStorage`, `sessionStorage`, `history`, `location`, `alert`, `confirm`, `prompt`, `requestAnimationFrame`, `cancelAnimationFrame`, `requestIdleCallback`, `cancelIdleCallback`, `getComputedStyle`, `matchMedia`, `customElements`, `screen`, `IntersectionObserver`, `ResizeObserver`, and `MutationObserver`. It also catches static property reads and destructuring from the global `globalThis` object.
+
+Local bindings, parameters, and type-only `typeof` queries remain valid. `Request`, `Response`, `Headers`, `fetch`, and `URL` remain available for host code. A host-specific file can use an Oxlint disable comment or a narrower config override when it deliberately depends on one deployment target.
+
+This rule is a portability guardrail, not a security boundary or an exhaustive catalog of browser APIs. It does not follow aliases, resolve dynamic property names, inspect dependencies, or match filenames outside the patterns above.
 
 ## Message Naming and Construction {#message-rules}
 


### PR DESCRIPTION
Fixes #1030.

## What changed

- Adds `foldkit/no-nonportable-server-globals` to the recommended and all presets for `entry.server.ts`, `entry.server.tsx`, TypeScript files under `server/`, and `prerender.ts`.
- Catches a curated set of browser-only globals when used directly, through static `globalThis` properties, or through direct `globalThis` destructuring.
- Preserves local and parameter bindings, type-only `typeof` queries, and the portable host APIs `Request`, `Response`, `Headers`, `fetch`, and `URL`.
- Uses a Foldkit-owned rule so a consumer's `no-restricted-globals` policy continues to apply in the same server file.
- Treats `.spec.ts` and `.spec.tsx` as test files alongside the existing `.test.ts` and `.test.tsx` patterns.
- Applies the same rule to this repository and documents the public portability boundary on the linting page.

## Boundary

This is a portability guardrail, not a security boundary or an exhaustive browser sandbox. It does not follow aliases, resolve dynamic property names, inspect dependencies, or match filenames outside the documented patterns.

## Verification

- 336 oxlint-plugin tests
- Plugin typecheck and build
- Repository lint, Knip, formatting, and changeset checks
- Real Oxlint coverage using an actual consumer `extends` configuration
- Mutation checks for scope resolution, type-only queries, server globs, test exclusions, and consumer rule composition
- Independent final review with no actionable blockers

The full repository gate is running in CI on the exact one-commit head.
