### PR TITLE
fix(foldkit): align controlled select hydration

### DIFF
--- a/.changeset/hydrate-controlled-selects.md
+++ b/.changeset/hydrate-controlled-selects.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Compare controlled select hydration against the effective selection owned by the select value, and synchronize duplicate-valued option defaults after that value takes effect.

--- a/examples/ssr/src/main.ts
+++ b/examples/ssr/src/main.ts
@@ -165,7 +165,7 @@ const parseEquivalenceView = (h: HtmlBuilder<Message>): Html =>
         [h.Id('equivalence-select'), h.Value('a')],
         [
           h.option([h.Value('a')], ['A']),
-          h.option([h.Value('b'), h.Selected(true)], ['B']),
+          h.option([h.Value('a'), h.Selected(true)], ['B']),
         ],
       ),
       h.pre([h.Id('equivalence-pre'), h.InnerHTML('\nleading')]),

--- a/packages/examples-e2e/e2e/ssr.spec.ts
+++ b/packages/examples-e2e/e2e/ssr.spec.ts
@@ -10,12 +10,22 @@ import * as Page from '../page'
 const readEquivalence = (page: BrowserPage) =>
   page.evaluate(() => {
     const select = document.querySelector('#equivalence-select')
+    const firstOption =
+      select instanceof HTMLSelectElement ? select.options.item(0) : null
+    const secondOption =
+      select instanceof HTMLSelectElement ? select.options.item(1) : null
     const pre = document.querySelector('#equivalence-pre')
     const textarea = document.querySelector('#equivalence-textarea')
     return {
+      firstDefaultSelected: firstOption?.defaultSelected ?? null,
+      firstHasSelected: firstOption?.hasAttribute('selected') ?? null,
+      firstSelected: firstOption?.selected ?? null,
       selectValue: select instanceof HTMLSelectElement ? select.value : null,
       selectedIndex:
         select instanceof HTMLSelectElement ? select.selectedIndex : null,
+      secondDefaultSelected: secondOption?.defaultSelected ?? null,
+      secondHasSelected: secondOption?.hasAttribute('selected') ?? null,
+      secondSelected: secondOption?.selected ?? null,
       preText: pre === null ? null : pre.textContent,
       textareaValue:
         textarea instanceof HTMLTextAreaElement ? textarea.value : null,
@@ -42,6 +52,21 @@ test.describe('ssr example', () => {
     // The select's own value owns the selection, not the later `selected`.
     expect(served.selectValue).toBe('a')
     expect(served.selectedIndex).toBe(0)
+    expect({
+      firstDefaultSelected: served.firstDefaultSelected,
+      firstHasSelected: served.firstHasSelected,
+      firstSelected: served.firstSelected,
+      secondDefaultSelected: served.secondDefaultSelected,
+      secondHasSelected: served.secondHasSelected,
+      secondSelected: served.secondSelected,
+    }).toEqual({
+      firstDefaultSelected: true,
+      firstHasSelected: true,
+      firstSelected: true,
+      secondDefaultSelected: false,
+      secondHasSelected: false,
+      secondSelected: false,
+    })
     // The leading newline survives the parser's strip on both sides.
     expect(served.preText).toBe('\nleading')
     expect(served.textareaValue).toBe('\nleading')

--- a/packages/foldkit/src/controlledDomState.ts
+++ b/packages/foldkit/src/controlledDomState.ts
@@ -74,13 +74,17 @@ export const synchronizeControlledDefault = (
     return
   }
   if (propertyName === 'value' && tagName === 'select') {
+    // NOTE: set the live selection before copying it into the defaults. Two
+    // options can share one value, so `select.value` may already equal the
+    // controlled value while a later child `selected` still owns the live
+    // selection. The value setter gives the first matching option ownership.
+    Reflect.set(element, 'value', value)
     for (const option of element.querySelectorAll('option')) {
       if (option.defaultSelected !== option.selected) {
         option.defaultSelected = option.selected
       }
       setBooleanDefaultAttribute(option, 'selected', option.selected)
     }
-    Reflect.set(element, 'value', value)
   }
 }
 

--- a/packages/foldkit/src/hydrate.test.ts
+++ b/packages/foldkit/src/hydrate.test.ts
@@ -86,6 +86,23 @@ describe('__hydrateVNode', () => {
     return vnode.elm
   }
 
+  // NOTE: happy-dom reads the selected attribute into `option.selected` but
+  // does not initialize `defaultSelected` or `select.selectedIndex` the way a
+  // browser parser does. Complete that parser-derived state before testing
+  // hydration. The SSR Playwright suite covers the same path in Chromium.
+  const completeParsedSelectState = (select: HTMLSelectElement): void => {
+    const options = Array.from(select.options)
+    const selectedOption = options.find(option =>
+      option.hasAttribute('selected'),
+    )
+    for (const option of options) {
+      const isSelected = option === selectedOption
+      option.defaultSelected = isSelected
+      option.selected = isSelected
+    }
+    select.selectedIndex = selectedOption?.index ?? -1
+  }
+
   beforeEach(() => {
     dispatched = []
     host = document.createElement('div')
@@ -903,6 +920,277 @@ describe('__hydrateVNode', () => {
 
     expect(root.value).toBe('us')
     expect(root.querySelector('option[value="us"]')).toBe(serverOption)
+  })
+
+  it('adopts effective controlled selection without reporting a mismatch', () => {
+    const view = () =>
+      h.div(
+        [],
+        [
+          h.select(
+            [h.Value('a')],
+            [
+              h.option([h.Value('a')], ['A']),
+              h.option([h.Value('b'), h.Selected(true)], ['B']),
+            ],
+          ),
+        ],
+      )
+    const root = mountServerHtml(serializeHydratable(buildView(view)))
+    const select = root.querySelector('select')
+    const firstOption = root.querySelector('option[value="a"]')
+    const secondOption = root.querySelector('option[value="b"]')
+    if (!(select instanceof HTMLSelectElement)) {
+      throw new Error('expected a select')
+    }
+    if (!(firstOption instanceof HTMLOptionElement)) {
+      throw new Error('expected the first option')
+    }
+    if (!(secondOption instanceof HTMLOptionElement)) {
+      throw new Error('expected the second option')
+    }
+    completeParsedSelectState(select)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const hydrated = buildView(() => hydrateVNode(root, view()))
+
+      expect(hydrated.elm).toBe(root)
+      expect(root.querySelector('select')).toBe(select)
+      expect(root.querySelector('option[value="a"]')).toBe(firstOption)
+      expect(root.querySelector('option[value="b"]')).toBe(secondOption)
+      expect({
+        firstDefaultSelected: firstOption.defaultSelected,
+        firstHasSelected: firstOption.hasAttribute('selected'),
+        firstSelected: firstOption.selected,
+        secondDefaultSelected: secondOption.defaultSelected,
+        secondHasSelected: secondOption.hasAttribute('selected'),
+        secondSelected: secondOption.selected,
+        selectedIndex: select.selectedIndex,
+        value: select.value,
+      }).toEqual({
+        firstDefaultSelected: true,
+        firstHasSelected: true,
+        firstSelected: true,
+        secondDefaultSelected: false,
+        secondHasSelected: false,
+        secondSelected: false,
+        selectedIndex: 0,
+        value: 'a',
+      })
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('adopts controlled selection through an optgroup', () => {
+    const view = () =>
+      h.div(
+        [],
+        [
+          h.select(
+            [h.Value('a')],
+            [
+              h.optgroup(
+                [],
+                [
+                  h.option(
+                    [h.Id('first-a'), h.Value('a'), h.Selected(false)],
+                    ['First'],
+                  ),
+                  h.option(
+                    [h.Id('second-b'), h.Value('b'), h.Selected(true)],
+                    ['Second'],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      )
+    const root = mountServerHtml(serializeHydratable(buildView(view)))
+    const select = root.querySelector('select')
+    const firstOption = root.querySelector('#first-a')
+    const secondOption = root.querySelector('#second-b')
+    if (!(select instanceof HTMLSelectElement)) {
+      throw new Error('expected a select')
+    }
+    if (!(firstOption instanceof HTMLOptionElement)) {
+      throw new Error('expected the first option')
+    }
+    if (!(secondOption instanceof HTMLOptionElement)) {
+      throw new Error('expected the second option')
+    }
+    completeParsedSelectState(select)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      buildView(() => hydrateVNode(root, view()))
+
+      expect(root.querySelector('#first-a')).toBe(firstOption)
+      expect(root.querySelector('#second-b')).toBe(secondOption)
+      expect({
+        firstDefaultSelected: firstOption.defaultSelected,
+        firstSelected: firstOption.selected,
+        secondDefaultSelected: secondOption.defaultSelected,
+        secondSelected: secondOption.selected,
+        selectedIndex: select.selectedIndex,
+        value: select.value,
+      }).toEqual({
+        firstDefaultSelected: true,
+        firstSelected: true,
+        secondDefaultSelected: false,
+        secondSelected: false,
+        selectedIndex: 0,
+        value: 'a',
+      })
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('adopts an allowed controlled value that matches no option', () => {
+    const view = () =>
+      h.select(
+        [h.Value('missing'), h.Multiple(true)],
+        [h.option([h.Value('a')], ['A'])],
+      )
+    const root = mountServerHtml(serializeHydratable(buildView(view)))
+    if (!(root instanceof HTMLSelectElement)) {
+      throw new Error('expected a select')
+    }
+    completeParsedSelectState(root)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      buildView(() => hydrateVNode(root, view()))
+
+      expect(root.value).toBe('')
+      expect(root.selectedIndex).toBe(-1)
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('reports extra selected state beneath a controlled select', () => {
+    const view = () =>
+      h.div(
+        [],
+        [
+          h.select(
+            [h.Value('a'), h.Multiple(true)],
+            [
+              h.option([h.Value('a')], ['A']),
+              h.option([h.Value('b'), h.Selected(false)], ['B']),
+            ],
+          ),
+        ],
+      )
+    const root = mountServerHtml(serializeHydratable(buildView(view)))
+    const select = root.querySelector('select')
+    const firstOption = root.querySelector('option[value="a"]')
+    const secondOption = root.querySelector('option[value="b"]')
+    if (!(select instanceof HTMLSelectElement)) {
+      throw new Error('expected a select')
+    }
+    if (!(secondOption instanceof HTMLOptionElement)) {
+      throw new Error('expected the second option')
+    }
+    if (!(firstOption instanceof HTMLOptionElement)) {
+      throw new Error('expected the first option')
+    }
+    completeParsedSelectState(select)
+    secondOption.selected = true
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      buildView(() => hydrateVNode(root, view()))
+
+      expect(select.value).toBe('a')
+      expect(select.selectedIndex).toBe(0)
+      expect(secondOption.selected).toBe(false)
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The server DOM did not match the first client view during hydration',
+        ),
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('reports stale default selection beneath a controlled select', () => {
+    const view = () =>
+      h.div(
+        [],
+        [
+          h.select(
+            [h.Value('a')],
+            [h.option([h.Value('a')], ['A']), h.option([h.Value('b')], ['B'])],
+          ),
+        ],
+      )
+    const root = mountServerHtml(serializeHydratable(buildView(view)))
+    const select = root.querySelector('select')
+    const secondOption = root.querySelector('option[value="b"]')
+    if (!(select instanceof HTMLSelectElement)) {
+      throw new Error('expected a select')
+    }
+    if (!(secondOption instanceof HTMLOptionElement)) {
+      throw new Error('expected the second option')
+    }
+    completeParsedSelectState(select)
+    secondOption.defaultSelected = true
+    secondOption.selected = false
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      buildView(() => hydrateVNode(root, view()))
+
+      expect(secondOption.defaultSelected).toBe(false)
+      expect(secondOption.selected).toBe(false)
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('still reports selected state owned by an uncontrolled select', () => {
+    const view = () =>
+      h.div(
+        [],
+        [
+          h.select(
+            [h.Multiple(true)],
+            [h.option([h.Value('a'), h.Selected(false)], ['A'])],
+          ),
+        ],
+      )
+    const root = mountServerHtml(serializeHydratable(buildView(view)))
+    const select = root.querySelector('select')
+    const option = root.querySelector('option')
+    if (!(select instanceof HTMLSelectElement)) {
+      throw new Error('expected a select')
+    }
+    if (!(option instanceof HTMLOptionElement)) {
+      throw new Error('expected an option')
+    }
+    completeParsedSelectState(select)
+    option.selected = true
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      buildView(() => hydrateVNode(root, view()))
+
+      expect(option.selected).toBe(false)
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it('keeps an adopted innerHTML subtree when the markup round-trips unchanged', () => {

--- a/packages/foldkit/src/hydrate.ts
+++ b/packages/foldkit/src/hydrate.ts
@@ -223,6 +223,74 @@ const isControlledCurrentState = (
 
 const STALE_REFLECTED_PROPERTY = Symbol('foldkit/stale-reflected-property')
 
+type AdoptedSignature = Readonly<{ vnode: VNode; server: string }>
+type ControlledSelectState = Readonly<{
+  selectedIndex: number
+  value: string
+}>
+type HydrationStatus = {
+  isMismatchDetected: boolean
+  adoptedSignatures: Map<Element, AdoptedSignature>
+  controlledOptionSelection: Map<Element, boolean>
+  controlledSelectState: Map<Element, ControlledSelectState>
+}
+
+const NO_SELECTED_OPTION = -1
+
+// NOTE: a controlled select owns the effective state of every descendant
+// option. The serializer marks the first matching option, and the browser's
+// value setter does the same during a fresh render. Compare hydration against
+// that parent-owned state instead of each option's shadowed `selected` prop.
+const registerControlledSelectState = (
+  element: Element,
+  vnode: VNode,
+  status: HydrationStatus,
+): void => {
+  const properties = vnode.data?.props
+  const authoredValue = properties?.['value']
+  if (
+    !(element instanceof HTMLSelectElement) ||
+    typeof authoredValue !== 'string' ||
+    isClientOnlyProperty(properties, 'value')
+  ) {
+    return
+  }
+
+  const options = Array.from(element.options)
+  const selectedOption = options.find(option => option.value === authoredValue)
+  for (const option of options) {
+    status.controlledOptionSelection.set(option, option === selectedOption)
+  }
+  status.controlledSelectState.set(element, {
+    selectedIndex: selectedOption?.index ?? NO_SELECTED_OPTION,
+    value: selectedOption?.value ?? '',
+  })
+}
+
+const detectControlledSelectMismatch = (
+  element: Element,
+  status: HydrationStatus,
+): void => {
+  const selectState = status.controlledSelectState.get(element)
+  if (
+    selectState !== undefined &&
+    (Reflect.get(element, 'value') !== selectState.value ||
+      Reflect.get(element, 'selectedIndex') !== selectState.selectedIndex)
+  ) {
+    detectMismatch(status)
+  }
+
+  const isSelected = status.controlledOptionSelection.get(element)
+  if (isSelected !== undefined) {
+    if (
+      Reflect.get(element, 'selected') !== isSelected ||
+      Reflect.get(element, 'defaultSelected') !== isSelected
+    ) {
+      detectMismatch(status)
+    }
+  }
+}
+
 const seedReflectedProperties = (
   element: Element,
   vnode: VNode,
@@ -240,6 +308,13 @@ const seedReflectedProperties = (
     const authored = properties[name]
     const attributeName = reflectedAttributeName(name)
     if (attributeName === undefined) {
+      continue
+    }
+    const isOwnedByControlledSelect =
+      (name === 'value' && status.controlledSelectState.has(element)) ||
+      (name === 'selected' && status.controlledOptionSelection.has(element))
+    if (isOwnedByControlledSelect) {
+      seeded[name] = authored
       continue
     }
     const isEquivalent =
@@ -319,6 +394,7 @@ const seedAdoptedState = (
   status: HydrationStatus,
   isCustomElement: boolean,
 ): void => {
+  detectControlledSelectMismatch(element, status)
   const classOwnedByModule =
     vnode.data?.class !== undefined &&
     htmlAttributeValue(vnode.data?.attrs, 'class') === undefined
@@ -420,12 +496,6 @@ const seedAdoptedState = (
       server: __elementSignature(element, vnode),
     })
   }
-}
-
-type AdoptedSignature = Readonly<{ vnode: VNode; server: string }>
-type HydrationStatus = {
-  isMismatchDetected: boolean
-  adoptedSignatures: Map<Element, AdoptedSignature>
 }
 
 const detectMismatch = (status: HydrationStatus): void => {
@@ -684,6 +754,7 @@ const adoptElement = (
     return clonePreparedTree(replaceHydrationElement(element, vnode))
   }
   const clone = cloneOf(vnode, element)
+  registerControlledSelectState(element, vnode, status)
   // Strip the hydration markers the serializer stamped: they are internal to the
   // handoff, already verified by the parent's positional walk before this call,
   // and must not remain on the adopted element.
@@ -1016,6 +1087,8 @@ export const __hydrateVNode = (
   const status: HydrationStatus = {
     isMismatchDetected: false,
     adoptedSignatures: new Map(),
+    controlledOptionSelection: new Map(),
+    controlledSelectState: new Map(),
   }
 
   // The build token is checked again here, though the runtime has already


### PR DESCRIPTION
## Summary

- compare controlled select hydration against the effective selection owned by the parent select value
- apply the controlled value before synchronizing option defaults, so duplicate-valued options match server serialization and fresh client rendering
- preserve mismatch reporting for genuinely stale current and default selection state

## Verification

- Foldkit: 2,278 passed, 1 skipped
- SSR Chromium: 13 passed
- focused hydration and serialization tests: 204 passed
- Foldkit and examples-e2e typechecks
- lint, formatting, and changeset validation
- mutation checks proved the false-warning, stale-state, and duplicate-default regressions fail independently when their fixes are removed

## Deferred

Native client-only `Prop({ key: "value" })` on `<select>` has a separate pre-existing serializer and fresh-render contract inconsistency. This PR excludes it from controlled-select adoption rather than partially redefining that API.