### PR TITLE
fix(website): isolate deployed Monaco workers

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -178,6 +178,13 @@ jobs:
                 "continue": true
               },
               {
+                "src": "^/monacoworkers/.*",
+                "headers": {
+                  "Cross-Origin-Embedder-Policy": "credentialless"
+                },
+                "continue": true
+              },
+              {
                 "src": ".*",
                 "headers": {
                   "Cross-Origin-Resource-Policy": "same-origin"
@@ -262,6 +269,31 @@ jobs:
           done
           echo "foldkit.dev did not reach build ${{ needs.authorize.outputs.target }}" >&2
           exit 1
+
+      - name: Check deployed Monaco worker isolation
+        run: |
+          headers_file="${RUNNER_TEMP}/foldkit-monaco-worker-headers.txt"
+          curl -fsSIL \
+            -H 'Cache-Control: no-cache' \
+            -D "${headers_file}" \
+            -o /dev/null \
+            "https://foldkit.dev/monacoworkers/ts.worker.bundle.js?release-smoke=${GITHUB_RUN_ID}"
+          header_value() {
+            grep -i "^${1}:" "${headers_file}" |
+              sed -E 's/^[^:]+:[[:space:]]*//; s/\r$//'
+          }
+          coep_value="$(header_value 'Cross-Origin-Embedder-Policy' || true)"
+          corp_value="$(header_value 'Cross-Origin-Resource-Policy' || true)"
+          if [[ "${coep_value}" != 'credentialless' ]]; then
+            echo "Expected one COEP credentialless header; received '${coep_value:-<missing>}'." >&2
+            cat "${headers_file}" >&2
+            exit 1
+          fi
+          if [[ "${corp_value}" != 'same-origin' ]]; then
+            echo "Expected one CORP same-origin header; received '${corp_value:-<missing>}'." >&2
+            cat "${headers_file}" >&2
+            exit 1
+          fi
 
       - name: Smoke the deployed SSR and SSG playgrounds
         run: pnpm --filter website exec playwright test

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -831,18 +831,20 @@ const embeddedExampleRedirectPlugin = (): Plugin => ({
 // boots in `pnpm dev` and `pnpm preview`. The deployed Vercel config is
 // the source of truth; this is the dev-mode equivalent.
 //
-// CORP same-origin goes on every response (not just /playground/*) so
-// that Monaco's editor and worker scripts loaded by the credentialless
-// /playground/* page satisfy COEP. Workers in credentialless contexts
-// require their script URLs to return a CORP-compatible response, and
-// Vite serves those from non-/playground paths.
+// CORP same-origin goes on every response so Monaco's scripts satisfy
+// the playground page's embedder policy. Monaco worker responses also
+// carry COEP credentialless so their WorkerGlobalScope stays isolated.
 const setIsolationHeaders = (
   url: string | undefined,
   res: { setHeader: (name: string, value: string) => void },
 ) => {
+  const isPlaygroundRequest = url?.startsWith('/playground/') ?? false
+  const isMonacoWorkerRequest = url?.startsWith('/monacoworkers/') ?? false
   res.setHeader('Cross-Origin-Resource-Policy', 'same-origin')
-  if (url?.startsWith('/playground/')) {
+  if (isPlaygroundRequest || isMonacoWorkerRequest) {
     res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless')
+  }
+  if (isPlaygroundRequest) {
     res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
   }
 }

--- a/scripts/deploy-website-workflow.test.mjs
+++ b/scripts/deploy-website-workflow.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const workflow = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/deploy-website.yml'),
+  'utf8',
+)
+const maybeConfigSource = workflow.match(
+  /cat > \.vercel\/output\/config\.json << 'EOF'\n(?<config>[\s\S]*?)\n\s+EOF/,
+)?.groups?.config
+
+assert.ok(maybeConfigSource, 'Vercel output config was not found')
+const config = JSON.parse(maybeConfigSource)
+
+const matchingRoutesFor = pathname =>
+  config.routes.filter(
+    route =>
+      typeof route.src === 'string' && new RegExp(route.src).test(pathname),
+  )
+
+const headersFor = pathname =>
+  matchingRoutesFor(pathname).reduce(
+    (headers, route) => ({ ...headers, ...route.headers }),
+    {},
+  )
+
+const isolationHeadersFor = pathname =>
+  Object.fromEntries(
+    Object.entries(headersFor(pathname)).filter(([name]) =>
+      name.startsWith('Cross-Origin-'),
+    ),
+  )
+
+test('the deployed playground and Monaco workers share an embedder policy', () => {
+  assert.deepEqual(isolationHeadersFor('/playground/ssr'), {
+    'Cross-Origin-Embedder-Policy': 'credentialless',
+    'Cross-Origin-Opener-Policy': 'same-origin',
+    'Cross-Origin-Resource-Policy': 'same-origin',
+  })
+  assert.deepEqual(isolationHeadersFor('/monacoworkers/ts.worker.bundle.js'), {
+    'Cross-Origin-Embedder-Policy': 'credentialless',
+    'Cross-Origin-Resource-Policy': 'same-origin',
+  })
+  const workerEmbedderRoutes = matchingRoutesFor(
+    '/monacoworkers/ts.worker.bundle.js',
+  ).filter(
+    route => route.headers?.['Cross-Origin-Embedder-Policy'] !== undefined,
+  )
+  assert.equal(workerEmbedderRoutes.length, 1)
+  assert.equal(
+    workerEmbedderRoutes.every(route => route.continue === true),
+    true,
+  )
+})


### PR DESCRIPTION
## Summary

- add `Cross-Origin-Embedder-Policy: credentialless` to deployed Monaco worker responses
- make `vite preview` use the same worker isolation policy as development and production
- verify the generated Vercel routes and the headers served after each deployment

## Why

The playground document is cross-origin isolated, but the deployed worker response only carried CORP. Chromium rejected the worker because its response defaulted to `COEP: unsafe-none`. Monaco then loaded the worker code on the main thread, which can freeze the editor while its language service starts.

Development already supplied both headers. This change gives production and local preview the same contract. COOP remains limited to playground documents, and CORP remains `same-origin` globally.

## Verification

- 56 script tests passed
- script and website typechecks passed
- root lint, formatting, and workflow YAML validation passed
- website production build passed
- local preview returned exact COEP and CORP values for the TypeScript worker
- removing the worker route failed the deploy regression
- removing `continue: true` failed the route-composition regression
- removing preview COEP reproduced the missing header locally

## Follow-up

After #1086 lands, extend the live Playwright smoke to require a Monaco worker and reject the main-thread fallback warning. This PR uses a post-deploy header check to avoid conflicting with that PR's changes to the same smoke file.
