### PR TITLE
fix(ci): exempt generated release PR from changeset status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,12 @@ jobs:
         run: pnpm check:changeset-unwrapped
 
       - name: Check changeset status
-        if: github.event_name == 'pull_request'
-        run: pnpm changeset status --since=origin/main
+        env:
+          FOLDKIT_CI_EVENT_NAME: ${{ github.event_name }}
+          FOLDKIT_CI_HEAD_REF: ${{ github.head_ref }}
+          FOLDKIT_CI_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          FOLDKIT_CI_REPOSITORY: ${{ github.repository }}
+        run: node scripts/check-changeset-status.mjs
 
       - name: Lint
         run: pnpm --filter @foldkit/oxlint-plugin build && pnpm lint:ci

--- a/scripts/check-changeset-status.mjs
+++ b/scripts/check-changeset-status.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from 'node:child_process'
+
+import { shouldCheckChangesetStatus } from './lib/changeset-status.mjs'
+
+const context = {
+  eventName: process.env.FOLDKIT_CI_EVENT_NAME,
+  headRef: process.env.FOLDKIT_CI_HEAD_REF,
+  headRepository: process.env.FOLDKIT_CI_HEAD_REPOSITORY,
+  repository: process.env.FOLDKIT_CI_REPOSITORY,
+}
+
+if (shouldCheckChangesetStatus(context)) {
+  const result = spawnSync(
+    'pnpm',
+    ['changeset', 'status', '--since=origin/main'],
+    { stdio: 'inherit' },
+  )
+
+  if (result.error !== undefined) {
+    throw result.error
+  }
+  if (result.status === null) {
+    throw new Error(`Changeset status terminated with ${result.signal}.`)
+  }
+
+  process.exitCode = result.status
+} else {
+  console.log('Skipping changeset status for this workflow event.')
+}

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const workflow = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/ci.yml'),
+  'utf8',
+)
+
+test('changeset status receives trusted pull request context', () => {
+  assert.match(
+    workflow,
+    /- name: Check changeset status\n\s+env:\n\s+FOLDKIT_CI_EVENT_NAME: \$\{\{ github\.event_name \}\}\n\s+FOLDKIT_CI_HEAD_REF: \$\{\{ github\.head_ref \}\}\n\s+FOLDKIT_CI_HEAD_REPOSITORY: \$\{\{ github\.event\.pull_request\.head\.repo\.full_name \}\}\n\s+FOLDKIT_CI_REPOSITORY: \$\{\{ github\.repository \}\}\n\s+run: node scripts\/check-changeset-status\.mjs/,
+  )
+})

--- a/scripts/lib/changeset-status.mjs
+++ b/scripts/lib/changeset-status.mjs
@@ -1,0 +1,10 @@
+const RELEASE_BRANCH = 'changeset-release/main'
+
+export const shouldCheckChangesetStatus = ({
+  eventName,
+  headRef,
+  headRepository,
+  repository,
+}) =>
+  eventName === 'pull_request' &&
+  (headRef !== RELEASE_BRANCH || headRepository !== repository)

--- a/scripts/lib/changeset-status.test.mjs
+++ b/scripts/lib/changeset-status.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { shouldCheckChangesetStatus } from './changeset-status.mjs'
+
+const repository = 'foldkit/foldkit'
+
+const cases = [
+  {
+    name: 'the generated release pull request',
+    context: {
+      eventName: 'pull_request',
+      headRef: 'changeset-release/main',
+      headRepository: repository,
+      repository,
+    },
+    expected: false,
+  },
+  {
+    name: 'an ordinary same-repository pull request',
+    context: {
+      eventName: 'pull_request',
+      headRef: 'fix/something',
+      headRepository: repository,
+      repository,
+    },
+    expected: true,
+  },
+  {
+    name: 'a same-named fork pull request',
+    context: {
+      eventName: 'pull_request',
+      headRef: 'changeset-release/main',
+      headRepository: 'contributor/foldkit',
+      repository,
+    },
+    expected: true,
+  },
+  {
+    name: 'an ordinary fork pull request',
+    context: {
+      eventName: 'pull_request',
+      headRef: 'fix/something',
+      headRepository: 'contributor/foldkit',
+      repository,
+    },
+    expected: true,
+  },
+  {
+    name: 'a case-variant same-repository pull request',
+    context: {
+      eventName: 'pull_request',
+      headRef: 'changeset-release/Main',
+      headRepository: repository,
+      repository,
+    },
+    expected: true,
+  },
+  {
+    name: 'a push event',
+    context: {
+      eventName: 'push',
+      headRef: undefined,
+      headRepository: undefined,
+      repository,
+    },
+    expected: false,
+  },
+]
+
+for (const { name, context, expected } of cases) {
+  test(`changeset status decision for ${name}`, () => {
+    assert.equal(shouldCheckChangesetStatus(context), expected)
+  })
+}


### PR DESCRIPTION
Generated Version Packages PRs consume their changesets before CI runs, so changeset status rejects the version bumps they are designed to publish.

Skip only the exact same-repository release branch. Keep ordinary and forked pull requests subject to the existing check.