### PR TITLE
fix(website): wait for playground hydration before smoke interactions

### DIFF
--- a/packages/website/e2e/livePlaygrounds.ts
+++ b/packages/website/e2e/livePlaygrounds.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import type { Page } from '@playwright/test'
+import type { FrameLocator, Page } from '@playwright/test'
 
 const PLAYGROUND_BOOT_TIMEOUT_MILLISECONDS = 240_000
 
@@ -12,6 +12,11 @@ const playgroundFrame = async (page: Page, slug: string) => {
   return page.frameLocator('iframe[title="Foldkit Playground"]')
 }
 
+const waitForHydration = (frame: FrameLocator) =>
+  expect(frame.locator('[data-foldkit-build]')).toHaveCount(0, {
+    timeout: PLAYGROUND_BOOT_TIMEOUT_MILLISECONDS,
+  })
+
 test.describe.configure({ mode: 'serial' })
 
 test('deployed SSR playground installs, boots, and hydrates', async ({
@@ -21,6 +26,7 @@ test('deployed SSR playground installs, boots, and hydrates', async ({
   await expect(
     frame.getByRole('heading', { name: 'Server-rendered counter' }),
   ).toBeVisible({ timeout: PLAYGROUND_BOOT_TIMEOUT_MILLISECONDS })
+  await waitForHydration(frame)
 
   const count = frame.locator('#count')
   const initialCount = Number(await count.textContent())
@@ -36,6 +42,7 @@ test('deployed SSG playground installs, boots, and hydrates', async ({
   await expect(
     frame.getByRole('heading', { name: 'Statically generated home' }),
   ).toBeVisible({ timeout: PLAYGROUND_BOOT_TIMEOUT_MILLISECONDS })
+  await waitForHydration(frame)
 
   const count = frame.getByRole('button', { name: 'Count: 0' })
   await count.click()


### PR DESCRIPTION
## Summary

- wait for Foldkit's build marker to be consumed before interacting with the deployed SSR and SSG playgrounds
- keep server-rendered content visibility separate from client hydration readiness

## Root cause

The live deployment smoke treated a server-rendered heading as proof that the client had booted. In a cold WebContainer, the heading and controls can be visible while Vite is still loading and optimizing the client module graph. The test clicked during that interval, before Foldkit attached the handler, and reported a healthy deployment as failed.

This change waits for the hydration handoff marker to disappear before interacting. It does not retry clicks, so a real boot or interaction failure still fails the smoke.

## Validation

- live production SSR and SSG Playwright smoke: 2 passed
- website unit suite: 457 passed
- website typecheck
- Oxlint on the changed test
- Prettier and `git diff --check`

No changeset is needed because this changes only the website deployment test.