### PR TITLE
fix(website): cover playgrounds until preview load

### DIFF
--- a/packages/website/e2e/livePlaygrounds.ts
+++ b/packages/website/e2e/livePlaygrounds.ts
@@ -3,13 +3,66 @@ import type { FrameLocator, Page } from '@playwright/test'
 
 const PLAYGROUND_BOOT_TIMEOUT_MILLISECONDS = 240_000
 
+const capturePlaygroundFrame = (page: Page) =>
+  page.addInitScript(() => {
+    const findNode = () =>
+      document.querySelector('iframe[title="Foldkit Playground"]')
+    const existingNode = findNode()
+    if (existingNode !== null) {
+      Reflect.set(window, '__foldkitPlaygroundFrame', existingNode)
+      return
+    }
+    const observer = new MutationObserver(() => {
+      const node = findNode()
+      if (node !== null) {
+        Reflect.set(window, '__foldkitPlaygroundFrame', node)
+        observer.disconnect()
+      }
+    })
+    observer.observe(document, { childList: true, subtree: true })
+  })
+
+const assertPlaygroundFrameRemains = async (page: Page) => {
+  const iframeIdentity = await page.evaluate(() => {
+    const capturedFrame = Reflect.get(window, '__foldkitPlaygroundFrame')
+    const current = document.querySelector('iframe[title="Foldkit Playground"]')
+    if (!(capturedFrame instanceof HTMLIFrameElement)) {
+      return 'not captured'
+    }
+    if (!capturedFrame.isConnected) {
+      return 'detached'
+    }
+    return capturedFrame === current ? 'preserved' : 'different'
+  })
+  expect(iframeIdentity).toBe('preserved')
+}
+
 const playgroundFrame = async (page: Page, slug: string) => {
+  await capturePlaygroundFrame(page)
   await page.goto(`/playground/${slug}`, { waitUntil: 'domcontentloaded' })
   const frameElement = page.locator('iframe[title="Foldkit Playground"]')
+  await expect(frameElement).toBeAttached({
+    timeout: PLAYGROUND_BOOT_TIMEOUT_MILLISECONDS,
+  })
+
+  const frame = page.frameLocator('iframe[title="Foldkit Playground"]')
   await expect(frameElement).toBeVisible({
     timeout: PLAYGROUND_BOOT_TIMEOUT_MILLISECONDS,
   })
-  return page.frameLocator('iframe[title="Foldkit Playground"]')
+  await expect(frameElement).toHaveAttribute('aria-hidden', 'false')
+  await expect(frameElement).not.toHaveAttribute('inert')
+  const isInert = await frameElement.evaluate(element => {
+    if (!(element instanceof HTMLIFrameElement)) {
+      throw new Error('The playground preview is not an iframe')
+    } else {
+      return element.inert
+    }
+  })
+  expect(isInert).toBe(false)
+  await expect(frameElement).toHaveAttribute('tabindex', '0')
+  expect(await frame.locator('[data-foldkit-build]').count()).toBe(0)
+  await assertPlaygroundFrameRemains(page)
+  return frame
 }
 
 const waitForHydration = (frame: FrameLocator) =>

--- a/packages/website/src/page/playground.ts
+++ b/packages/website/src/page/playground.ts
@@ -27,13 +27,14 @@ import type { FileSystemTree, WebContainer } from '@webcontainer/api'
 import { Icon } from '../icon'
 import { exampleDetailRouter, examplesRouter } from '../route'
 import { type ExampleMeta, findBySlug } from './example/meta'
