### PR TITLE
fix(foldkit): harden hydration refusal across browsers

### DIFF
--- a/.changeset/block-refused-page-input.md
+++ b/.changeset/block-refused-page-input.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Block keyboard input from reaching same-document stale handlers when WebKit lets an older modal reclaim focus during hydration refusal.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,12 @@ jobs:
       # A Foldkit installed from a tarball is externalized from a server build,
       # where the plugin's compile-time define never reaches it. Nothing inside
       # this workspace has that shape, so the build id contract is only
-      # observable from a project built outside it.
-      - name: Install Playwright chromium for the packed consumer gate
+      # observable from a project built outside it. Chromium runs the complete
+      # gate; Firefox and WebKit reuse its builds for the browser-sensitive
+      # hydration, form, Custom Element, and refusal checks.
+      - name: Install Playwright browsers for the packed consumer gate
         if: steps.scope.outputs.packed_ssr_consumer == 'true'
-        run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium
+        run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium firefox webkit
 
       - name: Check packed SSR consumer
         if: steps.scope.outputs.packed_ssr_consumer == 'true'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "check:create-foldkit-app-smoke": "tsx scripts/check-create-foldkit-app-smoke.ts",
     "check:create-foldkit-app-smoke:ci": "tsx scripts/check-create-foldkit-app-smoke.ts --skip-build",
     "check:packed-ssr-consumer": "tsx scripts/check-packed-ssr-consumer.ts",
-    "check:packed-ssr-consumer:ci": "tsx scripts/check-packed-ssr-consumer.ts --skip-build",
+    "check:packed-ssr-consumer:ci": "tsx scripts/check-packed-ssr-consumer.ts --skip-build --critical-browser-matrix",
     "check:scaffold-server-rendering": "tsx scripts/check-scaffold-server-rendering.ts",
     "check:scaffold-server-rendering:ci": "tsx scripts/check-scaffold-server-rendering.ts --skip-build",
     "check:host-parity": "tsx scripts/check-host-parity.ts",

