### PR TITLE
fix(ci): close focused gate scope gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
       - name: Build reusable packages
         run: pnpm build:packages && pnpm --filter @typing-game/shared build
 
+      - name: Check packed peer dependency floors
+        if: steps.scope.outputs.peer_floors == 'true'
+        run: pnpm check:peer-floors
+
       - name: Check dead code
         run: pnpm check:dead-code
 
@@ -117,6 +121,10 @@ jobs:
           # and its own scripts recurse over the whole workspace, so leaving it
           # in runs every package a second time concurrently.
           pnpm -r --filter "...[$base]" --filter '!foldkit-monorepo' run --if-present typecheck
+
+      - name: Typecheck website
+        if: steps.scope.outputs.website == 'true' && steps.scope.outputs.full_workspace_checks == 'false'
+        run: pnpm --filter website typecheck
 
       - name: Smoke test create-foldkit-app
         if: steps.scope.outputs.create_foldkit_smoke == 'true'
@@ -208,6 +216,10 @@ jobs:
           # concurrently with this one. Two `vitest run --coverage` processes
           # in the same package then race on coverage/.tmp.
           pnpm -r --filter "...[$base]" --filter '!foldkit-monorepo' run --if-present test
+
+      - name: Test website
+        if: steps.scope.outputs.website == 'true' && steps.scope.outputs.full_workspace_checks == 'false'
+        run: pnpm --filter website test
 
       - name: Install Playwright browsers
         if: steps.scope.outputs.website == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ on:
       - 'pnpm-workspace.yaml'
       - 'scripts/check-changeset-ignore.ts'
       - 'scripts/check-create-foldkit-app-smoke.ts'
