### PR TITLE
test(ci): verify generated scaffold hydration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,14 +140,20 @@ jobs:
         if: steps.scope.outputs.packed_ssr_consumer == 'true'
         run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium firefox webkit
 
+      # The generated-project gate also drives its packed output in Chromium.
+      # Reuse the packed consumer's installation when both gates are selected.
+      - name: Install Chromium for the generated SSR gate
+        if: steps.scope.outputs.scaffold_server_rendering == 'true' && steps.scope.outputs.packed_ssr_consumer != 'true'
+        run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium
+
       - name: Check packed SSR consumer
         if: steps.scope.outputs.packed_ssr_consumer == 'true'
         run: pnpm check:packed-ssr-consumer:ci
 
-      # Generates an SSR and an SSG project and builds each through the command
-      # its own README documents. A generated project has to satisfy the build
-      # id contract before its author has read about it, and only running that
-      # build shows whether it does.
+      # Generates an SSR and an SSG project, builds each through the command its
+      # own README documents, and drives the result in Chromium. This proves the
+      # generated build id reaches both sides and hydration adopts the served
+      # DOM before the application responds to input.
       - name: Check generated server-rendered projects
         if: steps.scope.outputs.scaffold_server_rendering == 'true'
         run: pnpm check:scaffold-server-rendering:ci
@@ -168,7 +174,7 @@ jobs:
       # everywhere. This measures both in Chromium rather than reasoning about
       # the IDL.
       - name: Install Playwright chromium for the DOM state gate
-        if: steps.scope.outputs.dom_state_parity == 'true' && steps.scope.outputs.packed_ssr_consumer != 'true'
+        if: steps.scope.outputs.dom_state_parity == 'true' && steps.scope.outputs.packed_ssr_consumer != 'true' && steps.scope.outputs.scaffold_server_rendering != 'true'
         run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium
 
       - name: Check server and client DOM state parity

--- a/knip.json
+++ b/knip.json
@@ -130,5 +130,5 @@
     "tailwindcss",
     "madge"
   ],
-  "ignoreBinaries": ["typecheck"]
+  "ignoreBinaries": ["taskkill", "typecheck"]
 }

--- a/scripts/check-scaffold-server-rendering.ts
+++ b/scripts/check-scaffold-server-rendering.ts
@@ -1,4 +1,5 @@
-import { spawn, spawnSync } from 'node:child_process'
+import { Array as Array_ } from 'effect'
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process'
 import {
   mkdirSync,
   mkdtempSync,
@@ -7,6 +8,9 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs'
+import { request } from 'node:http'
+import { createRequire } from 'node:module'
+import { createServer as createNetServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { extname, join } from 'node:path'
 
@@ -20,7 +24,8 @@ import { extname, join } from 'node:path'
 // same id, and a hydratable render with none fails outright, so a generated
 // project has to satisfy a requirement its author has not read about yet. This
 // gate asserts the generated project does: it builds, the served or generated
-// page carries an id, and the client bundle carries the same one.
+// page carries an id, the client bundle carries the same one, Chromium adopts
+// the server DOM, and the generated application responds to interaction.
 //
 // Checking the template files says nothing about this. Only running the
 // generated project's own build command does.
@@ -35,7 +40,14 @@ const DEPENDENCY_MANIFESTS_DIRECTORY_ENV =
 const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 
 const SSR_PORT = 5312
+const SSG_PORT = 5313
 const BUILD_ID_ATTRIBUTE = /data-foldkit-build="([^"]*)"/
+const EXPECTED_ALLOW = 'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS'
+const HOST_OUTPUT_LIMIT = 16_000
+const HOST_READY_ATTEMPTS = 60
+const HOST_REQUEST_TIMEOUT_MS = 5_000
+const HOST_STOP_TIMEOUT_MS = 3_000
+const HYDRATION_TIMEOUT_MS = 10_000
 
 const isSkipBuild = process.argv.includes('--skip-build')
 
@@ -106,6 +118,432 @@ const runRequired = (
     fail(`${label} failed${output === '' ? '' : `:\n${output}`}`)
   }
   return result
