### PR TITLE
fix(foldkit): preserve raw style ownership

### DIFF
--- a/.changeset/preserve-raw-style-ownership.md
+++ b/.changeset/preserve-raw-style-ownership.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Preserve raw style attributes when an element moves from typed style ownership to `h.Attribute('style', ...)`, including hydration updates, CSS shorthands, and custom properties.

--- a/packages/foldkit/src/hydrate.test.ts
+++ b/packages/foldkit/src/hydrate.test.ts
@@ -2023,6 +2023,46 @@ describe('__hydrateVNode', () => {
     expect(root.style.color).toBe('blue')
   })
 
+  it('hands hydrated typed style ownership to a raw style attribute', () => {
+    const typedView = () =>
+      h.div(
+        [
+          h.Style({
+            color: 'red',
+            borderLeftColor: 'red',
+            margin: '1px',
+            '--accent': 'old',
+          }),
+        ],
+        ['content'],
+      )
+    const rawView = () =>
+      h.div(
+        [
+          h.Attribute(
+            'STYLE',
+            'color: blue; border: 2px solid black; margin-left: 12px; --accent: next',
+          ),
+        ],
+        ['content'],
+      )
+    const root = mountServerHtml(serializeHydratable(buildView(typedView)))
+    if (!(root instanceof HTMLDivElement)) {
+      throw new Error('expected a div root')
+    }
+
+    const hydrated = buildView(() => hydrateVNode(root, typedView()))
+    const updated = buildView(() => patch(hydrated, requireVNode(rawView())))
+
+    expect(updated.elm).toBe(root)
+    expect(root.style.color).toBe('blue')
+    expect(root.style.borderLeftWidth).toBe('2px')
+    expect(root.style.borderLeftStyle).toBe('solid')
+    expect(root.style.borderLeftColor).toBe('black')
+    expect(root.style.marginLeft).toBe('12px')
+    expect(root.style.getPropertyValue('--accent')).toBe('next')
+  })
+
   it('converges class and typed style state together', () => {
     const view = () =>
       h.div(

--- a/packages/foldkit/src/snabbdom/modules.test.ts
+++ b/packages/foldkit/src/snabbdom/modules.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { attributesModule } from './attributes.js'
 import { classModule } from './class.js'
@@ -195,6 +195,46 @@ describe('styleModule', () => {
     const removed = patch(updated, h('div', { style: {} }))
     expect(elementOf(removed).style.color).toBe('')
     expect(elementOf(removed).style.position).toBe('fixed')
+  })
+
+  it('hands complete ownership to a raw style attribute', () => {
+    const container = document.createElement('div')
+    const mounted = patch(
+      container,
+      h('div', {
+        style: {
+          color: 'red',
+          borderLeftColor: 'red',
+          margin: '1px',
+          '--accent': 'old',
+        },
+      }),
+    )
+    const element = elementOf(mounted)
+    const rawStyle =
+      'color: blue; border: 2px solid black; margin-left: 12px; --accent: next'
+    const next = h('div', { attrs: { STYLE: rawStyle } })
+    next.elm = element
+    element.setAttribute('style', rawStyle)
+    const getAttribute = vi.spyOn(element, 'getAttribute')
+    const removeProperty = vi.spyOn(element.style, 'removeProperty')
+
+    if (styleModule.update === undefined) {
+      throw new Error('expected a style update hook')
+    }
+    styleModule.update(mounted, next)
+
+    expect(elementOf(next)).toBe(element)
+    expect(getAttribute).not.toHaveBeenCalled()
+    expect(removeProperty).not.toHaveBeenCalled()
+    getAttribute.mockRestore()
+    removeProperty.mockRestore()
+    expect(element.style.color).toBe('blue')
+    expect(element.style.borderLeftWidth).toBe('2px')
+    expect(element.style.borderLeftStyle).toBe('solid')
+    expect(element.style.borderLeftColor).toBe('black')
+    expect(element.style.marginLeft).toBe('12px')
+    expect(element.style.getPropertyValue('--accent')).toBe('next')
   })
 
   it('ignores inherited style entries in every module path', () => {

--- a/packages/foldkit/src/snabbdom/style.ts
+++ b/packages/foldkit/src/snabbdom/style.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { serializedStylePropertyName } from '../domReflection.js'
+import {
+  htmlAttributeValue,
+  serializedStylePropertyName,
+} from '../domReflection.js'
 import type { Module } from './module.js'
 import { type VNode, type VNodeData, VNodeDataMask } from './vnode.js'
 
@@ -75,6 +78,12 @@ function updateStyle(oldVnode: VNode, vnode: VNode): void {
 
   if (!oldStyle && !style) return
   if (oldStyle === style) return
+  if (
+    style === undefined &&
+    htmlAttributeValue((vnode.data as VNodeData).attrs, 'style') !== undefined
+  ) {
+    return
+  }
   oldStyle = oldStyle || ({} as VNodeStyle)
   style = style || ({} as VNodeStyle)
   const oldHasDel = Object.hasOwn(oldStyle, 'delayed')


### PR DESCRIPTION
## What changed

- Treat a raw `style` attribute as the complete next owner when a view moves away from `h.Style`.
- Match raw HTML attribute names case-insensitively, including `STYLE`.
- Preserve CSS shorthands, longhands, and custom properties written by the new raw declaration block.
- Add direct module and post-hydration regressions that preserve DOM identity and prohibit live DOM reads during the handoff.

## Why

The attributes module wrote the new raw declaration block first. The style module then removed every property owned by the previous typed value, but those removals landed on the newly written raw block. A render could therefore silently lose color, spacing, border, and custom-property values.

The style module now settles ownership from VNode data and leaves the raw block untouched. Typed-to-none cleanup and raw-to-typed updates are unchanged.

## Validation

- Watched both regressions fail against the old cleanup path.
- Mutation-checked the ownership guard and case-insensitive lookup.
- Focused module and hydration tests: 93 passed.
- Full Foldkit suite: 2,274 passed, 1 skipped.
- Foldkit typecheck and package build.
- Repository lint and formatting.
- Changeset policy checks.
- Independent review found no remaining actionable findings.
