### PR TITLE
fix(foldkit): preserve mixed class ownership

### DIFF
--- a/.changeset/quiet-class-ownership.md
+++ b/.changeset/quiet-class-ownership.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Preserve tokens from `h.Class` when a raw `class` attribute changes, and keep raw class tokens when typed ownership changes.

--- a/packages/foldkit/src/hydrate.test.ts
+++ b/packages/foldkit/src/hydrate.test.ts
@@ -2046,6 +2046,62 @@ describe('__hydrateVNode', () => {
     expect(root.style.color).toBe('blue')
   })
 
+  it('preserves raw and typed class ownership after hydration', () => {
+    const initialView = () =>
+      h.div([h.Attribute('class', 'raw-a'), h.Class('typed')], ['content'])
+    const root = mountServerHtml(serializeHydratable(buildView(initialView)))
+    if (!(root instanceof HTMLDivElement)) {
+      throw new Error('expected a div root')
+    }
+
+    const hydrated = buildView(() => hydrateVNode(root, initialView()))
+    const changedRawClass = buildView(() =>
+      patch(
+        hydrated,
+        requireVNode(
+          h.div(
+            [h.Attribute('CLASS', 'raw-b shared'), h.Class('typed')],
+            ['content'],
+          ),
+        ),
+      ),
+    )
+
+    expect(changedRawClass.elm).toBe(root)
+    expect(root.classList.contains('raw-a')).toBe(false)
+    expect(root.classList.contains('raw-b')).toBe(true)
+    expect(root.classList.contains('shared')).toBe(true)
+    expect(root.classList.contains('typed')).toBe(true)
+
+    const sharedClass = buildView(() =>
+      patch(
+        changedRawClass,
+        requireVNode(
+          h.div(
+            [h.Attribute('class', 'raw-b shared'), h.Class('shared')],
+            ['content'],
+          ),
+        ),
+      ),
+    )
+    const rawClassOnly = buildView(() =>
+      patch(
+        sharedClass,
+        requireVNode(
+          h.div(
+            [h.Attribute('class', 'raw-b shared'), h.Class('')],
+            ['content'],
+          ),
+        ),
+      ),
+    )
+
+    expect(rawClassOnly.elm).toBe(root)
+    expect(root.classList.contains('raw-b')).toBe(true)
+    expect(root.classList.contains('shared')).toBe(true)
+    expect(root.classList.contains('typed')).toBe(false)
+  })
+
   it('keeps uppercase raw HTML attributes during hydration', () => {
     const view = () =>
       h.div(

--- a/packages/foldkit/src/snabbdom/class.ts
+++ b/packages/foldkit/src/snabbdom/class.ts
@@ -1,8 +1,60 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { parsedAttributeName } from '../domReflection.js'
 import type { Module } from './module.js'
 import { type VNode, type VNodeData, VNodeDataMask } from './vnode.js'
 
 export type Classes = Record<string, boolean>
+
+type RawClassAttribute =
+  | Readonly<{ _tag: 'Absent' }>
+  | Readonly<{
+      _tag: 'Present'
+      value: string | number | boolean
+    }>
+
+const absentRawClassAttribute: RawClassAttribute = { _tag: 'Absent' }
+const ASCII_WHITESPACE = /[\t\n\f\r ]+/
+
+const rawClassAttributeFor = (
+  vnode: VNode,
+  namespace: string | null,
+): RawClassAttribute => {
+  const attrs = (vnode.data as VNodeData).attrs
+  if (attrs === undefined) {
+    return absentRawClassAttribute
+  }
+
+  let attribute: RawClassAttribute = absentRawClassAttribute
+  for (const name of Object.keys(attrs)) {
+    if (parsedAttributeName(namespace, name) === 'class') {
+      attribute = { _tag: 'Present', value: attrs[name]! }
+    }
+  }
+  return attribute
+}
+
+const rawClassAttributesAgree = (
+  previous: RawClassAttribute,
+  next: RawClassAttribute,
+): boolean => {
+  if (previous._tag === 'Absent') {
+    return next._tag === 'Absent'
+  }
+  return next._tag === 'Present' && previous.value === next.value
+}
+
+const rawClassNamesFor = (attribute: RawClassAttribute): Set<string> => {
+  const names = new Set<string>()
+  if (attribute._tag === 'Absent' || typeof attribute.value === 'boolean') {
+    return names
+  }
+  for (const name of String(attribute.value).split(ASCII_WHITESPACE)) {
+    if (name !== '') {
+      names.add(name)
+    }
+  }
+  return names
+}
 
 function updateClass(oldVnode: VNode, vnode: VNode): void {
   let cur: any
@@ -10,22 +62,47 @@ function updateClass(oldVnode: VNode, vnode: VNode): void {
   const elm: Element = vnode.elm as Element
   let oldClass = (oldVnode.data as VNodeData).class
   let klass = (vnode.data as VNodeData).class
+  const oldAttrs = (oldVnode.data as VNodeData).attrs
+  const attrs = (vnode.data as VNodeData).attrs
 
   if (!oldClass && !klass) return
-  if (oldClass === klass) return
+  if (oldClass === klass && oldAttrs === attrs) return
+  const previousRawClass = rawClassAttributeFor(oldVnode, elm.namespaceURI)
+  const nextRawClass = rawClassAttributeFor(vnode, elm.namespaceURI)
+  if (
+    oldClass === klass &&
+    rawClassAttributesAgree(previousRawClass, nextRawClass)
+  ) {
+    return
+  }
   oldClass = oldClass || {}
   klass = klass || {}
 
+  if (oldClass === klass) {
+    for (name in klass) {
+      if (klass[name] && !elm.classList.contains(name)) {
+        elm.classList.add(name)
+      }
+    }
+    return
+  }
+
+  const nextRawClassNames = rawClassNamesFor(nextRawClass)
   for (name in oldClass) {
-    if (oldClass[name] && !Object.prototype.hasOwnProperty.call(klass, name)) {
-      // was `true` and now not provided
+    if (
+      oldClass[name] &&
+      klass[name] !== true &&
+      !nextRawClassNames.has(name)
+    ) {
       elm.classList.remove(name)
     }
   }
   for (name in klass) {
     cur = klass[name]
-    if (cur !== oldClass[name]) {
-      elm.classList[cur ? 'add' : 'remove'](name)
+    if (cur && !elm.classList.contains(name)) {
+      elm.classList.add(name)
+    } else if (cur !== oldClass[name] && !nextRawClassNames.has(name)) {
+      elm.classList.remove(name)
     }
   }
 }

--- a/packages/foldkit/src/snabbdom/modules.test.ts
+++ b/packages/foldkit/src/snabbdom/modules.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { attributesModule } from './attributes.js'
 import { classModule } from './class.js'
@@ -124,6 +124,109 @@ describe('classModule', () => {
 
     expect(patchedElement.classList.contains('active')).toBe(false)
     expect(patchedElement.classList.contains('hidden')).toBe(true)
+  })
+
+  it('preserves raw and typed class ownership across patches', () => {
+    const container = document.createElement('div')
+    const typedClass = { typed: true }
+    const mounted = patch(
+      container,
+      h('div', { attrs: { class: 'raw-a' }, class: typedClass }),
+    )
+    const element = elementOf(mounted)
+
+    const changedRawClass = patch(
+      mounted,
+      h('div', { attrs: { CLASS: 'raw-b shared' }, class: typedClass }),
+    )
+
+    expect(elementOf(changedRawClass)).toBe(element)
+    expect(element.classList.contains('raw-a')).toBe(false)
+    expect(element.classList.contains('raw-b')).toBe(true)
+    expect(element.classList.contains('shared')).toBe(true)
+    expect(element.classList.contains('typed')).toBe(true)
+
+    const disabledRawClass = patch(
+      changedRawClass,
+      h('div', { attrs: { class: false }, class: typedClass }),
+    )
+    const absentRawClass = patch(
+      disabledRawClass,
+      h('div', { class: typedClass }),
+    )
+    expect(elementOf(absentRawClass)).toBe(element)
+    expect(element.className).toBe('typed')
+
+    const sharedClass = patch(
+      absentRawClass,
+      h('div', {
+        attrs: { class: 'raw-b shared' },
+        class: { shared: true },
+      }),
+    )
+    const rawClassOnly = patch(
+      sharedClass,
+      h('div', { attrs: { class: 'raw-b shared' }, class: {} }),
+    )
+
+    expect(elementOf(rawClassOnly)).toBe(element)
+    expect(element.classList.contains('raw-b')).toBe(true)
+    expect(element.classList.contains('shared')).toBe(true)
+    expect(element.classList.contains('typed')).toBe(false)
+  })
+
+  it('does not touch typed classes when an unrelated raw attribute changes', () => {
+    const container = document.createElement('div')
+    const typedClass = { typed: true }
+    const mounted = patch(
+      container,
+      h('div', { attrs: { 'data-step': 'one' }, class: typedClass }),
+    )
+    const element = elementOf(mounted)
+    const contains = vi.spyOn(element.classList, 'contains')
+    const add = vi.spyOn(element.classList, 'add')
+    const remove = vi.spyOn(element.classList, 'remove')
+
+    patch(
+      mounted,
+      h('div', { attrs: { 'data-step': 'two' }, class: typedClass }),
+    )
+
+    expect(contains).not.toHaveBeenCalled()
+    expect(add).not.toHaveBeenCalled()
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  it('normalizes raw class aliases on foreign elements', () => {
+    const namespace = 'http://www.w3.org/2000/svg'
+    const container = document.createElement('div')
+    const typedClass = { typed: true }
+    const mounted = patch(
+      container,
+      h('svg', {
+        ns: namespace,
+        attrs: { CLASS: 'raw-a' },
+        class: typedClass,
+      }),
+    )
+    const element = mounted.elm
+    if (!(element instanceof SVGElement)) {
+      throw new Error('expected an SVG element')
+    }
+
+    const patched = patch(
+      mounted,
+      h('svg', {
+        ns: namespace,
+        attrs: { class: 'raw-b' },
+        class: typedClass,
+      }),
+    )
+
+    expect(patched.elm).toBe(element)
+    expect(element.classList.contains('raw-a')).toBe(false)
+    expect(element.classList.contains('raw-b')).toBe(true)
+    expect(element.classList.contains('typed')).toBe(true)
   })
 })
 


### PR DESCRIPTION
## What changed

- Preserve unchanged `h.Class` tokens when a raw `class` attribute changes.
- Keep tokens that remain owned by the next raw class value when typed ownership changes.
- Normalize raw class aliases consistently across HTML and foreign namespaces.
- Retain the cached-class fast path when only unrelated raw attributes change.

## Why

The raw attribute module runs before the typed class module. Replacing the raw `class` attribute therefore replaced the element's complete class value. The typed module then skipped its cached `h.Class` object and silently lost those tokens.

The patch compares the effective raw class state before taking that fast path. When raw ownership changes, it restores missing typed tokens and preserves overlapping tokens that the raw value still owns.

## Impact

Elements can safely combine `h.Attribute('class', ...)` and `h.Class(...)` across fresh renders and hydrated updates without losing tokens or replacing the DOM node.

## Validation

- Mutation-checked low-level and hydrated update regressions
- Mutation-checked fast-path regression for unrelated raw attributes
- HTML and SVG alias coverage
- Foldkit test suite: 2,276 passed, 1 skipped
- Foldkit typecheck and build
- Repository lint and format checks
- Changeset checks
- Independent diff review with no remaining findings