+}
+
+type RunningHost = Readonly<{
+  process: ChildProcess
+  port: number
+  output: () => string
+}>
+
+const activeHosts = new Set<RunningHost>()
+const stoppingHosts = new WeakMap<RunningHost, Promise<void>>()
+
+const tryBindPort = (port: number): Promise<Error | undefined> =>
+  new Promise(resolveResult => {
+    const server = createNetServer()
+    server.once('error', error => resolveResult(error))
+    server.listen(port, '127.0.0.1', () => {
+      server.close(error => resolveResult(error ?? undefined))
+    })
+  })
+
+const assertPortIsFree = async (port: number): Promise<void> => {
+  const error = await tryBindPort(port)
+  if (error !== undefined) {
+    fail(
+      `port ${String(port)} is already in use. A host left by an earlier run ` +
+        'would answer this gate instead of the generated project.',
+    )
+  }
+}
+
+const waitForPortToClose = async (port: number): Promise<void> => {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    if ((await tryBindPort(port)) === undefined) {
+      return
+    }
+    await new Promise(resolveWait => setTimeout(resolveWait, 100))
+  }
+  fail(`the generated host did not release port ${String(port)}`)
+}
+
+const startHost = (
+  command: string,
+  args: ReadonlyArray<string>,
+  projectDir: string,
+  port: number,
+  env: Readonly<Record<string, string>> = {},
+): RunningHost => {
+  let output = ''
+  const host = spawn(command, [...args], {
+    cwd: projectDir,
+    detached: true,
+    env: { ...process.env, ...env },
+    shell: process.platform === 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const capture = (chunk: Buffer | string): void => {
+    output = `${output}${String(chunk)}`.slice(-HOST_OUTPUT_LIMIT)
+  }
+  host.stdout?.on('data', capture)
+  host.stderr?.on('data', capture)
+  host.on('error', error => capture(error.message))
+  const runningHost = {
+    process: host,
+    port,
+    output: () => output,
+  }
+  activeHosts.add(runningHost)
+  return runningHost
+}
+
+const waitForExit = (
+  host: ChildProcess,
+  timeoutMs: number,
+): Promise<boolean> => {
+  if (host.exitCode !== null || host.signalCode !== null) {
+    return Promise.resolve(true)
+  }
+  return new Promise(resolveExit => {
+    const onExit = (): void => {
+      clearTimeout(timeout)
+      resolveExit(true)
+    }
+    const timeout = setTimeout(() => {
+      host.off('exit', onExit)
+      resolveExit(false)
+    }, timeoutMs)
+    host.once('exit', onExit)
+  })
+}
+
+const terminateHost = (host: ChildProcess, isForce: boolean): void => {
+  if (host.pid === undefined) {
+    return
+  }
+  if (process.platform === 'win32') {
+    spawnSync(
+      'taskkill',
+      ['/PID', String(host.pid), '/T', ...(isForce ? ['/F'] : [])],
+      { stdio: 'ignore' },
+    )
+    return
+  }
+  try {
+    process.kill(-host.pid, isForce ? 'SIGKILL' : 'SIGTERM')
+  } catch {
+    host.kill(isForce ? 'SIGKILL' : 'SIGTERM')
+  }
+}
+
+const stopHost = (host: RunningHost): Promise<void> => {
+  const existing = stoppingHosts.get(host)
+  if (existing !== undefined) {
+    return existing
+  }
+
+  const stopping = (async () => {
+    terminateHost(host.process, false)
+    const didExit = await waitForExit(host.process, HOST_STOP_TIMEOUT_MS)
+    const isPortStillOpen = (await tryBindPort(host.port)) !== undefined
+    if (!didExit || isPortStillOpen) {
+      terminateHost(host.process, true)
+      await waitForExit(host.process, HOST_STOP_TIMEOUT_MS)
+    }
+    await waitForPortToClose(host.port)
+  })().finally(() => activeHosts.delete(host))
+  stoppingHosts.set(host, stopping)
+  return stopping
+}
+
+let isStoppingForSignal = false
+
+const stopForSignal = (exitCode: number): void => {
+  if (isStoppingForSignal) {
+    return
+  }
+  isStoppingForSignal = true
+  void Promise.allSettled(Array.from(activeHosts, stopHost)).then(() =>
+    process.exit(exitCode),
+  )
+}
+
+process.once('SIGINT', () => stopForSignal(130))
+process.once('SIGTERM', () => stopForSignal(143))
+
+const fetchServedPage = async (
+  host: RunningHost,
+  origin: string,
+  path = '/',
+): Promise<string> => {
+  const url = `${origin}${path}`
+  for (let attempt = 0; attempt < HOST_READY_ATTEMPTS; attempt++) {
+    if (host.process.exitCode !== null || host.process.signalCode !== null) {
+      fail(`the generated host exited before serving ${url}:\n${host.output()}`)
+    }
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(1_000),
+      })
+      assertScaffold(
+        response.status === 200,
+        `the generated host answered ${response.status} for ${url}`,
+      )
+      return await response.text()
+    } catch (error) {
+      if (error instanceof ScaffoldCheckError) {
+        throw error
+      }
+      await new Promise(resolveWait => setTimeout(resolveWait, 250))
+    }
+  }
+  return fail(
+    `the generated host never accepted a connection at ${url}:\n${host.output()}`,
+  )
+}
+
+type RawAnswer = Readonly<{
+  status: number
+  body: string
+  headers: Readonly<Record<string, string | undefined>>
+}>
+
+const askRaw = (
+  origin: string,
+  path: string,
+  method: string,
+  headers: Readonly<Record<string, string>> = {},
+): Promise<RawAnswer> =>
+  new Promise((resolveAnswer, reject) => {
+    const { hostname, port } = new URL(origin)
+    const clientRequest = request(
+      {
+        hostname,
+        port,
+        path,
+        method,
+        headers: { ...headers },
+        signal: AbortSignal.timeout(HOST_REQUEST_TIMEOUT_MS),
+      },
+      response => {
+        let body = ''
+        response.setEncoding('utf8')
+        response.on('error', reject)
+        response.on('data', chunk => {
+          body += chunk
+        })
+        response.on('end', () => {
+          const responseHeaders: Record<string, string | undefined> = {}
+          for (const [name, value] of Object.entries(response.headers)) {
+            responseHeaders[name] = Array.isArray(value)
+              ? value.join(', ')
+              : value
+          }
+          resolveAnswer({
+            status: response.statusCode ?? 0,
+            body,
+            headers: responseHeaders,
+          })
+        })
+      },
+    )
+    clientRequest.on('error', reject)
+    clientRequest.end()
+  })
+
+type PlaywrightConsoleMessage = Readonly<{
+  type: () => string
+  text: () => string
+}>
+
+type PlaywrightLocator = Readonly<{
+  click: () => Promise<void>
+  textContent: () => Promise<string | null>
+}>
+
+type PlaywrightResponse = Readonly<{
+  status: () => number
+  text: () => Promise<string>
+}>
+
+type PlaywrightRoute = Readonly<{
+  fetch: () => Promise<PlaywrightResponse>
+  fulfill: (options: {
+    response: PlaywrightResponse
+    body: string
+  }) => Promise<void>
+}>
+
+type PlaywrightPage = Readonly<{
+  route: (
+    url: string,
+    handler: (route: PlaywrightRoute) => Promise<void>,
+  ) => Promise<void>
+  goto: (
+    url: string,
+    options: { waitUntil: 'domcontentloaded' },
+  ) => Promise<PlaywrightResponse | null>
+  waitForFunction: (
+    expression: string,
+    argument?: unknown,
+    options?: { timeout?: number },
+  ) => Promise<void>
+  evaluate: <A>(expression: string) => Promise<A>
+  locator: (selector: string) => PlaywrightLocator
+  getByRole: (role: string, options: { name: string }) => PlaywrightLocator
+  url: () => string
+  on: {
+    (event: 'pageerror', listener: (error: Error) => void): void
+    (
+      event: 'console',
+      listener: (message: PlaywrightConsoleMessage) => void,
+    ): void
+  }
+  close: () => Promise<void>
+}>
+
+type PlaywrightBrowser = Readonly<{
+  newPage: () => Promise<PlaywrightPage>
+  close: () => Promise<void>
+}>
+
+type PlaywrightBrowserType = Readonly<{
+  launch: (options: { executablePath?: string }) => Promise<PlaywrightBrowser>
+}>
+
+const loadChromium = (): PlaywrightBrowserType => {
+  const requireFromE2e = createRequire(
+    join(REPO_ROOT, 'packages/examples-e2e/package.json'),
+  )
+  const playwright: Readonly<{ chromium: PlaywrightBrowserType }> =
+    requireFromE2e('playwright')
+  return playwright.chromium
+}
+
+type HydratedPage = Readonly<{
+  page: PlaywrightPage
+  diagnostics: Array<string>
+}>
+
+type AdoptionReading = Readonly<{
+  rootWasCaptured: boolean
+  sentinelWasCaptured: boolean
+  rootContainsCurrentSentinel: boolean
+  rootIsConnected: boolean
+  sentinelIsSame: boolean
+  buildMarkerIsRemoved: boolean
+  bodyIsContained: boolean
+}>
+
+const openHydratedPage = async (
+  browser: PlaywrightBrowser,
+  url: string,
+  sentinelExpression: string,
+  label: string,
+): Promise<HydratedPage> => {
+  const page = await browser.newPage()
+  const diagnostics: Array<string> = []
+  page.on('pageerror', error =>
+    diagnostics.push(`page error: ${error.message}`),
+  )
+  page.on('console', message => {
+    if (message.type() === 'error') {
+      diagnostics.push(`console error: ${message.text()}`)
+    }
+  })
+
+  try {
+    await page.route(url, async route => {
+      const response = await route.fetch()
+      const html = await response.text()
+      assertScaffold(
+        html.includes('</body>'),
+        `${label} has no closing body for the parser-time identity probe`,
+      )
+      const probe =
+        '<script>' +
+        "window.__foldkitServedRoot=document.querySelector('[data-foldkit-app]');" +
+        `window.__foldkitServedSentinel=${sentinelExpression};` +
+        '</script>'
+      await route.fulfill({
+        response,
+        body: html.replace('</body>', `${probe}</body>`),
+      })
+    })
+
+    const response = await page.goto(url, { waitUntil: 'domcontentloaded' })
+    assertScaffold(
+      response?.status() === 200,
+      `${label} navigation answered ${String(response?.status())}`,
+    )
+    try {
+      await page.waitForFunction(
+        "window.__foldkitServedRoot instanceof Element && !window.__foldkitServedRoot.hasAttribute('data-foldkit-build')",
+        undefined,
+        { timeout: HYDRATION_TIMEOUT_MS },
+      )
+    } catch (error) {
+      const state = await page.evaluate<unknown>(`(() => {
+        const root = window.__foldkitServedRoot
+        return {
+          bodyInert: document.body.inert,
+          bodyRefused: document.body.hasAttribute('data-foldkit-refused'),
+          buildId: root?.getAttribute('data-foldkit-build'),
+          rootConnected: root?.isConnected,
+        }
+      })()`)
+      fail(
+        `${label} did not finish hydration: ${JSON.stringify({
+          state,
+          diagnostics,
+          error: error instanceof Error ? error.message : String(error),
+        })}`,
+      )
+    }
+
+    const reading = await page.evaluate<AdoptionReading>(`(() => {
+      const root = window.__foldkitServedRoot
+      const sentinel = ${sentinelExpression}
+      return {
+        rootWasCaptured: window.__foldkitServedRoot instanceof Element,
+        sentinelWasCaptured:
+          window.__foldkitServedSentinel instanceof Element,
+        rootContainsCurrentSentinel:
+          root instanceof Element &&
+          sentinel instanceof Element &&
+          root.contains(sentinel),
+        rootIsConnected: window.__foldkitServedRoot?.isConnected === true,
+        sentinelIsSame:
+          window.__foldkitServedSentinel === sentinel,
+        buildMarkerIsRemoved:
+          root instanceof Element && !root.hasAttribute('data-foldkit-build'),
+        bodyIsContained:
+          document.body.inert ||
+          document.body.hasAttribute('data-foldkit-refused') ||
+          document.body.getAttribute('aria-hidden') === 'true',
+      }
+    })()`)
+    assertScaffold(
+      reading.rootWasCaptured && reading.sentinelWasCaptured,
+      `${label} did not expose its parser-created root and sentinel node`,
+    )
+    assertScaffold(
+      reading.rootContainsCurrentSentinel &&
+        reading.rootIsConnected &&
+        reading.sentinelIsSame,
+      `${label} rebuilt instead of adopting its parser-created DOM: ` +
+        JSON.stringify(reading),
+    )
+    assertScaffold(
+      reading.buildMarkerIsRemoved && !reading.bodyIsContained,
+      `${label} did not complete hydration normally: ${JSON.stringify(reading)}`,
+    )
+    return { page, diagnostics }
+  } catch (error) {
+    await page.close()
+    throw error
+  }
+}
+
+const assertNoBrowserDiagnostics = (
+  label: string,
+  diagnostics: ReadonlyArray<string>,
+): void => {
+  assertScaffold(
+    Array_.isReadonlyArrayEmpty(diagnostics),
+    `${label} emitted browser errors:\n${diagnostics.join('\n')}`,
+  )
 }
 
 type PackOutput = ReadonlyArray<Readonly<{ filename?: string }>>
