### PR TITLE
fix(create-foldkit-app): verify checkout manifests

### DIFF
--- a/.changeset/local-scaffold-manifests.md
+++ b/.changeset/local-scaffold-manifests.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Accept an absolute `CREATE_FOLDKIT_APP_DEPENDENCY_MANIFESTS_DIRECTORY` for repository verification. The SSR and SSG scaffold gate now generates from the example manifests in the checkout under test instead of the moving `main` branch.

--- a/packages/create-foldkit-app/src/commands/create.ts
+++ b/packages/create-foldkit-app/src/commands/create.ts
@@ -18,6 +18,7 @@ type CreateInput = Readonly<{
   rendering: Option.Option<Rendering>
   example: Option.Option<Example>
   packageManager: Option.Option<PackageManager>
+  maybeDependencyManifestsDirectory: Option.Option<string>
 }>
 
 const isWindows = process.platform === 'win32'
@@ -149,13 +150,19 @@ const installProjectDependencies = (
   projectPath: string,
   packageManager: PackageManager,
   scaffold: Scaffold,
+  maybeDependencyManifestsDirectory: Option.Option<string>,
 ) =>
   Effect.gen(function* () {
     yield* Console.log(
       chalk.blue(`📦 Installing dependencies with ${packageManager}...`),
     )
 
-    yield* installDependencies(projectPath, packageManager, scaffold)
+    yield* installDependencies(
+      projectPath,
+      packageManager,
+      scaffold,
+      maybeDependencyManifestsDirectory,
+    )
 
     yield* Console.log(chalk.green('✅ Dependencies installed'))
     yield* Console.log('')
@@ -220,11 +227,24 @@ export const create = (input: CreateInput) =>
   Effect.gen(function* () {
     const { name, scaffold, packageManager } = yield* resolveInput(input)
     const path = yield* Path.Path
+    if (
+      Option.isSome(input.maybeDependencyManifestsDirectory) &&
+      !path.isAbsolute(input.maybeDependencyManifestsDirectory.value)
+    ) {
+      return yield* Effect.fail(
+        'CREATE_FOLDKIT_APP_DEPENDENCY_MANIFESTS_DIRECTORY must be an absolute path.',
+      )
+    }
     const projectPath = path.resolve(name)
 
     yield* validateProject(name, projectPath, packageManager)
     yield* setupProject(name, projectPath, scaffold, packageManager)
-    yield* installProjectDependencies(projectPath, packageManager, scaffold)
+    yield* installProjectDependencies(
+      projectPath,
+      packageManager,
+      scaffold,
+      input.maybeDependencyManifestsDirectory,
+    )
     yield* displaySuccessMessage(name, packageManager)
 
     return name

--- a/packages/create-foldkit-app/src/index.ts
+++ b/packages/create-foldkit-app/src/index.ts
@@ -63,6 +63,10 @@ const packageManager = Flag.choice('package-manager', [
   Flag.optional,
 )
 
+const maybeDependencyManifestsDirectory = Option.fromNullishOr(
+  process.env['CREATE_FOLDKIT_APP_DEPENDENCY_MANIFESTS_DIRECTORY'],
+)
+
 const create = Command.make(
   'create',
   {
@@ -71,7 +75,7 @@ const create = Command.make(
     example,
     packageManager,
   },
-  create_,
+  input => create_({ ...input, maybeDependencyManifestsDirectory }),
 ).pipe(Command.withDescription('Create a new Foldkit application'))
 
 const cli = Command.run(create, {

--- a/packages/create-foldkit-app/src/utils/packages.ts
+++ b/packages/create-foldkit-app/src/utils/packages.ts
@@ -4,6 +4,7 @@ import {
   Effect,
   FileSystem,
   Match,
+  Option,
   Order,
   Path,
   Record,
@@ -231,6 +232,25 @@ const fetchExamplePackageJson = (example: string) =>
     return yield* Schema.decodeUnknownEffect(PackageJson)(json)
   })
 
+const readExamplePackageJson = (
+  example: string,
+  maybeDependencyManifestsDirectory: Option.Option<string>,
+) =>
+  Option.match(maybeDependencyManifestsDirectory, {
+    onNone: () => fetchExamplePackageJson(example),
+    onSome: directory =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem
+        const path = yield* Path.Path
+        const content = yield* fs.readFileString(
+          path.join(directory, example, 'package.json'),
+        )
+        return yield* Schema.decodeUnknownEffect(PackageJson)(
+          JSON.parse(content),
+        )
+      }),
+  })
+
 const writeManifest = (
   projectPath: string,
   dependencies: Record<string, string>,
@@ -293,10 +313,12 @@ export const installDependencies = (
   projectPath: string,
   packageManager: PackageManager,
   scaffold: Scaffold,
+  maybeDependencyManifestsDirectory: Option.Option<string>,
 ) =>
   Effect.gen(function* () {
-    const examplePackageJson = yield* fetchExamplePackageJson(
+    const examplePackageJson = yield* readExamplePackageJson(
       dependencyExample(scaffold),
+      maybeDependencyManifestsDirectory,
     )
 
     const dependencies = yield* resolveSpecs(

--- a/scripts/check-scaffold-server-rendering.ts
+++ b/scripts/check-scaffold-server-rendering.ts
@@ -1,5 +1,12 @@
 import { spawn, spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { extname, join } from 'node:path'
 
@@ -21,6 +28,11 @@ import { extname, join } from 'node:path'
 const CLI_DIR = 'packages/create-foldkit-app'
 const FOLDKIT_DIR = 'packages/foldkit'
 const PLUGIN_DIR = 'packages/vite-plugin-foldkit'
+const REPO_ROOT = process.cwd()
+
+const DEPENDENCY_MANIFESTS_DIRECTORY_ENV =
+  'CREATE_FOLDKIT_APP_DEPENDENCY_MANIFESTS_DIRECTORY'
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 
 const SSR_PORT = 5312
 const BUILD_ID_ATTRIBUTE = /data-foldkit-build="([^"]*)"/
@@ -146,10 +158,79 @@ const assertBuildIdReachesBothSides = (
 
 type Tarballs = Readonly<{ cli: string; foldkit: string; plugin: string }>
 
+type DependencyMap = Readonly<Record<string, string>>
+
+type PackageManifest = Readonly<{
+  dependencies?: DependencyMap
+  devDependencies?: DependencyMap
+}>
+
+const readManifest = (path: string): PackageManifest =>
+  JSON.parse(readFileSync(path, 'utf8'))
+
+const prepareDependencyManifests = (workspaceDir: string): string => {
+  const manifestDirectory = join(workspaceDir, 'dependency-manifests')
+
+  for (const rendering of ['ssr', 'ssg'] as const) {
+    const source = readManifest(
+      join(REPO_ROOT, 'examples', rendering, 'package.json'),
+    )
+    const effectSpec = source.dependencies?.['effect']
+    assertScaffold(
+      effectSpec !== undefined && EXACT_VERSION.test(effectSpec),
+      `the ${rendering.toUpperCase()} example must pin effect to one exact ` +
+        'version so the scaffold gate can distinguish its local manifest',
+    )
+    const manifest = {
+      ...source,
+      dependencies: { ...source.dependencies, effect: `=${effectSpec}` },
+    }
+    const directory = join(manifestDirectory, rendering)
+    mkdirSync(directory, { recursive: true })
+    writeFileSync(
+      join(directory, 'package.json'),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    )
+  }
+
+  return manifestDirectory
+}
+
+const assertGeneratedDependencySpecs = (
+  rendering: 'ssr' | 'ssg',
+  projectDir: string,
+  manifestDirectory: string,
+): void => {
+  const source = readManifest(
+    join(manifestDirectory, rendering, 'package.json'),
+  )
+  const generated = readManifest(join(projectDir, 'package.json'))
+
+  for (const field of ['dependencies', 'devDependencies'] as const) {
+    const generatedDependencies = generated[field] ?? {}
+    for (const [name, spec] of Object.entries(source[field] ?? {})) {
+      if (spec.includes('workspace:')) {
+        continue
+      }
+      assertScaffold(
+        generatedDependencies[name] === spec,
+        `the generated ${rendering.toUpperCase()} ${field} resolved ${name} ` +
+          `to ${JSON.stringify(generatedDependencies[name])}, but the local ` +
+          `verification manifest declares ${JSON.stringify(spec)}. The packed ` +
+          'CLI did not read the dependency manifest under review.',
+      )
+    }
+  }
+  log(
+    `The generated ${rendering.toUpperCase()} dependency specs match the checkout-derived manifest`,
+  )
+}
+
 const generateProject = (
   workspaceDir: string,
   rendering: 'ssr' | 'ssg',
   tarballs: Tarballs,
+  manifestDirectory: string,
 ): string => {
   const projectName = `my-${rendering}-app`
   runRequired(
@@ -164,10 +245,16 @@ const generateProject = (
       '--package-manager',
       'npm',
     ],
-    { cwd: workspaceDir },
+    {
+      cwd: workspaceDir,
+      env: {
+        [DEPENDENCY_MANIFESTS_DIRECTORY_ENV]: manifestDirectory,
+      },
+    },
   )
 
   const projectDir = join(workspaceDir, projectName)
+  assertGeneratedDependencySpecs(rendering, projectDir, manifestDirectory)
 
   // NOTE: the CLI resolves `foldkit` and `@foldkit/vite-plugin` from the
   // registry, so a generated project installs the published versions rather
@@ -200,6 +287,32 @@ const generateProject = (
   return projectDir
 }
 
+const assertRejectsRelativeManifestDirectory = (workspaceDir: string): void => {
+  const result = run(
+    'node',
+    [
+      join(workspaceDir, 'node_modules/.bin/create-foldkit-app'),
+      '--name',
+      'invalid-manifest-source',
+      '--rendering',
+      'ssr',
+      '--package-manager',
+      'npm',
+    ],
+    {
+      cwd: workspaceDir,
+      env: { [DEPENDENCY_MANIFESTS_DIRECTORY_ENV]: 'relative/examples' },
+    },
+  )
+  const output = `${result.stdout}${result.stderr}`
+  assertScaffold(
+    result.status !== 0 && output.includes('must be an absolute path'),
+    'the packed CLI accepted a relative dependency manifest directory or ' +
+      `failed without the expected diagnostic:\n${output}`,
+  )
+  log('The packed CLI refuses a relative dependency manifest directory')
+}
+
 const fetchServedPage = async (origin: string): Promise<string> => {
   for (let attempt = 0; attempt < 60; attempt++) {
     try {
@@ -222,8 +335,14 @@ const fetchServedPage = async (origin: string): Promise<string> => {
 const checkSsr = async (
   workspaceDir: string,
   tarballs: Tarballs,
+  manifestDirectory: string,
 ): Promise<void> => {
-  const projectDir = generateProject(workspaceDir, 'ssr', tarballs)
+  const projectDir = generateProject(
+    workspaceDir,
+    'ssr',
+    tarballs,
+    manifestDirectory,
+  )
 
   const server = spawn('node', ['dist/server/main.js'], {
     cwd: projectDir,
@@ -242,8 +361,17 @@ const checkSsr = async (
   }
 }
 
-const checkSsg = (workspaceDir: string, tarballs: Tarballs): void => {
-  const projectDir = generateProject(workspaceDir, 'ssg', tarballs)
+const checkSsg = (
+  workspaceDir: string,
+  tarballs: Tarballs,
+  manifestDirectory: string,
+): void => {
+  const projectDir = generateProject(
+    workspaceDir,
+    'ssg',
+    tarballs,
+    manifestDirectory,
+  )
   const clientDir = join(projectDir, 'dist/client')
 
   const home = readFileSync(join(clientDir, 'index.html'), 'utf8')
@@ -274,6 +402,8 @@ const main = async (): Promise<void> => {
   log(`Workspace: ${workspaceDir}`)
 
   try {
+    const manifestDirectory = prepareDependencyManifests(workspaceDir)
+
     if (!isSkipBuild) {
       runRequired(
         'Building the packages the generated projects install...',
@@ -313,8 +443,9 @@ const main = async (): Promise<void> => {
       { cwd: workspaceDir },
     )
 
-    await checkSsr(workspaceDir, tarballs)
-    checkSsg(workspaceDir, tarballs)
+    assertRejectsRelativeManifestDirectory(workspaceDir)
+    await checkSsr(workspaceDir, tarballs, manifestDirectory)
+    checkSsg(workspaceDir, tarballs, manifestDirectory)
   } finally {
     log('Cleaning up...')
     rmSync(workspaceDir, { recursive: true, force: true })

--- a/scripts/plan-ci.mjs
+++ b/scripts/plan-ci.mjs
@@ -58,7 +58,11 @@ const hostParity =
 const scaffoldServerRendering =
   fullWorkspaceChecks ||
   hasChanged({
-    files: ['scripts/check-scaffold-server-rendering.ts'],
+    files: [
+      'examples/ssg/package.json',
+      'examples/ssr/package.json',
+      'scripts/check-scaffold-server-rendering.ts',
+    ],
     prefixes: [
       'packages/create-foldkit-app/',
       'packages/foldkit/',

--- a/scripts/plan-ci.test.mjs
+++ b/scripts/plan-ci.test.mjs
@@ -134,6 +134,8 @@ test('a scaffold or framework change selects the generated-app build gate', () =
   // lost, and it depends on the templates, on the render that stamps the id,
   // and on the plugin that compiles it in.
   for (const file of [
+    'examples/ssg/package.json',
+    'examples/ssr/package.json',
     'packages/create-foldkit-app/templates/rendering/ssr/scripts/build.mjs',
     'packages/foldkit/src/experimental/server/server.ts',
     'packages/vite-plugin-foldkit/src/buildToken.ts',


### PR DESCRIPTION
## What changed

- let repository verification supply an absolute local directory for dependency manifests
- make the packed SSR/SSG scaffold gate generate from checkout-derived manifests
- give those manifests a permanent distinguishing spec so the source check cannot pass vacuously
- select the scaffold gate when either server-rendering example manifest changes

## Why

The packed CLI previously fetched dependency manifests from the moving `main` branch. A pull request could pass while testing different dependency specs from the ones in its checkout, and the same commit could produce different results as `main` changed.

Normal CLI behavior is unchanged when the verification environment variable is absent.

## Validation

- packed SSR and SSG generation, installation, and documented builds pass
- generated dependency maps match the checkout-derived local manifests
- the packed CLI refuses a relative manifest directory
- removing local-directory forwarding fails on the permanent `effect` spec sentinel
- planner regression failed before the mapping and now passes
- `pnpm test:scripts` (54 passed)
- create-foldkit-app tests (18 passed)
- package and script typechecking
- create-foldkit-app packed smoke test
- lint, dead-code, formatting, and changeset checks
- independent read-only review with no remaining findings
