### PR TITLE
fix(foldkit): enforce one hydratable app per document

### DIFF
--- a/.changeset/refuse-multiple-hydration-roots.md
+++ b/.changeset/refuse-multiple-hydration-roots.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Contain and refuse a server handoff unless it is the document's single nonempty stamped root in the body light DOM. `injectIntoTemplate` now rejects a second hydratable application even when it uses a distinct runtime id. Static body output can still coexist because it carries no handoff stamp. Each insertion still applies its `Document` head fields, so insertion order determines the initial metadata.

--- a/packages/foldkit/src/experimental/server/server.ts
+++ b/packages/foldkit/src/experimental/server/server.ts
@@ -985,9 +985,10 @@ export { FOLDKIT_APP_ATTRIBUTE, FOLDKIT_FLAGS_ATTRIBUTE }
 
 const DEFAULT_RUNTIME_ID = 'app'
 
-/** The server render of one request: the stamped root markup (plus the Flags
- *  payload script when the application declares Flags) and the `Document`
- *  head fields for the host to place into its HTML template.
+/** The server render of one request: the body markup and the `Document` head
+ *  fields for the host to place into its HTML template. Hydratable output
+ *  contains a stamped root and, when the application declares Flags, its
+ *  payload script. Static output carries no handoff markers.
  *
  * @experimental Ships from `foldkit/experimental/server`; expect breaking changes while the API settles.
  */
