### PR TITLE
chore: clean up server rendering follow-ups

### DIFF
--- a/.changeset/shorten-scaffold-build-comments.md
+++ b/.changeset/shorten-scaffold-build-comments.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Keep the generated SSR and SSG build scripts concise while preserving the one-build-id invariant beside the code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,14 +53,7 @@ The principles below apply broadly. Calibrate to the right context: library desi
 
 ## Code Style
 
-Match the implementation style to the subsystem and the behavior being modeled.
-Do not homogenize the repository around a preferred abstraction. Use pure
-transformations for deterministic data work; direct imperative code when DOM
-identity, lifecycle ordering, browser behavior, or host timing are observable;
-and Effect when interruption, resources, services, typed failure, or composition
-justify it. Preserve deliberate non-Effect code, and do not introduce or remove
-Effect solely for stylistic consistency. When styles mix, keep the boundary
-explicit and follow the surrounding module and exemplar code.
+Match the implementation style to the subsystem and the behavior being modeled. Do not homogenize the repository around a preferred abstraction. Use pure transformations for deterministic data work; direct imperative code when DOM identity, lifecycle ordering, browser behavior, or host timing are observable; and Effect when interruption, resources, services, typed failure, or composition justify it. Preserve deliberate non-Effect code, and do not introduce or remove Effect solely for stylistic consistency. When styles mix, keep the boundary explicit and follow the surrounding module and exemplar code.
 
 - Use Effect's `Match` instead of `switch`. For tagged unions prefer `M.tagsExhaustive({ ... })` over `M.tag(...)` chains.
 - `pipe` is for multi-step data flow. Never `pipe` a single operation; call the function directly.

--- a/packages/create-foldkit-app/templates/rendering/ssg/scripts/build.mjs
+++ b/packages/create-foldkit-app/templates/rendering/ssg/scripts/build.mjs
@@ -1,20 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 
-// NOTE: one id names this build, and every command below is given that same
-// id, so the client bundle and the server bundle of a deployment agree on which
-// deployment they are. `renderToString` stamps it on the prerendered pages and
-// `Runtime.hydrate` compares it before adopting any DOM, so a page left over
-// from an earlier deployment is refused and contained rather than reconciled
-// against a client that no longer means the same thing by it.
-//
-// The id is published in the HTML every visitor receives. It identifies a
-// deployment and is never a credential, so keep secrets out of it. Set
-// FOLDKIT_BUILD_ID to name builds from a value the deployment already has, such
-// as a commit or a release tag; without one, each build takes a fresh id.
-// NOTE: `??` alone would take an empty FOLDKIT_BUILD_ID as a real value, and
-// the plugin treats empty as absent, so the build would compile no id at all and
-// fail later at the render. Empty is unset here too.
+// NOTE: one nonempty id must reach every step in this build.
 const supplied = process.env.FOLDKIT_BUILD_ID
 const buildId =
   supplied === undefined || supplied === '' ? randomUUID() : supplied

--- a/packages/create-foldkit-app/templates/rendering/ssr/scripts/build.mjs
+++ b/packages/create-foldkit-app/templates/rendering/ssr/scripts/build.mjs
@@ -1,20 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 
-// NOTE: one id names this build, and every command below is given that same
-// id, so the client bundle and the server bundle of a deployment agree on which
-// deployment they are. `renderToString` stamps it on the rendered root and
-// `Runtime.hydrate` compares it before adopting any DOM, so a page left over
-// from an earlier deployment is refused and contained rather than reconciled
-// against a client that no longer means the same thing by it.
-//
-// The id is published in the HTML every visitor receives. It identifies a
-// deployment and is never a credential, so keep secrets out of it. Set
-// FOLDKIT_BUILD_ID to name builds from a value the deployment already has, such
-// as a commit or a release tag; without one, each build takes a fresh id.
-// NOTE: `??` alone would take an empty FOLDKIT_BUILD_ID as a real value, and
-// the plugin treats empty as absent, so the build would compile no id at all and
-// fail later at the render. Empty is unset here too.
+// NOTE: one nonempty id must reach every step in this build.
 const supplied = process.env.FOLDKIT_BUILD_ID
 const buildId =
   supplied === undefined || supplied === '' ? randomUUID() : supplied

--- a/packages/foldkit/src/runtime/hydrateBoot.test.ts
+++ b/packages/foldkit/src/runtime/hydrateBoot.test.ts
@@ -592,8 +592,11 @@ describe('hydrating boot', () => {
       run(application, { flags: Effect.succeed({ start: 1 }) })
       // @ts-expect-error hydration requires the client's build id
       hydrate(application)
-      // @ts-expect-error hydration owns Flags and accepts no client producer
-      hydrate(application, { flags: Effect.succeed({ start: 1 }) })
+      hydrate(application, {
+        buildId: BUILD_ID,
+        // @ts-expect-error hydration owns Flags and accepts no client producer
+        flags: Effect.succeed({ start: 1 }),
+      })
       hydrate(application, { buildId: BUILD_ID })
     }
   })


### PR DESCRIPTION
## Summary

- Make the hydration type test satisfy the build-id requirement before asserting that client Flags are forbidden.
- Replace duplicated generated SSR and SSG build-script explanations with the one invariant the code must preserve.
- Remove manual line wrapping from the repository's Code Style guidance without changing its words.

## Why

The previous negative type test could pass because `buildId` was missing, so it did not prove that hydration rejects a client Flags producer. The generated build scripts also repeated deployment guidance that their READMEs already carry. The scripts now keep only the one-nonempty-id invariant beside the code.

This PR changes no runtime behavior. The generated README guidance and build logic are unchanged.

## Validation

- Mutation check: removing the targeted `@ts-expect-error` reports TS2353 because `flags` is not a hydration option.
- Foldkit typecheck passed.
- `hydrateBoot.test.ts`: 42 passed.
- create-foldkit-app typecheck passed.
- create-foldkit-app tests: 18 passed.
- Prettier and changeset checks passed.
