### PR TITLE
fix(foldkit): refuse invalid hydration build ids

### DIFF
--- a/.changeset/hydrate-invalid-build-id.md
+++ b/.changeset/hydrate-invalid-build-id.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Validate deployment build ids at the JavaScript boundary so missing or non-string client and server values refuse the handoff instead of throwing natively or adopting unstamped HTML.

--- a/packages/foldkit/src/experimental/server/server.test.ts
+++ b/packages/foldkit/src/experimental/server/server.test.ts
@@ -336,6 +336,18 @@ describe('renderToString', () => {
     }),
   )
 
+  it.effect('fails when the build id is not a string', () =>
+    Effect.gen(function* () {
+      for (const buildId of [null, 0, false, {}]) {
+        const error = yield* Effect.flip(
+          renderToStringUnchecked(configWithoutFlags, { buildId }),
+        )
+
+        expect(error).toMatchObject({ _tag: 'MissingBuildId' })
+      }
+    }),
+  )
+
   it.effect('renders without a build id when nothing will hydrate', () =>
     Effect.gen(function* () {
       // Static output carries no hydration contract, so there is nothing for a

--- a/packages/foldkit/src/experimental/server/server.ts
+++ b/packages/foldkit/src/experimental/server/server.ts
@@ -6,6 +6,7 @@ import {
   Option,
   Predicate,
   Schema,
+  String,
   pipe,
 } from 'effect'
 import type { DefaultTreeAdapterMap } from 'parse5'
@@ -1410,13 +1411,15 @@ export function renderToString(
     // builds of one deployment or be shared by two that render differently.
     // Refusing is the only honest answer, and it names what to supply.
     const configuredBuildId = options?.buildId
-    if (
-      isHydratable &&
-      (configuredBuildId === undefined || configuredBuildId === '')
-    ) {
+    const isConfiguredBuildId =
+      Predicate.isString(configuredBuildId) &&
+      !String.isEmpty(configuredBuildId)
+
+    if (isHydratable && !isConfiguredBuildId) {
       return yield* Effect.fail(new MissingBuildId())
     }
-    const buildId = configuredBuildId ?? ''
+
+    const buildId = isConfiguredBuildId ? configuredBuildId : ''
 
     const url = hasRouting ? yield* parseUrl(options?.url ?? '') : undefined
 

--- a/packages/foldkit/src/runtime/hydrateBoot.test.ts
+++ b/packages/foldkit/src/runtime/hydrateBoot.test.ts
@@ -71,6 +71,21 @@ const makeClientApplication = () =>
     container: nullContainer(),
   })
 
+const hydrateUnchecked = (
+  application: ReturnType<typeof makeClientApplication>,
+  optionsArguments: ReadonlyArray<unknown>,
+): void => {
+  Reflect.apply(hydrate, undefined, [application, ...optionsArguments])
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+const startHydrationUnchecked = (
+  application: ReturnType<typeof makeClientApplication>,
+  buildId: any,
+): Effect.Effect<void> =>
+  /* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */
+  __startProgram(application, undefined, 'Hydrate', undefined, buildId)
+
 const awaitBodyText = (text: string): Promise<void> =>
   vi.waitFor(() => {
     expect(document.body.textContent).toContain(text)
@@ -728,6 +743,78 @@ describe('hydrating boot', () => {
     expect(document.body.hasAttribute('data-foldkit-refused')).toBe(false)
     expect(document.querySelector('[data-foldkit-refusal-shield]')).toBeNull()
   }
+
+  it.each([
+    { name: 'omitted options', optionsArguments: [] },
+    { name: 'undefined options', optionsArguments: [undefined] },
+    { name: 'null options', optionsArguments: [null] },
+  ])(
+    'contains the page when a JavaScript caller supplies $name',
+    async ({ optionsArguments }) => {
+      await renderServerPage({ start: 5 })
+      const servedRoot = document.querySelector('[data-foldkit-app]')
+      const application = makeClientApplication()
+      const runtimeLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const hmrWarning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        expect(() =>
+          hydrateUnchecked(application, optionsArguments),
+        ).not.toThrow()
+        await vi.waitFor(() => expectContained(servedRoot))
+      } finally {
+        runtimeLog.mockRestore()
+        hmrWarning.mockRestore()
+      }
+    },
+  )
+
+  it.each([
+    { name: 'null', buildId: null },
+    { name: 'a number', buildId: 0 },
+    { name: 'a boolean', buildId: false },
+    { name: 'an object', buildId: {} },
+  ])('refuses $name as a JavaScript build id', async ({ buildId }) => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector('[data-foldkit-app]')
+    const application = makeClientApplication()
+
+    await expect(
+      Effect.runPromise(startHydrationUnchecked(application, buildId)),
+    ).rejects.toThrow('was given no build id')
+    expectContained(servedRoot)
+  })
+
+  it('refuses a null build id before adopting an unstamped root', async () => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector('[data-foldkit-app]')
+    servedRoot?.removeAttribute('data-foldkit-build')
+    const initAttempts: Array<number> = []
+    const application = makeApplication({
+      Model,
+      Flags,
+      init: (
+        flags: Flags,
+      ): readonly [Model, ReadonlyArray<Command<Message>>] => {
+        initAttempts.push(flags.start)
+        throw new Error('the invalid handoff reached init')
+      },
+      update,
+      view,
+      container: nullContainer(),
+    })
+    const runtimeLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const hmrWarning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      hydrateUnchecked(application, [{ buildId: null }])
+      await vi.waitFor(() => expectContained(servedRoot))
+      expect(initAttempts).toEqual([])
+    } finally {
+      runtimeLog.mockRestore()
+      hmrWarning.mockRestore()
+    }
+  })
 
   it('takes a rejected page out of reach before stopping', async () => {
     // Refusing to adopt keeps this build's code off the page, but the markup is

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -696,10 +696,10 @@ const assertRuntimeIdsAreUnique = (
 // exact case the id exists to refuse.
 const buildSkew = (
   root: HTMLElement,
-  buildId: string | undefined,
+  buildId: unknown,
   runtimeId: string,
 ): Error | undefined => {
-  if (buildId === undefined || buildId === '') {
+  if (!Predicate.isString(buildId) || buildId === '') {
     return new Error(
       '[foldkit] Runtime.hydrate was given no build id. Hydration compares ' +
         'the id the server stamped on the root with this client’s own before ' +
@@ -4410,7 +4410,7 @@ export const hydrate = <P extends Ports | undefined, Flags, Resources>(
   program: MakeRuntimeReturn<P, Flags, Resources, 'Application'>,
   options: HydrateOptions,
 ): void => {
-  startProgram(program, 'Hydrate', undefined, options.buildId)
+  startProgram(program, 'Hydrate', undefined, options?.buildId)
 }
 
 const buildPortHandles = <P extends Ports | undefined>(


### PR DESCRIPTION
## What changed

- Treat omitted, `undefined`, and `null` hydrate options as an invalid handoff instead of throwing a native `TypeError`.
- Require hydratable client and server build ids to be non-empty primitive strings.
- Route invalid client ids through the existing hydration containment policy.
- Return `MissingBuildId` for invalid server render ids.
- Add JavaScript-boundary regressions, including the exact unstamped-page plus null-id adoption case.

## Why

A JavaScript caller could pass `{ buildId: null }` while hydrating HTML produced before build stamps existed. Both values were `null`, so the equality check accepted the stale root and allowed its Flags to reach the current client. Omitted options also failed before Foldkit could contain the page.

Valid TypeScript consumers are unchanged. `HydrateOptions` remains required, static rendering remains build-id-free, and malformed runtime values now fail closed.

## Validation

- Watched the new regressions fail against the old implementation.
- Focused runtime and server tests: 138 passed.
- Full Foldkit suite: 2,281 passed, 1 skipped.
- Foldkit typecheck and package build.
- Repository lint and formatting.
- Changeset policy checks.
- Independent review found no remaining actionable findings.