+      - 'scripts/check-peer-floors.ts'
       - 'scripts/reset-peer-deps.ts'
       - '.github/workflows/release.yml'
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -16,6 +16,10 @@ const examplesWorkflow = readFileSync(
 const rootPackage = JSON.parse(
   readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
 )
+const releaseWorkflow = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/release.yml'),
+  'utf8',
+)
 
 test('required workflows check pull requests and merge groups', () => {
   for (const requiredWorkflow of [workflow, examplesWorkflow]) {
@@ -51,4 +55,29 @@ test('the packed SSR consumer runs its critical browser matrix in CI', () => {
     rootPackage.scripts['check:packed-ssr-consumer:ci'],
     'tsx scripts/check-packed-ssr-consumer.ts --skip-build --critical-browser-matrix',
   )
+})
+
+test('the website scope runs unit tests and typechecking', () => {
+  const scopedCondition =
+    "steps.scope.outputs.website == 'true' && steps.scope.outputs.full_workspace_checks == 'false'"
+
+  assert.ok(
+    workflow.includes(
+      `      - name: Typecheck website\n        if: ${scopedCondition}\n        run: pnpm --filter website typecheck`,
+    ),
+  )
+  assert.ok(
+    workflow.includes(
+      `      - name: Test website\n        if: ${scopedCondition}\n        run: pnpm --filter website test`,
+    ),
+  )
+})
+
+test('peer floor changes run the packed-manifest check before release', () => {
+  assert.ok(
+    workflow.includes(
+      "      - name: Check packed peer dependency floors\n        if: steps.scope.outputs.peer_floors == 'true'\n        run: pnpm check:peer-floors",
+    ),
+  )
+  assert.match(releaseWorkflow, /^\s+- 'scripts\/check-peer-floors\.ts'$/m)
 })

--- a/scripts/plan-ci.mjs
+++ b/scripts/plan-ci.mjs
@@ -41,7 +41,11 @@ const createFoldkitSmoke =
 const packedSsrConsumer =
   fullWorkspaceChecks ||
   hasChanged({
-    files: ['scripts/check-packed-ssr-consumer.ts'],
+    files: [
+      'examples/ssr/package.json',
+      'packages/examples-e2e/package.json',
+      'scripts/check-packed-ssr-consumer.ts',
+    ],
     prefixes: ['packages/foldkit/', 'packages/vite-plugin-foldkit/'],
   })
 const hostParity =
@@ -68,8 +72,21 @@ const scaffoldServerRendering =
 const domStateParity =
   fullWorkspaceChecks ||
   hasChanged({
-    files: ['scripts/check-dom-state-parity.mts'],
+    files: [
+      'packages/examples-e2e/package.json',
+      'scripts/check-dom-state-parity.mts',
+    ],
     prefixes: ['packages/foldkit/'],
+  })
+const peerFloors =
+  fullWorkspaceChecks ||
+  hasChanged({
+    files: [
+      'packages/vite-plugin-foldkit/package.json',
+      'scripts/check-peer-floors.ts',
+      'scripts/reset-peer-deps.ts',
+    ],
+    prefixes: ['.changeset/'],
   })
 const typingGame =
   fullWorkspaceChecks ||
@@ -121,6 +138,7 @@ process.stdout.write(`packed_ssr_consumer=${packedSsrConsumer}\n`)
 process.stdout.write(`scaffold_server_rendering=${scaffoldServerRendering}\n`)
 process.stdout.write(`host_parity=${hostParity}\n`)
 process.stdout.write(`dom_state_parity=${domStateParity}\n`)
+process.stdout.write(`peer_floors=${peerFloors}\n`)
 process.stdout.write(`typing_game=${typingGame}\n`)
 process.stdout.write(`website=${website}\n`)
 process.stdout.write(`full_workspace_checks=${fullWorkspaceChecks}\n`)

--- a/scripts/plan-ci.test.mjs
+++ b/scripts/plan-ci.test.mjs
@@ -15,6 +15,7 @@ const SCOPES = [
   'scaffold_server_rendering',
   'host_parity',
   'dom_state_parity',
+  'peer_floors',
   'typing_game',
   'website',
   'full_workspace_checks',
@@ -125,6 +126,31 @@ test('a website-only change leaves the packed consumer gate alone', () => {
     planCiForFile('packages/website/src/page/landing.ts')[
       'packed_ssr_consumer'
     ],
+    'false',
+  )
+})
+
+test('browser-backed gate manifests select their consumers', () => {
+  const ssrManifest = planCiForFile('examples/ssr/package.json')
+  assert.equal(ssrManifest['packed_ssr_consumer'], 'true')
+
+  const browserManifest = planCiForFile('packages/examples-e2e/package.json')
+  assert.equal(browserManifest['packed_ssr_consumer'], 'true')
+  assert.equal(browserManifest['dom_state_parity'], 'true')
+})
+
+test('peer floor inputs select their packed-manifest gate', () => {
+  for (const fileName of [
+    '.changeset/plugin-peer-floor.md',
+    'packages/vite-plugin-foldkit/package.json',
+    'scripts/check-peer-floors.ts',
+    'scripts/reset-peer-deps.ts',
+  ]) {
+    assert.equal(planCiForFile(fileName)['peer_floors'], 'true', fileName)
+  }
+
+  assert.equal(
+    planCiForFile('packages/website/src/page/landing.ts')['peer_floors'],
     'false',
   )
 })


### PR DESCRIPTION
## What changed

- map browser gate manifests to the packed SSR and DOM state checks that consume them
- run website unit tests and typechecking whenever the website scope is selected
- add a focused peer-floor scope to ordinary CI and the release workflow trigger

## Why

Several cross-package inputs could change without selecting the focused checks that depended on them. The website scope could also build and run browser tests without running its unit tests or typechecking when only an indirect input changed.

## Validation

- `pnpm test:scripts` (58 passed)
- `pnpm typecheck:scripts`
- `pnpm check:peer-floors`
- `pnpm --filter website test` (457 passed)
- `pnpm --filter website typecheck`
- `pnpm lint:ci`
- `pnpm format`
- focused planner and workflow tests (24 passed)
- independent read-only review with no findings

No changeset is included because this changes repository CI only.