@@ -1119,10 +1120,10 @@ export type ApplicationConfig<Model, Message> = Readonly<{
 
 // Shared by both render shapes. `runtimeId` names the application in the root
 // stamp and Flags payload; it defaults to `'app'` and must be non-empty. It
-// also keys the Model and scroll position hot reloading preserves, so two roots
-// carrying one id would take each other's state and are refused. Hydrating more
-// than one application on a page is not supported: each owns the document's
-// metadata and its navigation listeners, which distinct ids do not divide.
+// also keys the Model and scroll position hot reloading preserves. A document
+// may contain one hydratable root. Template injection and hydration refuse a
+// second root whether it carries the same id or a distinct one because runtime
+// ids do not divide ownership of document metadata and navigation listeners.
 
 type CommonRenderOptions = Readonly<{
   runtimeId?: string
@@ -1160,6 +1161,8 @@ export type StaticRenderOptions = CommonRenderOptions &
 
 /** Options for {@link renderToString}. `runtimeId` names the application in the
  *  root stamp and Flags payload; it defaults to `'app'` and must be non-empty.
+ *  A nondefault `runtimeId` changes the root, Flags, and HMR pairing. It does
+ *  not permit a second hydratable application in one document.
  *
  *  A hydratable render (the default) requires `buildId`. Pass
  *  `isHydratable: false` for static markup that nothing will hydrate, which
@@ -1326,10 +1329,10 @@ const validateHydrationRoot = (
  *
  * Resolves `init` for the request (with the given Flags and URL when the
  * config declares them), runs the pure `view` under a no-op dispatch frame,
- * and serializes the resulting `Document` body. The root element is stamped
- * with {@link FOLDKIT_APP_ATTRIBUTE} and, when the config declares `Flags`,
- * the Schema-encoded Flags ride along in a JSON script tag so a hydrating
- * client boots from the same Model.
+ * and serializes the resulting `Document` body. For hydratable output, the
+ * root element is stamped with {@link FOLDKIT_APP_ATTRIBUTE} and, when the
+ * config declares `Flags`, the Schema-encoded Flags ride along in a JSON script
+ * tag so a hydrating client boots from the same Model.
  *
  * Commands returned by `init` are not run: the rendered HTML is the
  * post-`init` state, and the client runs those Commands after hydration.

--- a/packages/foldkit/src/experimental/server/template.test.ts
+++ b/packages/foldkit/src/experimental/server/template.test.ts
@@ -643,14 +643,12 @@ describe('injectIntoTemplate insertion context', () => {
   })
 
   it('does not validate against an earlier same-tag sibling', () => {
-    // The earlier section holds a second application whose root looks like what
-    // the injection should produce. Resolving the path by tag name alone would
-    // find that one and accept a page whose real injection is somewhere else
-    // entirely. It carries its own runtime id, since two roots sharing one is
-    // refused in its own right.
+    // The earlier section holds static markup that looks like the rendered
+    // output. Resolving the path by tag name alone would find that one and
+    // accept a page whose real injection is somewhere else entirely.
     const template =
       '<!doctype html><html lang="en"><head><title>old</title></head>' +
-      '<body><section><div data-foldkit-app="other" data-foldkit-build="build-zero">hi</div></section>' +
+      '<body><section><div class="lookalike">hi</div></section>' +
       '<section><div id="root"></div><p>tail</p></section></body></html>'
 
     const result = injectIntoTemplate(template, rendered())
@@ -777,28 +775,20 @@ describe('injectIntoTemplate insertion context', () => {
     expect(result).toContain('<main><div>static</div></main>')
   })
 
-  it('accepts a second injection beside an existing root with another runtime id', () => {
-    // Structural injection is identified by the position its own placeholder
-    // held, so an unrelated existing marker is not mistaken for this render.
-    // Hydrating multiple page-owning applications remains unsupported.
+  it('rejects a second injection beside an existing hydratable root', () => {
     const template =
       '<!doctype html><html lang="en"><head><title>old</title></head>' +
       '<body><div data-foldkit-app="app-a" data-foldkit-build="build-zero">existing</div>' +
       '<div id="root"></div></body></html>'
 
-    const result = injectIntoTemplate(
-      template,
-      rendered({
-        html: '<div data-foldkit-app="app-b" data-foldkit-build="build-one">hi</div>',
-      }),
-    )
-
-    expect(result).toContain(
-      '<div data-foldkit-app="app-a" data-foldkit-build="build-zero">existing</div>',
-    )
-    expect(result).toContain(
-      '<div data-foldkit-app="app-b" data-foldkit-build="build-one">hi</div>',
-    )
+    expect(() =>
+      injectIntoTemplate(
+        template,
+        rendered({
+          html: '<div data-foldkit-app="app-b" data-foldkit-build="build-one">hi</div>',
+        }),
+      ),
+    ).toThrow('page already holds a server-rendered application')
   })
 })
 
@@ -886,10 +876,7 @@ describe('runtime id uniqueness', () => {
     ).toThrow(/already holds a Flags payload/)
   })
 
-  it('accepts distinct runtime ids, which the pairing needs', () => {
-    // Distinct ids keep two roots from reading each other's Flags. They are not
-    // support for hydrating two page-owning applications, which each rewrite
-    // the document's metadata and own its navigation listeners.
+  it('refuses a second application with a distinct runtime id', () => {
     const first = injectIntoTemplate(
       twoRootTemplate,
       rendered({
@@ -897,29 +884,51 @@ describe('runtime id uniqueness', () => {
       }),
       { containerId: 'first' },
     )
-    const both = injectIntoTemplate(
-      first,
+
+    expect(() =>
+      injectIntoTemplate(
+        first,
+        rendered({
+          html: '<div data-foldkit-app="beta" data-foldkit-build="build-one">second</div>',
+        }),
+        { containerId: 'second' },
+      ),
+    ).toThrow('page already holds a server-rendered application')
+  })
+
+  it('allows static output after one hydratable application', () => {
+    const withApplication = injectIntoTemplate(
+      twoRootTemplate,
       rendered({
-        html: '<div data-foldkit-app="beta" data-foldkit-build="build-one">second</div>',
+        html: '<div data-foldkit-app="app" data-foldkit-build="build-one">application</div>',
       }),
+      { containerId: 'first' },
+    )
+    const injected = injectIntoTemplate(
+      withApplication,
+      rendered({ html: '<div>static</div>' }),
       { containerId: 'second' },
     )
 
-    expect(both).toContain(
-      '<div data-foldkit-app="alpha" data-foldkit-build="build-one">first</div>',
-    )
-    expect(both).toContain(
-      '<div data-foldkit-app="beta" data-foldkit-build="build-one">second</div>',
-    )
+    expect(injected).toContain('>application</div>')
+    expect(injected).toContain('<div>static</div>')
   })
 
-  it('leaves static output alone, which carries no stamp', () => {
-    const injected = injectIntoTemplate(
+  it('allows one hydratable application after static output', () => {
+    const withStaticOutput = injectIntoTemplate(
       twoRootTemplate,
       rendered({ html: '<div>static</div>' }),
       { containerId: 'first' },
     )
+    const injected = injectIntoTemplate(
+      withStaticOutput,
+      rendered({
+        html: '<div data-foldkit-app="app" data-foldkit-build="build-one">application</div>',
+      }),
+      { containerId: 'second' },
+    )
 
     expect(injected).toContain('<div>static</div>')
+    expect(injected).toContain('>application</div>')
   })
 })

--- a/packages/foldkit/src/experimental/server/template.ts
+++ b/packages/foldkit/src/experimental/server/template.ts
@@ -708,7 +708,11 @@ export type InjectIntoTemplateOptions = Readonly<{
  * top-level JSON Flags script. Static output may contain one element, text, or
  * comment root, or no body output. The helper rejects additional top-level
  * content, ambiguous handoff markers, and source that the HTML parser drops,
- * splits, moves, or reconstructs before insertion.
+ * splits, moves, or reconstructs before insertion. It also refuses to place a
+ * hydratable application in a template that already contains one. Static body
+ * output may be inserted beside a hydratable application because no runtime
+ * adopts it. Each insertion still applies that render's `Document` head
+ * fields.
  *
  * This helper is pure with no module state, so a host process may import it
  * directly even when the render itself must stay inside the server entry's
@@ -741,7 +745,7 @@ export const injectIntoTemplate = (
   if (containers.length > 1) {
     throw new Error(
       `[foldkit] injectIntoTemplate found more than one <div id="${containerId}"></div> placeholder in the template. ` +
-        'Keep exactly one placeholder for each application root.',
+        'Keep exactly one placeholder with that id.',
     )
   }
 
@@ -769,8 +773,21 @@ export const injectIntoTemplate = (
           'that id. A runtime id names one application for the whole page: it ' +
           'pairs a root with its Flags payload and keys the Model and scroll ' +
           'position hot reloading preserves, so two roots sharing one would ' +
-          "take each other's state. Give each application its own " +
-          '`runtimeId` when rendering.',
+          "take each other's state. Remove the duplicate root. Foldkit " +
+          'supports one page-owning hydratable application per document.',
+      )
+    }
+    const existingApplications = collectMatching(
+      document,
+      element => attributeValue(element, FOLDKIT_APP_ATTRIBUTE) !== undefined,
+    )
+    if (existingApplications.length > 0) {
+      throw new Error(
+        '[foldkit] injectIntoTemplate is placing a hydratable application, ' +
+          'but the page already holds a server-rendered application. Foldkit ' +
+          'supports one page-owning application per document because each ' +
+          'application owns the document metadata and installs document-wide ' +
+          'navigation listeners. Render one application per page.',
       )
     }
     const existingFlags = collectMatching(

--- a/packages/foldkit/src/hydrationMarker.ts
+++ b/packages/foldkit/src/hydrationMarker.ts
@@ -1,6 +1,7 @@
-/** Attribute stamped on the server-rendered application root. Its presence
- *  tells a booting runtime to hydrate instead of rendering fresh, and its
- *  value is the runtime id used for HMR model preservation. */
+/** Attribute stamped on a hydratable server-rendered application root. Its
+ *  nonempty value is the runtime id used to pair the root with its Flags
+ *  payload and scope preserved HMR state. `makeApplication` locates the root;
+ *  `Runtime.hydrate` adopts it. */
 export const FOLDKIT_APP_ATTRIBUTE = 'data-foldkit-app'
 
 /** Attribute on the JSON script tag carrying the Schema-encoded flags the

--- a/packages/foldkit/src/runtime/hydrateBoot.test.ts
+++ b/packages/foldkit/src/runtime/hydrateBoot.test.ts
@@ -83,6 +83,9 @@ const resetRootAttributes = (): void => {
 
 afterEach(() => {
   document.body.innerHTML = ''
+  document.head
+    .querySelectorAll('[data-foldkit-app]')
+    .forEach(root => root.remove())
   document
     .querySelectorAll('[data-foldkit-refusal-shield]')
     .forEach(shield => shield.remove())
@@ -345,28 +348,27 @@ describe('hydrating boot', () => {
     }
   })
 
-  it('fails hydration on an unstamped container without adopting another app root', async () => {
+  it('contains a server-rendered page when the container is outside its root', async () => {
     await renderServerPage({ start: 5 })
     const serverRoot = document.querySelector('[data-foldkit-app]')
     const widgetContainer = document.createElement('div')
     widgetContainer.id = 'widget'
     document.body.appendChild(widgetContainer)
 
-    const widget = makeApplication({
-      Model,
-      Flags,
-      init,
-      update,
-      view,
-      container: document.getElementById('widget'),
-    })
-
-    await expect(
-      Effect.runPromise(__startProgram(widget, undefined, 'Hydrate')),
-    ).rejects.toThrow('could not find a server-rendered root')
+    expect(() =>
+      makeApplication({
+        Model,
+        Flags,
+        init,
+        update,
+        view,
+        container: document.getElementById('widget'),
+      }),
+    ).toThrow("container outside the document's server-rendered application")
     expect(serverRoot?.isConnected).toBe(true)
     expect(serverRoot?.textContent).toContain('5')
     expect(serverRoot?.hasAttribute('data-foldkit-app')).toBe(true)
+    expectContained(serverRoot)
   })
 
   it('hydrates the stamped root when the container id resolves to a rendered descendant', async () => {
@@ -417,7 +419,7 @@ describe('hydrating boot', () => {
     }
   })
 
-  it('does not adopt an outer app root from an unstamped container in a multi-rooted page', async () => {
+  it('refuses a multi-rooted page before resolving an unstamped container', async () => {
     await renderServerPage({ start: 5 })
     const ownRoot = document.querySelector('[data-foldkit-app]')
     const otherRoot = document.createElement('div')
@@ -427,22 +429,19 @@ describe('hydrating boot', () => {
     otherRoot.appendChild(nested)
     document.body.appendChild(otherRoot)
 
-    const application = makeApplication({
-      Model,
-      Flags,
-      init,
-      update,
-      view,
-      container: document.getElementById('nested'),
-    })
-
-    await expect(
-      Effect.runPromise(
-        __startProgram(application, undefined, 'Hydrate', undefined, BUILD_ID),
-      ),
-    ).rejects.toThrow('could not find a server-rendered root')
+    expect(() =>
+      makeApplication({
+        Model,
+        Flags,
+        init,
+        update,
+        view,
+        container: document.getElementById('nested'),
+      }),
+    ).toThrow('more than one page-owning application')
     expect(ownRoot?.isConnected).toBe(true)
     expect(otherRoot.getAttribute('data-foldkit-app')).toBe('other')
+    expectContained(ownRoot)
   })
 
   it('throws when two stamped roots share a runtime id', async () => {
@@ -474,10 +473,8 @@ describe('hydrating boot', () => {
     ).toThrow(/more than one server-rendered root stamped "app"/)
   })
 
-  it('accepts two stamped roots with distinct runtime ids', () => {
-    document.body.innerHTML =
-      '<div data-foldkit-app="alpha" id="alpha"></div>' +
-      '<div data-foldkit-app="beta" id="beta"></div>'
+  it('accepts one stamped root with a nondefault runtime id', () => {
+    document.body.innerHTML = '<div data-foldkit-app="alpha" id="alpha"></div>'
 
     const application = makeApplication({
       Model,
@@ -490,38 +487,17 @@ describe('hydrating boot', () => {
     expect(application.runtimeId).toBe('alpha')
   })
 
-  it('pairs each stamped root with its own Flags payload', async () => {
-    // What distinct ids buy is the pairing: a root reads the payload stamped
-    // with its own id and not the other's. They do not make two hydrated
-    // applications independent, which is why that is unsupported: both own the
-    // document's metadata and its navigation listeners.
-    const alpha = await Effect.runPromise(
-      renderToString(serverConfig, {
-        flags: { start: 1 },
-        buildId: BUILD_ID,
-        runtimeId: 'alpha',
-      }),
-    )
-    const beta = await Effect.runPromise(
+  it('pairs a nondefault runtime id with its Flags payload', async () => {
+    const rendered = await Effect.runPromise(
       renderToString(serverConfig, {
         flags: { start: 7 },
         buildId: BUILD_ID,
         runtimeId: 'beta',
       }),
     )
-    document.body.innerHTML = `${alpha.html}${beta.html}`
-
-    const alphaRoot = document.querySelector('[data-foldkit-app="alpha"]')
+    document.body.innerHTML = rendered.html
     const betaRoot = document.querySelector('[data-foldkit-app="beta"]')
 
-    const alphaApplication = makeApplication({
-      Model,
-      Flags,
-      init,
-      update,
-      view,
-      container: document.querySelector('[data-foldkit-app="alpha"]'),
-    })
     const betaApplication = makeApplication({
       Model,
       Flags,
@@ -531,18 +507,8 @@ describe('hydrating boot', () => {
       container: document.querySelector('[data-foldkit-app="beta"]'),
     })
 
-    expect(alphaApplication.runtimeId).toBe('alpha')
     expect(betaApplication.runtimeId).toBe('beta')
 
-    const alphaFiber = Effect.runFork(
-      __startProgram(
-        alphaApplication,
-        undefined,
-        'Hydrate',
-        undefined,
-        BUILD_ID,
-      ),
-    )
     const betaFiber = Effect.runFork(
       __startProgram(
         betaApplication,
@@ -555,28 +521,22 @@ describe('hydrating boot', () => {
 
     try {
       await vi.waitFor(() => {
-        expect(alphaRoot?.textContent).toContain('1')
         expect(betaRoot?.textContent).toContain('7')
       })
-      // Each adopted its own root rather than replacing the other's. Document
-      // metadata and navigation are not divided between them, so nothing here
-      // asserts that they are.
-      expect(alphaRoot?.isConnected).toBe(true)
       expect(betaRoot?.isConnected).toBe(true)
     } finally {
-      await Effect.runPromise(Fiber.interrupt(alphaFiber))
       await Effect.runPromise(Fiber.interrupt(betaFiber))
     }
   })
 
-  it('throws when multiple stamped roots exist and no container disambiguates', async () => {
+  it('throws when multiple stamped roots exist', async () => {
     await renderServerPage({ start: 5 })
     const secondRoot = document.createElement('div')
     secondRoot.setAttribute('data-foldkit-app', 'other')
     document.body.appendChild(secondRoot)
 
     expect(() => makeClientApplication()).toThrow(
-      'multiple server-rendered roots',
+      'more than one page-owning application',
     )
   })
 
@@ -1076,7 +1036,172 @@ describe('hydrating boot', () => {
         view,
         container: nullContainer(),
       }),
-    ).toThrow('no container to disambiguate them')
+    ).toThrow('more than one page-owning application')
+
+    expectContained(servedRoot)
+  })
+
+  it('contains the page when an explicit container selects one of two roots', async () => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector<HTMLElement>('[data-foldkit-app]')
+    if (servedRoot === null) {
+      throw new Error('expected a served root')
+    }
+    const other = servedRoot.cloneNode(true)
+    if (other instanceof Element) {
+      other.setAttribute('data-foldkit-app', 'other-application')
+    }
+    document.body.appendChild(other)
+
+    expect(() =>
+      makeApplication({
+        Model,
+        Flags,
+        init,
+        update,
+        view,
+        container: servedRoot,
+      }),
+    ).toThrow('more than one page-owning application')
+
+    expectContained(servedRoot)
+  })
+
+  it('contains the page when the root stamp is empty', async () => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector<HTMLElement>('[data-foldkit-app]')
+    servedRoot?.setAttribute('data-foldkit-app', '')
+
+    expect(() =>
+      makeApplication({
+        Model,
+        Flags,
+        init,
+        update,
+        view,
+        container: servedRoot,
+      }),
+    ).toThrow('nonempty runtime id')
+
+    expectContained(servedRoot)
+  })
+
+  it('contains the page when its stamped root is inside a shadow tree', async () => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector<HTMLElement>('[data-foldkit-app]')
+    if (servedRoot === null) {
+      throw new Error('expected a served root')
+    }
+    const host = document.createElement('div')
+    const shadowRoot = host.attachShadow({ mode: 'open' })
+    document.body.appendChild(host)
+    shadowRoot.appendChild(servedRoot)
+
+    expect(() =>
+      makeApplication({
+        Model,
+        Flags,
+        init,
+        update,
+        view,
+        container: servedRoot,
+      }),
+    ).toThrow('document light DOM')
+
+    expectContained(servedRoot)
+  })
+
+  it('contains the page when an unstamped container is under a shadow-tree root', async () => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector<HTMLElement>('[data-foldkit-app]')
+    const container = servedRoot?.querySelector<HTMLElement>('#count')
+    if (servedRoot === null || container == null) {
+      throw new Error('expected a served root and descendant')
+    }
+    const host = document.createElement('div')
+    const shadowRoot = host.attachShadow({ mode: 'closed' })
+    document.body.appendChild(host)
+    shadowRoot.appendChild(servedRoot)
+
+    expect(() =>
+      makeApplication({ Model, Flags, init, update, view, container }),
+    ).toThrow('stamped root outside the document body light DOM')
+
+    expectContained(servedRoot)
+  })
+
+  it('contains the document when an unstamped container is under a detached root', async () => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector<HTMLElement>('[data-foldkit-app]')
+    const container = servedRoot?.querySelector<HTMLElement>('#count')
+    if (servedRoot === null || container == null) {
+      throw new Error('expected a served root and descendant')
+    }
+    servedRoot.remove()
+
+    expect(() =>
+      makeApplication({ Model, Flags, init, update, view, container }),
+    ).toThrow('stamped root outside the document body light DOM')
+
+    expect(servedRoot.isConnected).toBe(false)
+    expectContained(null)
+  })
+
+  it('contains a foreign document when its stamped root owns the container', async () => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector<HTMLElement>('[data-foldkit-app]')
+    if (servedRoot === null) {
+      throw new Error('expected a served root')
+    }
+    const otherDocument = document.implementation.createHTMLDocument('other')
+    const adoptedRoot = otherDocument.adoptNode(servedRoot)
+    otherDocument.body.appendChild(adoptedRoot)
+    const container = adoptedRoot.querySelector<HTMLElement>('#count')
+    if (container === null) {
+      throw new Error('expected a served descendant')
+    }
+
+    const showModal = vi
+      .spyOn(HTMLDialogElement.prototype, 'showModal')
+      .mockImplementation(() => {
+        throw new DOMException('The document is not fully active')
+      })
+    try {
+      expect(() =>
+        makeApplication({ Model, Flags, init, update, view, container }),
+      ).toThrow('another document')
+    } finally {
+      showModal.mockRestore()
+    }
+
+    expect(adoptedRoot.isConnected).toBe(true)
+    expect(otherDocument.body.hasAttribute('inert')).toBe(true)
+    expect(otherDocument.body.getAttribute('aria-hidden')).toBe('true')
+    expect(otherDocument.body.hasAttribute('data-foldkit-refused')).toBe(true)
+    const shield = otherDocument.querySelector<HTMLDialogElement>(
+      ':root > dialog[data-foldkit-refusal-shield]',
+    )
+    expect(shield?.open).toBe(true)
+  })
+
+  it('contains the page when its stamped root is outside the body', async () => {
+    await renderServerPage({ start: 5 })
+    const servedRoot = document.querySelector<HTMLElement>('[data-foldkit-app]')
+    if (servedRoot === null) {
+      throw new Error('expected a served root')
+    }
+    document.head.appendChild(servedRoot)
+
+    expect(() =>
+      makeApplication({
+        Model,
+        Flags,
+        init,
+        update,
+        view,
+        container: servedRoot,
+      }),
+    ).toThrow('outside the document body')
 
     expectContained(servedRoot)
   })

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -649,13 +649,10 @@ const hydrationForRoot = (
 // id (a descendant `id="root"`) and `getElementById` returned that inner element
 // instead of the stamped root above it. That inner element resolves to the app
 // root only when the page has exactly one stamped root and this container sits
-// inside it, so a sibling widget (a stamped root the container is not inside) or
-// an outer application's root (when a nested page carries more than one stamped
-// root) is never wrongly adopted; those fall through to a fresh boot or a hard
-// failure instead. A null container is the replace-parity case, where the server
-// root took the placeholder's place and `getElementById` no longer finds it, so
-// the stamp is the only handle; more than one stamped root is then ambiguous and
-// a hard error rather than a silent wrong-DOM adoption.
+// inside it. A container outside that root is a refused handoff, not a fresh
+// application beside server markup that remains live. A null container is the
+// replace-parity case, where the server root took the placeholder's place and
+// `getElementById` no longer finds it, so the stamp is the only handle.
 // A runtime id names one application for the whole page: it pairs a root with
 // its Flags payload, and it keys the Model and scroll position hot reloading
 // preserves. Two roots sharing one are not two applications but one claimed
@@ -672,6 +669,24 @@ const assertRuntimeIdsAreUnique = (
   const seen = new Set<string>()
   for (const root of stampedRoots) {
     const runtimeId = root.getAttribute(FOLDKIT_APP_ATTRIBUTE) ?? ''
+    if (runtimeId === '') {
+      containRefusedPage(root.ownerDocument)
+      throw new Error(
+        '[foldkit] Found a server-rendered root with an empty ' +
+          `\`${FOLDKIT_APP_ATTRIBUTE}\` stamp. A hydratable root must carry ` +
+          'a nonempty runtime id so the runtime can pair it with its Flags ' +
+          'payload and preserved HMR state.',
+      )
+    }
+    if (!root.ownerDocument.body?.contains(root)) {
+      containRefusedPage(root.ownerDocument)
+      throw new Error(
+        '[foldkit] Found a server-rendered root outside the document body. ' +
+          'Runtime.hydrate supports one page-owning application in the ' +
+          'document light DOM. Do not hydrate a root in the head, a shadow ' +
+          'tree, or a detached subtree.',
+      )
+    }
     if (seen.has(runtimeId)) {
       containRefusedPage(root.ownerDocument)
       throw new Error(
@@ -679,11 +694,26 @@ const assertRuntimeIdsAreUnique = (
           `"${runtimeId}". A runtime id names one application for the whole ` +
           'page: it pairs a root with its Flags payload and keys the Model and ' +
           'scroll position hot reloading preserves, so two roots sharing one ' +
-          "would take each other's state. Render each application with its " +
-          'own `runtimeId`.',
+          "would take each other's state. Remove the duplicate root. Foldkit " +
+          'hydrates one page-owning application per document.',
       )
     }
     seen.add(runtimeId)
+  }
+}
+
+const assertSinglePageApplication = (
+  stampedRoots: ReadonlyArray<HTMLElement>,
+): void => {
+  if (stampedRoots.length > 1) {
+    containRefusedPage(document)
+    throw new Error(
+      '[foldkit] Found more than one page-owning application stamped with ' +
+        `\`${FOLDKIT_APP_ATTRIBUTE}\`. Hydrating multiple applications in ` +
+        'one document is not supported: each application owns the document ' +
+        'metadata and installs document-wide navigation listeners. Render ' +
+        'one application per page.',
+    )
   }
 }
 
@@ -793,15 +823,28 @@ const preventRefusalShieldInteraction = (event: Event): void => {
   event.stopImmediatePropagation()
 }
 
+// NOTE: `showModal` throws when the owning document is not fully active. A
+// foreign or detached document still needs the original Foldkit refusal rather
+// than a browser exception from its containment UI.
+const tryOpenRefusalShieldAsModal = (shield: HTMLDialogElement): boolean => {
+  if (typeof shield.showModal !== 'function') {
+    return false
+  }
+  try {
+    shield.showModal()
+    return true
+  } catch {
+    return false
+  }
+}
+
 const openRefusalShield = (shield: HTMLDialogElement): void => {
   shield.inert = true
   shield.setAttribute('inert', '')
   if (shield.open && typeof shield.close === 'function') {
     shield.close()
   }
-  if (typeof shield.showModal === 'function') {
-    shield.showModal()
-  } else {
+  if (!tryOpenRefusalShieldAsModal(shield)) {
     shield.setAttribute('open', '')
   }
   shield.inert = false
@@ -888,29 +931,53 @@ const findDocumentHydration = (
     document.querySelectorAll<HTMLElement>(`[${FOLDKIT_APP_ATTRIBUTE}]`),
   )
   assertRuntimeIdsAreUnique(stampedRoots)
+  assertSinglePageApplication(stampedRoots)
   if (container !== null) {
+    const stampedAncestor = container.closest<HTMLElement>(
+      `[${FOLDKIT_APP_ATTRIBUTE}]`,
+    )
     if (container.hasAttribute(FOLDKIT_APP_ATTRIBUTE)) {
+      const isDocumentRoot = Option.match(Array.head(stampedRoots), {
+        onNone: () => false,
+        onSome: root => root === container,
+      })
+      if (!isDocumentRoot) {
+        containRefusedPage(container.ownerDocument)
+        throw new Error(
+          '[foldkit] Runtime.hydrate received a stamped container that is ' +
+            'not the single server root in the document light DOM. Hydration ' +
+            'supports one page-owning application under the document body. ' +
+            'Do not hydrate a root in a shadow tree or detached subtree.',
+        )
+      }
       return hydrationForRoot(container, isFlagsRequired)
     }
     return Array.match(stampedRoots, {
-      onEmpty: () => undefined,
+      onEmpty: () => {
+        if (stampedAncestor === null) {
+          return undefined
+        }
+        containRefusedPage(container.ownerDocument)
+        throw new Error(
+          '[foldkit] Runtime.hydrate received a container under a stamped ' +
+            'root outside the document body light DOM. Do not hydrate a root ' +
+            'in a shadow tree, detached subtree, or another document.',
+        )
+      },
       onNonEmpty: roots => {
         const onlyRoot = Array.headNonEmpty(roots)
-        return roots.length === 1 &&
-          container.closest(`[${FOLDKIT_APP_ATTRIBUTE}]`) === onlyRoot
-          ? hydrationForRoot(onlyRoot, isFlagsRequired)
-          : undefined
+        if (stampedAncestor === onlyRoot) {
+          return hydrationForRoot(onlyRoot, isFlagsRequired)
+        }
+        containRefusedPage(container.ownerDocument)
+        throw new Error(
+          '[foldkit] Runtime.hydrate received a container outside the ' +
+            "document's server-rendered application root. A page-owning " +
+            'application must adopt that single root rather than boot beside ' +
+            'server markup it does not own.',
+        )
       },
     })
-  }
-  if (stampedRoots.length > 1) {
-    containRefusedPage(document)
-    throw new Error(
-      '[foldkit] Found multiple server-rendered roots stamped with ' +
-        `\`${FOLDKIT_APP_ATTRIBUTE}\` but no container to disambiguate them. ` +
-        'Give each app its own container element so the runtime can tell ' +
-        'which root to hydrate.',
-    )
   }
   return Option.match(Array.head(stampedRoots), {
     onNone: () => undefined,
@@ -3747,8 +3814,9 @@ const renderCrashView = <Model, Message>(
 /** Creates a Foldkit application that owns the page and returns a runtime that
  *  can be passed to `run`. The `view` returns a `Document`, so the runtime
  *  manages `document.title` and the canonical / og:url tags. Add a `routing`
- *  config for URL routing. To mount an app scoped to a node without touching the
- *  document `<head>`, use `makeElement`. */
+ *  config for URL routing. Use one page-owning application per document. To
+ *  mount an app scoped to a node without touching the document `<head>`, use
+ *  `makeElement`. */
 export function makeApplication<
   Model,
   Message extends { _tag: string },
@@ -4400,10 +4468,11 @@ export type HydrateOptions = Readonly<{
  *  of building it fresh. Use this as the client entry for a page served by
  *  `renderToString`: the first render attaches to the stamped root, keeps the
  *  existing nodes, and reconstructs the Model from the Flags the server
- *  embedded. The handoff is strict: a missing server root, a root stamped more
- *  than once, more than one root with no container to choose between them, a
- *  missing Flags payload, an undecodable payload, or a page from another
- *  deployment terminates startup. Every one of those contains the page first:
+ *  embedded. The handoff is strict: a missing server root, an empty or
+ *  duplicated root stamp, more than one stamped root, a requested root outside
+ *  the document body light DOM, a missing Flags payload, an undecodable
+ *  payload, or a page from another deployment terminates startup. Every one of
+ *  those contains the page first:
  *  the document's body is marked `inert` and a nondismissable modal shield is
  *  opened above existing top-layer content, so pointer and physical keyboard
  *  input do not activate same-document native links, forms, or controls.

--- a/packages/website/src/page/core/serverRendering.md
+++ b/packages/website/src/page/core/serverRendering.md
@@ -103,11 +103,17 @@ Foldkit rejects extra top-level content, ambiguous handoff markers, and source t
 
 ### Application ownership
 
-`runtimeId` names one application on the page. It pairs a root with its Flags payload. It also keys the Model and scroll position preserved by hot reloading.
+`runtimeId` pairs one hydratable root with its Flags payload. It also keys the Model and scroll position preserved by hot reloading. A nondefault id changes that pairing. It does not create another document owner.
 
-Two roots with the same id are one application claimed twice. The second boot would read the first root's Flags and restore its Model. `injectIntoTemplate` refuses to build that page, and `Runtime.hydrate` refuses one assembled elsewhere. This rule also applies when the applications declare no Flags because hot reloading still uses the id.
+A document may contain one hydratable Foldkit root. `injectIntoTemplate` refuses to insert a hydratable render when the template already contains one, even when the ids differ. `Runtime.hydrate` refuses and contains a page assembled elsewhere when it finds more than one stamped root. An explicit container does not override this rule.
 
-Hydrating more than one application on a page is not supported. A page-owning `makeApplication` controls the document title, language, text direction, canonical URL, and Open Graph URL. It also installs document-wide navigation listeners. With two applications, the last render owns the metadata and the first listener handles every link. Distinct ids prevent roots from taking each other's handoff, but they do not divide document ownership. Render one application per page.
+Two roots with the same id would also read the same Flags and preserved HMR state. Foldkit reports that collision specifically, but distinct ids do not make multiple page-owning applications valid.
+
+The root stamp must have a nonempty id and name the document's single stamped root in the body light DOM. A requested root in `<head>`, a shadow tree, a detached subtree, or another document is refused and the page is contained before startup. When the configured container resolves to an element, it must be that root or one of its descendants.
+
+A page-owning `makeApplication` controls the document title, language, text direction, canonical URL, and Open Graph URL. It also installs document-wide navigation listeners. With two applications, the last render would own the metadata and the first listener would handle every link. Render one application per page.
+
+Static body output carries no handoff stamp. It may coexist with the document's one hydratable application. Each call to `injectIntoTemplate` still applies that render's `Document` head fields, so insertion order decides which render supplies the initial page metadata.
 
 ### Supported templates and roots
 
@@ -289,8 +295,8 @@ Every refusal reports a `[foldkit]` error that names the cause. Failures found w
 Build skew is one reason to refuse. The same policy also covers:
 
 - A Flags payload that is missing, duplicated, malformed, or rejected by the Schema.
-- A runtime id claimed by two roots.
-- More than one stamped root when no container identifies the one to adopt.
+- A runtime id claimed by two roots, or more than one stamped root with distinct ids.
+- An empty root stamp, or a requested stamped root outside the document body light DOM.
 - A served root that lost its stamp. A generated client reaches this state when template insertion already replaced its `#root` placeholder, leaving neither the stamp nor the placeholder.
 
 One missing-container case is different. If `makeApplication` cannot find its container and the document contains no `data-foldkit-app`, `data-foldkit-build`, or `data-foldkit-flags`, then no server rendered the page. The application's `<div id="root">` is simply absent, usually because of a typo or because the script ran too early. Foldkit reports the setup error and leaves the page alone.

--- a/scripts/check-packed-ssr-consumer.ts
+++ b/scripts/check-packed-ssr-consumer.ts
@@ -2476,7 +2476,7 @@ const main = async (): Promise<void> => {
           for (const [path, expected] of [
             ['/no-stamp', 'Container is null'],
             ['/duplicate-roots', 'more than one server-rendered root stamped'],
-            ['/ambiguous-roots', 'no container to disambiguate them'],
+            ['/ambiguous-roots', 'more than one page-owning application'],
           ]) {
             const reading = await readPage(browser, String(path), 'Refused')
             assertConsumer(


### PR DESCRIPTION
## Summary

- Enforce the documented one page-owning hydratable application per document contract.
- Refuse and contain multiple roots, empty runtime IDs, roots outside the document body light DOM, foreign-document roots, and configured containers outside the served root.
- Reject a second hydratable template insertion while preserving static body composition. Document that insertion order still controls the initial Document metadata.
- Preserve the Foldkit refusal diagnostic when an inactive foreign document rejects `dialog.showModal()`.

## Verification

- Foldkit: 2,280 passed, 1 skipped
- Website: 456 passed
- Focused hydration and template tests: 118 passed
- Foldkit, scripts, and website typechecks
- Oxlint, Knip, and Prettier
- Website production build
- Packed npm consumer with real Chromium hydration and containment
- Script tests: 55 passed
- Mutation checks for every new refusal guard, template enforcement, packed diagnostic, and modal fallback
- Two independent final reviews: no remaining findings