+import * as PlaygroundPreview from './playgroundPreview'
 
 // MODEL
 
 const PlaygroundStateIdle = ts('PlaygroundStateIdle')
 const PlaygroundStateBooting = ts('PlaygroundStateBooting')
 const PlaygroundStateBooted = ts('PlaygroundStateBooted', {
-  previewUrl: S.String,
+  preview: PlaygroundPreview.State,
 })
 const PlaygroundStateFailed = ts('PlaygroundStateFailed', {
   reason: S.String,
@@ -74,6 +75,9 @@ export const FailedBootPlayground = m('FailedBootPlayground', {
   reason: S.String,
 })
 export const ReleasedPlayground = m('ReleasedPlayground')
+export const LoadedPlaygroundPreview = m('LoadedPlaygroundPreview', {
+  previewUrl: S.String,
+})
 export const GotFileTabsMessage = m('GotFileTabsMessage', {
   message: Tabs.Message,
 })
@@ -96,6 +100,7 @@ export const Message = S.Union([
   BootedPlayground,
   FailedBootPlayground,
   ReleasedPlayground,
+  LoadedPlaygroundPreview,
   GotFileTabsMessage,
   EditedPlaygroundFile,
   SucceededMountPlaygroundEditor,
@@ -623,13 +628,35 @@ const flushDirtyPaths = (
     ),
   )
 
+const markPreviewLoaded = (
+  state: PlaygroundState,
+  previewUrl: string,
+): PlaygroundState =>
+  M.value(state).pipe(
+    M.tag('PlaygroundStateBooted', bootedState => {
+      const nextPreview = PlaygroundPreview.load(
+        bootedState.preview,
+        previewUrl,
+      )
+      if (nextPreview === bootedState.preview) {
+        return state
+      } else {
+        return PlaygroundStateBooted({ preview: nextPreview })
+      }
+    }),
+    M.orElse(() => state),
+  )
+
 export const update = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
     withUpdateReturn,
     M.tags({
       BootedPlayground: ({ previewUrl }) => [
         evo(model, {
-          state: () => PlaygroundStateBooted({ previewUrl }),
+          state: () =>
+            PlaygroundStateBooted({
+              preview: PlaygroundPreview.start(previewUrl),
+            }),
           dirtyPaths: () => [],
           lastWriteError: () => Option.none(),
         }),
@@ -641,6 +668,10 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       ],
       ReleasedPlayground: () => [
         evo(model, { state: () => PlaygroundStateIdle() }),
+        [],
+      ],
+      LoadedPlaygroundPreview: ({ previewUrl }) => [
+        evo(model, { state: state => markPreviewLoaded(state, previewUrl) }),
         [],
       ],
       GotFileTabsMessage: ({ message: tabsMessage }) => {
@@ -823,16 +854,19 @@ const editorPanelContent = (
     ],
   )
 
-const previewPaneView = (state: PlaygroundState): Html =>
-  ih.div(
+const previewPaneView = (
+  state: PlaygroundState,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
     [
-      ih.Class(
+      h.Class(
         'flex-1 min-w-0 min-h-0 flex flex-col border-l max-playground-wide:border-l-0 max-playground-wide:border-t border-gray-200 dark:border-gray-800 bg-white',
       ),
     ],
     [
-      ih.div(
-        [ih.Class('flex-1 min-w-0 min-h-0 flex flex-col')],
+      h.div(
+        [h.Class('flex-1 min-w-0 min-h-0 flex flex-col')],
         [
           M.value(state).pipe(
             M.tagsExhaustive({
@@ -846,13 +880,18 @@ const previewPaneView = (state: PlaygroundState): Html =>
                   'Starting playground…',
                   'Hang tight. The preview will appear automatically. First load takes about 30 seconds.',
                 ),
-              PlaygroundStateBooted: ({ previewUrl }) =>
-                ih.iframe([
-                  ih.Src(previewUrl),
-                  ih.Allow('cross-origin-isolated'),
-                  ih.Class('w-full h-full border-0'),
-                  ih.Title('Foldkit Playground'),
-                ]),
+              PlaygroundStateBooted: ({ preview }) =>
+                PlaygroundPreview.view(
+                  preview,
+                  LoadedPlaygroundPreview({
+                    previewUrl: preview.previewUrl,
+                  }),
+                  bootingPanelView(
+                    'Preparing preview…',
+                    'The server is running. The preview will appear when the page finishes loading.',
+                  ),
+                  h,
+                ),
               PlaygroundStateFailed: ({ reason }) => failurePanelView(reason),
             }),
           ),
@@ -984,7 +1023,7 @@ const editorLayoutView = (model: Model, h: HtmlBuilder<Message>): Html => {
             },
             toParentMessage: message => GotFileTabsMessage({ message }),
           }),
-          previewPaneView(model.state),
+          previewPaneView(model.state, h),
         ],
       ),
     ],

--- a/packages/website/src/page/playgroundPreview.test.ts
+++ b/packages/website/src/page/playgroundPreview.test.ts
@@ -1,0 +1,97 @@
+import { Schema as S } from 'effect'
+import { type HtmlBuilder, inertHtml as ih } from 'foldkit/html'
+import { m } from 'foldkit/message'
+import {
+  type SceneSimulation,
+  expect,
+  given,
+  scene,
+  selector,
+  text,
+} from 'foldkit/scene'
+import { describe, expect as expectValue, test } from 'vitest'
+
+import * as PlaygroundPreview from './playgroundPreview'
+
+const PREVIEW_URL = 'https://preview.example.test'
+const STALE_PREVIEW_URL = 'https://stale.example.test'
+const preview = selector('iframe')
+const LoadedPreview = m('LoadedPreview')
+const Message = S.Union([LoadedPreview])
+type Message = typeof Message.Type
+
+const previewApp = {
+  update: (state: PlaygroundPreview.State, _message: Message) =>
+    [state, []] as const,
+  view: (state: PlaygroundPreview.State, h: HtmlBuilder<Message>) =>
+    PlaygroundPreview.view(
+      state,
+      LoadedPreview(),
+      ih.div([], ['Preparing preview…']),
+      h,
+    ),
+}
+
+const expectPreviewKey =
+  (expectedKey: string) =>
+  (simulation: SceneSimulation<PlaygroundPreview.State, Message>) => {
+    const frame = simulation.html.children?.find(
+      child => typeof child !== 'string' && child.sel === 'iframe',
+    )
+    if (frame === undefined || typeof frame === 'string') {
+      throw new Error('The preview iframe was not rendered')
+    } else {
+      expectValue(frame.key).toBe(expectedKey)
+      return simulation
+    }
+  }
+
+describe('playground preview', () => {
+  test('loads only the current preview', () => {
+    const loading = PlaygroundPreview.start(PREVIEW_URL)
+    const loaded = PlaygroundPreview.load(loading, PREVIEW_URL)
+    expectValue(PlaygroundPreview.load(loading, STALE_PREVIEW_URL)).toBe(
+      loading,
+    )
+    expectValue(loaded).toEqual(
+      PlaygroundPreview.Loaded({ previewUrl: PREVIEW_URL }),
+    )
+    expectValue(PlaygroundPreview.load(loaded, PREVIEW_URL)).toBe(loaded)
+  })
+
+  test('keeps a loading frame out of reach', () => {
+    scene(
+      previewApp,
+      given(PlaygroundPreview.start(PREVIEW_URL)),
+      expect(preview).toHaveHandler('load'),
+      expect(preview).toHaveAttr('inert', 'true'),
+      expect(preview).toHaveAttr('aria-hidden', 'true'),
+      expect(preview).toHaveAttr('tabIndex', '-1'),
+      expect(preview).toHaveClass('invisible'),
+      expect(preview).toHaveClass('pointer-events-none'),
+      expect(text('Preparing preview…')).toExist(),
+      expectPreviewKey(PREVIEW_URL),
+    )
+  })
+
+  test('reveals a loaded frame', () => {
+    scene(
+      previewApp,
+      given(PlaygroundPreview.Loaded({ previewUrl: PREVIEW_URL })),
+      expect(preview).toHaveAttr('inert', 'false'),
+      expect(preview).toHaveAttr('aria-hidden', 'false'),
+      expect(preview).toHaveAttr('tabIndex', '0'),
+      expect(preview).toHaveClass('opacity-100'),
+      expect(selector('.hidden')).toContainText('Preparing preview…'),
+      expectPreviewKey(PREVIEW_URL),
+    )
+  })
+
+  test('keys a different preview URL as a different frame', () => {
+    scene(
+      previewApp,
+      given(PlaygroundPreview.start(STALE_PREVIEW_URL)),
+      expectPreviewKey(STALE_PREVIEW_URL),
+    )
+  })
+})

--- a/packages/website/src/page/playgroundPreview.ts
+++ b/packages/website/src/page/playgroundPreview.ts
@@ -1,0 +1,61 @@
+import { clsx } from 'clsx'
+import { Schema as S } from 'effect'
+import { type Html, type HtmlBuilder } from 'foldkit/html'
+import { ts } from 'foldkit/schema'
+
+export const Loading = ts('PlaygroundPreviewLoading', {
+  previewUrl: S.String,
+})
+export const Loaded = ts('PlaygroundPreviewLoaded', {
+  previewUrl: S.String,
+})
+export const State = S.Union([Loading, Loaded])
+export type State = typeof State.Type
+
+export const start = (previewUrl: string): State => Loading({ previewUrl })
+
+export const load = (state: State, previewUrl: string): State => {
+  if (
+    state.previewUrl !== previewUrl ||
+    state._tag === 'PlaygroundPreviewLoaded'
+  ) {
+    return state
+  } else {
+    return Loaded({ previewUrl })
+  }
+}
+
+export const view = <Message>(
+  state: State,
+  loadedMessage: Message,
+  loadingView: Html,
+  h: HtmlBuilder<Message>,
+): Html => {
+  const isLoaded = state._tag === 'PlaygroundPreviewLoaded'
+  return h.div(
+    [h.Class('relative flex-1 min-w-0 min-h-0'), h.AriaBusy(!isLoaded)],
+    [
+      h.keyed('iframe')(state.previewUrl, [
+        h.Src(state.previewUrl),
+        h.Allow('cross-origin-isolated'),
+        h.Class(
+          clsx(
+            'w-full h-full border-0',
+            isLoaded
+              ? 'opacity-100'
+              : 'invisible opacity-0 pointer-events-none',
+          ),
+        ),
+        h.Title('Foldkit Playground'),
+        h.Inert(!isLoaded),
+        h.AriaHidden(!isLoaded),
+        h.Tabindex(isLoaded ? 0 : -1),
+        h.OnLoad(loadedMessage),
+      ]),
+      h.div(
+        [h.Class(clsx('absolute inset-0', isLoaded ? 'hidden' : 'flex'))],
+        [loadingView],
+      ),
+    ],
+  )
+}


### PR DESCRIPTION
## Summary

- keep editable playground previews hidden, inert, and untabbable until their iframe finishes loading
- preserve the same iframe across the loading transition, while keying different preview URLs as different entities
- extend the deployed SSR and SSG smoke tests to verify iframe identity, hydration, accessibility state, and interaction

## Why

The editable WebContainer playgrounds expose server-rendered or statically generated controls before Vite finishes loading and evaluating the cold client dependency graph. In live measurements, controls could remain visibly inert for roughly four to six seconds. Warm reloads and production-built embeds became interactive within tens of milliseconds, so Foldkit hydration is not the long pole.

The parent now keeps an opaque loading panel over the mounted iframe until its native load event. This removes the misleading visible-but-dead interval without adding a flaky timing threshold or claiming that iframe load is a formal hydration protocol.

## Verification

- full repository pre-push gate
- website unit tests: 460 passed
- website typecheck, lint, formatting, and production build
- local live SSR and SSG playground smoke: 2 passed
- mutation check: keying by loading state detached the captured iframe and failed the identity assertion
- mutation check: removing the URL key failed the focused key regressions