@@ -313,29 +751,143 @@ const assertRejectsRelativeManifestDirectory = (workspaceDir: string): void => {
   log('The packed CLI refuses a relative dependency manifest directory')
 }
 
-const fetchServedPage = async (origin: string): Promise<string> => {
-  for (let attempt = 0; attempt < 60; attempt++) {
-    try {
-      const response = await fetch(origin)
-      assertScaffold(
-        response.status === 200,
-        `the generated SSR host answered ${response.status} for ${origin}`,
-      )
-      return await response.text()
-    } catch (error) {
-      if (error instanceof ScaffoldCheckError) {
-        throw error
-      }
-      await new Promise(resolveWait => setTimeout(resolveWait, 250))
-    }
+const assertGeneratedHostPolicies = async (origin: string): Promise<void> => {
+  const offOrigin = await askRaw(origin, '//evil.example/page', 'GET')
+  assertScaffold(
+    offOrigin.status === 400,
+    `the generated SSR host answered an off-origin request target with ` +
+      `${String(offOrigin.status)} instead of 400`,
+  )
+
+  const missingAsset = await fetch(`${origin}/assets/not-a-real-bundle.js`, {
+    headers: { accept: '*/*' },
+    signal: AbortSignal.timeout(HOST_REQUEST_TIMEOUT_MS),
+  })
+  const missingAssetBody = await missingAsset.text()
+  assertScaffold(
+    missingAsset.status === 404 &&
+      !missingAssetBody.includes('data-foldkit-app'),
+    'the generated SSR host answered a missing JavaScript asset with ' +
+      `${String(missingAsset.status)} or an application shell`,
+  )
+
+  const options = await askRaw(origin, '/', 'OPTIONS', {
+    origin: 'https://browser.example',
+    'access-control-request-method': 'POST',
+  })
+  assertScaffold(
+    options.status === 204 &&
+      options.body === '' &&
+      options.headers['allow'] === EXPECTED_ALLOW,
+    'the generated SSR host did not forward OPTIONS to its entry: ' +
+      JSON.stringify(options),
+  )
+  log(
+    'The generated SSR host refuses off-origin targets and missing assets, and forwards OPTIONS',
+  )
+}
+
+const checkSsrInBrowser = async (
+  browser: PlaywrightBrowser,
+  origin: string,
+): Promise<void> => {
+  const hydrated = await openHydratedPage(
+    browser,
+    `${origin}/deep/route`,
+    "document.querySelectorAll('button')[1]",
+    'The generated SSR application',
+  )
+  try {
+    const initialCount = await hydrated.page.locator('#count').textContent()
+    const provenance = await hydrated.page.locator('#provenance').textContent()
+    assertScaffold(
+      initialCount === '0' &&
+        provenance?.includes('Rendered on the Server') === true,
+      'the generated SSR deep route did not preserve its server-rendered state',
+    )
+    await hydrated.page.getByRole('button', { name: '+' }).click()
+    await hydrated.page.waitForFunction(
+      "document.querySelector('#count')?.textContent === '1' && document.title === 'Count 1'",
+      undefined,
+      { timeout: HYDRATION_TIMEOUT_MS },
+    )
+    assertNoBrowserDiagnostics(
+      'The generated SSR application',
+      hydrated.diagnostics,
+    )
+  } finally {
+    await hydrated.page.close()
   }
-  return fail('the generated SSR host never accepted a connection')
+  log('The generated SSR application hydrates in place and responds to input')
+}
+
+const checkSsgInBrowser = async (
+  browser: PlaywrightBrowser,
+  origin: string,
+): Promise<void> => {
+  const home = await openHydratedPage(
+    browser,
+    `${origin}/`,
+    "document.querySelector('button')",
+    'The generated SSG home page',
+  )
+  try {
+    await home.page.getByRole('button', { name: 'Count: 0' }).click()
+    await home.page.waitForFunction(
+      "document.querySelector('button')?.textContent === 'Count: 1'",
+      undefined,
+      { timeout: HYDRATION_TIMEOUT_MS },
+    )
+    await home.page.getByRole('link', { name: 'About' }).click()
+    await home.page.waitForFunction(
+      "document.title === 'About | Foldkit App' && document.querySelector('#page-title')?.textContent === 'Statically generated about page'",
+      undefined,
+      { timeout: HYDRATION_TIMEOUT_MS },
+    )
+    assertScaffold(
+      new URL(home.page.url()).pathname === '/about',
+      `the generated SSG application navigated to ${home.page.url()} instead of /about`,
+    )
+    await home.page.getByRole('link', { name: 'Home' }).click()
+    await home.page.waitForFunction(
+      "document.title === 'Home | Foldkit App' && document.querySelector('button')?.textContent === 'Count: 1'",
+      undefined,
+      { timeout: HYDRATION_TIMEOUT_MS },
+    )
+    assertNoBrowserDiagnostics('The generated SSG home page', home.diagnostics)
+  } finally {
+    await home.page.close()
+  }
+
+  const about = await openHydratedPage(
+    browser,
+    `${origin}/about/`,
+    "document.querySelector('#page-title')",
+    'The generated SSG about page',
+  )
+  try {
+    assertScaffold(
+      (await about.page.locator('#page-title').textContent()) ===
+        'Statically generated about page',
+      'the generated SSG about file did not render its own route',
+    )
+    assertNoBrowserDiagnostics(
+      'The generated SSG about page',
+      about.diagnostics,
+    )
+  } finally {
+    await about.page.close()
+  }
+  log(
+    'The generated SSG pages hydrate in place and preserve state across navigation',
+  )
 }
 
 const checkSsr = async (
   workspaceDir: string,
   tarballs: Tarballs,
   manifestDirectory: string,
+  browser: PlaywrightBrowser,
 ): Promise<void> => {
   const projectDir = generateProject(
     workspaceDir,
@@ -344,28 +896,31 @@ const checkSsr = async (
     manifestDirectory,
   )
 
-  const server = spawn('node', ['dist/server/main.js'], {
-    cwd: projectDir,
-    env: { ...process.env, PORT: String(SSR_PORT) },
-    stdio: 'ignore',
+  const origin = `http://127.0.0.1:${String(SSR_PORT)}`
+  const host = startHost('npm', ['run', 'start'], projectDir, SSR_PORT, {
+    PORT: String(SSR_PORT),
+    ORIGIN: origin,
   })
   try {
-    const html = await fetchServedPage(`http://127.0.0.1:${SSR_PORT}/`)
+    const html = await fetchServedPage(host, origin)
     assertBuildIdReachesBothSides(
       'The generated SSR host',
       html,
       join(projectDir, 'dist/client'),
     )
+    await assertGeneratedHostPolicies(origin)
+    await checkSsrInBrowser(browser, origin)
   } finally {
-    server.kill()
+    await stopHost(host)
   }
 }
 
-const checkSsg = (
+const checkSsg = async (
   workspaceDir: string,
   tarballs: Tarballs,
   manifestDirectory: string,
-): void => {
+  browser: PlaywrightBrowser,
+): Promise<void> => {
   const projectDir = generateProject(
     workspaceDir,
     'ssg',
@@ -394,6 +949,29 @@ const checkSsg = (
       `"${aboutBuildId}"), so the prerender step did not run under the id the ` +
       'client build was given.',
   )
+
+  const origin = `http://127.0.0.1:${String(SSG_PORT)}`
+  const host = startHost(
+    'npm',
+    [
+      'run',
+      'preview',
+      '--',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(SSG_PORT),
+      '--strictPort',
+    ],
+    projectDir,
+    SSG_PORT,
+  )
+  try {
+    await fetchServedPage(host, origin)
+    await checkSsgInBrowser(browser, origin)
+  } finally {
+    await stopHost(host)
+  }
 }
 
 const main = async (): Promise<void> => {
@@ -402,6 +980,8 @@ const main = async (): Promise<void> => {
   log(`Workspace: ${workspaceDir}`)
 
   try {
+    await assertPortIsFree(SSR_PORT)
+    await assertPortIsFree(SSG_PORT)
     const manifestDirectory = prepareDependencyManifests(workspaceDir)
 
     if (!isSkipBuild) {
@@ -444,8 +1024,17 @@ const main = async (): Promise<void> => {
     )
 
     assertRejectsRelativeManifestDirectory(workspaceDir)
-    await checkSsr(workspaceDir, tarballs, manifestDirectory)
-    checkSsg(workspaceDir, tarballs, manifestDirectory)
+    const chromium = loadChromium()
+    const executablePath = process.env['PLAYWRIGHT_CHROMIUM_EXECUTABLE']
+    const browser = await chromium.launch(
+      executablePath === undefined ? {} : { executablePath },
+    )
+    try {
+      await checkSsr(workspaceDir, tarballs, manifestDirectory, browser)
+      await checkSsg(workspaceDir, tarballs, manifestDirectory, browser)
+    } finally {
+      await browser.close()
+    }
   } finally {
     log('Cleaning up...')
     rmSync(workspaceDir, { recursive: true, force: true })

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -81,3 +81,16 @@ test('peer floor changes run the packed-manifest check before release', () => {
   )
   assert.match(releaseWorkflow, /^\s+- 'scripts\/check-peer-floors\.ts'$/m)
 })
+
+test('browser-backed scaffold checks install Chromium exactly once', () => {
+  assert.ok(
+    workflow.includes(
+      "      - name: Install Chromium for the generated SSR gate\n        if: steps.scope.outputs.scaffold_server_rendering == 'true' && steps.scope.outputs.packed_ssr_consumer != 'true'\n        run: pnpm --filter @foldkit/examples-e2e exec playwright install --with-deps chromium",
+    ),
+  )
+  assert.ok(
+    workflow.includes(
+      "      - name: Install Playwright chromium for the DOM state gate\n        if: steps.scope.outputs.dom_state_parity == 'true' && steps.scope.outputs.packed_ssr_consumer != 'true' && steps.scope.outputs.scaffold_server_rendering != 'true'",
+    ),
+  )
+})

--- a/scripts/plan-ci.mjs
+++ b/scripts/plan-ci.mjs
@@ -65,6 +65,7 @@ const scaffoldServerRendering =
     files: [
       'examples/ssg/package.json',
       'examples/ssr/package.json',
+      'packages/examples-e2e/package.json',
       'scripts/check-scaffold-server-rendering.ts',
     ],
     prefixes: [

--- a/scripts/plan-ci.test.mjs
+++ b/scripts/plan-ci.test.mjs
@@ -162,6 +162,7 @@ test('a scaffold or framework change selects the generated-app build gate', () =
   for (const file of [
     'examples/ssg/package.json',
     'examples/ssr/package.json',
+    'packages/examples-e2e/package.json',
     'packages/create-foldkit-app/templates/rendering/ssr/scripts/build.mjs',
     'packages/foldkit/src/experimental/server/server.ts',
     'packages/vite-plugin-foldkit/src/buildToken.ts',


### PR DESCRIPTION
Stacked on #1081. Review only the top commit, `b845b0b71`.

## Summary

- drive the packed SSR and SSG scaffolds in Chromium after running their documented build commands
- prove hydration preserves the parser-created root and a representative descendant before testing interaction and SSG navigation
- probe the generated SSR host's off-origin request refusal, missing-asset behavior, and OPTIONS forwarding
- manage hosts as process groups, refuse occupied ports, bound diagnostics and requests, and verify ports are released after every run
- install Chromium once when any selected browser-backed SSR gate needs it

This is a CI-only follow-up. It does not change a published package and does not add a changeset.

## Verification

- `pnpm check:scaffold-server-rendering:ci`
- `pnpm typecheck:scripts`
- `pnpm test:scripts`
- `pnpm lint:ci`
- `pnpm check:dead-code`
- `pnpm format:check`
- changeset hygiene checks
- independent read-only review of the final diff

## Mutation checks

- replacing the parser-created button failed the DOM identity assertion
- retaining the old Model after the increment Message failed the interaction assertion
- changing the generated host's off-origin response failed the host-policy assertion
- occupying the fixed SSR port made the gate refuse to start before packing or building
- assertion failures released the host port for the next run
