### PR TITLE
ci: support merge queue checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,8 +25,8 @@ jobs:
       - name: Plan change-scoped checks
         id: scope
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: node scripts/plan-ci.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm
@@ -106,7 +106,7 @@ jobs:
       - name: Typecheck affected packages
         if: steps.scope.outputs.full_workspace_checks == 'false'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           # NOTE: pnpm compares the ref against the working tree, so pass the
           # merge base rather than the base tip. Otherwise a base branch that
@@ -195,7 +195,7 @@ jobs:
       - name: Test affected packages
         if: steps.scope.outputs.full_workspace_checks == 'false'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           # NOTE: pnpm compares the ref against the working tree, so pass the
           # merge base rather than the base tip. Otherwise a base branch that

--- a/.github/workflows/examples-e2e.yml
+++ b/.github/workflows/examples-e2e.yml
@@ -1,12 +1,12 @@
 name: Examples E2E
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,8 +28,8 @@ jobs:
       - name: Plan affected examples
         id: plan
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: node scripts/plan-examples-e2e.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   examples-e2e:

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -9,9 +9,31 @@ const workflow = readFileSync(
   resolve(REPO_ROOT, '.github/workflows/ci.yml'),
   'utf8',
 )
+const examplesWorkflow = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/examples-e2e.yml'),
+  'utf8',
+)
 const rootPackage = JSON.parse(
   readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
 )
+
+test('required workflows check pull requests and merge groups', () => {
+  for (const requiredWorkflow of [workflow, examplesWorkflow]) {
+    assert.match(
+      requiredWorkflow,
+      /on:\n\s+pull_request:\n\s+branches:\n\s+- main\n\s+merge_group:\n\s+types:\n\s+- checks_requested/,
+    )
+    assert.doesNotMatch(requiredWorkflow, /^\s+push:/m)
+    assert.match(
+      requiredWorkflow,
+      /BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.merge_group\.base_sha \}\}/,
+    )
+    assert.match(
+      requiredWorkflow,
+      /HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.event\.merge_group\.head_sha \}\}/,
+    )
+  }
+})
 
 test('changeset status receives trusted pull request context', () => {
   assert.match(


### PR DESCRIPTION
## Summary

- run both required workflows for GitHub merge groups
- scope affected checks to the merge queue's base and speculative head
- stop rerunning the same required workflows after the queue updates `main`
- guard the queue triggers and SHA context with a workflow regression test

## Why

The current ruleset requires every pull request branch to be up to date with
`main`. With many active pull requests and long-running CI, each merge
invalidates otherwise-ready branches and starts another round of checks.

GitHub's merge queue replaces that update-and-retest cycle by checking a
speculative merge group. Required Actions workflows must handle the
`merge_group` event before the queue can be enabled, and their change planners
need the merge group's SHA fields.

This change is the first stage of the rollout. After it reaches `main`, the
repository ruleset can require the merge queue and stop requiring pull request
branches to be up to date.

## Validation

- full Foldkit pre-push gate
- 56 script tests
- full build, typecheck, unit-test, and website E2E suites
- lint, formatting, dead-code, circular-dependency, changeset, and
  commit-message checks
- mutation check confirming the workflow guard fails when a required
  merge-group trigger is removed

No changeset is included because this only changes repository CI.
