### PR TITLE
fix(foldkit): harden hydration marker contract

### DIFF
--- a/.changeset/reject-nan-hydration-keys.md
+++ b/.changeset/reject-nan-hydration-keys.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Reject `NaN` element keys in hydratable server output because they cannot identify the same element across renders. Hydration key and view-identity markers are now documented as public, non-cryptographic fingerprints rather than one-way digests.

--- a/packages/foldkit/src/experimental/server/serialize.test.ts
+++ b/packages/foldkit/src/experimental/server/serialize.test.ts
@@ -586,10 +586,10 @@ describe('serializeHtml', () => {
     expect(serializeHtml(view)).toBe('<button id="submit">Send</button>')
   })
 
-  it('stamps a hydratable key as a digest rather than the key itself', () => {
+  it('stamps a hydratable key as a fingerprint rather than the key itself', () => {
     // A key is application data (a row id, an account identifier, an email) that
-    // the view never renders, so hydration compares digests and the key itself
-    // never reaches the markup.
+    // the view never renders, so hydration compares fingerprints and the key
+    // itself never reaches the markup.
     const view = h.keyed('li')('user@example.com', [], ['Ada'])
     const serialized = serializeHtml(view, { emitHydrationMarkers: true })
 
@@ -599,9 +599,9 @@ describe('serializeHtml', () => {
     )
   })
 
-  it('stamps a hydratable view identity as a digest rather than the source path', () => {
+  it('stamps a hydratable view identity as a fingerprint rather than the source path', () => {
     // The compiler's identity spells out a relative source path and function
-    // name. Digesting it keeps the build's file layout out of public HTML.
+    // name. Fingerprinting it keeps the build's file layout out of public HTML.
     const view = h.div([], ['Home'])
     if (view === null) {
       throw new Error('expected the view to produce a vnode')
@@ -616,10 +616,10 @@ describe('serializeHtml', () => {
     )
   })
 
-  it('digests a numeric key differently from the same digits as a string', () => {
+  it('fingerprints a numeric key differently from the same digits as a string', () => {
     // The runtime compares keys with `===`, so 1 and '1' are different keys. A
-    // digest that collapsed them would let a numeric server row adopt a string
-    // client row, carrying one row's typed state onto another.
+    // fingerprint that collapsed them would let a numeric server row adopt a
+    // string client row, carrying one row's typed state onto another.
     const numeric = serializeHtml(h.keyed('li')(1, [], ['one']), {
       emitHydrationMarkers: true,
     })
@@ -629,6 +629,16 @@ describe('serializeHtml', () => {
 
     expect(numeric).not.toBe(string)
     expect(hydrationKeyMarker(1)).not.toBe(hydrationKeyMarker('1'))
+  })
+
+  it('refuses to render an element keyed by NaN as hydratable', () => {
+    expect(hydrationKeyMarker(Number.NaN)).toBeUndefined()
+
+    const view = h.keyed('li')(Number.NaN, [], ['one'])
+    expect(() => serializeHtml(view, { emitHydrationMarkers: true })).toThrow(
+      'keyed by NaN',
+    )
+    expect(serializeHtml(view)).toBe('<li>one</li>')
   })
 
   it('refuses to render an element keyed by a symbol as hydratable', () => {

--- a/packages/foldkit/src/experimental/server/serialize.ts
+++ b/packages/foldkit/src/experimental/server/serialize.ts
@@ -829,14 +829,22 @@ const serializeElement = (
   }
 
   // The server HTML does not otherwise carry a vnode's key or identity, so
-  // hydration would adopt keyed children positionally. Stamp a digest of each so
-  // hydration can verify it is adopting the same logical entity without the raw
-  // key or source identity appearing in public markup; it strips the markers as
-  // it adopts.
+  // hydration would adopt keyed children positionally. Stamp a fingerprint of
+  // each so hydration can verify it is adopting the same logical entity without
+  // the raw key or source identity appearing in public markup; it strips the
+  // markers as it adopts.
   if (context.emitHydrationMarkers) {
     if (node.key !== undefined) {
       const keyMarker = hydrationKeyMarker(node.key)
       if (keyMarker === undefined) {
+        if (typeof node.key === 'number' && Number.isNaN(node.key)) {
+          throw new Error(
+            '[foldkit] Cannot server-render an element keyed by NaN as ' +
+              'hydratable. NaN is not equal to itself, so hydration cannot ' +
+              'tell whether the server and client mean the same element. ' +
+              'Key hydratable elements by a string or a number other than NaN.',
+          )
+        }
         throw new Error(
           '[foldkit] Cannot server-render an element keyed by a symbol. A ' +
             'symbol key cannot be compared across the server and the client ' +
@@ -1013,10 +1021,10 @@ const serializeNode = (
  *  tree serializes to an empty comment, mirroring how the runtime patches
  *  `null` as a comment node.
  *
- * A hydratable render also stamps a digest of each vnode's key and identity, so
- * hydration can tell one logical entity from another; the raw key and the
- * compiler's source identity never appear in the markup. A render that is not
- * hydratable emits neither.
+ * A hydratable render also stamps a fingerprint of each vnode's key and
+ * identity, so hydration can tell one logical entity from another; the raw key
+ * and the compiler's source identity never appear in the markup. A render that
+ * is not hydratable emits neither.
  *
  * @internal Not part of the `foldkit/experimental/server` surface; `renderToString` is the public entry to serialization.
  */

--- a/packages/foldkit/src/hydrate.ts
+++ b/packages/foldkit/src/hydrate.ts
@@ -478,11 +478,11 @@ const matchesNamespace = (element: Element, vnode: VNode): boolean =>
 // The server DOM does not encode a vnode's key or identity, so a positional
 // match on tag and namespace alone could adopt a different logical entity: a
 // reordered or stale keyed list would take over the wrong DOM node, and the user
-// state sitting on it. The serializer stamps a digest of key and identity; here
-// the same digest is computed for the vnode and compared, so a mismatch rebuilds
-// instead of transferring state to the wrong row or branch. A key type the
-// digest does not support (a symbol, which a hydratable render refuses) never
-// matches, so it rebuilds rather than adopting on a guess.
+// state sitting on it. The serializer stamps a fingerprint of the key and
+// identity; here the same fingerprint is computed for the vnode and compared,
+// so a mismatch rebuilds instead of transferring state to the wrong row or
+// branch. An unsupported key (NaN or a symbol, which a hydratable render
+// refuses) never matches, so it rebuilds rather than adopting on a guess.
 const matchesAdoptionKey = (element: Element, vnode: VNode): boolean => {
   const serverKey = element.getAttribute(HYDRATION_KEY_ATTRIBUTE)
   if (vnode.key === undefined) {
@@ -490,9 +490,9 @@ const matchesAdoptionKey = (element: Element, vnode: VNode): boolean => {
   }
   const clientKey = hydrationKeyMarker(vnode.key)
   if (clientKey === undefined) {
-    // A key type the digest cannot represent (a symbol, which a hydratable
-    // render refuses) cannot be compared, so it never matches: rebuilding beats
-    // adopting on a guess.
+    // An unsupported key (NaN or a symbol, which a hydratable render refuses)
+    // cannot be compared, so it never matches: rebuilding beats adopting on a
+    // guess.
     return false
   }
   return serverKey === clientKey

--- a/packages/foldkit/src/hydrationMarkers.ts
+++ b/packages/foldkit/src/hydrationMarkers.ts
@@ -6,15 +6,13 @@
 // lets hydration verify it is adopting the same logical entity by key and
 // identity, not just by tag and position, and rebuild when it is not.
 //
-// A marker carries a digest of the key, never the key itself. Application keys
-// are database ids, account identifiers, and email addresses the view otherwise
-// never renders, and a compiler identity spells out a source path and function
-// name; neither belongs in public HTML. A digest is a one-way comparison token:
-// it is enough for hydration, which only ever asks whether two markers are
-// equal, and it does not read back to the value it was computed from. It is not
-// a secret, since a reader who guesses a candidate key can hash it and compare,
-// so it is sized to make an accidental collision between two distinct keys
-// vanishingly unlikely rather than to withstand a guessing attack.
+// A marker carries a deterministic, non-cryptographic fingerprint of the key,
+// never the key itself. Application keys are database ids, account identifiers,
+// and email addresses the view otherwise never renders, and a compiler identity
+// spells out a source path and function name; neither belongs directly in public
+// HTML. The fingerprint is public. A reader can fingerprint a guessed value and
+// compare it, and a caller can deliberately construct a collision. Hydration
+// uses it only to detect accidental disagreement between supported inputs.
 //
 // Markers are part of the hydration handoff, so they are emitted only for a
 // hydratable render. Non-hydratable output carries no key or identity channel
@@ -24,14 +22,15 @@ export const HYDRATION_KEY_ATTRIBUTE = 'data-foldkit-key'
 export const HYDRATION_IDENTITY_ATTRIBUTE = 'data-foldkit-identity'
 
 // FNV-1a, run as two 32-bit lanes from different offset bases and concatenated
-// to 64 bits. The lanes are plain integer arithmetic over the string's code
-// units, so the server and the browser compute the same digest for the same
-// input with no platform dependency and no async crypto API.
+// into one 16-character value. The lanes are plain integer arithmetic over the
+// string's code units, so the server and the browser compute the same value with
+// no platform dependency or async crypto API. This construction is intended to
+// catch accidental differences. It does not resist deliberate collisions.
 const FNV_PRIME = 16777619
 const FNV_OFFSET_BASIS = 2166136261
 const SECOND_LANE_OFFSET_BASIS = 1099511628
 
-const digest = (value: string): string => {
+const fingerprint = (value: string): string => {
   let lowLane = FNV_OFFSET_BASIS
   let highLane = SECOND_LANE_OFFSET_BASIS
   for (let index = 0; index < value.length; index += 1) {
@@ -49,24 +48,27 @@ const digest = (value: string): string => {
   )
 }
 
-// Each digest is taken over a type-tagged string, which keeps the supported key
+// Each fingerprint covers a type-tagged string, which keeps the supported key
 // types apart. The runtime compares keys with `===`, so the number 1 and the
-// string '1' are different keys and must digest differently; untagged, both
-// would reach the digest as "1" and a server-rendered numeric key would adopt a
-// client string key's node, and the state on it.
+// string '1' are different keys and must produce different fingerprints;
+// untagged, both would reach the fingerprint as "1" and a server-rendered
+// numeric key would adopt a client string key's node, and the state on it.
 
-/** The marker value for a vnode key, or `undefined` for a key type the
- *  hydration handoff does not support (a symbol, which the server refuses to
- *  render and hydration therefore never adopts).
+/** The marker value for a vnode key, or `undefined` for a key the hydration
+ *  handoff does not support (`NaN` or a symbol, both of which the server
+ *  refuses in hydratable output).
  *
  * @internal
  */
 export const hydrationKeyMarker = (key: PropertyKey): string | undefined => {
   if (typeof key === 'string') {
-    return digest(`s:${key}`)
+    return fingerprint(`s:${key}`)
   }
   if (typeof key === 'number') {
-    return digest(`n:${key}`)
+    if (Number.isNaN(key)) {
+      return undefined
+    }
+    return fingerprint(`n:${key}`)
   }
   return undefined
 }
@@ -76,4 +78,4 @@ export const hydrationKeyMarker = (key: PropertyKey): string | undefined => {
  * @internal
  */
 export const hydrationIdentityMarker = (identity: string): string =>
-  digest(`i:${identity}`)
+  fingerprint(`i:${identity}`)

--- a/packages/website/src/page/core/serverRendering.md
+++ b/packages/website/src/page/core/serverRendering.md
@@ -19,27 +19,27 @@ One program gives Foldkit one rendering pipeline with two delivery policies:
 
 An application can use either policy, or use SSG for some URLs and SSR for others. The application code does not need a second rendering API.
 
-Here is one page from request to live application:
+For an application with Flags, here is the handoff from server input to a live application:
 
 ```diagram
-GET /page  (from the browser)
-   │
-   ▼
-── on the host ──  Vite in dev, your server in production
-     renderPage      [you write]
-        derives Flags from the request
-     renderToString  [Foldkit]
-        calls your init, runs your view → HTML
-     toResponse      [Foldkit]
-        fills index.html, embeds the Flags payload
-   │
-   ▼  HTML page + Flags payload
-── on the browser ──
-     Runtime.hydrate [Foldkit]
-        reads the Flags, calls the same init
-        adopts matching DOM, rebuilds mismatches
-     live application
-        listeners and Mounts attach to the existing elements
+              SERVER                         BROWSER
+
+request or build input                 normal Foldkit app
+         │                                     ▲
+         ▼                                     │
+       Flags                           adopt matching DOM
+         │                                     ▲
+         ▼                                     │
+        init                                same view
+         │                                     ▲
+         ▼                                     │
+       Model                          equivalent Model
+         │                                     ▲
+         ▼                                     │
+        view                               same init
+         │                                     ▲
+         ▼                                     │
+HTML + serialized Flags ────────► Runtime.hydrate reads Flags
 ```
 
 Once the live application takes over, it behaves like any other Foldkit application. Routing, update, Commands, and Subscriptions run in the browser. Navigation moves between routes without contacting the server. The server renders again only on a full page load, such as a reload or a link the runtime does not handle.
@@ -124,9 +124,9 @@ A hydratable render carries these markers:
 - The application root has `data-foldkit-app`. Its value is the `runtimeId`.
 - The root also has `data-foldkit-build`. Its value identifies the deployment that rendered the page.
 - An application with Flags emits a `<script type="application/json" data-foldkit-flags="...">`. It carries the Schema-encoded Flags that produced the server Model. The attribute value matches the root's `runtimeId`.
-- Keyed elements carry `data-foldkit-key`. Elements with build-assigned view identity carry `data-foldkit-identity`. Both values are digests. The marker contains neither the original key, which may hold an account id or email address, nor the build's source path. Hydration compares each digest and removes the marker as it adopts the element. A render with `isHydratable: false` emits neither marker.
+- Keyed elements carry `data-foldkit-key`. Elements with build-assigned view identity carry `data-foldkit-identity`. Both values are deterministic, non-cryptographic fingerprints. Neither marker contains the original key, which may hold an account id or email address, or the build's source path. Hydration compares each fingerprint and removes the marker as it adopts the element. A render with `isHydratable: false` emits neither marker.
 
-  A digest is a comparison token, not a secret. A reader cannot reverse it directly, but can hash a guessed value and test for a match. Key by values that are safe to publish.
+  A fingerprint is a public comparison token, not a secret or an authentication check. A reader can compute the fingerprint of a guessed key or view identity and test for a match. An attacker can also construct two values with the same fingerprint. Key by values that are safe to publish. Hydratable keys must be strings or numbers other than `NaN`.
 
 Conceptually, the handoff appears next to the rendered root:
 


### PR DESCRIPTION
## Summary

- Refuse `NaN` keys when serializing hydratable output while preserving static and client-only behavior.
- Describe hydration markers as public, non-cryptographic fingerprints and document guessed-value and deliberate-collision limits.
- Replace the Server Rendering overview flow with a compact server-to-browser handoff diagram.

## Why

`NaN` is not equal to itself, so it cannot identify the same vnode across renders. The previous marker function converted it into one stable string and could let hydration adopt DOM under ownership semantics that the normal differ does not share. Hydratable output now refuses that key instead.

The marker construction is meant to catch accidental disagreement. It is not an authentication boundary or a one-way digest, so the implementation comments and public documentation now state that contract directly.

## Validation

- Mutation check: removing the `Number.isNaN` exclusion makes the new regression fail.
- Foldkit tests: 2,273 passed, 1 skipped.
- Website tests: 457 passed.
- Foldkit typecheck passed.
- Website client and SSR builds passed.
- Website prerender passed for all 184 routes.
- Server Rendering page inspected in the rendered site.
- Prettier and changeset checks passed.
