### PR TITLE
fix(website): post the newsletter form directly to Buttondown

### DIFF
--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -11,15 +11,12 @@ import {
   Schema as S,
   pipe,
 } from 'effect'
-import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { KeyValueStore } from 'effect/unstable/persistence'
 import {
   AsyncData,
   Calendar,
   Command,
   Dom,
-  FieldValidation,
-  Http,
   ManagedResource,
   Runtime,
   Subscription,
@@ -59,7 +56,6 @@ import {
   CompletedWaitBeforeHidingCopiedIndicator,
   FailedCopyLink,
   FailedCopySnippet,
-  FailedSubscribeToNewsletter,
   GotApiReferenceMessage,
   GotAsyncCounterDemoMessage,
   GotComingFromReactMessage,
@@ -75,7 +71,6 @@ import {
   ResolvedTheme,
   SucceededCopyLink,
   SucceededCopySnippet,
-  SucceededSubscribeToNewsletter,
   ThemePreference,
 } from './message'
 import * as Page from './page'
@@ -133,19 +128,6 @@ const resolveTheme = (
     M.when('System', () => systemTheme),
     M.exhaustive,
   )
-
-const emailRules = FieldValidation.makeRules({
-  required: 'Email is required',
-  rules: [FieldValidation.Rule.email('Please enter a valid email address')],
-})
-
-const EmailSubscriptionStatus = S.Literals([
-  'Idle',
-  'Submitting',
-  'Succeeded',
-  'Failed',
-])
-export type EmailSubscriptionStatus = typeof EmailSubscriptionStatus.Type
 
 // FLAGS
 
@@ -235,8 +217,6 @@ export const Model = S.Struct({
   route: AppRoute,
   url: Url,
   copiedSnippets: S.HashSet(S.String),
-  emailField: FieldValidation.Field(S.String),
-  emailSubscriptionStatus: EmailSubscriptionStatus,
   maybeGitHubStarCount: S.Option(S.Number),
   currentYear: S.Number,
   mobileMenuDialog: Dialog.Model,
@@ -457,8 +437,6 @@ export const init: Runtime.RoutingApplicationInit<
       route: initialRoute,
       url,
       copiedSnippets: HashSet.empty(),
-      emailField: FieldValidation.NotValidated({ value: '' }),
-      emailSubscriptionStatus: 'Idle',
       maybeGitHubStarCount: Option.fromNullishOr(githubStarCount),
       currentYear: flags.currentYear,
       mobileMenuDialog: Dialog.init({ id: 'mobile-menu' }),
@@ -901,43 +879,6 @@ export const update = (
         [],
       ],
 
-      UpdatedEmailField: ({ value }) => [
-        evo(model, {
-          emailField: () => FieldValidation.NotValidated({ value }),
-          emailSubscriptionStatus: () => 'Idle',
-        }),
-        [],
-      ],
-
-      SubmittedEmailForm: () => {
-        const result = validateEmail(model.emailField.value)
-
-        return result._tag === 'Valid'
-          ? [
-              evo(model, {
-                emailField: () => result,
-                emailSubscriptionStatus: () => 'Submitting',
-              }),
-              [SubscribeToNewsletter({ email: model.emailField.value })],
-            ]
-          : [evo(model, { emailField: () => result }), []]
-      },
-
-      SucceededSubscribeToNewsletter: () => [
-        evo(model, {
-          emailField: () => FieldValidation.NotValidated({ value: '' }),
-          emailSubscriptionStatus: () => 'Succeeded',
-        }),
-        [],
-      ],
-
-      FailedSubscribeToNewsletter: () => [
-        evo(model, {
-          emailSubscriptionStatus: () => 'Failed',
-        }),
-        [],
-      ],
-
       ClickedOpenMobileMenu: () => {
         const [nextMobileMenuDialog, mobileMenuDialogCommands] = Dialog.open(
           model.mobileMenuDialog,
@@ -1262,33 +1203,6 @@ const ApplyTheme = Command.define('ApplyTheme', {
       )
       return CompletedApplyTheme()
     }),
-})
-
-const BUTTONDOWN_SUBSCRIBE_URL =
-  'https://buttondown.com/api/emails/embed-subscribe/foldkit'
-
-const validateEmail = FieldValidation.validate(emailRules)
-
-const SubscribeToNewsletter = Command.define('SubscribeToNewsletter', {
-  args: { email: S.String },
-  messages: [SucceededSubscribeToNewsletter, FailedSubscribeToNewsletter],
-  execute: ({ email }) =>
-    Effect.gen(function* () {
-      const client = yield* HttpClient.HttpClient
-      const request = HttpClientRequest.post(BUTTONDOWN_SUBSCRIBE_URL).pipe(
-        HttpClientRequest.bodyUrlParams({ email }),
-      )
-      const response = yield* client.execute(request)
-
-      if (response.status >= 400) {
-        return yield* Effect.fail('Subscription failed')
-      }
-
-      return SucceededSubscribeToNewsletter()
-    }).pipe(
-      Effect.catch(() => Effect.succeed(FailedSubscribeToNewsletter())),
-      Effect.provide(Http.layer),
-    ),
 })
 
 const SaveThemePreference = Command.define('SaveThemePreference', {

--- a/packages/website/src/message.ts
+++ b/packages/website/src/message.ts
@@ -67,12 +67,6 @@ export const CompletedWaitBeforeHidingCopiedIndicator = m(
   'CompletedWaitBeforeHidingCopiedIndicator',
   { text: S.String },
 )
-export const UpdatedEmailField = m('UpdatedEmailField', { value: S.String })
-export const SubmittedEmailForm = m('SubmittedEmailForm')
-export const SucceededSubscribeToNewsletter = m(
-  'SucceededSubscribeToNewsletter',
-)
-export const FailedSubscribeToNewsletter = m('FailedSubscribeToNewsletter')
 export const GotMobileMenuDialogMessage = m('GotMobileMenuDialogMessage', {
   message: Dialog.Message,
 })
@@ -159,10 +153,6 @@ export const Message = S.Union([
   SucceededCopySnippet,
   FailedCopySnippet,
   CompletedWaitBeforeHidingCopiedIndicator,
-  UpdatedEmailField,
-  SubmittedEmailForm,
-  SucceededSubscribeToNewsletter,
-  FailedSubscribeToNewsletter,
   GotMobileMenuDialogMessage,
   ClickedOpenMobileMenu,
   ToggledMobileTableOfContents,

--- a/packages/website/src/view/blog.ts
+++ b/packages/website/src/view/blog.ts
@@ -68,17 +68,7 @@ export const blogView = (
             ],
             [content],
           ),
-          h.div(
-            [PagefindIgnore],
-            [
-              docsFooterView(
-                model.emailField,
-                model.emailSubscriptionStatus,
-                model.currentYear,
-                h,
-              ),
-            ],
-          ),
+          h.div([PagefindIgnore], [docsFooterView(model.currentYear, h)]),
         ],
       ),
     ],

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -1,7 +1,6 @@
 import { clsx } from 'clsx'
 import { Match as M, Option, String as S } from 'effect'
 import { AsyncData } from 'foldkit'
-import type { Field } from 'foldkit/fieldValidation'
 import {
   Html,
   type HtmlBuilder,
@@ -12,11 +11,7 @@ import {
 import { pageNeighbors } from '../docsNav'
 import { Icon } from '../icon'
 import { Link } from '../link'
-import {
-  type EmailSubscriptionStatus,
-  type Model,
-  type TableOfContentsEntry,
-} from '../main'
+import { type Model, type TableOfContentsEntry } from '../main'
 import {
   ClickedOpenMobileMenu,
   GotApiReferenceMessage,
@@ -170,8 +165,6 @@ export const docsHeaderView = (model: Model, h: HtmlBuilder<Message>) =>
 // DOCS FOOTER
 
 export const docsFooterView = (
-  emailField: Field<string>,
-  emailSubscriptionStatus: EmailSubscriptionStatus,
   currentYear: number,
   h: HtmlBuilder<Message>,
 ): Html =>
@@ -190,26 +183,7 @@ export const docsFooterView = (
         [h.Class('text-sm text-gray-600 dark:text-gray-300 mb-4')],
         ['New releases, patterns, and the occasional deep dive.'],
       ),
-      M.value(emailSubscriptionStatus).pipe(
-        M.withReturnType<Html>(),
-        M.when('Succeeded', () =>
-          h.p(
-            [
-              h.AriaLive('polite'),
-              h.Class('text-accent-600 dark:text-accent-400 font-normal'),
-            ],
-            ['You’re in! Check your email for confirmation.'],
-          ),
-        ),
-        M.orElse(status =>
-          emailFormView(
-            emailField,
-            status,
-            'flex flex-col sm:flex-row gap-3 max-w-md',
-            h,
-          ),
-        ),
-      ),
+      emailFormView,
       h.hr([
         h.Class(
           'my-6 -mx-4 md:-mx-6 border-t border-gray-300 dark:border-gray-800',
@@ -1168,17 +1142,7 @@ export const docsView = (
                   ),
                 ],
               ),
-              h.div(
-                [PagefindIgnore],
-                [
-                  docsFooterView(
-                    model.emailField,
-                    model.emailSubscriptionStatus,
-                    model.currentYear,
-                    h,
-                  ),
-                ],
-              ),
+              h.div([PagefindIgnore], [docsFooterView(model.currentYear, h)]),
             ],
           ),
           Option.match(currentPageTableOfContents, {

--- a/packages/website/src/view/landing.ts
+++ b/packages/website/src/view/landing.ts
@@ -303,12 +303,6 @@ export const landingView = (model: Model, h: HtmlBuilder<Message>) => {
     h,
   ])
 
-  const emailSignupView = emailSignupContentView(
-    model.emailField,
-    model.emailSubscriptionStatus,
-    h,
-  )
-
   const playgroundMenu = withChromeRecommendedHint(
     playgroundMenuView(
       model.playgroundMenu,
@@ -384,7 +378,7 @@ export const landingView = (model: Model, h: HtmlBuilder<Message>) => {
           Page.Landing.view(
             model.copiedSnippets,
             demoTabsView,
-            emailSignupView,
+            emailSignupContentView,
             playgroundMenu,
             model.aiHeadingToggleCount,
             model.maybeGitHubStarCount,
@@ -411,13 +405,7 @@ export const newsletterView = (model: Model, h: HtmlBuilder<Message>) =>
             'flex-1 flex items-center justify-center px-6 pb-20 pt-[calc(var(--header-height)+5rem)] md:px-12 lg:px-20',
           ),
         ],
-        [
-          emailSignupContentView(
-            model.emailField,
-            model.emailSubscriptionStatus,
-            h,
-          ),
-        ],
+        [emailSignupContentView],
       ),
       landingFooter(model.currentYear),
     ],

--- a/packages/website/src/view/shared.ts
+++ b/packages/website/src/view/shared.ts
@@ -1,12 +1,9 @@
 import { clsx } from 'clsx'
-import { Array, Match as M, Option } from 'effect'
-import type { Field } from 'foldkit/fieldValidation'
-import { Html, type HtmlBuilder, inertHtml as ih } from 'foldkit/html'
+import { Option } from 'effect'
+import { Html, inertHtml as ih } from 'foldkit/html'
 
 import { formatStarCount } from '../githubStars'
 import { Icon } from '../icon'
-import { type EmailSubscriptionStatus } from '../main'
-import { type Message, SubmittedEmailForm, UpdatedEmailField } from '../message'
 
 export const betaTag: Html = ih.span(
   [
@@ -75,114 +72,63 @@ export const skipNavLink: Html = ih.a(
   ['Skip to main content'],
 )
 
-export const emailFormView = (
-  emailField: Field<string>,
-  status: 'Idle' | 'Submitting' | 'Failed',
-  formClassName: string,
-  h: HtmlBuilder<Message>,
-): Html => {
-  const isSubmitting = status === 'Submitting'
+const BUTTONDOWN_SUBSCRIBE_URL =
+  'https://buttondown.com/api/emails/embed-subscribe/foldkit'
 
-  return h.div(
-    [],
-    [
-      h.form(
-        [h.OnSubmit(SubmittedEmailForm()), h.Class(formClassName)],
-        [
-          h.div(
-            [h.Class('flex-1')],
-            [
-              h.input([
-                h.Type('email'),
-                h.AriaLabel('Email address'),
-                h.Placeholder('you@example.com'),
-                h.Value(emailField.value),
-                h.OnInput(value => UpdatedEmailField({ value })),
-                h.Disabled(isSubmitting),
-                h.Class(
-                  clsx(
-                    'w-full px-4 py-2.5 rounded-lg border bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-accent-500 dark:focus:ring-accent-400 disabled:opacity-60',
-                    emailField._tag === 'Invalid'
-                      ? 'border-red-500 dark:border-red-400'
-                      : 'border-gray-300 dark:border-gray-800',
-                  ),
-                ),
-              ]),
-              emailField._tag === 'Invalid'
-                ? h.p(
-                    [
-                      h.AriaLive('polite'),
-                      h.Class('mt-1.5 text-sm text-red-600 dark:text-red-400'),
-                    ],
-                    [Array.headNonEmpty(emailField.errors)],
-                  )
-                : h.empty,
-            ],
+// NOTE: Buttondown's embed endpoint only accepts native form submissions. A
+// fetch request cannot hand the subscriber over when Buttondown needs them to
+// solve a CAPTCHA or fix a rejected address, so this form posts straight to
+// Buttondown and the browser follows the response into a new tab.
+export const emailFormView: Html = ih.form(
+  [
+    ih.Action(BUTTONDOWN_SUBSCRIBE_URL),
+    ih.Method('post'),
+    ih.Target('popupwindow'),
+    ih.Class('flex flex-col sm:flex-row gap-3 max-w-md'),
+  ],
+  [
+    ih.div(
+      [ih.Class('flex-1')],
+      [
+        ih.input([
+          ih.Type('email'),
+          ih.Name('email'),
+          ih.Required(true),
+          ih.AriaLabel('Email address'),
+          ih.Placeholder('you@example.com'),
+          ih.Class(
+            'w-full px-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-800 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-accent-500 dark:focus:ring-accent-400',
           ),
-          h.button(
-            [
-              h.Type('submit'),
-              h.Disabled(isSubmitting),
-              h.Class(
-                'px-6 py-2.5 rounded-lg bg-accent-600 dark:bg-accent-500 text-white dark:text-accent-900 font-normal transition hover:bg-accent-700 dark:hover:bg-accent-600 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer',
-              ),
-            ],
-            [isSubmitting ? 'Subscribing...' : 'Subscribe'],
-          ),
-        ],
-      ),
-      status === 'Failed'
-        ? h.p(
-            [
-              h.AriaLive('polite'),
-              h.Class('mt-3 text-sm text-red-600 dark:text-red-400'),
-            ],
-            ['Something went wrong. Please try again.'],
-          )
-        : h.empty,
-    ],
-  )
-}
+        ]),
+      ],
+    ),
+    ih.button(
+      [
+        ih.Type('submit'),
+        ih.Class(
+          'px-6 py-2.5 rounded-lg bg-accent-600 dark:bg-accent-500 text-white dark:text-accent-900 font-normal transition hover:bg-accent-700 dark:hover:bg-accent-600 cursor-pointer',
+        ),
+      ],
+      ['Subscribe'],
+    ),
+  ],
+)
 
-export const emailSignupContentView = (
-  emailField: Field<string>,
-  emailSubscriptionStatus: EmailSubscriptionStatus,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.div(
-    [h.Id('newsletter')],
-    [
-      h.h2(
-        [
-          h.Class(
-            'text-3xl md:text-4xl font-normal text-gray-900 dark:text-white mb-4 text-balance',
-          ),
-        ],
-        ['Stay in the update loop.'],
-      ),
-      h.p(
-        [h.Class('text-lg text-gray-600 dark:text-gray-300 mb-8 max-w-xl')],
-        ['New releases, patterns, and the occasional deep dive.'],
-      ),
-      M.value(emailSubscriptionStatus).pipe(
-        M.withReturnType<Html>(),
-        M.when('Succeeded', () =>
-          h.p(
-            [
-              h.AriaLive('polite'),
-              h.Class('text-accent-600 dark:text-accent-400 font-normal'),
-            ],
-            ['You’re in! Check your email for confirmation.'],
-          ),
+export const emailSignupContentView: Html = ih.div(
+  [ih.Id('newsletter')],
+  [
+    ih.h2(
+      [
+        ih.Class(
+          'text-3xl md:text-4xl font-normal text-gray-900 dark:text-white mb-4 text-balance',
         ),
-        M.orElse(status =>
-          emailFormView(
-            emailField,
-            status,
-            'flex flex-col sm:flex-row gap-3 max-w-md',
-            h,
-          ),
-        ),
-      ),
-    ],
-  )
+      ],
+      ['Stay in the update loop.'],
+    ),
+    ih.p(
+      [ih.Class('text-lg text-gray-600 dark:text-gray-300 mb-8 max-w-xl')],
+      ['New releases, patterns, and the occasional deep dive.'],
+    ),
+    emailFormView,
+  ],
+)


### PR DESCRIPTION
## What was wrong

Buttondown emailed to say the site sends requests to their embed-subscribe endpoint through the fetch API, and that endpoint only supports native form submissions. When Buttondown needs a subscriber to solve a CAPTCHA or correct a rejected address, a fetch request cannot hand them over, so those people could not sign up at all.

The old path made that failure look like a transient one. `SubscribeToNewsletter` POSTed through `HttpClient` and turned every response at or above 400 into `FailedSubscribeToNewsletter`, which rendered "Something went wrong. Please try again." Retrying could never work, because the page the subscriber needed to reach was the one fetch would not open.

## What changed

The email signup is now inert HTML that posts straight to Buttondown and lets the browser follow the response:

```ts
export const emailFormView: Html = ih.form(
  [
    ih.Action(BUTTONDOWN_SUBSCRIBE_URL),
    ih.Method('post'),
    ih.Target('popupwindow'),
    ...
```

The input carries `name="email"`, `type="email"`, and `required`, so native constraint validation covers what the `emailRules` field validation used to do.

That let the surrounding machinery go: the `SubscribeToNewsletter` Command, the four email Messages (`UpdatedEmailField`, `SubmittedEmailForm`, `SucceededSubscribeToNewsletter`, `FailedSubscribeToNewsletter`), the `emailField` and `emailSubscriptionStatus` Model fields with their `init` values, the `EmailSubscriptionStatus` schema, and the now-unused `HttpClient`, `Http`, and `FieldValidation` imports in `main.ts`. Call sites in `view/landing.ts`, `view/docs.ts`, and `view/blog.ts` stop threading that state through, and `docsFooterView` drops two parameters.

`emailFormView` and `emailSignupContentView` are now `Html` consts rather than functions. Both call sites passed the same `formClassName`, and with no Model state left to read there is nothing for a builder argument to do. `view/shared.ts` no longer imports from `../main` or `../message` at all.

## Scope decisions

Three calls worth stating rather than leaving to be found in the diff.

**The on-page success state is gone.** "You're in! Check your email for confirmation." cannot survive a submission the browser navigates away from, since confirmation now happens on Buttondown's page. This is inherent to the change Buttondown asked for, not a separate simplification.

**Client-side validation is replaced rather than kept alongside.** Foldkit's `h.OnSubmit` calls `preventDefault` on every submission, which is the behavior Buttondown asked us to stop. Keeping the field rules would mean submitting the form from a Command instead, which is more machinery for the same outcome that `required` plus `type="email"` already gives.

**The response opens in a new tab.** `target="popupwindow"` matches Buttondown's documented embed markup, minus their inline `onsubmit` window.open, so visitors keep the docs page they were reading and repeat submissions reuse the one named tab. Dropping the target would send the reader to Buttondown in the same tab instead.

## Verification

Checked in Chromium against the dev server, with requests to buttondown.com intercepted so nothing was actually submitted to the list:

- A valid address produces exactly one `POST https://buttondown.com/api/emails/embed-subscribe/foldkit` with body `email=verify-newsletter%40example.com`, opened in a new tab, with the main page URL unchanged.
- Empty and malformed (`nope`) submissions produce no request at all, blocked by native validation. That is the failing case, so the check discriminates on this bug class rather than passing vacuously.
- Hydration was established before submitting by clicking a Foldkit-driven tab and asserting `aria-selected` flipped, so this exercises the client render rather than only the server-rendered markup.
- `curl -H 'Accept: text/html'` against the dev SSR route returns the complete form, so the signup works before hydration and with JS off.
- Screenshots of `/newsletter` and the docs footer show no layout change.

`pnpm pre-push` passes in full: formatting, lint, knip, circular dependencies, the whole build, workspace typecheck, and every suite (foldkit 2,272 passed with 1 skipped, ui 998, oxlint-plugin 330, website 456, plus every example).

**Not verified locally:** the website Playwright e2e step skipped itself, because the pinned browser build is absent in this environment and `scripts/run-website-e2e.sh` skips by design in that case. CI runs it on this PR. The browser check above used the sandbox's preinstalled Chromium instead. A real end-to-end subscription is also unverified, since the request was intercepted. The endpoint URL and the `email` field name are unchanged from what the fetch version sent.

No changeset, since `website` is in the changeset `ignore` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LR3qduDzVjtcApyUzyEcAe

---
_Generated by [Claude Code](https://claude.ai/code/session_01LR3qduDzVjtcApyUzyEcAe)_