--- a/packages/foldkit/src/runtime/hydrateBoot.test.ts
+++ b/packages/foldkit/src/runtime/hydrateBoot.test.ts
@@ -890,6 +890,10 @@ describe('hydrating boot', () => {
     const servedRoot = document.querySelector('[data-foldkit-app]')
     const dialog = document.createElement('dialog')
     dialog.setAttribute('open', '')
+    const field = document.createElement('input')
+    dialog.appendChild(field)
+    const bodyKeys: Array<string> = []
+    document.body.addEventListener('keydown', () => bodyKeys.push('keydown'))
     const closed: Array<string> = []
     dialog.addEventListener('cancel', () => closed.push('cancel'))
     dialog.addEventListener('close', () => closed.push('close'))
@@ -918,6 +922,15 @@ describe('hydrating boot', () => {
     expect(shield?.open).toBe(true)
     expect(dialog.open).toBe(true)
     expect(closed).toEqual([])
+    field.focus()
+    const keydown = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'A',
+    })
+    expect(field.dispatchEvent(keydown)).toBe(false)
+    expect(keydown.defaultPrevented).toBe(true)
+    expect(bodyKeys).toEqual([])
     expectContained(servedRoot)
   })
 

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -752,15 +752,17 @@ const buildSkew = (
 // root. It is a sibling of `body`, outside the inert and `aria-hidden` boundary,
 // covers the viewport, and refuses its cancel action. Existing dialogs are not
 // closed: calling author-owned `close` or `cancel` listeners while startup is
-// failing can run arbitrary stale code.
+// failing can run arbitrary stale code. Same-document input guards stop
+// physical keyboard input if older top-layer content requests focus.
 //
 // This runs when the client reaches the failure, so it cannot undo what the page
 // already did: subresources the parser fetched, custom elements that upgraded,
 // scripts the served deployment authored, or anything a visitor managed before
 // the client entry ran. Nor is this a script sandbox. A capture listener on
 // `window` or `document` runs before an event reaches the shield, and a timer or
-// listener can open newer top-layer UI. The boundary disables the old page's
-// native links, forms, controls, and focus targets without reconnecting its DOM.
+// listener can open newer top-layer UI. The boundary stops pointer and physical
+// keyboard input from activating the old page's same-document native links,
+// forms, and controls without reconnecting its DOM.
 // NOTE: this module declares its own `Document` (the page metadata a view
 // describes), so the DOM interface is reached through the global binding.
 type DomDocument = typeof document
@@ -783,6 +785,8 @@ const REFUSAL_SHIELD_INPUT_EVENTS: ReadonlyArray<keyof HTMLElementEventMap> = [
   'touchend',
   'touchstart',
 ]
+const REFUSAL_DOCUMENT_INPUT_EVENTS: ReadonlyArray<keyof HTMLElementEventMap> =
+  ['keydown', 'keypress', 'keyup']
 
 const preventRefusalShieldInteraction = (event: Event): void => {
   event.preventDefault()
@@ -841,6 +845,12 @@ const installRefusalShield = (ownerDocument: DomDocument): void => {
   shield.addEventListener('cancel', preventRefusalShieldInteraction)
   for (const eventName of REFUSAL_SHIELD_INPUT_EVENTS) {
     shield.addEventListener(eventName, preventRefusalShieldInteraction, {
+      capture: true,
+      passive: false,
+    })
+  }
+  for (const eventName of REFUSAL_DOCUMENT_INPUT_EVENTS) {
+    ownerDocument.addEventListener(eventName, preventRefusalShieldInteraction, {
       capture: true,
       passive: false,
     })
@@ -4395,12 +4405,15 @@ export type HydrateOptions = Readonly<{
  *  missing Flags payload, an undecodable payload, or a page from another
  *  deployment terminates startup. Every one of those contains the page first:
  *  the document's body is marked `inert` and a nondismissable modal shield is
- *  opened above existing top-layer content, so native links, forms, controls,
- *  and focus targets stop responding. Containment leaves author-owned dialogs
- *  open without calling `close` or dispatching `cancel`. Nothing is moved, so
- *  no custom element reconnects and no frame reloads. This is not a script or
- *  event sandbox: existing capture-phase handlers, browser-generated top-layer
- *  events, timers, and other stale scripts can still run and can open newer
+ *  opened above existing top-layer content, so pointer and physical keyboard
+ *  input do not activate same-document native links, forms, or controls.
+ *  Containment leaves author-owned dialogs open without calling `close` or
+ *  dispatching `cancel`.
+ *  Nothing is moved, so no custom element reconnects and no frame reloads.
+ *  This is not a script, event, or embedded-document sandbox: existing
+ *  capture-phase handlers, browser-generated top-layer events, timers, and
+ *  stale scripts can still run. Controls in embedded documents can still
+ *  receive input if stale code focuses them. Stale code can also open newer
  *  top-layer UI. Use `run` in a separate client-only entry when the page should
  *  boot without server output.
  *

--- a/packages/website/src/page/core/serverRendering.md
+++ b/packages/website/src/page/core/serverRendering.md
@@ -299,11 +299,11 @@ Every other refusal contains the page. This includes calling `Runtime.hydrate` w
 
 ### Page containment
 
-Foldkit marks the document body with `inert`, `aria-hidden`, and `data-foldkit-refused`. It opens a nondismissable modal shield beside the body and above existing top-layer content, including dialogs in closed shadow roots. The shield takes focus so physical keyboard input cannot reach stale body handlers.
+Foldkit marks the document body with `inert`, `aria-hidden`, and `data-foldkit-refused`. It opens a nondismissable modal shield beside the body and above existing top-layer content, including dialogs in closed shadow roots. The shield takes focus. Document-level input guards keep physical keyboard input from reaching stale handlers in the same document if older top-layer content requests focus.
 
 Author-owned dialogs remain open behind the shield. Containment does not call `close()` or dispatch `cancel`, either of which could run a stale listener while startup is failing.
 
-Links, forms, and focusable controls stop responding. The shield asks the visitor to reload. The served DOM remains connected, and `data-foldkit-refused` is available for styling or monitoring. Nothing else in Foldkit sets that attribute.
+Pointer and physical keyboard input do not activate links, forms, or controls in that document. The shield asks the visitor to reload. The served DOM remains connected, and `data-foldkit-refused` is available for styling or monitoring. Nothing else in Foldkit sets that attribute.
 
 Nothing moves. Foldkit marks the existing body instead of wrapping the application root. Wrapping would reparent the subtree, call `disconnectedCallback` and then `connectedCallback` on every upgraded custom element, and reload every iframe. Marking the body avoids those lifecycle effects.
 
@@ -317,6 +317,7 @@ Containment starts only after the client detects a refusal. It cannot undo earli
 - A custom element may already have run `connectedCallback`.
 - A visitor may have interacted with the page before the client entry ran. A script can still submit a form programmatically despite `inert`.
 - Containment is not a script or global-event sandbox. Capture listeners on `window` or `document` run before an event reaches the shield. The browser may also dispatch global or top-layer events.
+- An iframe has its own document. Stale code can focus a control inside it, and physical keyboard input dispatched there does not reach the parent document's guards.
 - A timer or stale listener can open a new dialog after containment. That dialog enters the top layer above the shield. The shield covers top-layer content that existed when refusal began without invoking its lifecycle.
 
 ### Stale HTML and caches

--- a/scripts/check-packed-ssr-consumer.ts
+++ b/scripts/check-packed-ssr-consumer.ts
@@ -48,6 +48,9 @@ const ORIGIN = `http://127.0.0.1:${PORT}`
 const DOM_COMMIT_TIMEOUT_MS = 10_000
 
 const isSkipBuild = process.argv.includes('--skip-build')
+const isCriticalBrowserMatrix = process.argv.includes(
+  '--critical-browser-matrix',
+)
 
 class ConsumerCheckError extends Error {}
 
@@ -1112,6 +1115,7 @@ type TopLayerProbe = Readonly<{
   controlClicks: number
   documentInputs: number
   bodyKeyEvents: number
+  fieldValues: ReadonlyArray<string>
   modalNodesAreConnected: boolean
   openShadowIdentityIsIntact: boolean
   frameIdentityIsIntact: boolean
@@ -1181,7 +1185,10 @@ type PlaywrightPage = Readonly<{
     selector: string,
     options?: { force?: boolean; timeout?: number },
   ) => Promise<unknown>
-  keyboard: Readonly<{ press: (key: string) => Promise<void> }>
+  keyboard: Readonly<{
+    press: (key: string) => Promise<void>
+    type: (text: string) => Promise<void>
+  }>
   mouse: Readonly<{
     click: (x: number, y: number) => Promise<void>
   }>
@@ -1198,16 +1205,20 @@ type PlaywrightBrowserType = Readonly<{
   launch: (options: { executablePath?: string }) => Promise<PlaywrightBrowser>
 }>
 
+type Playwright = Readonly<{
+  chromium: PlaywrightBrowserType
+  firefox: PlaywrightBrowserType
+  webkit: PlaywrightBrowserType
+}>
+
 // Playwright is installed for the browser suites in `packages/examples-e2e`
 // rather than at the root, and it is CommonJS, so it is required from that
 // package rather than imported from here.
-const loadChromium = (): PlaywrightBrowserType => {
+const loadPlaywright = (): Playwright => {
   const requireFromE2e = createRequire(
     join(REPO_ROOT, 'packages/examples-e2e/package.json'),
   )
-  const playwright: Readonly<{ chromium: PlaywrightBrowserType }> =
-    requireFromE2e('playwright')
-  return playwright.chromium
+  return requireFromE2e('playwright')
 }
 
 const PROBE_SCRIPT = `(() => {
@@ -1328,6 +1339,7 @@ const TOP_LAYER_PROBE_SCRIPT = `(() => {
     controlClicks: probe.events.click,
     documentInputs: probe.events.documentInput,
     bodyKeyEvents: probe.events.bodyKey,
+    fieldValues: probe.fields.map(field => field.value),
     modalNodesAreConnected:
       probe.dialogs.every(dialog => dialog.isConnected) &&
       probe.fields.every(field => field.isConnected),
@@ -1432,9 +1444,25 @@ type PageReading = Readonly<{
   diagnostics: ReadonlyArray<string>
 }>
 
+type HydrationOutcome = 'Hydrated' | 'Refused'
+
+const waitForHydrationOutcome = async (
+  page: PlaywrightPage,
+  outcome: HydrationOutcome,
+): Promise<void> => {
+  const completion =
+    outcome === 'Hydrated'
+      ? `document.querySelector('[data-foldkit-app]') === null`
+      : `document.body.hasAttribute('data-foldkit-refused') && document.querySelector('[data-foldkit-refusal-shield]')?.open === true`
+  await page.waitForFunction(completion, undefined, {
+    timeout: DOM_COMMIT_TIMEOUT_MS,
+  })
+}
+
 const readPage = async (
   browser: PlaywrightBrowser,
   path: string,
+  outcome: HydrationOutcome,
 ): Promise<PageReading> => {
   const page = await browser.newPage()
   // Every console level, not only `error`. What matters is that an operator
@@ -1450,6 +1478,7 @@ const readPage = async (
     diagnostics.push(raised.message)
   })
   await page.goto(`${ORIGIN}${path}`, { waitUntil: 'networkidle' })
+  await waitForHydrationOutcome(page, outcome)
   return { probe: await page.evaluate<Probe>(PROBE_SCRIPT), diagnostics }
 }
 
@@ -1546,6 +1575,7 @@ const assertControlledDomTransitions = async (
 ): Promise<void> => {
   const page = await browser.newPage()
   await page.goto(`${ORIGIN}/same`, { waitUntil: 'networkidle' })
+  await waitForHydrationOutcome(page, 'Hydrated')
   const controlled = await page.evaluate<ControlledDomProbe>(
     CONTROLLED_DOM_PROBE_SCRIPT,
   )
@@ -1733,6 +1763,7 @@ const assertPageIsInert = async (
 ): Promise<void> => {
   const page = await browser.newPage()
   await page.goto(`${ORIGIN}${path}`, { waitUntil: 'networkidle' })
+  await waitForHydrationOutcome(page, 'Refused')
   const before = requestedPaths.length
 
   await page.click('#increment', { force: true, timeout: 2_000 })
@@ -1780,6 +1811,7 @@ const assertTopLayerIsContained = async (
 ): Promise<void> => {
   const page = await browser.newPage()
   await page.goto(`${ORIGIN}/modal`, { waitUntil: 'networkidle' })
+  await waitForHydrationOutcome(page, 'Refused')
   const requestsBeforeInteraction = requestedPaths.length
   const before = await page.evaluate<TopLayerProbe>(TOP_LAYER_PROBE_SCRIPT)
 
@@ -1827,15 +1859,14 @@ const assertTopLayerIsContained = async (
       return null
     })()`,
   )
+  await page.keyboard.type('stale input')
   await page.keyboard.press('Tab')
 
   const after = await page.evaluate<TopLayerProbe>(TOP_LAYER_PROBE_SCRIPT)
   assertConsumer(
-    after.shieldIsOpen &&
-      after.shieldIsVisible &&
-      after.shieldHasFocus &&
-      after.shieldCount === 1,
-    'Escape, backdrop input, or focus traversal dismissed the refusal shield.',
+    after.shieldIsOpen && after.shieldIsVisible && after.shieldCount === 1,
+    'Escape, backdrop input, or focus traversal dismissed the refusal shield: ' +
+      JSON.stringify(after),
   )
   assertConsumer(
     after.dialogsAreOpen && after.closeEvents === 0,
@@ -1851,6 +1882,11 @@ const assertTopLayerIsContained = async (
     after.bodyKeyEvents === 0,
     'keyboard input escaped the refusal shield and reached a stale body ' +
       `handler (${String(after.bodyKeyEvents)} events).`,
+  )
+  assertConsumer(
+    after.fieldValues.every(value => value === ''),
+    'keyboard input changed a stale same-document field: ' +
+      JSON.stringify(after.fieldValues),
   )
   assertConsumer(
     page.url() === `${ORIGIN}/modal`,
@@ -1875,6 +1911,184 @@ const assertTopLayerIsContained = async (
     '/modal: light/open/closed-shadow top layers covered without lifecycle ' +
       'or native interaction',
   )
+}
+
+const assertLifecycleIsContained = async (
+  browser: PlaywrightBrowser,
+  requestedPaths: ReadonlyArray<string>,
+): Promise<void> => {
+  const framesBefore = requestedPaths.filter(path => path === FRAME_PATH).length
+  const lifecycleReading = await readPage(browser, '/lifecycle', 'Refused')
+  const framesAfter = requestedPaths.filter(path => path === FRAME_PATH).length
+  assertConsumer(
+    lifecycleReading.probe.rootIsContained,
+    '/lifecycle left its page interactive.',
+  )
+  assertConsumer(
+    lifecycleReading.probe.customElementConnections === 1,
+    'containment reconnected an upgraded custom element ' +
+      `(${String(lifecycleReading.probe.customElementConnections)} ` +
+      'connections). Reparenting the served root disconnects and reconnects ' +
+      'everything inside it.',
+  )
+  assertConsumer(
+    framesAfter - framesBefore === 1,
+    `containment reloaded an embedded document (${String(framesAfter - framesBefore)} ` +
+      'requests for the frame, expected 1). Moving the root reloads every ' +
+      'browsing context inside it.',
+  )
+  assertConsumer(
+    lifecycleReading.probe.reconnectModalIsOpen === false,
+    'a custom element opened a modal from a second connection, which reaches ' +
+      'the top layer above an earlier refusal shield.',
+  )
+  assertConsumer(
+    lifecycleReading.probe.shieldIsVisible,
+    'the refusal shield was not visibly covering served content.',
+  )
+  await assertPageIsInert(browser, '/lifecycle', requestedPaths)
+  log('/lifecycle: nothing reconnected, reloaded, or took focus')
+}
+
+const assertCriticalSameBuild = (browserName: string, probe: Probe): void => {
+  assertConsumer(
+    probe.rootIsConnected && probe.fieldIsSameElement,
+    `${browserName}: agreeing hydration replaced the root or input.`,
+  )
+  assertConsumer(
+    probe.fieldValue === TYPED_VALUE,
+    `${browserName}: agreeing hydration lost the value typed before startup.`,
+  )
+  assertConsumer(
+    probe.adoptedFrameIsSameElement &&
+      probe.adoptedFrameLoads === 1 &&
+      probe.adoptedFrameDocumentIsSame,
+    `${browserName}: agreeing hydration replaced or reloaded its iframe.`,
+  )
+  assertConsumer(
+    probe.parserOwnedHostIsFresh &&
+      probe.parserOldHostIsDisconnected &&
+      probe.parserViewChildIsFresh &&
+      probe.parserComponentChildIsDisconnected &&
+      probe.parserServerChildIsDisconnected &&
+      probe.parserLiveTitleIsRestored &&
+      probe.parserAncestorTitleIsRestored &&
+      probe.parserEarlierSiblingTitleIsRestored &&
+      probe.parserEarlierSiblingTextIsRestored &&
+      probe.parserDisconnectMutationsAreIsolated &&
+      probe.parserRetainedMutationIsIsolated,
+    `${browserName}: a view-owned Custom Element was not rebuilt cleanly ` +
+      `during hydration: ${JSON.stringify(probe)}`,
+  )
+  assertConsumer(
+    probe.renderedCount === 'Count: 0' && !probe.rootIsContained,
+    `${browserName}: agreeing hydration did not start cleanly.`,
+  )
+}
+
+const assertCriticalControlledDomTransitions = async (
+  browserName: string,
+  browser: PlaywrightBrowser,
+): Promise<void> => {
+  const page = await browser.newPage()
+  await page.goto(`${ORIGIN}/same`, { waitUntil: 'networkidle' })
+  await waitForHydrationOutcome(page, 'Hydrated')
+  const controlled = await page.evaluate<ControlledDomProbe>(
+    CONTROLLED_DOM_PROBE_SCRIPT,
+  )
+  assertProbeValues(`${browserName} controlled hydration`, controlled, {
+    nodeIdentityIsIntact: true,
+    customInnerHtmlHostWasRebuilt: true,
+    customInnerHtmlWasRebuilt: true,
+    nativeInnerHtmlWasAdopted: true,
+    value: 'same',
+    defaultValue: 'same',
+    valueAttribute: 'same',
+    checked: true,
+    defaultChecked: true,
+    hasCheckedAttribute: true,
+    rawSelectValue: 'a',
+    rawSelectIndex: 0,
+    rawSelectFirstDefault: true,
+    rawSelectSecondDefault: false,
+    textareaValue: 'controlled',
+    textareaDefaultValue: 'controlled',
+    innerSelectValue: 'b',
+    innerSelectIndex: 1,
+  })
+
+  await releaseControlledDomOwnership(page)
+  const released = await page.evaluate<ControlledDomProbe>(
+    RELEASED_DOM_PROBE_SCRIPT,
+  )
+  assertProbeValues(`${browserName} released ownership`, released, {
+    nodeIdentityIsIntact: true,
+    customInnerHtmlHostWasRebuilt: true,
+    customInnerHtmlWasRebuilt: true,
+    nativeInnerHtmlWasAdopted: true,
+    value: '',
+    defaultValue: '',
+    valueAttribute: null,
+    checked: false,
+    defaultChecked: false,
+    hasCheckedAttribute: false,
+    rawSelectValue: 'b',
+    rawSelectIndex: 1,
+    rawSelectFirstDefault: false,
+    rawSelectSecondDefault: true,
+    textareaValue: 'textarea default',
+    textareaDefaultValue: 'textarea default',
+    innerSelectValue: 'a',
+    innerSelectIndex: 0,
+    valueAfterReset: '',
+    checkedAfterReset: false,
+  })
+}
+
+const runCriticalBrowserChecks = async (
+  browserName: string,
+  browserType: PlaywrightBrowserType,
+  requestedPaths: ReadonlyArray<string>,
+): Promise<void> => {
+  log(`Running the critical server-rendering checks in ${browserName}...`)
+  const browser = await browserType.launch({})
+  try {
+    const adoptedFramesBefore = requestedPaths.filter(
+      path => path === ADOPTED_FRAME_PATH,
+    ).length
+    const sameReading = await readPage(browser, '/same', 'Hydrated')
+    const adoptedFramesAfter = requestedPaths.filter(
+      path => path === ADOPTED_FRAME_PATH,
+    ).length
+    assertConsumer(
+      adoptedFramesAfter - adoptedFramesBefore === 1,
+      `${browserName}: agreeing hydration requested its iframe ` +
+        `${String(adoptedFramesAfter - adoptedFramesBefore)} times.`,
+    )
+    assertCriticalSameBuild(browserName, sameReading.probe)
+    await assertCriticalControlledDomTransitions(browserName, browser)
+
+    const staleReading = await readPage(browser, '/stale', 'Refused')
+    assertRefusesOtherBuild(staleReading)
+    await assertPageIsInert(browser, '/stale', requestedPaths)
+    await assertTopLayerIsContained(browser, requestedPaths)
+    await assertLifecycleIsContained(browser, requestedPaths)
+  } finally {
+    await browser.close()
+  }
+  log(`${browserName}: critical server-rendering checks agree`)
+}
+
+const runCriticalBrowserMatrix = async (
+  playwright: Playwright,
+  requestedPaths: ReadonlyArray<string>,
+): Promise<void> => {
+  for (const [browserName, browserType] of Object.entries({
+    Firefox: playwright.firefox,
+    WebKit: playwright.webkit,
+  })) {
+    await runCriticalBrowserChecks(browserName, browserType, requestedPaths)
+  }
 }
 
 // DRIVER
@@ -2190,138 +2404,107 @@ const main = async (): Promise<void> => {
         },
         requestedPaths,
       )
-      const chromium = loadChromium()
-      const executablePath = process.env['PLAYWRIGHT_CHROMIUM_EXECUTABLE']
-      const browser = await chromium.launch(
-        executablePath === undefined ? {} : { executablePath },
-      )
+      const playwright = loadPlaywright()
       try {
-        const adoptedFramesBefore = requestedPaths.filter(
-          path => path === ADOPTED_FRAME_PATH,
-        ).length
-        const sameReading = await readPage(browser, '/same')
-        const adoptedFramesAfter = requestedPaths.filter(
-          path => path === ADOPTED_FRAME_PATH,
-        ).length
-        assertConsumer(
-          adoptedFramesAfter - adoptedFramesBefore === 1,
-          `agreeing hydration requested its iframe ${String(adoptedFramesAfter - adoptedFramesBefore)} ` +
-            'times instead of once.',
+        const executablePath = process.env['PLAYWRIGHT_CHROMIUM_EXECUTABLE']
+        const browser = await playwright.chromium.launch(
+          executablePath === undefined ? {} : { executablePath },
         )
-        assertAdoptsSameBuild(sameReading.probe)
-        assertConsumer(
-          !sameReading.probe.rootIsContained,
-          'a page from this build was contained. Containment is for a handoff ' +
-            'this client refuses, and firing it on a good page would take a ' +
-            'working application out of reach.',
-        )
-        await assertControlledDomTransitions(browser)
-        assertRefusesOtherBuild(await readPage(browser, '/stale'))
-        await assertPageIsInert(browser, '/stale', requestedPaths)
+        try {
+          const adoptedFramesBefore = requestedPaths.filter(
+            path => path === ADOPTED_FRAME_PATH,
+          ).length
+          const sameReading = await readPage(browser, '/same', 'Hydrated')
+          const adoptedFramesAfter = requestedPaths.filter(
+            path => path === ADOPTED_FRAME_PATH,
+          ).length
+          assertConsumer(
+            adoptedFramesAfter - adoptedFramesBefore === 1,
+            `agreeing hydration requested its iframe ${String(adoptedFramesAfter - adoptedFramesBefore)} ` +
+              'times instead of once.',
+          )
+          assertAdoptsSameBuild(sameReading.probe)
+          assertConsumer(
+            !sameReading.probe.rootIsContained,
+            'a page from this build was contained. Containment is for a handoff ' +
+              'this client refuses, and firing it on a good page would take a ' +
+              'working application out of reach.',
+          )
+          await assertControlledDomTransitions(browser)
+          assertRefusesOtherBuild(await readPage(browser, '/stale', 'Refused'))
+          await assertPageIsInert(browser, '/stale', requestedPaths)
 
-        for (const [path, expected] of [
-          ['/no-flags', 'server Flags payload is missing'],
-          ['/duplicate-flags', 'multiple server Flags payloads'],
-          ['/malformed-flags', 'could not decode the server'],
-          ['/incompatible-flags', 'could not decode the server'],
-        ]) {
-          const reading = await readPage(browser, String(path))
+          for (const [path, expected] of [
+            ['/no-flags', 'server Flags payload is missing'],
+            ['/duplicate-flags', 'multiple server Flags payloads'],
+            ['/malformed-flags', 'could not decode the server'],
+            ['/incompatible-flags', 'could not decode the server'],
+          ]) {
+            const reading = await readPage(browser, String(path), 'Refused')
+            assertConsumer(
+              reading.diagnostics.some(message =>
+                message.includes(String(expected)),
+              ),
+              `${String(path)} produced no "${String(expected)}" diagnostic. ` +
+                `Saw: ${JSON.stringify(reading.diagnostics)}`,
+            )
+            assertConsumer(
+              reading.probe.rootIsContained,
+              `${String(path)} left its root interactive. A handoff that cannot ` +
+                'be read leaves the same live page behind that build skew does.',
+            )
+            await assertPageIsInert(browser, String(path), requestedPaths)
+            log(`${String(path)}: refused and contained`)
+          }
+
+          const modalFramesBefore = requestedPaths.filter(
+            path => path === FRAME_PATH,
+          ).length
+          await assertTopLayerIsContained(browser, requestedPaths)
+          const modalFramesAfter = requestedPaths.filter(
+            path => path === FRAME_PATH,
+          ).length
           assertConsumer(
-            reading.diagnostics.some(message =>
-              message.includes(String(expected)),
-            ),
-            `${String(path)} produced no "${String(expected)}" diagnostic. ` +
-              `Saw: ${JSON.stringify(reading.diagnostics)}`,
+            modalFramesAfter - modalFramesBefore === 1,
+            `containment reloaded the modal probe frame (${String(modalFramesAfter - modalFramesBefore)} ` +
+              'requests, expected 1).',
           )
-          assertConsumer(
-            reading.probe.rootIsContained,
-            `${String(path)} left its root interactive. A handoff that cannot ` +
-              'be read leaves the same live page behind that build skew does.',
-          )
-          await assertPageIsInert(browser, String(path), requestedPaths)
-          log(`${String(path)}: refused and contained`)
+
+          // Refusals that land while the container is being resolved, before
+          // `Runtime.hydrate` runs. The generated client has no handle to the root
+          // in any of them, and the page it leaves behind is as live as any other.
+          for (const [path, expected] of [
+            ['/no-stamp', 'Container is null'],
+            ['/duplicate-roots', 'more than one server-rendered root stamped'],
+            ['/ambiguous-roots', 'no container to disambiguate them'],
+          ]) {
+            const reading = await readPage(browser, String(path), 'Refused')
+            assertConsumer(
+              reading.diagnostics.some(message =>
+                message.includes(String(expected)),
+              ),
+              `${String(path)} produced no "${String(expected)}" diagnostic. ` +
+                `Saw: ${JSON.stringify(reading.diagnostics)}`,
+            )
+            assertConsumer(
+              reading.probe.rootIsContained,
+              `${String(path)} left its page interactive. A refusal that lands ` +
+                'before hydration leaves the same live markup behind as one that ' +
+                'lands after it.',
+            )
+            await assertPageIsInert(browser, String(path), requestedPaths)
+            log(`${String(path)}: refused and contained`)
+          }
+
+          await assertLifecycleIsContained(browser, requestedPaths)
+        } finally {
+          await browser.close()
         }
 
-        const modalFramesBefore = requestedPaths.filter(
-          path => path === FRAME_PATH,
-        ).length
-        await assertTopLayerIsContained(browser, requestedPaths)
-        const modalFramesAfter = requestedPaths.filter(
-          path => path === FRAME_PATH,
-        ).length
-        assertConsumer(
-          modalFramesAfter - modalFramesBefore === 1,
-          `containment reloaded the modal probe frame (${String(modalFramesAfter - modalFramesBefore)} ` +
-            'requests, expected 1).',
-        )
-
-        // Refusals that land while the container is being resolved, before
-        // `Runtime.hydrate` runs. The generated client has no handle to the root
-        // in any of them, and the page it leaves behind is as live as any other.
-        for (const [path, expected] of [
-          ['/no-stamp', 'Container is null'],
-          ['/duplicate-roots', 'more than one server-rendered root stamped'],
-          ['/ambiguous-roots', 'no container to disambiguate them'],
-        ]) {
-          const reading = await readPage(browser, String(path))
-          assertConsumer(
-            reading.diagnostics.some(message =>
-              message.includes(String(expected)),
-            ),
-            `${String(path)} produced no "${String(expected)}" diagnostic. ` +
-              `Saw: ${JSON.stringify(reading.diagnostics)}`,
-          )
-          assertConsumer(
-            reading.probe.rootIsContained,
-            `${String(path)} left its page interactive. A refusal that lands ` +
-              'before hydration leaves the same live markup behind as one that ' +
-              'lands after it.',
-          )
-          await assertPageIsInert(browser, String(path), requestedPaths)
-          log(`${String(path)}: refused and contained`)
+        if (isCriticalBrowserMatrix) {
+          await runCriticalBrowserMatrix(playwright, requestedPaths)
         }
-
-        // Containment must mark the page, not move it. Reparenting the root
-        // reconnects every custom element in the subtree and reloads every
-        // frame, and the second connection could run stale author code during
-        // refusal.
-        const framesBefore = requestedPaths.filter(
-          path => path === FRAME_PATH,
-        ).length
-        const lifecycleReading = await readPage(browser, '/lifecycle')
-        const framesAfter = requestedPaths.filter(
-          path => path === FRAME_PATH,
-        ).length
-        assertConsumer(
-          lifecycleReading.probe.rootIsContained,
-          '/lifecycle left its page interactive.',
-        )
-        assertConsumer(
-          lifecycleReading.probe.customElementConnections === 1,
-          'containment reconnected an upgraded custom element ' +
-            `(${String(lifecycleReading.probe.customElementConnections)} ` +
-            'connections). Reparenting the served root disconnects and ' +
-            'reconnects everything inside it.',
-        )
-        assertConsumer(
-          framesAfter - framesBefore === 1,
-          `containment reloaded an embedded document (${String(framesAfter - framesBefore)} ` +
-            'requests for the frame, expected 1). Moving the root reloads every ' +
-            'browsing context inside it.',
-        )
-        assertConsumer(
-          lifecycleReading.probe.reconnectModalIsOpen === false,
-          'a custom element opened a modal from a second connection, which ' +
-            'reaches the top layer above an earlier refusal shield.',
-        )
-        assertConsumer(
-          lifecycleReading.probe.shieldIsVisible,
-          'the refusal shield was not visibly covering served content.',
-        )
-        await assertPageIsInert(browser, '/lifecycle', requestedPaths)
-        log('/lifecycle: nothing reconnected, reloaded, or took focus')
       } finally {
-        await browser.close()
         server.close()
       }
     })

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -9,10 +9,24 @@ const workflow = readFileSync(
   resolve(REPO_ROOT, '.github/workflows/ci.yml'),
   'utf8',
 )
+const rootPackage = JSON.parse(
+  readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
+)
 
 test('changeset status receives trusted pull request context', () => {
   assert.match(
     workflow,
     /- name: Check changeset status\n\s+env:\n\s+FOLDKIT_CI_EVENT_NAME: \$\{\{ github\.event_name \}\}\n\s+FOLDKIT_CI_HEAD_REF: \$\{\{ github\.head_ref \}\}\n\s+FOLDKIT_CI_HEAD_REPOSITORY: \$\{\{ github\.event\.pull_request\.head\.repo\.full_name \}\}\n\s+FOLDKIT_CI_REPOSITORY: \$\{\{ github\.repository \}\}\n\s+run: node scripts\/check-changeset-status\.mjs/,
+  )
+})
+
+test('the packed SSR consumer runs its critical browser matrix in CI', () => {
+  assert.match(
+    workflow,
+    /playwright install --with-deps chromium firefox webkit/,
+  )
+  assert.equal(
+    rootPackage.scripts['check:packed-ssr-consumer:ci'],
+    'tsx scripts/check-packed-ssr-consumer.ts --skip-build --critical-browser-matrix',
   )
 })


### PR DESCRIPTION
## What changed

- Run a focused Firefox and Playwright WebKit matrix through the packed SSR consumer gate while keeping the exhaustive suite in Chromium.
- Cover hydration adoption and DOM identity, mismatch rebuilding, form state, Custom Elements, stale-build refusal, and refusal lifecycle behavior.
- Block same-document keyboard events after hydration refusal when WebKit lets older modal content reclaim focus.
- Document the embedded-document boundary: events inside an iframe do not cross the parent document's containment guards.

## Why

The Chromium suite did not exercise browser-specific hydration and top-layer behavior. The WebKit pass reproduced a case where an older modal could reclaim focus after Foldkit opened the refusal shield. Moving or closing served DOM would trigger Custom Element lifecycle hooks and iframe reloads, so the runtime instead blocks same-document keyboard propagation without reparenting author content.

## Impact

Hydration refusal remains fail-closed for same-document pointer and physical keyboard activation across the three Playwright browser engines. Embedded documents remain outside that event boundary and are explicitly documented as a containment limitation.

## Validation

- Packed npm consumer gate: Chromium full suite, Firefox critical suite, WebKit critical suite
- Foldkit: 2,272 passed, 1 skipped
- Script tests: 55 passed
- Full workspace build, recursive typecheck, lint, Knip, formatting, circular-dependency, Effect prebundle, package, and example checks
- Independent diff re-review: no actionable findings

The local website Playwright step could not claim its fixed port because another active worktree was serving it. CI runs that suite in an isolated runner.