### PR TITLE
fix(foldkit): refuse client-only select values

### DIFF
--- a/.changeset/refuse-client-only-select-value.md
+++ b/.changeset/refuse-client-only-select-value.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Refuse server rendering a native `select` controlled through a client-only `CustomElement.define` property named `value`. Foldkit applies the property at different points in a fresh render and hydration, so it cannot describe one portable selection. Use `h.Value` for a server-rendered controlled select.

--- a/packages/foldkit/src/experimental/server/serialize.test.ts
+++ b/packages/foldkit/src/experimental/server/serialize.test.ts
@@ -981,6 +981,120 @@ describe('one owner for an element\u2019s content', () => {
 })
 
 describe('controlled select selection ownership', () => {
+  const selectLikeDefinition = CustomElement.define({
+    tag: 'x-select-like',
+    properties: { value: S.Unknown },
+    events: {},
+  })
+  const expectClientOnlyValueRefusal = (view: Html, name: string): void => {
+    expect(() => serializeHtml(view), name).toThrow(
+      /client-only value property/,
+    )
+    expect(
+      () => serializeHtml(view, { emitHydrationMarkers: true }),
+      name,
+    ).toThrow(/client-only value property/)
+  }
+
+  it('refuses every client-only value on a native select', () => {
+    const selectLike = selectLikeDefinition.withMessage(h)
+    for (const value of ['b', 1, null, undefined, Symbol('value'), { id: 1 }]) {
+      expectClientOnlyValueRefusal(
+        h.select([selectLike.Value(value)]),
+        `client-only ${typeof value}`,
+      )
+    }
+  })
+
+  it('refuses the client-only value across select arrangements', () => {
+    const selectLike = selectLikeDefinition.withMessage(h)
+    const arrangements: ReadonlyArray<Readonly<{ name: string; view: Html }>> =
+      [
+        {
+          name: 'direct options',
+          view: h.select(
+            [selectLike.Value('b')],
+            [h.option([h.Value('a')], ['A']), h.option([h.Value('b')], ['B'])],
+          ),
+        },
+        {
+          name: 'duplicate option values',
+          view: h.select(
+            [selectLike.Value('b')],
+            [
+              h.option([h.Value('b')], ['First']),
+              h.option([h.Value('b')], ['Second']),
+            ],
+          ),
+        },
+        {
+          name: 'an optgroup descendant',
+          view: h.select(
+            [selectLike.Value('b')],
+            [
+              h.optgroup(
+                [],
+                [
+                  h.option([h.Value('a')], ['A']),
+                  h.option([h.Value('b')], ['B']),
+                ],
+              ),
+            ],
+          ),
+        },
+        {
+          name: 'a multiple select',
+          view: h.select(
+            [selectLike.Value('b'), h.Multiple(true)],
+            [h.option([h.Value('b')], ['B'])],
+          ),
+        },
+        {
+          name: 'a sized select',
+          view: h.select(
+            [selectLike.Value('b'), h.Size(2)],
+            [h.option([h.Value('b')], ['B'])],
+          ),
+        },
+        {
+          name: 'raw value and selected attributes',
+          view: h.select(
+            [h.Attribute('value', 'a'), selectLike.Value('b')],
+            [h.option([h.Value('a'), h.Attribute('selected', '')], ['A'])],
+          ),
+        },
+        {
+          name: 'a dynamic uppercase native select',
+          view: customElement<Message>()('SELECT')(
+            [selectLike.Value('b')],
+            [h.option([h.Value('b')], ['B'])],
+          ),
+        },
+      ]
+
+    for (const { name, view } of arrangements) {
+      expectClientOnlyValueRefusal(view, name)
+    }
+  })
+
+  it('uses the last property builder as the select value owner', () => {
+    const selectLike = selectLikeDefinition.withMessage(h)
+    const options = [
+      h.option([h.Value('a')], ['A']),
+      h.option([h.Value('b')], ['B']),
+    ]
+    expectClientOnlyValueRefusal(
+      h.select([h.Value('a'), selectLike.Value('b')], options),
+      'client-only property written last',
+    )
+    expect(
+      serializeHtml(h.select([selectLike.Value('b'), h.Value('a')], options)),
+    ).toBe(
+      '<select><option value="a" selected="">A</option>' +
+        '<option value="b">B</option></select>',
+    )
+  })
+
   it('canonicalizes a dynamic HTML tag before applying select semantics', () => {
     const dynamicSelect = (): Html =>
       customElement<never>()('SELECT')(

--- a/packages/foldkit/src/experimental/server/serialize.ts
+++ b/packages/foldkit/src/experimental/server/serialize.ts
@@ -721,7 +721,19 @@ const selectValueForChildren = (
   if (tagName !== 'select') {
     return inherited
   }
-  const value = node.data?.props?.['value']
+  const properties = node.data?.props
+  if (isClientOnlyProperty(properties, 'value')) {
+    throw new Error(
+      '[foldkit] Cannot server-render a native <select> with a client-only ' +
+        'value property. Foldkit applies that value before options exist in ' +
+        'a fresh client render and after they exist during hydration, so the ' +
+        'two renders can select different options. CustomElement property ' +
+        'factories belong on their declared Custom Element. Use h.Value(...) ' +
+        'to give a native select one controlled selection to serialize and ' +
+        'hydrate.',
+    )
+  }
+  const value = properties?.['value']
   if (typeof value === 'string') {
     return {
       value,

--- a/packages/website/src/page/core/serverRendering.md
+++ b/packages/website/src/page/core/serverRendering.md
@@ -361,6 +361,7 @@ Server HTML and client DOM must give each attribute, property, and content slot 
 - A controlled `h.Value` cannot share a `textarea` or `output` with declared children because both own the element's content. Keep either the controlled value or the children. This rule also applies to client-only rendering.
 - A raw `h.Attribute` and a typed builder cannot name the same attribute on one element. `h.Style` likewise cannot share an element with a raw `style` attribute. Keep one owner for each piece of state.
 - A typed reflected builder is client-only when the HTML element's native interface does not own that property. For example: spreading `h.Type('button')` onto a `div` creates an expando, so server rendering omits it instead of creating an attribute that a fresh client render would not. Use the matching element when the value must appear in markup, or use an intentional raw `h.Attribute`.
+- A `CustomElement.define` property named `value` cannot control a native `select` in a server-rendered view. A fresh client assigns the property before the options exist, while hydration assigns it after the parser has created them. The two writes can select different options. Property factories belong on the Custom Element they declare. Use `h.Value` so a native select has one controlled selection.
 
 ### Custom Elements
 

--- a/scripts/check-dom-state-parity.mts
+++ b/scripts/check-dom-state-parity.mts
@@ -1,4 +1,5 @@
-import { Effect } from 'effect'
+import { Effect, Schema as S } from 'effect'
+import * as CustomElement from 'foldkit/customElement'
 import { Server } from 'foldkit/experimental'
 import { type Html, type HtmlBuilder } from 'foldkit/html'
 import { createRequire } from 'node:module'
@@ -193,12 +194,28 @@ const STRING_TO_NUMBER_REFUSALS: ReadonlyArray<Refusal> = [
   },
 ]
 
-// A controlled select value naming no option, on an element a browser renders
-// single-line. HTML gives the first option the selection there, so the served
-// page cannot express what the client's `value` assignment produces. Which
-// elements those are is decided by `multiple` and by `size` as a browser parses
-// it, not as `parseInt` reads it.
+// Select property states with no equivalent source markup. Foldkit applies a
+// client-only value property before options exist in a fresh render and after
+// they exist during hydration. A controlled value naming no option disagrees
+// with a single-line element, where HTML selects the first option. Whether an
+// element permits no selection is decided by `multiple` and by `size` as a
+// browser parses it, not as `parseInt` reads it.
 const SELECT_REFUSALS: ReadonlyArray<Refusal> = [
+  {
+    name: 'a native select with a client-only value property',
+    build: h => {
+      const selectLike = CustomElement.define({
+        tag: 'x-select-like',
+        properties: { value: S.Unknown },
+        events: {},
+      }).withMessage(h)
+      return h.select(
+        [selectLike.Value('b')],
+        [h.option([h.Value('a')], ['A']), h.option([h.Value('b')], ['B'])],
+      )
+    },
+    expected: /client-only value property/,
+  },
   {
     name: 'a single-line select whose value names no option',
     build: h => h.select([h.Value('zzz')], [h.option([h.Value('a')], ['A'])]),


### PR DESCRIPTION
## Summary

- Refuse a client-only `CustomElement.define` value property on native `select` elements during server rendering.
- Preserve last-writer ownership so a later typed `h.Value` remains valid.
- Document the boundary and cover static, hydratable, non-string, nested, and uppercase-tag cases.
- Add the public reproduction to the real Chromium DOM-state-parity gate.

## Why

Fresh client rendering applies this client-only property before option creation. Hydration applies it after the browser has parsed the options. The same view can therefore select different options. The property also accepts arbitrary unknown values, so server rendering now refuses the class instead of attempting to model selected instances.

## Validation

- Foldkit tests: 2,281 passed, 1 skipped
- Focused serializer tests: 120 passed
- Chromium DOM-state parity: 3,149 reflections and 42 views passed
- Foldkit, website, and script typechecks
- Website tests: 456 passed
- Website production build and 183-route prerender
- Lint, Prettier, and changeset gates
- Four mutation checks for guard presence, non-string values, empty selects, and provenance

## Stack

This draft is stacked on #1088. Retarget it to `main` after #1088 merges.
