### PR TITLE
docs(website): improve documentation clarity and structure

### DIFF
--- a/packages/website/src/markdown/docPage.test.ts
+++ b/packages/website/src/markdown/docPage.test.ts
@@ -170,7 +170,7 @@ describe('proof pages', () => {
 
   test('commands table of contents', () => {
     expect(tocOf(commandsSource)).toEqual([
-      { level: 'h2', id: 'overview', text: 'Overview' },
+      { level: 'h2', id: 'overview', text: 'One-Shot Effects as Data' },
       { level: 'h2', id: 'anatomy-of-a-command', text: 'Anatomy of a Command' },
       { level: 'h2', id: 'testable-by-design', text: 'Testable by Design' },
       { level: 'h2', id: 'http-requests', text: 'HTTP Requests' },

--- a/packages/website/src/page/asyncData.md
+++ b/packages/website/src/page/asyncData.md
@@ -1,6 +1,6 @@
 # Async Data
 
-`foldkit/asyncData` is a shipped Foldkit module: a plain value type in the spirit of `Option` and `Result` from Effect, built for data that arrives asynchronously. It provides a value type, not an application pattern. This page introduces the type, the mental model, and the combinators you reach for most. The [API Reference](/api-reference/async-data) has the exhaustive catalog.
+`foldkit/asyncData` is a plain value type in the spirit of Effect’s `Option` and `Result`, built for data that arrives asynchronously. This page introduces the state model and the combinators you reach for most. The [API Reference](/api-reference/async-data) has the exhaustive catalog.
 
 ## Overview
 
@@ -31,7 +31,7 @@ Three classifications recur across the API, and every combinator is derived from
 
 - “has data”: `Success`, `Refreshing`, `Stale`.
 - “no data”: `Idle`, `Loading`, `Failure`.
-- “pending” (a request in flight): `Loading` and `Refreshing` only. `Stale` is NOT pending; its fetch already failed.
+- “pending” (a request in flight): `Loading` and `Refreshing` only. `Stale` is not pending; its fetch already failed.
 
 :::Info{label="Coming from Elm"}
 The classic Elm RemoteData has four states (`NotAsked`, `Loading`, `Failure`, `Success`). `Refreshing` and `Stale` are the two states this module adds, and they are the whole point of the next section.
@@ -49,7 +49,7 @@ Because both are type-level states, “show stale data while revalidating” and
 
 ## The Schema Builder
 
-`AsyncData.Schema(dataSchema, errorSchema)` returns the codec you embed in a Model, plus Schema-tightened constructors. The returned `.schema` is the six-state Union codec. This is the generic successor to the monomorphic factory the app used to hand-roll.
+`AsyncData.Schema(dataSchema, errorSchema)` returns the codec you embed in a Model, plus constructors constrained to those data and error types. The returned `.schema` is the six-state Union codec.
 
 ::Snippet{name="asyncDataSchema" label="Schema builder code"}
 
@@ -65,17 +65,17 @@ To construct a value, use the namespace constructors (generic in `A`/`E`) or the
 
 ## Working With the Value
 
-The API is a namespace of free, curried-dual functions over `AsyncData<A, E>` values, exactly like `Option`, `Result`, and `Exit`. Every dual ships its data-last overload first, so `pipe(notes, AsyncData.map(f))` and `AsyncData.map(notes, f)` both work.
+The API is a namespace of free, curried-dual functions over `AsyncData<A, E>` values, like `Option`, `Result`, and `Exit`. Both `pipe(notes, AsyncData.map(f))` and `AsyncData.map(notes, f)` work.
 
 The fundamental way to read a value is `match`. It dispatches on the tag and passes the unwrapped payload to each of six required handlers. Handler keys are tag-named here because each handler covers exactly one tag. The one asymmetry is `onStale`, which receives the whole `{ error, data }` object, because only `Stale` carries two fields.
 
 ::Snippet{name="asyncDataMatch" label="match code"}
 
-Most views do not need six arms. `matchData` collapses the six states into the three channels a view usually renders: `onData` spans `Success`, `Refreshing`, AND `Stale`, `onFailure` receives the `Failure` error, and `onEmpty` covers `Idle` and `Loading` together. Routing `Stale` through `onData` is the point of keeping its data. `matchDataSplitEmpty` is the same collapse with the two cold states split into `onIdle` and `onLoading`, for views that render them differently; reach for `match` when the stale error or the `Refreshing` signal matters.
+Most views do not need six arms. `matchData` collapses the six states into the three channels a view usually renders: `onData` spans `Success`, `Refreshing`, and `Stale`; `onFailure` receives the `Failure` error; and `onEmpty` covers `Idle` and `Loading` together. Routing `Stale` through `onData` is the point of keeping its data. `matchDataSplitEmpty` is the same collapse with the two cold states split into `onIdle` and `onLoading`, for views that render them differently. Reach for `match` when the stale error or the `Refreshing` signal matters.
 
 ::Snippet{name="asyncDataMatchData" label="matchData code"}
 
-`AsyncData.map` transforms every data-bearing state and preserves its tag, so a pure transform does not erase the `Refreshing` or `Stale` signal. `Stale` maps only its `data` and keeps its `error`. This is the free-function replacement for the app’s old bound `mapData`, and it is how a mutation edits the cached list in place.
+`AsyncData.map` transforms every data-bearing state and preserves its tag, so a pure transform does not erase the `Refreshing` or `Stale` signal. `Stale` maps only its `data` and keeps its `error`. This is how a mutation can edit cached data in place without erasing its request state.
 
 ::Snippet{name="asyncDataMap" label="map code"}
 
@@ -84,7 +84,7 @@ Most views do not need six arms. `matchData` collapses the six states into the t
 ::Snippet{name="asyncDataGetData" label="getData code"}
 
 :::Info{label="Stale is not pending"}
-`isPending` is true for `Loading` and `Refreshing` only, NOT `Stale`. It answers “is a request in flight”, so it drives a spinner regardless of whether data is held. `Stale` is not pending: in this union it does not mean merely outdated data, it is specifically the state a failed refresh leaves behind, which is why it always carries the error.
+`isPending` is true for `Loading` and `Refreshing` only, not `Stale`. It answers “is a request in flight”, so it drives a spinner regardless of whether data is held. `Stale` does not mean merely outdated data in this union. It is specifically the state a failed refresh leaves behind, which is why it always carries the error.
 :::
 
 The getter vocabulary is deliberate: predicates are tag-named (`isSuccess`, `isFailure`) but getters are payload-named (`getData`, `getError`, and their boolean twins `hasData`, `hasError`), because `getData` spans three tags and `getError` spans two, so a tag-named getter would be wrong.
@@ -138,8 +138,6 @@ The precedence, most to least dominant, is `Failure > Loading > Idle > Stale > R
 :::Warning{label="All-or-nothing on data"}
 The combine is all-or-nothing on data. Because the combined value needs every input’s data, a single no-data child collapses the whole result to that non-data state. `zipWith(Idle, Success(x), f)` discards `x` and yields `Idle`. This is forced, not a bug. Combining also requires a shared error type `E`; unify heterogeneous errors with `mapError` first.
 :::
-
-This section is the mental model; reach for the record form of `all` when one screen depends on several fields at once.
 
 An `AsyncData` field lives in one place: the [Model](/core/model), the single source of truth. Fetches are [Commands](/core/commands): run the fetch through `Effect.result`, carry the `Result` in the Message, and fold it in with `settle`. [Field Validation](/core/field-validation) is the sibling shipped module in the same tier, and the [API Reference](/api-reference/async-data) has the generated, exhaustive catalog of every name and its per-state behavior.
 

--- a/packages/website/src/page/core/architecture.md
+++ b/packages/website/src/page/core/architecture.md
@@ -1,21 +1,19 @@
 # Architecture
 
-## Overview
+## One State Tree {#overview}
 
-In most TypeScript UI frameworks, each component manages its own state and effects. In Foldkit, there’s a single state tree. Every change flows in one direction through the same loop.
+In most TypeScript UI frameworks, each component manages its own state and effects. Foldkit keeps application state in one `Model` and sends every change through the same loop.
 
-This pattern is called [The Elm Architecture](https://guide.elm-lang.org/architecture/). You don’t need to know Elm. Foldkit adapts it for TypeScript and Effect.
+This pattern is called [The Elm Architecture](https://guide.elm-lang.org/architecture/). You don’t need to know Elm to use it. Foldkit adapts the pattern for TypeScript and Effect so state transitions stay explicit and traceable.
 
 ## The Loop
 
-Every Foldkit app runs the same loop. A `Message` arrives: the user clicked a button, a timer fired, an HTTP response came back. The `update` function receives the current `Model` and the Message and returns a new Model along with any `Command`s to execute. The `view` function renders the new Model as HTML. When the user interacts with the view, it produces another Message, and the loop continues.
+Every Foldkit app repeats the same cycle:
 
-- **Commands:** descriptions of one-shot side effects: HTTP requests, focus operations, `localStorage` writes, navigation calls. The Foldkit runtime executes them and sends their results back as new Messages, feeding them into the same loop. Each Command carries a name, which surfaces in [DevTools](/core/devtools), [tests](/testing), and tracing.
-- **Mount:** an Effect scoped to the lifetime of an element in the live DOM. Mount is the seam where view code can drop down to imperative work with the live element. For example: portaling an overlay to the document body, attaching observers, or handing the element to a third-party library that owns its own DOM. `Mount.define` runs an Effect that emits a single Message at acquire; `Mount.defineStream` runs a Stream of Messages from observers or listeners on the element. The runtime dispatches results back through `update` and runs the paired cleanup when the element unmounts.
-- **Subscriptions:** a scoped Stream gated by a slice of your Model. You are subscribed to the Model, not to an external event source. The runtime keeps the Stream alive while the slice holds its value and starts a fresh scope when the slice changes. The body usually plugs an external source (timer ticks, keypresses, `WebSocket` frames, system theme changes) into a Stream that flows back through `update` as Messages. Some Subscriptions emit no Messages and instead maintain DOM state for their lifetime, like setting `user-select: none` while a drag is active.
-- **ManagedResources:** declarations of a resource (a camera stream, a `WebSocket` connection, a Web Worker pool) made available to Commands and Subscriptions while a slice of the Model holds a particular value. The runtime acquires the resource when the slice says it should be alive, releases it when the slice says it should not, and dispatches Messages for each lifecycle transition. Commands and Subscriptions consume the resource as a typed handle (capturing a photo from the camera, sending a frame on the socket), with `ResourceNotAvailable` rather than a crash if the handle is not currently available.
-
-That’s it. Every state transition in your app flows through a single loop. There’s no action-at-a-distance, no hidden state mutation, no effect that runs outside the cycle. If you want to know how the app got into its current state, you follow the Messages.
+1. Something happens, and a `Message` records that fact.
+2. `update` receives the current `Model` and the Message, then returns the next Model and any `Command`s to execute.
+3. `view` renders the next Model as HTML, and the runtime executes the Commands.
+4. User events and effect results produce more Messages, and the cycle begins again.
 
 The complete cycle looks like this:
 
@@ -45,25 +43,35 @@ Model    Array<Command<Message>>                                 |
 
 Every path on the right side produces a Message that feeds back into `update`. Five sources: Commands, the Browser, Mount, Subscriptions, and ManagedResources. One loop.
 
-Sitting beneath the loop are Resources: app-lifetime singletons like an `RpcClient`, an analytics client, or a background compute worker that Commands draw on. Resources don’t produce Messages themselves. They’re the ambient dependencies the Message-producing parts need to do their work.
+### Where Messages Come From
+
+- **Browser:** interactions with the rendered view, such as clicks and keypresses, produce Messages directly.
+- **Commands:** one-shot side effects such as HTTP requests, focus operations, `localStorage` writes, and navigation calls. The runtime executes each Command and sends its declared result back as a Message. Every Command has a name that appears in [DevTools](/core/devtools), [tests](/testing), and tracing.
+- **Mount:** imperative work scoped to the lifetime of an element in the live DOM. For example: portaling an overlay, attaching an observer, or handing an element to a third-party library. `Mount.define` runs an Effect that emits one Message at acquire. `Mount.defineStream` runs a Stream of Messages from listeners or observers. The runtime dispatches those results and runs the paired cleanup when the element unmounts.
+- **Subscriptions:** scoped Streams gated by a slice of the Model. The runtime keeps a Subscription alive while that slice holds its value, then starts a fresh scope when the value changes. A Subscription often turns an external source, such as timer ticks, `WebSocket` frames, or system theme changes, into Messages. It can also emit no Messages and maintain DOM state for its lifetime, such as setting `user-select: none` while a drag is active.
+- **ManagedResources:** stateful handles, such as a camera stream, a `WebSocket` connection, or a Web Worker pool, that exist while a slice of the Model holds a particular value. The runtime acquires and releases the handle and dispatches Messages for each lifecycle transition. Commands and Subscriptions can use the typed handle while it is live and receive `ResourceNotAvailable` rather than crashing when it is not.
+
+Resources sit beneath the loop instead of feeding it directly. They are app-lifetime dependencies such as an `RpcClient`, an analytics client, or a background compute worker. The runtime shares them with Commands, Subscriptions, and startup Flags, but Resources do not produce Messages themselves.
+
+These sources never mutate the Model. They report what happened with a Message, and only `update` decides the next state. If you want to know how the app reached its current state, follow the Messages.
 
 ## Definitions
 
-Each concept in one place, in plain terms:
+Use this table as a reference after you understand the loop:
 
-| Concept         | Definition                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Model           | The single data structure that holds your entire application state.                                                                                                                                                                                                                                                                                                                                                                                                           |
-| Message         | A fact about something that happened: a button was clicked, a key was pressed, a request succeeded with a payload.                                                                                                                                                                                                                                                                                                                                                            |
-| update          | A pure function that receives the current Model and a Message and returns a new Model along with any Commands to execute.                                                                                                                                                                                                                                                                                                                                                     |
-| view            | A pure function that renders the Model as HTML. User interactions produce Messages that flow back into update.                                                                                                                                                                                                                                                                                                                                                                |
-| Command         | A description of a one-shot side effect. The runtime executes it and sends the result back as one of its declared Messages.                                                                                                                                                                                                                                                                                                                                                   |
-| Mount           | The seam where view code reaches a live DOM element. Mount.define runs an Effect that emits a single Message at acquire; Mount.defineStream runs a Stream of Messages from observers on the element. The runtime dispatches results through update and runs the paired cleanup on unmount.                                                                                                                                                                                    |
-| Subscription    | A scoped Stream gated by a slice of your Model. The runtime keeps it alive while the slice holds its value and starts a fresh scope when the slice changes. The body usually pipes external events back as Messages; some Subscriptions emit nothing and just maintain DOM state for the subscription’s lifetime.                                                                                                                                                             |
-| Resource        | An app-lifetime singleton (an RPC client, an analytics client, a compute worker) that Commands can draw on. A dependency, not a Message source.                                                                                                                                                                                                                                                                                                                               |
-| ManagedResource | Like a Resource, but scoped to a window of Model state instead of the app lifetime: a WebSocket connection while the user is on a chat page, a camera stream during a video call. Commands and Subscriptions consume it as a typed handle while it’s live; the runtime acquires it on entry, releases it on exit, and dispatches Messages for each lifecycle transition.                                                                                                      |
-| Runtime         | The Foldkit engine that executes Commands, runs Subscriptions, manages resource and mount lifecycles, and routes Messages back into update.                                                                                                                                                                                                                                                                                                                                   |
-| Submodel        | A self-contained Model, Message, update, and Commands that a parent embeds as a field and delegates to in update. Submodels are how an app grows past a single update function: the stateful Foldkit UI components (Menu, Listbox, DatePicker, and friends) ship as Submodels, and you build your own for feature pages, repeated forms, or any unit of composition. Children surface high-level facts to parents through an OutMessage in the third tuple element of update. |
+| Concept         | Definition                                                                                                                                                                                                           |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Model           | The single data structure that holds the entire application state.                                                                                                                                                   |
+| Message         | A fact about something that happened, such as a button click, a keypress, or a successful request with a payload.                                                                                                    |
+| update          | A pure function that receives the current Model and a Message, then returns the next Model and any Commands to execute.                                                                                              |
+| view            | A pure function that renders the Model as HTML. Its event handlers construct Messages.                                                                                                                               |
+| Command         | A description of a one-shot side effect. The runtime executes it and sends the result back as one of its declared Messages.                                                                                          |
+| Mount           | Imperative work scoped to a live DOM element. It emits Messages through an Effect or Stream and cleans up when the element unmounts.                                                                                 |
+| Subscription    | A scoped Stream gated by a slice of the Model. The runtime restarts its scope when that slice changes.                                                                                                               |
+| Resource        | An app-lifetime singleton shared with Commands, Subscriptions, and startup Flags. It is a dependency, not a Message source.                                                                                          |
+| ManagedResource | A stateful handle scoped to a slice of the Model. The runtime manages its lifecycle, and Commands and Subscriptions can use it while it is live.                                                                     |
+| Runtime         | The Foldkit engine that executes Commands, runs Subscriptions, manages Mount and resource lifecycles, and routes Messages back into update.                                                                          |
+| Submodel        | A self-contained Model, Message, update, and Commands that a parent embeds and delegates to. A child can surface high-level facts to its parent through an OutMessage in the third tuple element returned by update. |
 
 ## The Restaurant Analogy
 
@@ -72,7 +80,7 @@ Think of a Foldkit app like a restaurant. The waiter keeps a notebook: a running
 Messages work the same way. “Table 3 asked for the check” is a fact given to the waiter, not an instruction. The waiter decides what to do: maybe bring the check immediately, maybe offer dessert first. The message stays the same either way.
 
 :::Info{label="The restaurant analogy"}
-This analogy maps to every concept you’ll encounter in Core Concepts. The table below is a reference you can come back to as you read.
+Use the analogy to remember who knows the state and who performs effects. The definitions above remain the literal contracts.
 :::
 
 | Foldkit         | Restaurant                                                                                                                  |

--- a/packages/website/src/page/core/canvas.md
+++ b/packages/website/src/page/core/canvas.md
@@ -2,22 +2,26 @@
 
 ## Overview
 
-The `Canvas` module is a declarative 2D rendering surface. `Canvas.view` produces a `<canvas>` VNode whose pixels are a pure function of a `shapes` prop: same shapes, same pixels. Because the view function is pure and the runtime re-paints on every patch, DevTools time-travel reproduces past frames exactly.
+The `Canvas` module makes 2D canvas rendering declarative. `Canvas.view` returns a `<canvas>` VNode whose dimensions, scene, styling, and pointer Messages come from one config object.
 
-Reach for it for pixel art, board games, card games, 2D puzzlers, generative art, charts, and dataviz. The [canvas-art example](/example-apps/canvas-art) demonstrates the API end-to-end with a click-to-spawn bouncing-balls scene.
+The scene is a `ReadonlyArray<Shape>`. Foldkit clears and repaints the canvas when the VNode is inserted and after every patch, so the pixels contain no hidden application state. The same shapes produce the same pixels, and DevTools time-travel can reproduce an earlier frame by rendering its Model again.
+
+Use Canvas for interfaces whose natural representation is a 2D scene. For example: pixel art, board games, generative art, charts, and data visualization. The [canvas-art example](/example-apps/canvas-art) shows the full update loop with a click-to-spawn bouncing-ball scene.
 
 ## Shapes
 
-A scene is a `ReadonlyArray<Shape>`. Each `Shape` is a tagged variant: `Rect`, `Circle`, `Path`, `Text`, or `Group`. `Group` wraps children in a 2D transform (`translate`, `rotate`, `scale`, `opacity`) and composes recursively. `Path` is built from a sequence of `PathInstruction` values: `MoveTo`, `LineTo`, `QuadTo`, `BezierTo`, `Close`.
+Canvas has five `Shape` variants: `Rect`, `Circle`, `Path`, `Text`, and `Group`. Each is a Schema-backed constructor.
 
-## Animation and input
+`Group` applies translation, rotation, scale, or opacity to child shapes. Groups can nest, so transforms compose into a scene graph. `Path` draws a sequence of `MoveTo`, `LineTo`, `QuadTo`, `BezierTo`, and `Close` instructions. Fill, stroke, and line styles stay on the shape that uses them.
 
-For continuous animation, pair `Canvas.view` with [Subscription.animationFrame](/core/subscriptions#animation-frames): a helper that emits a Message every `requestAnimationFrame` tick with the inter-frame delta in milliseconds. update advances the Model in response, and `Canvas.view` re-renders whenever the Model changes (Foldkit batches renders to one per frame).
+## Animation and Input
 
-Pointer handlers are config args on `Canvas.view`: `onPointerDown`, `onPointerMove`, `onPointerUp`. Each receives a `Point` already translated into the canvas’s internal coordinate space (the `width` and `height` you passed), regardless of how the canvas is sized in CSS.
+For continuous animation, pair `Canvas.view` with [`Subscription.animationFrame`](/core/subscriptions#animation-frames). The Subscription emits a Message on each `requestAnimationFrame` tick with the inter-frame delta in milliseconds. The update function advances the Model, view derives the next shapes, and Foldkit batches the resulting patches to one per frame.
+
+`Canvas.view` accepts `onPointerDown`, `onPointerMove`, and `onPointerUp` callbacks. Each receives a `Point` translated into the internal coordinate space set by `width` and `height`, regardless of the canvas's CSS size. Passing the current view builder as the second argument binds the callbacks to that view's Message type.
 
 ::Snippet{name="canvasBasic" label="Canvas example"}
 
-## Full API surface
+## Full API Surface
 
-The [Canvas API reference](/api-reference/canvas) lists every shape constructor, the `PathInstruction` variants, and `Canvas.view` with full signatures.
+The [Canvas API reference](/api-reference/canvas) lists every shape constructor, every `PathInstruction` variant, and the full `Canvas.view` config.

--- a/packages/website/src/page/core/commands.md
+++ b/packages/website/src/page/core/commands.md
@@ -1,101 +1,123 @@
 # Commands
 
-## Overview
+## One-Shot Effects as Data {#overview}
 
-A Command is a description of a side effect: an HTTP request, a one-shot delay, a DOM focus call. The update function doesn’t actually do anything on its own. It returns data, and the Foldkit runtime reads the Commands and carries them out.
+A Command describes one side effect, such as an HTTP request, a delay, or a DOM focus call. Update returns that description as data. The Foldkit runtime executes it and dispatches the resulting Message.
 
-In the [restaurant analogy](/core/architecture#the-restaurant-analogy), Commands are the slips the waiter hands to the kitchen. The waiter doesn’t cook. They describe what’s needed and hand it off. The kitchen does the work and reports back when it’s done.
-
-When update runs, no HTTP request fires, no timer starts, no DOM changes. It returns a new Model and a list of Commands that describe what should happen, and the runtime executes them.
+Nothing happens while update runs. No request fires, timer starts, or DOM changes. Update returns a Model and a list of Commands, preserving the purity of every state transition.
 
 :::Info{label="A different model for side effects"}
-In React, event handlers do things directly: call `fetch()`, start a timer, write to `localStorage`. In Foldkit, update is pure. It describes what should happen and the runtime does it.
+React event handlers often perform work directly by calling `fetch()`, starting a timer, or writing to `localStorage`. In Foldkit, update describes the work and the runtime performs it.
 :::
 
-So far, update has been returning an empty Commands array. Let’s put it to use. Say we want a delayed reset: when the user clicks reset, the count resets after one second:
+The counter has returned an empty Commands array so far. A delayed reset puts that second return value to work:
 
 ::Snippet{name="counterCommands" label="commands example"}
 
 ## Anatomy of a Command
 
-Look at what update does when `ClickedResetAfterDelay` arrives: it returns the Model unchanged, along with `DelayReset()`, a Command that describes a one-second delay. The update function didn’t start a timer. It handed the runtime a description that says “wait one second, then send me `CompletedDelayReset`.” The runtime does the waiting. When the delay fires, `CompletedDelayReset` arrives as a new Message, and update resets the count to zero.
+When `ClickedResetAfterDelay` arrives, update keeps the Model unchanged and returns `DelayReset()`. The runtime waits one second, then dispatches `CompletedDelayReset`. That new Message reaches update, which resets the count to zero.
 
-Every Command declares three things: a name identifying what it does, the Messages it can produce, and the Effect that produces one of them. You write all three with `Command.define`, which takes the name and then a config object where `messages` lists the Messages and `execute` holds the Effect. Two optional fields extend that. `args` declares a Schema of the inputs that vary per dispatch, which makes `execute` a builder that receives them, and `interrupt` makes the Command interruptible.
+`Command.define` gives the work a name and a result contract. A definition has three required parts:
 
-This is the same idea as Messages. Just as `m()` gives a Message a name that the type system knows, `Command.define` gives a Command a name and shape that DevTools can display, tests can reference, and traces can track. The name and args aren’t debug strings. They’re first-class values.
+- `messages` lists every Message the Command may produce.
+- `execute` contains the Effect that produces one of those Messages.
+- The first argument names the Command for DevTools, traces, and tests.
 
-Names are verb-first imperatives: `FetchWeather`, `FocusItems`, `LockScroll`. Messages describe what happened (past tense), Command names are imperatives: instructions to the runtime.
+Two optional fields extend that contract. `args` defines a Schema for inputs that vary by dispatch. `interrupt` makes in-flight work explicitly interruptible.
 
-Args carry the inputs that vary per dispatch. Anything else the Effect needs comes in through the Effect itself: module-level constants live in lexical scope, app-wide dependencies arrive through Foldkit `Resources`, model-driven handles arrive through `ManagedResources`, and any service tag on the Effect’s context channel is pulled with `yield*`. Args don’t have to carry every value the Effect uses; they carry the per-dispatch inputs.
+Command names are verb-first imperatives such as `FetchWeather`, `FocusItems`, and `LockScroll`. A Command names work for the runtime to perform. Its result Message records what happened, using a past-tense name such as `SucceededFetchWeather`, `FailedFetchWeather`, or `CompletedLockScroll`.
 
 ## Testable by Design
 
-Commands aren’t just a fancy way to organize side effects. They’re the reason Foldkit programs are easy to test. Because update is pure and Commands are data, you can simulate the entire update loop without running any Effects. Send a Message, check that the right Command was produced, resolve it with a result, and verify the Model.
+Because Commands are data and update is pure, a test can simulate the update loop without running any Effects. Dispatch a Message, inspect the returned Command, resolve it with a result Message, and assert on the final Model.
 
 ::Snippet{name="counterCommandsTest" label="test example"}
 
-The test reads as a story: start from a Model with count 5, send `ClickedResetAfterDelay()`, verify that update returned a `DelayReset` Command, resolve it with `CompletedDelayReset()`, and verify the count is 0. Every step is visible. The simulation called update, resolved the Command with the Message you provided, fed that back through update, and arrived at the final state.
+The story starts at count 5, dispatches `ClickedResetAfterDelay`, and checks for `DelayReset`. It then resolves that Command with `CompletedDelayReset` and verifies the count is 0. Every transition remains visible.
 
-Send Messages with `message`, resolve Commands inline with `Command.resolve`, and assert with `model`. See the [Testing](/testing) guide for the full API.
+Use `message` to dispatch Messages, `Command.resolve` to supply results, and `model` to assert on state. The [Testing](/testing) guide covers the full API.
 
 ## HTTP Requests
 
-Now, what if we want to get the next count from an API instead of incrementing locally? We can create a Command that performs the HTTP request and returns a Message when it completes:
+The same structure applies to network work. This version asks an API for the next count instead of incrementing locally:
 
 ::Snippet{name="counterHttpCommand" label="HTTP command example"}
 
-Let’s zoom in on `FetchCount` to see how an HTTP-backed Command takes shape. The Effect pulls `HttpClient` from the context, executes a typed request, decodes the JSON response with `Schema`, and produces `SucceededFetchCount`. Failures get caught and turned into `FailedFetchCount` Messages, so the runtime always sees a result. `Effect.provide(Http.layer)` wires the live implementation from `foldkit/http`: Effect’s Fetch-backed client with trace header propagation disabled. Effect’s default writes `traceparent` headers onto every request, a server-side default that in the browser triggers CORS preflights against plain APIs and dev proxies. Tests can swap it for a mock.
+`FetchCount` obtains `HttpClient` from the Effect context, executes the request, and decodes the response with Schema. Success produces `SucceededFetchCount`. `Effect.catch` converts failures into `FailedFetchCount`, so a failed request becomes another fact for update to handle instead of crashing the application.
+
+`Effect.provide(Http.layer)` supplies Foldkit's Fetch-backed client with trace-header propagation disabled. Effect enables those headers by default, which can trigger browser CORS preflights against APIs and development proxies. A test can provide a mock client instead.
 
 :::Info{label="Errors are tracked, not hidden"}
-Commands use Effect’s typed error channel: if a Command can fail, the type signature tells you. `Effect.catch` turns failures into Messages like `FailedFetchCount`, and once all errors are handled, the type confirms it. The update function handles errors the same way it handles success: as facts about what happened.
+The Effect error channel records whether a Command can fail. Once every failure has been converted into a Message, the type confirms that the error channel is empty. Update then handles failure and success through the same Message loop.
 :::
 
 ## Commands with Args
 
-The Commands so far have taken no inputs. But many Commands need values that vary per dispatch: for example, the zip code for a weather lookup, the element id for a focus call, or the duration for a delay. Declare those values in the config object’s `args` field. The Definition then accepts them as a typed record, and each call supplies the values for that dispatch.
+Many Commands need an input that changes from one dispatch to the next. For example: a weather lookup needs a zip code, a focus call needs an element id, and a delay may need a duration. Declare those values in `args`. The Command Definition then accepts a typed record, and `execute` receives that record when the runtime starts the work.
 
 ::Snippet{name="commandWithArgs" label="command with args example"}
 
-Args appear in DevTools alongside the Command name and let Story/Scene tests assert on the exact dispatch with `Command.expectExact(FetchWeather({ zipCode: '90210' }))`.
+Args appear beside the Command name in DevTools. Story and Scene tests can also match the exact dispatch with `Command.expectExact(FetchWeather({ zipCode: '90210' }))`.
+
+Args should contain per-dispatch inputs, not every dependency used by the Effect. Module constants remain in lexical scope. App-wide services come from [Resources](/core/resources), Model-gated handles come from [ManagedResources](/core/managed-resources), and other Effect services can be obtained with `yield*`.
 
 ## Interrupting Commands
 
-Commands normally run to completion. Sometimes the user changes their mind first, for example an upload they no longer want or a search superseded by new input. Adding an `interrupt` field to the config declares a Command that can be stopped mid-flight, and gives the Definition an `Interrupt` constructor.
+Commands normally run to completion. Sometimes the user cancels an upload or new input supersedes a request. Adding `interrupt` to the definition makes that work stoppable and adds an `Interrupt` constructor to the Definition.
 
-`interrupt` chooses the key that identifies the invocation. `interrupt: true` keys every invocation by the Command name, which is what you want when at most one invocation is meaningfully in flight; `Interrupt` then takes only `toMessage`. `interrupt: { keyFields, toKey }` selects the args that distinguish invocations and maps them to the key part, so concurrent invocations can be interrupted independently. The selected fields become the exact args required by `Interrupt`. Foldkit prefixes the Command name automatically, so keys never collide across definitions. Derive the key part from the Model identity that owns the in-flight work. A Command with no declared args has nothing to derive a key from, so `interrupt: true` is its only option.
+`interrupt` determines the address of each invocation:
+
+- `interrupt: true` uses the Command name as the key. Use it when at most one invocation is meaningfully in flight. `Interrupt` then needs only its `toMessage` function.
+- `interrupt: { keyFields, toKey }` derives a key from selected args. Use it when concurrent invocations must be interrupted independently. The selected fields become the exact args required by `Interrupt`.
+
+Foldkit prefixes a derived key with the Command name, so definitions with distinct names occupy distinct namespaces. A Command without declared args has no values from which to derive a key, so `interrupt: true` is its only form.
 
 ::Snippet{name="commandInterruptible" label="interruptible command example"}
 
 ### Choosing a Key
 
-Derive the key from the Model identity that owns the in-flight work, for example a list item id or an entity id. The update function is pure, so keys are never generated. If two invocations are distinguishable enough to cancel one and not the other, the Model already holds the fact that distinguishes them, and that fact is the key. Two uploads of the same file still get different keys, because the Model tracks each upload as its own entity with its own id.
+Derive the key from the Model identity that owns the in-flight work, such as a list item id or entity id. Update is pure, so it never generates a cancellation key. If two invocations can be targeted separately, the Model already contains the fact that distinguishes them. Two uploads of the same file still need different keys because the Model tracks them as separate entities.
 
-The Command name is the interrupt namespace, so interruptible Command names must be unique across the app. Two definitions that share a name share a key space, and an Interrupt stops every holder of its key regardless of which definition dispatched it. Unique names are already the rule in practice, because DevTools traces, Story matchers, and span names all identify Commands by name.
+The Command name is the interrupt namespace, so interruptible Command names must be unique across the application. Two definitions with the same name share a key space. An Interrupt stops every holder of the addressed key, regardless of which duplicate definition dispatched it. Unique names also keep DevTools traces, Story matchers, and span names unambiguous.
 
-The same reasoning covers reusable Submodels. Two instances of one Submodel running the same Command share a key unless something distinguishes them, so include the instance identity in the key args, for example `({ instanceId }) => instanceId`. A Submodel that appears in a list already threads an instance id through its Message lifting; the Command args carry the same id. A Submodel with a single instance needs no scoping.
+Reusable Submodels need the same care. Two instances that run the same Command share its key unless the args distinguish them. Include the instance identity in the key args, such as `({ instanceId }) => instanceId`. A Submodel with only one instance needs no extra scoping.
 
 ### The Interrupt Constructor
 
-The definition carries an `Interrupt` constructor. It takes a function from the interrupt outcome to a Message, preceded by the key args for a definition whose key is derived from its args, and returns an ordinary Command: update stays pure, DevTools shows the dispatch, and tests resolve it like any other Command. The outcome is `Interrupted` when an in-flight Command was stopped, or `NotFound` when nothing held the key because the Command already completed or was never dispatched (the two are indistinguishable by design).
+`Definition.Interrupt` returns an ordinary Command. For a name-keyed definition, it accepts a function from the interruption outcome to a Message. For a definition keyed by args, those key args come first. Update stays pure, DevTools records the dispatch, and tests resolve it like any other Command.
 
-After `Interrupted`, the target’s result Message is guaranteed never to dispatch. Whoever requested the interruption owns the state transition, which is why the example moves the upload to `Cancelled` in the `Interrupted` branch and does nothing on `NotFound`.
+The outcome is `Interrupted` when at least one in-flight Command was stopped. It is `NotFound` when nothing held the key because the work had already completed or never started. Those two cases are intentionally indistinguishable within `NotFound`.
 
-A key is an address, not a lock. Any number of invocations can run under one key at once, and dispatching never interrupts anything. The only thing that stops an interruptible Command is an Interrupt Command returned from update, so every cancellation in the program is an explicit fact, visible in update, in DevTools history, and in tests.
+After `Interrupted`, the target's result Message is guaranteed never to dispatch. The code that requested interruption therefore owns the state transition. In the example, that branch marks the upload `Cancelled`; the `NotFound` branch leaves the Model alone.
+
+A key is an address, not a lock. Several invocations may run under one key, and dispatching a Command never stops existing work. Only an explicit Interrupt Command stops the current holders. Cancellation therefore remains visible in update, DevTools history, and tests.
 
 ### Replacing Cancelled Work
 
-To start a replacement after cancelling, sequence through the Interrupt’s result Message: return the new Command from the `CompletedCancel<CommandName>` handler. Commands in one batch run concurrently with no execution-order guarantee, so returning the Interrupt and its replacement together in one list is a race, not a sequence. A typeahead search makes the pattern concrete: `ChangedQuery` stores the query in the Model and returns the cancel Command, and the `CompletedCancelFetchWeather` handler returns the fetch, reading the latest query from the Model rather than the keystroke that triggered the cancel. Both outcomes proceed identically there, because `Interrupted` and `NotFound` agree on the fact that matters: the key is free now.
+Start replacement work from the Interrupt's result Message. Return the new Command from the `CompletedCancel<CommandName>` handler. Commands returned in one list run concurrently with no ordering guarantee, so returning the Interrupt and replacement together creates a race.
+
+For a typeahead search, `ChangedQuery` can store the newest query and return the cancel Command. `CompletedCancelFetchWeather` then reads the current query from the Model and starts the replacement. Both interruption outcomes can proceed because `Interrupted` and `NotFound` agree on the relevant fact: the key is now free.
 
 ### Cancellations with Multiple Meanings
 
-When the same Command can be cancelled with more than one meaning, for example a Cancel button and a fresh keystroke that supersedes the in-flight work, give each meaning its own result Message, named for its cause: `CompletedCancelUploadFileDueToClickedCancel` from one handler, `CompletedCancelUploadFileDueToSelectedNewFile` from the other. The `toMessage` function is written at the dispatch site and closes over it, so each handler builds its own Message. Name the cause that happened, never the action the handler intends next: a Message is a fact about the past, and the follow-up is a decision update makes at handling time. Messages are already tags, so two meanings get two Messages, not one Message carrying a cause field that update has to match a second time. Payload fields are for data the handler needs, for example the `uploadId`, not for selecting behavior. When every cancelling context records the same meaning, one plain `CompletedCancel<CommandName>` serves them all: a per-upload Cancel button and a Cancel all button differ only in how many keys they interrupt, so both dispatch sites share one Message.
+If cancellation can mean different things, give each cause its own result Message. A Cancel button and choosing another file produce different facts:
 
-When the cancelling contexts can interleave on the same key, anything chosen at dispatch time is a snapshot that can go stale: the user clicks Cancel, then types again before the acknowledgment arrives, and honoring the click would now be wrong. Keep the current intent in the Model instead, as a union such as `CancellingToStop | CancellingToRevalidate`, let later Messages update it, and have a single acknowledgment handler read it from the Model. Intent-first names are right here for the same reason cause-first names were right for Messages: a Message records what happened, while this Model field records what the app has decided to do next, and the Model is allowed to change its mind. The acknowledgment is only the fact that the key is free; what happens next is a function of the newest state, not of whichever context happened to dispatch the Interrupt.
+```text
+CompletedCancelUploadFileDueToClickedCancel
+CompletedCancelUploadFileDueToSelectedNewFile
+```
 
-The [interrupting-commands example](/example-apps/interrupting-commands) puts the whole pattern in one small app: concurrent uploads keyed by upload id, a per-upload Cancel that interrupts a single key, a Cancel all that returns one Interrupt per running upload, and a Restart that reuses a freed key.
+The `toMessage` function lives at the dispatch site, so each handler can construct the Message that records its cause.
+
+Do not encode the intended follow-up in that Message. A Message records what happened; update decides what to do next. Use payload fields for data the handler needs, such as `uploadId`, not as a second behavior tag. When every cancellation records the same meaning, one `CompletedCancel<CommandName>` Message is enough. A per-upload Cancel button and a Cancel all button differ in how many keys they interrupt, not in what each result means.
+
+Intent chosen at dispatch time can become stale when cancellation contexts interleave on the same key. The user may click Cancel, then type again before the acknowledgment arrives. Store the current intent in the Model as a union such as `CancellingToStop | CancellingToRevalidate`. Later Messages can update that intent, and one acknowledgment handler can read the newest state. The acknowledgment only says that the key is free; the Model decides what follows now.
+
+The [interrupting-commands example](/example-apps/interrupting-commands) shows concurrent uploads keyed by upload id, per-upload cancellation, Cancel all, and restarting work under a freed key.
 
 :::Info{label="Interruption is for one-shot work"}
-A long-running process that should stop when the Model says so is a Subscription or ManagedResource: gate it on a Model condition and it stops declaratively. Interruption is for work that is structurally a Command, fired once and normally left to finish, where stopping it is the exception: for example an in-flight HTTP request, a file read, or an upload.
+Use interruption for work that is structurally a Command, normally runs once, and only exceptionally needs to stop. For example: an in-flight HTTP request, file read, or upload. If the Model should control the lifetime of ongoing work, use a Subscription or ManagedResource instead.
 :::
 
-Commands fire once and produce one result Message when they finish (chosen from the result Messages they declare). For work bound to a specific DOM element’s lifetime, Foldkit has [Mount](/core/mount).
+Unless interrupted, a Command fires once and produces one declared result Message when it completes. Work tied to a particular DOM element's lifetime belongs in [Mount](/core/mount).

--- a/packages/website/src/page/core/counterExample.md
+++ b/packages/website/src/page/core/counterExample.md
@@ -1,17 +1,17 @@
 # A Simple Counter Example
 
-## Overview
+## See the Whole Loop {#overview}
 
-Here’s a complete counter application. It wires up the core of the loop from the [Architecture](/core/architecture) page (a Model, Messages, update, init, and view).
+This counter puts the core loop from [Architecture](/core/architecture) into one small application. Its Model holds the count. Its Messages record button clicks. Its update function decides the next count, and its view renders the result.
 
-A Foldkit app lives in two files. `src/main.ts` holds the pure definitions: Model, Messages, update, init, view, etc. `src/entry.ts` imports them and boots the runtime. The split keeps `main.ts` importable from tests without booting a runtime as a side effect.
+The example uses two files. `src/main.ts` holds the pure application definitions: Model, Messages, update, init, and view. Larger applications can split those definitions into focused modules. `src/entry.ts` remains the runtime boundary, so tests can import the application without starting it as a side effect.
 
 ::Snippet{name="counter" label="counter main.ts"}
 
-`entry.ts` is the only place runtime side effects happen. `Runtime.makeApplication` bundles the pieces together. `Runtime.run` starts the app.
+The entry imports those definitions and passes them to `Runtime.makeApplication`. `Runtime.run` then starts the application in the selected container.
 
 ::Snippet{name="counterEntry" label="counter entry.ts"}
 
-Don’t worry about understanding every line yet. The next four pages break this code apart piece by piece. After that, we’ll add new features to the counter (a delayed reset, auto-counting, loading saved state) and each one will introduce a new concept.
+Read the example once for its shape. The next four pages examine the [Model](/core/model), [Messages](/core/messages), [update](/core/update), and [view](/core/view) in order. Later pages extend the same counter with a delayed reset, automatic counting, and saved state to introduce side effects and ongoing work.
 
-Let’s start with the Model: the single data structure that holds everything your application can be.
+Start with the Model, the single data structure that describes the application right now.

--- a/packages/website/src/page/core/customElement.md
+++ b/packages/website/src/page/core/customElement.md
@@ -2,38 +2,40 @@
 
 ## Overview
 
-Native web components are a standard browser feature: a hyphenated tag, a class extending `HTMLElement`, observed attributes, JS properties, and `CustomEvent`s. They can render into a shadow DOM and handle their own keyboard and pointer behavior. Foldkit gives them a typed seam through `CustomElement.define`, so they slot into a view next to standard elements without manual property wiring or a separate Mount step.
+Native web components are browser elements with hyphenated tags, JavaScript properties, and `CustomEvent`s. They can render into a shadow DOM and own their internal keyboard, pointer, and display behavior.
 
-You declare the element’s shape once with Schema. Property factories arrive as PascalCase methods on the builder, event factories as `On{PascalCase}` methods. The builder is callable, so the element itself appears inline in your view alongside `h.div`, `h.button`, etc. Property changes diff across renders; CustomEvents come back as Messages.
+`CustomElement.define` gives that declarative interface a typed Foldkit binding. Properties become PascalCase factories on an element builder, events become `On{PascalCase}` factories, and the builder renders beside standard elements such as `h.div` and `h.button`. Properties flow from the Model into the element; event details return as Messages.
 
-:::Info{label="CustomElement.define mirrors Command.define and Mount.define"}
-The shape is consistent across Foldkit’s lifecycle primitives. Declare the foreign element once. The runtime owns the wiring. Your view stays a pure function from Model to VNode.
+:::Info{label="A declarative boundary"}
+The browser owns the custom element's implementation. Foldkit owns the typed property and event wiring. The view remains a pure function from Model to VNode, with no manual property assignment or separate Mount.
 :::
 
 ## Defining a Binding
 
-Foldkit only owns the typed binding. Registering the element class with the browser is the same step you would take in any other framework. Most third-party packages do it for you when imported: `import 'vanilla-colorful/hex-color-picker.js'` calls `customElements.define('hex-color-picker', HexColorPicker)` as a side effect, and `<hex-color-picker>` is then a real tag in the browser. If you author your own element, you do the same: `customElements.define('your-tag', YourClass)` once, usually alongside the class definition.
+Foldkit defines the typed binding, but the browser still needs the element's class. Third-party packages commonly register it through a side-effect import. For example: importing `vanilla-colorful/hex-color-picker.js` calls `customElements.define` for `<hex-color-picker>`. A custom element you author follows the same browser registration step.
 
-A `CustomElement.define` call takes the tag name, a record of properties keyed by their JS property name, and a record of events keyed by their kebab-case event name. It returns a spec you can export and share across modules. Inside the view, call `.withMessage(h)` with the builder the view received. That binds the element to the Message universe of the frame it renders in, so an event handler on it carries a Message the frame's dispatcher can route.
+`CustomElement.define` takes one config object with the element's `tag`, a record of JavaScript `properties`, and a record of custom `events`. Each property and event payload is described with Schema. The resulting spec is independent of any application Message type, so it can be exported and shared.
+
+Inside a view, call `.withMessage(h)` on the spec. The view builder acts as a type witness that binds event handlers to the current Message universe. The runtime builder is reusable after that binding.
 
 ::Snippet{name="customElementDefine" label="CustomElement.define example"}
 
-The element constructor is callable. Pass attributes (including the property and event factories) as the first argument and children as the second, same shape as `h.div` and friends. Property factories are checked against the declared Schema at the type level: `qr.Size("220")` is a compile error when `size` is declared as `S.Number`. Event factories receive a typed `detail` argument; the consumer returns a Message that the runtime dispatches when the CustomEvent fires.
+The bound element builder is callable. Pass attributes, including generated property and event factories, as the first argument and children as the second. Either argument can be omitted when it is not needed. Schema keeps both directions typed: a property factory accepts its declared value, while an event factory receives its declared `detail` and returns a Message.
 
 ## Properties and Events
 
-Each property in the config becomes a PascalCase factory: `value` → `Value`, `isDisabled` → `IsDisabled`. The factory writes a JS property on the live element through `propsModule`, not an HTML attribute. That distinction matters: properties can carry any JS value (arrays, dates, objects), and `propsModule` diffs them across renders so the element only receives writes when the value actually changes. Removed boolean properties get reset to `false` on cleanup.
+Each property name becomes a PascalCase factory. For example: `value` becomes `Value`, and `isDisabled` becomes `IsDisabled`. The factory writes a JavaScript property on the live element through `propsModule`, not an HTML attribute. This allows values such as arrays and objects, and Foldkit only writes a property again when its value changes across renders. When primitive properties are removed, booleans reset to `false`, strings to `''`, and numbers to `0`.
 
-Each event becomes an `On{PascalCase}` factory derived from the kebab-case name: `"color-changed"` → `OnColorChanged`. The factory takes a `(detail) => Message` callback. When the element dispatches the CustomEvent, the runtime extracts `event.detail`, runs your callback, and dispatches the resulting Message just like any other handler.
+Each kebab-case event name becomes an `On{PascalCase}` factory. For example: `color-changed` becomes `OnColorChanged`. Its callback receives the typed `detail` from a `CustomEvent` and returns the Message Foldkit dispatches.
 
 :::Info{label="Validation runs at define time"}
-`CustomElement.define` validates property and event names up front. Property names must be valid JS identifiers; event names must be hyphen-separated lowercase segments. Collisions between factory names (e.g. a `click` event and an `onClick` property both producing `OnClick`) throw immediately so you catch them before they ship.
+`CustomElement.define` validates the custom tag, property names, and event names when the binding is created. It also rejects generated factory-name collisions. For example: an `onClick` property and a `click` event would both produce `OnClick`, so the definition throws before the view can render it.
 :::
 
 ## When to Reach for CustomElement
 
-CustomElement is the right primitive when the foreign element has a declarative API: typed JS properties going in, `CustomEvent`s coming out. Everything you push to the element is a property; everything you read back is an event. The element owns its rendering and its internal state, and Foldkit sees the same surface a vanilla JS or React consumer would. Most modern web component libraries (Shoelace, UI5, Spectrum, Lit, Stencil) fit this shape by design.
+Use CustomElement when the foreign element exposes a declarative contract: JavaScript properties go in and `CustomEvent`s come out. The element owns its rendering and internal state, while the application shares state through the Model. Most web component libraries built with tools such as Lit or Stencil fit this shape.
 
-[Mount](/core/mount) stays the right primitive when the foreign API is imperative: when you need to call `new Map({ container }).flyTo(...)`, `editor.setValue(text)`, `dialog.showModal()`, or otherwise drive the element through method calls rather than property writes. `OnMount` hands you the live `Element` so you can instantiate the library, call methods on it, and pair a cleanup. The [Map example](/example-apps/map) is the canonical shape.
+Use [Mount](/core/mount) when the foreign API is imperative. Instantiating a map in a container, calling methods on an editor, or pairing setup with a destructor requires the live `Element` and an element-scoped Effect. The [Map example](/example-apps/map) shows that lifecycle.
 
-The [Web Components example](/example-apps/web-components) pairs two real third-party elements: `<hex-color-picker>` from `vanilla-colorful` emits color-changed CustomEvents that flow back as Messages, and `<sl-qr-code>` from `@shoelace-style/shoelace` accepts typed properties that the runtime diffs through `propsModule`. The picker and the QR code never touch each other directly; they share state through the Model.
+The [Web Components example](/example-apps/web-components) shows the declarative alternative. A `<hex-color-picker>` emits color changes as Messages, while `<sl-qr-code>` receives typed properties diffed from the Model. The elements never coordinate directly; update connects them through application state.

--- a/packages/website/src/page/core/dom.md
+++ b/packages/website/src/page/core/dom.md
@@ -2,18 +2,43 @@
 
 ## Overview
 
-The `Dom` module wraps the most common DOM operations as Effects: focusing an element, scrolling something into view, programmatically clicking, opening and closing dialogs, locking page scroll, marking surrounding elements inert. You use them inside your own [Commands](/core/commands).
+The `Dom` module packages common imperative browser operations as Effects for use inside your own [Commands](/core/commands). It covers focus, scrolling, programmatic clicks, dialogs, page scroll locks, inert isolation, element movement, and animation settling.
 
-Each helper is an Effect. `Dom.focus` returns an `Effect.Effect<void, ElementNotFound>`; `Dom.lockScroll` returns an `Effect.Effect<void>`. They gate themselves on the runtime's next render commit internally, so you can return one from `update` immediately after a state-changing Message and trust the element will be there.
+Use a Dom helper when a Message should cause a one-time DOM operation. For example: opening a dialog can return a Command that focuses its first input. The operation stays outside view, and its result still comes back through update as a Message.
+
+Each helper exposes its failure type in the Effect channel. `Dom.focus` returns `Effect.Effect<void, ElementNotFound>`, while helpers without an expected application failure, such as `Dom.lockScroll`, return `Effect.Effect<void>`.
 
 ## Using Dom
 
-Wrap a Dom helper in a Command at the call site. The helper produces a value (or fails with a typed error), and you map that into one of your Messages.
+Wrap the helper in a Command and map its success or failure into one of that Command's declared Messages.
 
 ::Snippet{name="domFocus" label="Dom.focus example"}
 
-Dom helpers that touch a specific element can fail. `Dom.focus`, `Dom.scrollIntoView`, `Dom.scrollIntoViewAfterPaint`, `Dom.scrollIntoViewIfNotVisible`, `Dom.clickElement`, and `Dom.advanceFocus` all fail with `ElementNotFound` when the selector does not match. Catch the failure with `Effect.catch` and turn it into a Message, or ignore it with `Effect.ignore` when the failure is not interesting (a stale focus call after the user has navigated away).
+Most helpers that resolve a live element wait until Foldkit has committed the latest render before querying the DOM. This lets update return a Command for an element that the same Message just brought into the view. You do not need to add `Render.afterCommit` before `Dom.focus`, `Dom.showDialog`, `Dom.clickElement`, `Dom.scrollIntoView`, or `Dom.advanceFocus`.
 
-## Full API surface
+Scrolling has two later-timing variants. `Dom.scrollIntoViewAfterPaint` waits until the target has been painted, which suits a route that just inserted a fragment target. `Dom.scrollIntoViewIfNotVisible` also waits through paint by default, but accepts `{ when: 'Commit' }` when the first visible frame should already be scrolled.
 
-The Dom module covers focus management, scrolling, dialog show/close, scroll locking, inert isolation, element movement detection, and animation settling. The [Dom API reference](/api-reference/dom) lists every function with its signature and an inline example.
+Cleanup and global-state helpers run immediately because they do not need a newly rendered target. These include `Dom.closeDialog`, `Dom.releaseDialogResources`, `Dom.lockScroll`, `Dom.unlockScroll`, and `Dom.restoreInert`. `Dom.waitForAnimationSettled` has its own timing contract: it checks the target's active Web Animations on the next animation frame and waits for them to settle.
+
+:::Info{label="Use Render for custom timing"}
+Dom helpers include the timing their operation needs. Reach for [Render](/core/render) directly when writing a custom Command or DOM-observing Subscription that must wait for a Foldkit commit or a browser paint.
+:::
+
+### Selector Failures
+
+Helpers that require one matching element fail with `ElementNotFound` when the selector resolves to the wrong element type or no element at all:
+
+- `Dom.focus`
+- `Dom.showDialog`
+- `Dom.closeDialog`
+- `Dom.clickElement`
+- `Dom.scrollIntoView`
+- `Dom.scrollIntoViewAfterPaint`
+- `Dom.scrollIntoViewIfNotVisible`
+- `Dom.advanceFocus`
+
+Catch a meaningful failure with `Effect.catch` and turn it into a Message. Use `Effect.ignore` only when a missing target is expected and does not matter, such as a stale focus Command after navigation.
+
+## Full API Surface
+
+The [Dom API reference](/api-reference/dom) lists every helper with its signature and an inline example.

--- a/packages/website/src/page/core/file.md
+++ b/packages/website/src/page/core/file.md
@@ -2,34 +2,44 @@
 
 ## Overview
 
-The `File` module wraps the browser file APIs as Effects you can run from a Command. It mirrors the design of Elm’s `elm/file` package: file values are opaque, file selection happens imperatively through a Command (not a form event), and file contents are read asynchronously via `FileReader`.
+The `File` module brings browser file APIs into the Foldkit architecture. It opens the native picker through Commands, reads contents through Effects, and exposes synchronous metadata helpers. Inline inputs and drop zones use the typed file handlers in `foldkit/html` or the FileDrop Submodel.
 
-A `File` is a direct alias for the browser’s native `File` type. You can hold one in your Model with `S.Option(File.File)`. Foldkit never serializes files, so the schema acts as an opaque guard rather than a parser.
+`File.File` is both a direct alias for the browser's native `File` type and a Schema that accepts native File instances. A Model can hold one with `S.Option(File.File)`. The Schema treats the value as an opaque browser object; it validates the instance but does not turn file contents into serializable Model data.
 
-## Metadata and reading
+## Metadata and Reading
 
-`File.name`, `File.size`, and `File.mimeType` return metadata synchronously. `File.readAsText`, `File.readAsDataUrl`, and `File.readAsArrayBuffer` wrap the browser’s `FileReader` as Effects that can fail with a `FileReadError`. Use `readAsDataUrl` when you want a preview thumbnail without uploading the file first.
+`File.name`, `File.size`, and `File.mimeType` read browser-provided metadata synchronously. A MIME type may be an empty string when the browser cannot determine it.
+
+`File.readAsText`, `File.readAsDataUrl`, and `File.readAsArrayBuffer` wrap `FileReader` as interruptible Effects. They fail with `FileReadError` when the browser reports an error or returns an unexpected result type. Catch that error inside the Command and convert it into a declared failure Message.
 
 ::Snippet{name="fileMetadataAndRead" label="file metadata and read example"}
 
-## Selecting files
+## Selecting Files
 
-`File.select` and `File.selectMultiple` open the native file picker and resolve with what the user chose. Both take a list of accepted MIME types or extensions. `File.select` resolves with `Option.some(file)` on a pick or `Option.none()` on cancel; `File.selectMultiple` resolves with the array of chosen files, empty if the user cancels. Mirrors Elm’s `File.Select.file` and `File.Select.files`.
+`File.select` and `File.selectMultiple` open a temporary native file input. Both accept a list of MIME types or extensions, which Foldkit forwards to the input's `accept` attribute.
 
-Wrap the Effect in a Command at the call site with `Effect.map` to produce your own Message. The `File` module never defines Messages, so you keep full control of your domain vocabulary.
+The `accept` list filters the picker UI; it does not validate the selected file. Validate type, size, and contents in your own update and Commands when those constraints matter.
+
+Cancellation is a normal result, not an Effect failure. `File.select` returns `Option.some(file)` after a selection and `Option.none()` after cancellation. `File.selectMultiple` returns all selected files, or an empty array after cancellation. Map either result into domain-specific Messages in the Command.
 
 ::Snippet{name="fileSelect" label="file select example"}
 
 ## Components
 
-For drop zones and inline file pickers, reach for `FileDrop`. It is a Submodel that wires a drop zone and a hidden `<input type="file">` together and emits a `ReceivedFiles` OutMessage when files arrive (whether dropped or picked through the input). It handles the easy-to-miss details for you: it resets the input so the same file can be picked again, calls `preventDefault` on drop, and tracks drag state that flips only on true entry and exit. When you need a shape it does not cover, build directly with the `OnFileChange` and `OnDropFiles` attributes in `foldkit/html`.
+Use [FileDrop](/ui/file-drop) for a headless drop zone with a hidden `<input type="file">`. Its Submodel resets the input so the same file can be selected twice, prevents the browser's default drop behavior, and tracks real drag entry and exit.
+
+FileDrop emits a `ReceivedFiles` OutMessage with a guaranteed non-empty file list. It emits `RejectedNonFiles` when a drop or change contains no files. Fold both variants in the parent update. When FileDrop does not fit the interaction, build directly with the `OnFileChange` and `OnDropFiles` attributes from `foldkit/html`.
 
 ::Snippet{name="uiFileDropBasic" label="FileDrop example"}
 
 ## Testing
 
-Scene tests exercise file flows through two helpers. `dropFiles` dispatches a synthetic drop event on a drop zone (e.g. the root of a `FileDrop`), and `changeFiles` dispatches a synthetic change event on a file input. Both accept a target locator and a `ReadonlyArray<File>`, and throw a clear error if the target element does not have the matching file-event handler registered.
+Scene provides `changeFiles` for file inputs and `dropFiles` for drop zones. Each takes a target locator and `ReadonlyArray<File>`, then checks that the matching file-event handler is present before dispatching the synthetic event.
 
-For button-triggered pickers that use the `File.select` Command, scene tests use `click` on the button and then `Command.resolve` to synthesize the result, bypassing the native file picker entirely. Use `Command.resolveAll` when an update returns multiple Commands at once, or when resolving one Command cascades into others, like reading a preview immediately after a successful selection.
+For a button-triggered `File.select` Command, click the button and resolve the Command with the result the picker would have produced. `Command.resolveAll` covers flows where selection immediately starts another Command, such as reading a preview.
 
 ::Snippet{name="fileSceneTest" label="file scene test example"}
+
+## Full API Surface
+
+The [File API reference](/api-reference/file) lists the Schema, metadata helpers, readers, selectors, and `FileReadError` signatures.

--- a/packages/website/src/page/core/http.md
+++ b/packages/website/src/page/core/http.md
@@ -2,26 +2,32 @@
 
 ## Overview
 
-The `Http` module has a single export, `Http.layer`: Effect’s Fetch-backed `HttpClient` with trace header propagation disabled by default. It is the browser-correct client to provide to an HTTP [Command](/core/commands). Yield `HttpClient.HttpClient` inside the Command and provide `Http.layer` at the edge of its Effect.
+The `Http` module has one export: `Http.layer`, a Fetch-backed Effect `HttpClient` Layer with trace-header propagation disabled by default. Provide it to an HTTP [Command](/core/commands), then yield `HttpClient.HttpClient` inside that Command.
 
-The snippet on this page imports from `effect/unstable/http`. In the Effect v4 release candidate that Foldkit pins, the `HttpClient` modules live under the unstable namespace, so that import path is expected and matches what Foldkit projects use.
+The examples import client modules from `effect/unstable/http`. Foldkit currently pins an Effect v4 release candidate, where these modules live under the unstable namespace. That import path is expected.
 
-## Why propagation is off
+## Why Propagation Is Off
 
-Effect’s `HttpClient` records an `http.client` span for every request and, by default, writes that span’s context onto the request as `traceparent` and `b3` headers. That default is tuned for servers, where propagating trace context to your own downstream services is desirable. In a browser those same headers make an otherwise CORS-simple request non-simple, so a plain API or a same-origin dev proxy suddenly sees a preflight. `Http.layer` defaults propagation off, so requests stay CORS-simple.
+Effect records an `http.client` span for each request. Its standard Fetch client also propagates the span context through `traceparent` and `b3` request headers. That default suits a server calling downstream services that participate in the same distributed trace.
 
-Local observability is unaffected. Disabling propagation removes only the outgoing `traceparent` and `b3` request headers: the `http.client` span with its method, URL, and status attributes is still recorded, and in a Foldkit app it still nests under the runtime’s Command span.
+In a browser, those extra headers can turn an otherwise CORS-simple cross-origin request into a preflighted request. `Http.layer` disables propagation so tracing alone does not change the request's CORS behavior.
 
-## Providing it in a Command
+Local observability remains intact. The `http.client` span still records request method, URL, and status, and a Foldkit app nests it under the Command span. Only the outgoing trace-context headers are removed.
 
-Provide `Http.layer` per Command with `Effect.provide`. It is a thin wrapper around `fetch`, so building it on each invocation costs nothing and the Command stays self-contained. When an app grows many HTTP Commands, or shares a derived client across modules, provide it once through [resources](/core/resources) instead.
+## Providing It in a Command
+
+Provide `Http.layer` at the edge of the Command's Effect with `Effect.provide`. The Layer is a thin wrapper around the browser's `fetch`, so it can stay local to a self-contained Command. When many HTTP Commands share one configured client, provide it once through [Resources](/core/resources).
+
+The Command remains responsible for status checks, response decoding, and converting failures into declared Messages.
 
 ::Snippet{name="counterHttpCommand" label="HTTP Command example"}
 
-## Customizing the client
+## Customizing the Client
 
-`Http.layer` folds one overridable default into `FetchHttpClient.layer`, so every seam Effect’s client exposes still works through it. Supply a custom `fetch` by also providing `FetchHttpClient.Fetch`. An app doing distributed tracing can re-enable propagation for one Command with `Effect.provideService(HttpClient.TracerPropagationEnabled, true)`. Add auth headers, a base URL, or retries by transforming the client with `HttpClient.mapRequest` at the call site. You would write your own layer only for a transport that is not `fetch`, which is unusual in the browser.
+`Http.layer` supplies an overridable default to `FetchHttpClient.layer`, so Effect's normal client customization remains available. Provide `FetchHttpClient.Fetch` to substitute a custom `fetch` implementation. Set `HttpClient.TracerPropagationEnabled` to `true` for a Command that participates in distributed tracing.
 
-## Full API surface
+Transform a yielded client with helpers such as `HttpClient.mapRequest` to add authentication headers or prepend a base URL. Use `HttpClient.retry` or `HttpClient.retryTransient` for request retry policies. A custom Layer is only necessary when the transport is not `fetch` or when the application wants to centralize a configured client.
 
-The [Http API reference](/api-reference/http) lists the export with its full signature.
+## Full API Surface
+
+The [Http API reference](/api-reference/http) lists `Http.layer` with its full signature.

--- a/packages/website/src/page/core/init.md
+++ b/packages/website/src/page/core/init.md
@@ -1,35 +1,39 @@
 # Init & Flags
 
-## Init
+## The First Model {#init}
 
-The counter works, but every time the user refreshes the page, the count resets to zero. What if we want to remember the last count? That’s where `init` comes in, and where Flags let you pass data into your app at startup.
+`init` constructs the first Model and returns any Commands that should run when the application starts. Its result has the same shape as update's result: `[Model, ReadonlyArray<Command<Message>>]`.
 
-In the restaurant analogy, init is the waiter’s notebook at the start of the shift: the state of every table before the first customer walks in.
-
-The `init` function returns the initial Model and any Commands to run on startup. It returns a tuple of `[Model, ReadonlyArray<Command<Message>>]`.
+The counter starts at zero and has no startup work:
 
 ::Snippet{name="initSimple" label="init example"}
 
-For elements (components without routing), init takes no arguments. For applications with routing, init receives the current URL so you can set up initial state based on the route.
+A non-routing application or element calls `init` with no arguments. A routing application passes the current URL, so its first Model can reflect the route. When the application declares Flags, they become the first argument in either form.
 
-## Flags
+## Startup Data from Flags {#flags}
 
-In the restaurant analogy, Flags are what the manager tells the waiter before the shift: “table 5 has a reservation at 7, and we’re out of the salmon.” Information from outside the app that shapes the initial state.
+Flags carry data from outside the application into `init`. Typical sources include persisted state, runtime configuration, and request-specific data supplied during server rendering.
 
-Flags let you pass initialization data into your application, like persisted state from localStorage or configuration values. Define a Flags Schema and, for a fresh client boot, an Effect that loads the value.
+Define the boundary with a Flags Schema. For a fresh client boot, also define an Effect that obtains a value matching that Schema:
 
 ::Snippet{name="flagsDefinition" label="Flags definition"}
 
-When using Flags, your init function receives them as the first argument:
+`init` receives the decoded Flags value and folds it into the first Model:
 
 ::Snippet{name="initWithFlags" label="init with Flags"}
 
-Pass the Schema to `makeApplication` as `Flags`. Pass the Effect to `Runtime.run`, where the client boot resolves it before `init`. Without the Schema, the runtime calls `init` with no arguments and the compiler rejects the config.
+### Fresh Client Boot
+
+Pass the Schema to `Runtime.makeApplication` as `Flags`, then pass the Effect to `Runtime.run`. The runtime resolves the Effect before calling `init`. If the configuration omits the Schema, `init` takes no Flags argument and the compiler rejects mismatched wiring.
 
 ::Snippet{name="counterEntryWithFlags" label="Flags wiring"}
 
-The example above discharges its own `KeyValueStore` requirement with `Effect.provide`, which is the right placement for a service used only at startup. When the Flags Effect needs an app-wide singleton that Commands also use, leave the requirement in its type and let the `resources` Layer provide it. The runtime builds that Layer once and shares it, so [Resources](/core/resources) covers the details.
+The example provides `KeyValueStore` inside the Flags Effect because that service is used only during startup. If the same singleton is also needed by Commands or Subscriptions, leave the requirement in the Effect type and provide it through the application's `resources` Layer. The runtime builds that Layer once and shares it. See [Resources](/core/resources) for the full setup.
 
-Server rendering has a different authority for the value. `renderToString` receives Flags from the request or build, embeds their Schema encoding in the HTML, and `Runtime.hydrate` decodes that exact value. A hydrating entry does not provide a client Flags Effect and fails startup if the handoff is missing or invalid.
+### Server Rendering and Hydration
 
-Once your app outgrows a single Model, Message, and update, the next step is to decompose it into [Submodels](/core/submodel): self-contained modules with their own state, Messages, and update, embedded under a parent.
+Server rendering provides Flags from the request or build instead of running a client Flags Effect. `renderToString` uses that value to call `init`, encodes it through the Schema, and embeds the result in the HTML. `Runtime.hydrate` decodes the same value and calls the same `init`, so the client reconstructs the Model that produced the server HTML.
+
+A hydrating entry does not provide a client Flags Effect. Missing or invalid handoff data fails startup instead of silently booting a different Model. The [Server Rendering](/core/server-rendering#flags-and-browser-facts) guide explains which data is safe and reproducible across that boundary.
+
+Once one Model, Message union, and update function become too large to reason about as a unit, decompose the state machine into [Submodels](/core/submodel). Each child owns its own Model, Messages, update, and Commands behind an explicit parent boundary.

--- a/packages/website/src/page/core/managedResources.md
+++ b/packages/website/src/page/core/managedResources.md
@@ -2,48 +2,55 @@
 
 ## Overview
 
-Resources live for the entire application lifecycle. But some resources are heavy and should only be active while the Model is in a particular state, like a camera stream during a video call, a `WebSocket` connection while on a chat page, or a Web Worker pool during a computation. Managed Resources provide Model-driven acquire/release lifecycle, using the same deps-diffing engine as Subscriptions.
+Resources live for the entire runtime. Some stateful handles should exist only while the Model is in a particular state: a camera stream during a video call, a `WebSocket` while on a chat page, or a Web Worker pool during a computation. Managed Resources give those handles a Model-driven acquire and release lifecycle, using the same dependency-diffing engine as Subscriptions.
 
 :::Info{label="The restaurant analogy"}
-If resources are kitchen equipment (permanent, always on), Managed Resources are specialty ingredients sourced on demand. When the menu shifts to a seafood special (Model state changes), the kitchen orders in fresh lobster and sets up the shellfish station. When the special ends, the lobster goes back to the supplier and the station is broken down. If the chef (Command) tries to plate lobster when it’s not in season, they get a clear signal: `ResourceNotAvailable`. And if the special changes from Maine lobster to king crab (params change), the old stock is returned and new stock is sourced, just like switching camera resolutions triggers release and reacquire.
+Resources are the kitchen equipment available all night. A Managed Resource is a specialty station set up only while the menu needs it. Changing the special tears down the old station and sets up the new one, just as changing camera requirements releases one stream and acquires another. A Command that asks for an inactive station receives `ResourceNotAvailable`.
 :::
 
-Define a Managed Resource identity with `ManagedResource.tag`, then wire its lifecycle with `ManagedResource.make`. The `modelToMaybeRequirements` function returns `Option.some(params)` when the resource should be active, and `Option.none()` when it should be released.
+Define the handle’s identity with `ManagedResource.tag`, then wire its lifecycle with `ManagedResource.make`. The `modelToMaybeRequirements` function returns `Option.some(params)` while the handle should be active and `Option.none()` while it should be absent.
 
 ::Snippet{name="managedResources" label="Managed Resources example"}
 
-When requirements change, the runtime handles the lifecycle automatically. If `modelToMaybeRequirements` transitions from `Option.none()` to `Option.some(params)`, the resource is acquired and `onAcquired` is sent. When it goes back to `Option.none()`, the resource is released and `onReleased` is sent. If the params change while active (e.g. switching cameras), the old resource is released and a new one is acquired with the new params.
+The runtime compares the requirements after every Model change and performs the corresponding transition.
 
-If acquisition fails, `onAcquireError` is sent as a Message. The resource daemon continues watching for the next deps change. A failed acquisition does not crash the application.
+| Requirements transition                          | Runtime behavior                                                           |
+| ------------------------------------------------ | -------------------------------------------------------------------------- |
+| `Option.none()` to `Option.some(params)`         | Acquire the handle, then dispatch `onAcquired`.                            |
+| `Option.some(params)` to `Option.none()`         | Release the handle, then dispatch `onReleased`.                            |
+| `Option.some(a)` to a different `Option.some(b)` | Release and dispatch `onReleased`, then acquire and dispatch `onAcquired`. |
+| Structurally equal requirements                  | Keep the current handle.                                                   |
+
+If acquisition fails, the runtime dispatches `onAcquireError` as a Message. The lifecycle keeps watching for the next requirements change, and the failed acquisition does not crash the application.
 
 ## Accessing Managed Resources in Commands {#accessing-managed-resources}
 
-Commands access the resource value via `.get`. Since the resource might not be active, `.get` can fail with `ResourceNotAvailable`. The type system enforces this: your Command won’t compile unless you handle the error.
+Commands access the current handle through `.get`. Because the handle may be inactive, `.get` can fail with `ResourceNotAvailable`. The Command must turn that error into one of its declared result Messages.
 
 ::Snippet{name="managedResourcesCommand" label="Managed Resource command example"}
 
-This is the same `catchTag` pattern you already use for Command errors. If your Model correctly gates Commands (only dispatching `takePhoto` after `AcquiredCamera` has been received), the `catchTag` is a safety net that never fires. But if your Model logic has a bug, you get a graceful error message instead of a crash.
+This is the usual Command error-to-Message boundary. The Model should gate the operation, for example by enabling `TakePhoto` only after `AcquiredCamera` has been received. The error handler remains a safety net if that Model logic is wrong or the handle disappears before the Command reads it.
 
 ## Building a Layer in acquire
 
-When a resource’s setup and teardown are already packaged as an Effect `Layer`, you do not have to unpack it by hand. `acquire` runs with the resource-lifetime `Scope` in its context, the same scope the runtime closes on release or re-acquire. So `Layer.build` registers the Layer’s finalizers on it, and you map the built context down to the bare service value.
+When setup and teardown are already packaged as an Effect `Layer`, keep that lifecycle intact. `acquire` runs with the Managed Resource’s `Scope` in its context. `Layer.build` registers the Layer’s finalizers on that Scope, and the runtime closes it on release or reacquisition. Map the built Context down to the bare service value that Commands need.
 
 ::Snippet{name="managedResourcesLayer" label="Layer-backed Managed Resource example"}
 
-The resource tag holds the bare service value, so Commands read it through `.get` with no wrapper to destructure. Any finalizer registered during `acquire`, whether through `Layer.build` or `Effect.addFinalizer`, tears down with the resource, so `release` is simply `() => Effect.void`. The explicit `release` callback still runs first, then the scope finalizers, matching the last-in-first-out order Effect uses for any scope.
+The resource tag holds that bare value, so Commands read it through `.get` with no wrapper to destructure. Any finalizer registered during `acquire`, through either `Layer.build` or `Effect.addFinalizer`, runs when the handle is released. In that case the explicit `release` can be `() => Effect.void`. The explicit callback runs first, followed by the Scope finalizers in Effect’s last-in-first-out order.
 
 ## Composing Child Submodels
 
-A child Submodel owns its Managed Resources in its own Model and Message terms, built with `ManagedResource.make` and knowing nothing about any parent. `ManagedResource.lift` translates that record into the parent through a single Model lens and a single Message wrapper, the same shape as update delegation and `Subscription.lift`. `ManagedResource.aggregate` then combines a root-level record with any lifted child records into the single record `makeApplication` expects, throwing at startup on duplicate keys.
+A child Submodel defines its Managed Resources in its own Model and Message terms, with no knowledge of its parent. `ManagedResource.lift` translates the child record through a Model accessor and a Message wrapper, matching the shape of update delegation and `Subscription.lift`. `ManagedResource.aggregate` combines root and lifted child records into the single record the runtime config expects. Duplicate keys throw at startup instead of silently replacing an entry.
 
-Unlike `Subscription.lift`, `toChildModel` returns an `Option`. A Managed Resource already speaks in `Option` (`modelToMaybeRequirements` returns `Option.none()` to release), so a Submodel embedded as `Option` that is not mounted is just another `none`: a missing child releases the resource through the same channel.
+Unlike `Subscription.lift`, `toChildModel` returns an `Option`. A Managed Resource already uses `Option.none()` to mean “release”, so an optional child that is not mounted naturally follows the same path. Removing the child releases its handle.
 
 ::Snippet{name="managedResourcesLift" label="Managed Resources composition example"}
 
-These verbs compose across Submodel levels the same way their Subscription counterparts do. The [Subscription Organization](/patterns/subscription-organization) page traces the full leaf-to-root walkthrough. It uses Subscriptions for its example, but the shape is identical here: `make` at each level, `lift` each child, `aggregate` the results.
+The same operations compose across every Submodel level: `make` at the owner, `lift` through each parent, and `aggregate` at the root. [Subscription Organization](/patterns/subscription-organization) traces that leaf-to-root shape with Subscriptions; the Managed Resource structure is identical.
 
 :::Info{label="Resources vs Managed Resources"}
-Use `resources` for things that live forever (an `RpcClient`, an analytics client). Use `managedResources` for things tied to a Model state (camera streams, an `AudioContext`, `WebSocket` connections).
+Use `resources` for services that live with the runtime, such as an `RpcClient` or analytics client. Use `managedResources` for handles whose lifetime follows the Model, such as camera streams, an `AudioContext`, or `WebSocket` connections.
 :::
 
-With resources and Managed Resources, your app can work with any browser API. But what happens when something goes seriously wrong, like an unrecoverable error in update, view, or a Command? The next page covers crash views.
+Resources and Managed Resources cover long-lived services and Model-scoped handles. Unrecoverable errors in update, view, or a Command follow a different runtime path. The next page covers crash views.

--- a/packages/website/src/page/core/messages.md
+++ b/packages/website/src/page/core/messages.md
@@ -1,23 +1,21 @@
 # Messages
 
-## Overview
+## Facts, Not Instructions {#overview}
 
-A Message is a fact about something that happened in your application. Not an instruction to do something, just a record of what occurred.
+A Message records something that happened in the application. It does not prescribe the response. The update function decides what the fact means for the current Model.
 
-In the [restaurant analogy](/core/architecture#the-restaurant-analogy), “table 3 asked for the check” is a Message. It doesn’t tell the waiter what to do: maybe they bring the check immediately, maybe they offer dessert first. The waiter (the update function) decides. The Message stays the same either way.
-
-`ClickedIncrement` doesn’t say “add one to the count.” It says “the user clicked the increment button.” The update function decides what that means. Maybe today it adds one. Maybe tomorrow it fetches a new count from a server. The Message stays the same.
+`ClickedIncrement` does not mean “add one.” It records that the user clicked the increment button. In this counter, update adds one. A later version may return a Command that obtains the next value elsewhere. The Message remains a stable account of the event.
 
 The counter has three Messages:
 
 ::Snippet{name="counterMessages" label="messages example"}
 
-By convention, Messages follow a verb-first, past-tense naming pattern: `ClickedIncrement`, not `Increment` or `ADD_COUNT`. The verb prefix functions as a category marker, e.g. `Clicked*` for button clicks, `Updated*` for input changes, `Succeeded*` and `Failed*` for Command results, and `Got*` for [Submodel results](/core/submodel).
+Messages use verb-first, past-tense names such as `ClickedIncrement`, not `Increment` or `ADD_COUNT`. Prefixes make their causes easy to scan. `Clicked*` records clicks, and `Updated*` records input changes. Command results use `Succeeded*` or `Failed*` when the distinction matters, and `Completed*` otherwise. `Got*` is reserved for results lifted from a child [Submodel](/core/submodel).
 
-The `m()` helper creates a `TaggedStruct` with a callable constructor. `m('ClickedIncrement')` gives you a type you can pattern match on and a function you can call to create instances: `ClickedIncrement()`.
+The `m()` helper creates a Schema-backed tagged struct with a callable constructor. `m('ClickedIncrement')` provides both the tag that update can match and the `ClickedIncrement()` constructor that creates the Message. `S.Union` then collects every variant into the application’s closed `Message` union.
 
-:::Info{label="Actions without the boilerplate"}
-Messages are similar to Redux action types, but more ergonomic with Effect Schema. Instead of string constants and action creators, you get type inference and pattern matching for free.
+:::Info{label="Name the cause"}
+A Message says what happened, not what update intends to do next. That keeps the same fact useful when the application’s response changes.
 :::
 
-Messages describe what happened. But who decides what to do about it? That’s the job of the update function: the single place where your application’s state transitions live.
+Messages describe what happened. The [update function](/core/update) defines every resulting state transition.

--- a/packages/website/src/page/core/model.md
+++ b/packages/website/src/page/core/model.md
@@ -1,23 +1,25 @@
 # Model
 
-## Overview
+## One State Tree {#overview}
 
-The Model represents your entire application state in a single, immutable data structure defined with [Effect Schema](https://effect.website/docs/schema/introduction/). Everything your app can be at any moment lives here, not scattered across components, not split between local and global state.
+The Model is the complete application state in one immutable data structure. Everything the application can be at a moment lives here, rather than being divided between component-local and global stores.
 
-In the [restaurant analogy](/core/architecture#the-restaurant-analogy), the Model is the waiter’s notebook: the running picture of everything happening right now. Orders in flight, tables seated, who’s waiting for dessert. Every fact about the current state of the restaurant lives in one place.
+In the [restaurant analogy](/core/architecture#the-restaurant-analogy), this is the waiter's notebook. The analogy is a memory aid; the literal contract is one state tree that every transition receives and returns.
 
-In the counter example, the Model is a Struct with a single field:
+The counter defines its Model with [Effect Schema](https://effect.website/docs/schema/introduction/):
 
 ::Snippet{name="counterModel" label="model example"}
 
-TypeScript types disappear when your code compiles. They help the compiler check your code, but they don’t exist at runtime. Schema keeps that type information alive as a value. This gives Foldkit knowledge of your Model at runtime: it can compare models for equality, decode state from unknown sources, and manage resource lifecycles, things that need the Model’s shape as a value, not just a compile-time annotation. You’ll see these capabilities pay off as the counter grows, especially on the Subscriptions page.
+`S.Struct` creates the runtime Schema. `typeof Model.Type` derives the TypeScript type from that same definition, so the runtime and compiler agree on the Model’s shape.
 
-The counter starts with a single field, but Models grow with your app. When we add auto-counting later, the Model will expand:
+That runtime value matters because TypeScript types disappear after compilation. Foldkit uses the Model Schema to encode and decode state preserved across hot updates. The same Schema can validate unknown data at application boundaries.
+
+The counter starts with one field. When automatic counting becomes part of the application state, the Model grows to record it:
 
 ::Snippet{name="counterModelPreview" label="expanded model example"}
 
-:::Info{label="One state tree, not many"}
-Think of the Model as combining useState, useContext, and your Redux store into one typed structure. Instead of state scattered across components, everything lives here.
+:::Info{label="Model the application, not the screen"}
+Store facts the application needs to remember. Values used only to render one frame can usually be derived in view instead of becoming another Model field.
 :::
 
-The Model captures what your app is at any moment. But how does it change? In Foldkit, every change starts with a [Message](/core/messages): a fact about something that happened.
+The Model describes the current state. Every change begins with a [Message](/core/messages), a fact about something that happened.

--- a/packages/website/src/page/core/mount.md
+++ b/packages/website/src/page/core/mount.md
@@ -2,88 +2,100 @@
 
 ## Overview
 
-Most Foldkit code is declarative. The [view](/core/view) is a function from Model to Html. It doesn’t reach into the DOM, it doesn’t hold references, it doesn’t run side effects. That purity is what makes Foldkit programs predictable.
+Most Foldkit code is declarative. The [view](/core/view) is a pure function from Model to Html. It does not reach into the DOM, hold element references, or run side effects.
 
-Mount binds an imperative, element-scoped side effect to a view element for as long as that element lives in the DOM. It sets up when the element enters and tears down when the element leaves. `OnMount` is the seam where view code drops down to imperative work on the live element. The common shape, `Mount.define`, runs an `Effect<Message>` that produces exactly one Message at acquire and keeps the scope open until the element unmounts. Cleanup is paired with setup via `Effect.acquireRelease` inside the Effect. For Mounts that emit a continuum of events from observers or listeners on the element, `Mount.defineStream` takes a `Stream<Message>` instead.
+Mount is the escape hatch for work whose cause is a particular element existing in the DOM. `OnMount` supplies the live `Element`, starts the work when that element enters the DOM, and tears it down when the element leaves.
 
-**Pick by the Mount’s job.** Use `Mount.define` when the Mount produces a single Message at acquire: anchor positioning, portaling, third-party library instantiation, reading element geometry on mount. Use `Mount.defineStream` only when the Mount’s job is to emit a continuous stream of Messages from listeners or observers attached to the element: scroll events, IntersectionObserver entries, MutationObserver records. Both forms require at least one declared result Message. Fire-and-forget Mounts follow the same convention as fire-and-forget Commands: declare a `Completed*` Message that `update` no-ops on, so DevTools, Scene tests, and replay still see the side effect.
+Use `Mount.define` for work that produces one Message when it starts. The returned `Effect<Message>` emits that Message, then its scope remains open until unmount so cleanup registered with `Effect.acquireRelease` runs at the right time. Use `Mount.defineStream` when listeners or observers on the element must emit a continuing `Stream<Message>`.
+
+Both forms require at least one declared result Message. When no result needs to change the Model, return a descriptive `Completed*` Message and leave the Model unchanged in update. The Message keeps the effect visible to DevTools, Scene tests, and replay.
 
 :::Info{label="Functional core, imperative shell"}
-The view describes what should be on screen. `OnMount` describes what to do at the boundary where the virtual DOM meets the real one. The Message the Effect produces flows back through update like any other Message, and cleanup is registered via `Effect.acquireRelease` inside the Effect, paired with the setup so "do the thing" and "undo the thing" stay together.
+The view describes what should be on screen. `OnMount` handles imperative work at the boundary between the virtual DOM and a live element. Results still return to update as Messages, and setup stays paired with cleanup inside the Mount's Effect or Stream.
 :::
 
 :::Info{label="Mounts surface in tests"}
-Scene tracks every `OnMount` in the rendered view as a pending Mount and requires the test to acknowledge each one with the result Message its factory would produce at runtime. See [Scene](/testing/scene) for the full contract.
+Scene records every `OnMount` in the rendered view as a pending Mount. A test must acknowledge or resolve each one with a declared result Message. See [Scene](/testing/scene) for the full contract.
 :::
 
 ## When to Reach for Mount
 
-Mount is one of the primitives Foldkit offers for side-effecting work. Pick by what causes the side effect, not by what feels most ergonomic.
+Choose a lifecycle primitive by what causes the work:
 
-[Command](/core/commands) fires a one-time side effect because `update` just returned it. The cause is a Message that just dispatched. `FocusInput` after `OpenedDialog`, `FetchWeather` after `ClickedRefresh`, `SaveTodos` after `EditedTodo`. Navigation, network, storage, analytics, and focus-on-state-change all belong in Commands.
+- A [Command](/core/commands) runs because update just handled a Message. Use it for one-time work such as navigation, network requests, storage, analytics, or focusing an input after `OpenedDialog`.
 
-Mount fires a per-instance lifecycle effect bound to a VNode existing in the rendered tree. The cause is the element appearing, and the author needs the live `Element` handle. Anchor positioning for floating panels, backdrop portaling, attaching observers to a specific element, handing the element to a third-party library: these are Mount cases.
+- A Mount runs because an element exists, and the work needs that live `Element`. Use it to measure geometry, portal a node, attach an element observer, or instantiate a library in a specific container.
 
-[Subscription](/core/subscriptions) catches a long-running external event source like timers, document or window events, system theme changes, or `WebSocket` message streams. It emits the events as Messages. Its lifetime is gated by a Model condition via `modelToDependencies`. Subscriptions look like `Mount.defineStream` in shape (both produce a `Stream<Message>` with `Effect.acquireRelease` cleanup), but the cause differs: Mount fires because an element appeared in the DOM, Subscription fires because a Model condition became true.
+- A [Subscription](/core/subscriptions) listens to an external event source while dependencies derived from the Model remain active. Timers, document events, system theme changes, and WebSocket messages fit this shape.
 
-[ManagedResource](/core/managed-resources) holds a stateful runtime object (a websocket, a camera stream, a third-party library instance) whose lifetime is tied to a Model condition AND whose handle is consumed by Commands via `yield*`. The condition determines lifetime; Commands do the work on the resource.
+- A [ManagedResource](/core/managed-resources) owns a stateful handle whose lifetime follows a Model condition and whose operations are performed by Commands.
 
-[CustomElement](/core/custom-element) covers the special case where the foreign DOM is a declarative web component: a hyphenated tag that exposes typed JS properties going in and dispatches `CustomEvent`s coming out. Shoelace, UI5, Spectrum, Lit, Stencil elements, and most modern web component libraries fit that shape. Declare the binding once with `CustomElement.define` and the element slots into the view like any other tag. Mount is the right reach only when the foreign element’s API is imperative instead.
+- A [CustomElement](/core/custom-element) renders a native web component with declarative properties and `CustomEvent`s. Use Mount only when the foreign element requires an imperative API instead.
 
-:::Info{label="Don’t reach for Mount just because the work happens to coincide with an element appearing"}
-Check what causes the work. If a Message just dispatched (like `Opened`), the cause is the Message, not the element. The element’s appearance is coincidentally co-timed with the Message but isn’t what causes the work. Use a Command returned from `update`’s handler instead. For example, focusing a search input when its dialog opens: the element appears, but the cause is `Opened`, not the input’s existence. A `FocusInput` Command returned from the `Opened` handler is the right shape.
+:::Info{label="Check the cause, not the timing"}
+Work that happens when an element appears is not necessarily caused by that element. For example: when `OpenedDialog` makes a search input visible, focusing it is still caused by the Message. Return a `FocusInput` Command from that Message's update handler. Reach for Mount only when the work is inseparable from the live element and its lifetime.
 :::
 
 ## Side Effects on Mount
 
-Mount’s lifecycle is tied to the DOM node, not the VNode. VNodes are reconstructed on every render; DOM nodes persist across renders unless the differ decides to replace them. If the differ matches an existing DOM node (same tag, same identity, and for keyed list siblings the same key), the Mount keeps running: `insert` doesn’t re-fire and `destroy` doesn’t fire. If the differ replaces the node (different tag, changed view-function identity, mismatched key), the old Mount’s scope closes (running `acquireRelease` finalizers) and the new node gets a fresh Mount. An unkeyed reordered list reuses DOM positions for different logical rows instead of replacing them, so view-function identity and stable keys on mapped list items are what keep the differ from mis-matching elements across renders and accidentally transferring Mount state to the wrong element.
+A Mount follows the lifetime of a DOM node, not a VNode. Foldkit reconstructs VNodes on every render, but the differ reuses an existing DOM node when its tag and identity still match. A reused node keeps its Mount running. A replaced node closes the old Mount's scope, runs its finalizers, and starts a fresh Mount on the new node.
 
-A typical Mount uses the element parameter to do DOM work that should pair with the element existing. Portal-to-body is the canonical small example: when this overlay element appears, move it to `document.body` so it escapes any clipping ancestor; when it unmounts, remove it. The Effect uses the element directly, the work is DOM manipulation, and the cleanup is registered via `Effect.acquireRelease` so it mirrors the setup.
+View-function identity and stable keys keep that lifecycle attached to the right logical element. This matters in mapped lists, where an unkeyed reorder can reuse the same DOM position for different data. Key each item by a stable Model identifier so its DOM node and Mount move together.
+
+Portal-to-body is a small example. When an overlay enters the DOM, its Mount moves the live element to `document.body` so it can escape clipping ancestors. When the element unmounts, the paired release removes it.
 
 ::Snippet{name="mountPortalToBody" label="portal-to-body example"}
 
-Cleanup is registered via `Effect.acquireRelease` inside the Effect, not as a separate hook. The runtime closes the Mount’s scope when the differ destroys the element, which runs the release. Pair the setup and the release in the same `acquireRelease` expression.
-
-:::Info{label="Two practical rules for Mount"}
-Both must hold. First, the factory uses the element parameter. Mount provides the live element handle, and that handle is what makes Mount distinct from the alternatives. If your factory doesn’t read or write the element, pick a different primitive. Second, the work is DOM measurement or DOM manipulation on that element: read its geometry, mutate its CSS, attach an observer to it, portal it, hand it to a third-party library. Anything else is a Command from update (network, storage, analytics, focus-on-transition, scroll lock for the page), a Subscription whose dependencies are derived from the Model (timers, document-level keyboard listeners, system theme observers), or a ManagedResource whose lifetime tracks a Model condition (a WebSocket connection, a camera stream). If you find yourself wanting a Mount that doesn’t use its element, the cause is a Model condition or a Message dispatch, not the element’s existence. Re-check the cause and pick the matching primitive.
+:::Info{label="Two rules for Mount work"}
+First, the factory must use the live element. If it does not read or write that element, a Message or Model condition is probably the real cause. Second, the work must be safe to repeat whenever that element is inserted again. DOM measurement, paired DOM manipulation, observers, and element-owned library instances fit these rules.
 :::
 
-Only one Mount can attach per element. The differ’s hook system stores a single `insert`/`destroy` hook per VNode, so writing `[h.OnMount(A), h.OnMount(B)]` on the same element silently overwrites: the second `OnMount` replaces the first, and `A`’s factory never runs. If you need multiple lifetime-scoped behaviors on the same element (e.g. restore-scroll AND listen-for-scroll), bundle them into a single Mount that does both in its acquire and releases both in its release.
+:::Warning{label="Attach one Mount per element"}
+A VNode has one `insert` and `destroy` hook. If the same element receives `[h.OnMount(A), h.OnMount(B)]`, the second action silently replaces the first and `A` never runs. Combine both behaviors in one Mount and register both releases in its scope.
+:::
 
 :::Warning{label="Mounts re-run during DevTools time-travel"}
-When a user scrubs through history with the DevTools timeline, Foldkit re-renders the historical Model. Elements that carry `OnMount` fire their factories again as their VNodes are inserted, and the `acquireRelease` finalizers run as they are destroyed. The two rules above are what keep Mount work inherently replay-safe: DOM measurement is read-only, DOM manipulation on an element that exists in both live and time-travel views is idempotent, observer attachment paired with release is self-balancing. Anything that mutates external state (network calls, storage writes, focus-on-transition, scroll lock for the page, library instantiation keyed on Model rather than element) is unsafe to re-run during replay and therefore not a Mount.
+DevTools re-renders historical Models. Elements inserted during replay run their Mounts again, and elements removed during replay run their finalizers. Keep Mount work replay-safe and local to the element. External mutations such as network calls, storage writes, and analytics belong in Commands.
 :::
 
 ## Per-Instance Args {#args}
 
-Mount factories often need a value that varies per instance: an element id to anchor against, the data driving a chart render, the stable host id another Mount will key on. Declare those values as `args` on `Mount.define` so the factory receives them as a typed record at view time. The shape mirrors [Commands](/core/commands): `Mount.define(name, args, ...results)(({ ...args }) => element => Effect<Message>)`. Calling the Definition with an args record at view time produces a MountAction the runtime feeds into `OnMount`. `Mount.defineStream` takes the same args overload; only the factory’s return type changes (from `Effect<Message>` to `Stream<Message>`). Every property below applies identically: captured-at-mount semantics, the args naming rule, and the post-mount-Model-change escape hatch.
+Mount factories often need an input that differs by element instance, such as an initial scroll position, chart data, or a stable host id. Declare a Schema record of `args` with the same shape used by [Commands](/core/commands):
 
-Args carry per-instance inputs only. Everything else the factory needs comes from outside args: module-level constants via lexical scope, app-wide services via Foldkit `Resources`, Model-driven handles via `ManagedResources`, and any Effect service via `yield*` inside the factory body.
+```ts
+Mount.define(name, args, ...results)(args => element => Effect<Message>)
+```
+
+Calling the Definition with an args record creates the MountAction passed to `OnMount`. `Mount.defineStream` supports the same overload and returns a `Stream<Message>` from its factory instead.
+
+Args are only per-instance inputs. Module constants stay in lexical scope, app-wide services come from Foldkit `Resources`, Model-owned handles come from `ManagedResources`, and Effect services remain available through `yield*` inside the factory.
 
 :::Info{label="Args surface in DevTools and tests"}
-Mount args appear in DevTools alongside the Mount name, and Scene tests can match a specific instance by passing the same args record to `Mount.expectHas` or `Mount.resolve`. See [Scene](/testing/scene) for the Definition-vs-Instance matcher contract.
+DevTools shows the args beside the Mount name. Scene tests can target one instance by passing the same args record to `Mount.expectHas` or `Mount.resolve`. See [Scene](/testing/scene) for the Definition and instance matcher contract.
 :::
 
-:::Warning{label="Args are captured at mount, not refreshed on subsequent renders"}
-The factory runs once when the element enters the DOM, with whatever arg values are passed at that moment. Every later render constructs a fresh `MountAction` with current arg values, but only the first invocation’s args ever execute. `OnMount` is bound to the differ’s `insert` and `destroy` hooks, with no `update` hook in between. Name args to express this lifecycle. Prefer `initialScroll` over `scroll`, `seedValue` over `value`. If you need Model changes to drive ongoing DOM behavior post-mount, the proximate cause is the Message that updated the Model. Dispatch a Command from `update`’s handler for that Message. The Command can find the element and do the imperative work. Don’t reach for a Subscription here. Subscriptions watch Model state via `modelToDependencies` to gate their lifetime, but their emissions come from external event sources (timers, document events, library callbacks), not from Model state itself. Translating Model changes into side effects is what `update` does on every Message, via the Commands it returns. This is different from the cases where Subscriptions do touch the DOM, and the distinction is worth naming. Subscriptions are Effect Streams that emit Messages. Their start and stop are diffed against dependencies derived from the Model via `modelToDependencies`: when the dependencies become satisfied the Stream’s body runs setup, and when they change the scope closes and any `Effect.acquireRelease` release runs. That makes Subscriptions the right fit when the lifetime of a DOM side effect is itself a Model condition: for example, applying `user-select: none` to the document while `isDragging` is true and undoing it when the drag ends sits naturally as one paired `Effect.acquireRelease` inside a Subscription whose dependency is `isDragging`. Subscriptions also handle the case where a DOM mutation has to run synchronously with the event itself, like calling `preventDefault` on a keydown listener: the Stream’s body is an Effect that can register the listener directly with the browser, so the listener runs in the same call stack as the browser’s event dispatch. Going through `update` would arrive after the browser had committed the default. Neither shape applies when an already-mounted element needs new DOM behavior in response to a Model change: the cause there is a Message that just dispatched, which is what Commands are for.
+:::Warning{label="Args are captured at mount"}
+The factory receives the args from the render that inserts the element. Later renders create new MountActions, but a reused DOM node does not run the factory again. Name values for that lifecycle, such as `initialScroll` or `seedValue`, rather than implying that they stay current.
 :::
+
+When a later Message changes the Model and should trigger new DOM work, return a Command from that Message's update handler. A Subscription is appropriate when a Model dependency controls the lifetime of an external stream or a paired DOM state, or when a browser event must be handled synchronously, such as calling `preventDefault` inside its listener. Mount args are not reactive properties for either case.
 
 ## Third-Party Libraries
 
-`OnMount` really earns its keep when a library owns its own DOM. Charts, code editors, map renderers, force-directed graphs: each expects a real element to render into and a way to be torn down later.
+Mount is especially useful when a library owns a rendered subtree. Charts, code editors, map renderers, and force-directed graphs all need a real element to render into and a way to release their resources.
 
-The factory takes the live `Element` (and its declared args, when any) and returns an `Effect<Message>`. The Mount’s scope is bound to the element’s lifetime: the Message the Effect produces is dispatched, and the scope is closed (running any registered `Effect.acquireRelease` finalizers) when the element unmounts. The Effect completes after producing its Message, but the scope stays open until the element unmounts so the cleanup runs at the right time. For Mounts that emit a continuum of events from observers or listeners on the element, `Mount.defineStream` takes a `Stream<Message>` instead and follows the same lifetime rules.
+Construct the handle in an acquire Effect, return the Mount's result Message, and register teardown with `Effect.acquireRelease`. The Effect can finish after emitting its Message because Foldkit keeps its scope open until the element unmounts.
 
 ::Snippet{name="mountThirdPartyChart" label="OnMount example"}
 
-:::Warning{label="Construct the handle inside the acquire body, never before it"}
-`Effect.acquireRelease` only guarantees atomicity of "acquire body completes → release is registered." If you construct the chart (or map, or audio context, or any stateful handle) before calling `acquireRelease` and the acquire body just returns the existing handle (`Effect.sync(() => alreadyExistingValue)`), interruption between the construction and the registration leaves the handle dangling. The fix is to express the construction as the success value of the acquire Effect: `Effect.tryPromise(() => import(...)).pipe(Effect.map(({ Lib }) => new Lib(...)))` for async imports, `Effect.sync(() => new Thing(...))` for sync construction. The discipline is: whatever the release function needs as input must be the success value of the acquire Effect.
+:::Warning{label="Construct the handle inside the acquire body"}
+`Effect.acquireRelease` registers the release only after its acquire Effect succeeds. Constructing a chart, map, or other stateful handle before that Effect can leak the handle if interruption happens before registration. Make construction the acquire Effect's success value. For example: use `Effect.sync(() => new Thing(...))`, or put an asynchronous import and construction in the same Effect pipeline. Whatever the release needs must be produced by the acquire Effect.
 :::
 
-The Model owns the data going in. The library owns its rendered subtree. The runtime owns the lifecycle.
+The Model owns the input data. The library owns its rendered subtree. Foldkit owns the lifecycle.
 
-:::Info{label="What if the factory emits or fails after the element is removed?"}
-The runtime handles this. When the element unmounts, Foldkit interrupts the Mount’s fiber. Interrupt propagates through the scope, running any registered `Effect.acquireRelease` finalizers (the canonical cleanup mechanism). Messages produced after interrupt are discarded; the Model never sees a Mount Message for an element that no longer exists.
+:::Info{label="Unmount interrupts the work"}
+When the element unmounts, Foldkit interrupts the Mount's fiber and runs registered finalizers. Any Messages produced after interruption are discarded, so update never receives a Mount Message for an element that no longer exists.
 :::
 
-Mount binds work to an element’s lifetime in the rendered tree. For a scoped Stream gated by a slice of your Model instead, one that runs while the slice holds its value and may emit Messages while it does, Foldkit has [Subscriptions](/core/subscriptions).
+When a foreign element already exposes a declarative property-and-event API, bind it with [CustomElement](/core/custom-element) instead.

--- a/packages/website/src/page/core/render.md
+++ b/packages/website/src/page/core/render.md
@@ -2,18 +2,30 @@
 
 ## Overview
 
-The `Render` module exposes two primitives for synchronizing with the browser's render cycle: `Render.afterCommit` resumes once the runtime has applied the latest VDOM patch to the DOM. `Render.afterPaint` resumes after the prior state has been displayed to the user. Both are Effects you yield inside your own [Commands](/core/commands) or [Subscriptions](/core/subscriptions).
+The `Render` module synchronizes an Effect with Foldkit's DOM commit and the browser's next paint. It exposes two Effects:
 
-The runtime batches renders to `requestAnimationFrame`. A Command runs on the microtask queue right after the dispatching Message, which means a synchronous DOM read or write inside that Command sees the tree from before the latest model was patched in. `Render.afterCommit` is how you wait for the matching patch to apply.
+- `Render.afterCommit` resumes after Foldkit applies the pending VDOM patch.
 
-## When to reach for it
+- `Render.afterPaint` waits for that commit, then one more animation frame so the committed state has been displayed.
 
-Reach for `Render.afterCommit` when you need to read or measure an element that was just brought into existence (or moved, or had attributes changed) by the same Message. Custom focus, custom scroll restoration, `IntersectionObserver` setup inside a Subscription, `getBoundingClientRect` for layout work. The [Dom helpers](/api-reference/dom) already gate themselves with this internally, so reach for `Render.afterCommit` directly when building your own.
+Yield either one inside a [Command](/core/commands) or [Subscription](/core/subscriptions). They do not render anything themselves. They mark the point after which a DOM read or write has the timing guarantee it needs.
 
-Reach for `Render.afterPaint` when you need the browser to actually display the prior state before you change to the next one, typically for CSS transition orchestration. A single `requestAnimationFrame` commits the DOM but the pixels have not been painted yet. A second one resumes after that paint is visible, so the from-state is on screen and the to-state can transition smoothly to it.
+The distinction matters because a Command can start after update but before Foldkit applies the render scheduled by the same Message. Reading the DOM immediately can still see the previous tree. `Render.afterCommit` waits for the actual pending patch, including a patch performed inside a View Transition.
+
+When no Foldkit patch is pending, `Render.afterCommit` yields one animation frame. The same fallback applies when the Effect runs without a Foldkit runtime, such as in a standalone helper.
+
+## When to Reach for It
+
+Use `Render.afterCommit` before custom DOM work whose target was created, moved, or updated by the same Message. For example: measure a new panel with `getBoundingClientRect`, restore a custom scroll position, or start DOM observation from a Subscription after its target exists.
+
+Use `Render.afterPaint` when the committed state must be visible before the next change. CSS transition orchestration is the usual case. The first state must reach the screen before update applies the transition's destination state, or the browser can collapse both into one frame and skip the animation.
+
+:::Info{label="Prefer Dom helpers for common operations"}
+The [Dom helpers](/core/dom) already wait for the commit or paint their operation requires. Use `Render` directly when implementing timing-sensitive DOM work that those helpers do not cover.
+:::
 
 ::Snippet{name="renderBasic" label="Render examples"}
 
-## Full API surface
+## Full API Surface
 
-The [Render API reference](/api-reference/render) lists every primitive with its signature and an inline example.
+The [Render API reference](/api-reference/render) lists both Effects with their signatures and inline examples.

--- a/packages/website/src/page/core/resources.md
+++ b/packages/website/src/page/core/resources.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-Commands are self-contained by default. Each execution starts fresh with no shared state. But some services need a single long-lived instance shared across Commands: clients that do real work at construction time, like an RPC client assembling its serialization and transport stack, or an analytics client that opens one session for the whole app. That’s what `resources` is for.
+Commands are self-contained by default. Each execution starts fresh with no shared state. Some services instead need one long-lived instance shared across Commands. An RPC client may assemble a serialization and transport stack at construction; an analytics client may open one session for the whole app. Put those services in `resources`.
 
 :::Info{label="Think of it like a restaurant kitchen"}
-Resources are kitchen equipment: the oven, the stand mixer, the deep fryer. They’re turned on when the kitchen opens and run all night. Every dish (Command) can use them. You don’t buy a new oven per order. An `RpcClient` and an analytics client are the same: expensive singletons that live for the entire app lifecycle. Need multiple pieces of equipment? Combine them with `Layer.mergeAll`.
+Resources are the kitchen equipment that stays available all night. Every dish can use the same oven; the kitchen does not install a new one for each order. An `RpcClient` or analytics client has the same app-wide lifetime. Combine several service Layers with `Layer.mergeAll`.
 :::
 
-Define a service using [Context.Service](https://effect.website/docs/requirements-management/services/), then pass its default layer to `makeApplication` via the `resources` config field. The runtime builds the Layer once, the first time it is needed: at startup when `Runtime.run` receives a Flags Effect or Subscriptions begin, otherwise when the first Command runs. The built services are shared for the application’s lifetime and released at teardown. Commands access a service by yielding its tag.
+Define a service with [Context.Service](https://effect.website/docs/requirements-management/services/), then pass its Layer through the runtime’s `resources` config. The runtime builds that Layer once, the first time it is needed: during startup when a fresh Flags Effect resolves or Subscriptions begin, otherwise when the first Command runs. It shares the built services for the runtime’s lifetime and releases them at teardown. Commands access a service by yielding its tag.
 
 ::Snippet{name="resources" label="resources example"}
 
@@ -16,14 +16,20 @@ Commands declare their resource requirements in the type signature via the third
 
 ## Resources or Per-Command Provision
 
-A Command can also discharge a requirement itself, with `Effect.provide` inside its Effect. Both placements work, so the question is which one a given service should use. The deciding lens: is the service an app-wide singleton every Command should reuse, or a per-Command decision where different Commands want different implementations? Four criteria sharpen the call.
+A Command can also satisfy a service requirement locally with `Effect.provide`. Choose the placement from the service’s intended lifetime and identity.
 
-- **Construction cost times invocation frequency.** A per-Command `Effect.provide` builds the layer on every invocation. For `Http.layer` from `foldkit/http`, a thin wrapper around `fetch`, that costs nothing. For an RPC client that assembles a serialization and transport stack, it means a Command that fires on every keystroke rebuilds the whole stack each time. Services whose construction does real work belong in `resources`, where construction happens once.
-- **Instance identity.** A per-Command provide constructs a fresh instance for each invocation, so Commands never share state through it. When every Command must talk to the same object, like one `RpcClient` that multiplexes their calls over a single connection, the service belongs in `resources`.
-- **Failure isolation versus fail-fast.** A per-Command provide scopes construction failure to the Commands that use the service: if the layer can’t be built, those Commands fail and the rest of the app keeps working. `resources` is the opposite contract. The runtime provides the Layer to every Command, so a Layer that fails to build crashes the app with the crash view. For a service the whole app depends on, that one loud failure is the better behavior; for a genuinely optional service, per-Command provision keeps the failure contained.
-- **Same tag, different implementations.** `resources` binds each service tag to one implementation for the whole app. Only per-Command provides can give two Commands different implementations of the same tag, like one Command using `KeyValueStore` over localStorage while another uses it over sessionStorage.
+| Question                       | `resources`                                      | Per-Command `Effect.provide`                     |
+| ------------------------------ | ------------------------------------------------ | ------------------------------------------------ |
+| How often is the Layer built?  | Once for the runtime.                            | Once per Command execution.                      |
+| Do Commands share an instance? | Yes.                                             | No. Each execution gets a fresh instance.        |
+| What if construction fails?    | The runtime fails loudly through its crash path. | The Command handles the failure at its boundary. |
+| Can one tag vary by Command?   | No. One implementation is bound for the runtime. | Yes. Each Command can provide its own.           |
 
-Run the criteria over the common cases and the split falls out. `HttpClient` defaults to per-Command: `Effect.provide(Http.layer)` is one line, the Command stays self-contained, and no type annotations change anywhere else. `Http.layer` from `foldkit/http` is Effect’s Fetch-backed client with trace header propagation disabled by default. Effect tunes that default for servers, where handing trace context to your own downstream services is desirable; in the browser the same `traceparent` headers make otherwise CORS-simple requests trigger preflights against plain APIs and dev proxies. `KeyValueStore` stays per-Command: which storage backs the tag is a per-Command decision, and `resources` could only pick one. An RPC client goes in `resources`: construction is expensive, every Command should reuse one client, and when its configuration is broken, one visible failure the first time the client is needed tells you more than every server call failing on its own.
+Common cases follow directly from that distinction:
+
+- **`HttpClient` starts per Command.** `Effect.provide(Http.layer)` keeps the Command self-contained, and the Layer is only a thin wrapper around `fetch`. Foldkit’s `Http.layer` uses Effect’s Fetch-backed client with trace header propagation disabled. Browser `traceparent` headers can turn otherwise CORS-simple requests into preflighted requests against plain APIs and development proxies.
+- **`KeyValueStore` stays per Command.** The backing store is often part of the operation: one Command may use localStorage while another uses sessionStorage. A runtime-wide Layer could bind only one implementation of the tag.
+- **An RPC client belongs in `resources`.** Construction does real work, every Command should reuse the same client, and broken configuration should produce one visible failure rather than isolated failures across every server operation.
 
 ::Snippet{name="resourcesPerCommandHttp" label="per-Command HTTP example"}
 
@@ -31,13 +37,19 @@ An HTTP client can still graduate. When an app grows many HTTP Commands, or shar
 
 ## Resources in Flags
 
-The Flags Effect passed to `Runtime.run` can require services too. Declare them in its type and the runtime provides them from the same `resources` Layer it gives Commands and Subscriptions, so a client needed both at startup and by Commands is constructed once rather than once per consumer.
+The Flags Effect can require services too. The runtime provides them from the same `resources` Layer used by Commands and Subscriptions, so a client needed during startup and later work is still constructed only once.
 
 ::Snippet{name="resourcesFlags" label="Flags consuming a resource"}
 
-During fresh boot, Flags resolve before `init`, so a Flags Effect that requires a Resource builds the Layer at startup rather than on the first Command. A Layer that fails to build still reaches the crash view, with one exception. When the Flags Effect itself needs the broken service it cannot proceed, and it fails before the first render, where there is no Model for the crash view to render against. That case fails startup, and neither cause is swallowed, so a Flags Effect that fails for its own unrelated reason stays visible alongside the build error. Every other case is unchanged: the app starts, and the failure reaches the crash view at the first Command or Subscription that needs the Layer.
+During a fresh boot, Flags resolve before init. An application with Flags therefore attempts to build its `resources` Layer during startup instead of waiting for the first Command.
 
-Requirements are checked where the Effect is supplied: `Runtime.run` for an application and `makeElement` for an element. A Flags Effect requiring a service that `resources` does not provide is a compile error whenever `Resources` is inferred from `resources`. Naming it explicitly in the type arguments detaches it from any Layer, which is the same gap Commands already have. Provide a service the Flags Effect alone needs with `Effect.provide` inside `flags` instead, exactly as a Command does: `KeyValueStore` reading persisted state at startup is the common case, and it belongs there rather than in `resources`.
+:::Warning{label="Failure before the first render"}
+If the Flags Effect needs a service whose Layer fails to build, startup cannot reach init or the first render. There is no Model for the crash view yet, so startup fails directly. The Layer build cause remains visible alongside any unrelated Flags failure. If Flags can resolve without the broken service, the app can render; the cached Layer failure then reaches the crash view when the first Command or Subscription needs it.
+:::
+
+Requirements are checked where the Effect is supplied: at `Runtime.run` for an application and in `makeElement` for an element. Let inference connect those requirements to the `resources` Layer. Explicitly naming the `Resources` type argument can detach the requirement from a concrete Layer and bypass that check.
+
+Provide a service used only by Flags with `Effect.provide` inside the Flags Effect, just as you would inside a Command. Reading persisted startup state through `KeyValueStore` is the common case.
 
 ## Providing Multiple Services
 
@@ -45,4 +57,4 @@ The `resources` field takes a single `Layer`, but Effect layers compose. Use `La
 
 ::Snippet{name="resourcesMultiple" label="multiple resources example"}
 
-Resources live for the entire application. But what if a resource should only exist while the Model is in a certain state, like a camera stream during a video call, or a `WebSocket` while on a chat page? That’s what [Managed Resources](/core/managed-resources) are for.
+Resources live for the entire runtime. When a camera stream, `WebSocket`, or other handle should exist only while the Model is in a particular state, use [Managed Resources](/core/managed-resources) instead.

--- a/packages/website/src/page/core/runtime.md
+++ b/packages/website/src/page/core/runtime.md
@@ -2,11 +2,16 @@
 
 ## Overview
 
-A Foldkit app lives in two files. `src/main.ts` holds the pure definitions: Model, Messages, update, init, and view. `src/entry.ts` imports them, creates a runtime with `makeApplication`, and calls `Runtime.run`. `entry.ts` is the only place runtime side effects happen, which keeps `main.ts` importable from tests.
+A Foldkit app usually starts in two files. `src/main.ts` holds the pure definitions: Model, Messages, update, init, and view. `src/entry.ts` imports them, creates the runtime, and starts it. Keeping runtime side effects in `entry.ts` leaves `main.ts` directly importable from tests.
+
+The Runtime API makes two independent choices:
+
+- `makeApplication` or `makeElement` decides what the app owns. An application owns the page; an element owns only its container.
+- `Runtime.run` or `Runtime.embed` decides who owns the runtime lifetime. `run` starts it for the page lifetime; `embed` returns a handle the host disposes.
 
 ## makeApplication {#make-application}
 
-`makeApplication` creates a Foldkit runtime for an app that owns the page. It handles both single-page apps and full applications with routing. The difference is whether you provide a `routing` config. To mount an app scoped to a node without owning the page, use `makeElement` (below).
+`makeApplication` creates a Foldkit program for an app that owns the page. It supports both apps that leave the URL alone and apps that manage routing. The difference is whether you provide a `routing` config. To scope an app to one node without owning the page, use `makeElement`.
 
 ### Without routing
 
@@ -16,24 +21,28 @@ Without a `routing` config, the program doesn't manage the URL bar. This is the 
 
 ### With routing
 
-With a `routing` config, the program manages the URL bar. The init function receives the current URL so it can set the initial route.
+With a `routing` config, the program manages the URL bar. The init function receives the current URL and can use it to set the initial route.
 
 ::Snippet{name="runMakeApplicationRouting" label="makeApplication with routing example"}
 
-The `routing` config has two handlers: `onUrlRequest` is called when a link is clicked (giving you a chance to handle internal vs external links), and `onUrlChange` is called when the URL changes (so you can update your Model with the new route). See the [Routing & Navigation](/core/routing-and-navigation) guide for a full walkthrough.
+The `routing` config has two handlers. `onUrlRequest` turns a clicked link into a Message, giving update the choice between internal and external navigation. `onUrlChange` turns the new URL into a Message so update can store the corresponding route in the Model. See [Routing & Navigation](/core/routing-and-navigation) for the full walkthrough.
 
-Your `view` function returns a `Document` rather than bare HTML: the body to render, plus the document-level state the runtime keeps in sync. `makeApplication` owns that state and reapplies it on every render, so the tab title, the `<html>` language and direction, and the canonical and og\:url tags all track your Model. The [View](/core/view#the-document) page lists every field and what to put in it.
+The view returns a `Document` rather than bare HTML. A `Document` contains the body plus the document-level state that `makeApplication` reapplies on every render. The tab title, the `<html>` language and direction, and the canonical and og\:url tags therefore stay in sync with the Model. [The Document](/core/view#the-document) lists every field.
 
 ## makeElement {#make-element}
 
-`makeApplication` assumes it owns the page, reapplying on every render whatever document state the view declares. That is what you want for an app that owns its tab, but not for a widget embedded on a page you do not control, where it would clobber the host page metadata.
+`makeApplication` assumes it owns the page. That is correct for an app that owns its tab, but not for a widget on a page controlled by another application, where document updates would overwrite the host page metadata.
 
-Use `makeElement` to mount a Foldkit app scoped to its container. Its `view` returns `Html` directly rather than a `Document`, so there is no title to discard, and the runtime never touches the document `<head>` or the `<html>` element. Everything else (Model, `init`, `update`, Commands, Subscriptions, flags, crash handling) works exactly as it does with `makeApplication`. Embedded apps do not own the URL bar, so `makeElement` has no `routing` config.
+Use `makeElement` to scope a Foldkit app to its container. Its view returns `Html` directly, and the runtime never touches the document `<head>` or the `<html>` element. The same Model, init, update, Command, Subscription, resource, and crash-handling architecture remains available. Element-scoped apps do not own the URL bar, so `makeElement` has no `routing` config.
+
+Flags still resolve before init, but their wiring follows the ownership boundary. A page-owning application receives its Flags Effect when `Runtime.run` starts it. A self-contained element receives its Flags Effect in the `makeElement` config.
 
 ::Snippet{name="runMakeElement" label="makeElement example"}
 
 ## embed
 
-`makeElement` mounts a self-contained app in a container. `Runtime.embed` goes further for a widget embedded in a host application, whether that host is React or anything else. The host starts the runtime, seeds it with Flags, exchanges values through Schema-typed Ports, and tears it down with `dispose`. The handle is the whole boundary: the host never reads the Model or dispatches Messages.
+`Runtime.run` starts a program for the lifetime of the page and returns no handle. `Runtime.embed` starts one under a host-controlled lifetime, whether the host is React or anything else. The host seeds the program with Flags, exchanges values through Schema-typed Ports, and tears it down with `dispose`.
+
+The returned handle is the whole boundary. The host never reads the Model or dispatches Messages directly. Disposing the handle stops the runtime and its lifecycle work, removes the rendered DOM, and restores the empty container so it can be embedded again.
 
 The [Embedding](/core/embedding) guide has the full walkthrough.

--- a/packages/website/src/page/core/subscriptions.md
+++ b/packages/website/src/page/core/subscriptions.md
@@ -1,8 +1,10 @@
 # Subscriptions
 
-## Overview
+## Ongoing Work with a Model-Driven Lifetime {#overview}
 
-A Subscription binds a slice of your Model to a scoped Stream that may emit Messages. You name a slice of the Model via `modelToDependencies`, and Foldkit runs the body of work in `dependenciesToStream` as a scoped Effect for exactly as long as that slice holds its dependency-equivalent value. When the slice changes, the scope closes (running any registered `Effect.acquireRelease` finalizers), and a fresh scope opens with the new dependencies.
+A Subscription describes ongoing work whose lifetime comes from the Model. Each entry maps the Model to a dependency record, then maps those dependencies to a scoped `Stream<Message>`.
+
+Foldkit compares the dependencies after every Model update. Equivalent dependencies keep the current Stream alive. A change closes its scope, runs any registered `Effect.acquireRelease` finalizers, and opens a fresh scope with the new dependencies.
 
 ```diagram
                Model
@@ -42,75 +44,87 @@ A Subscription binds a slice of your Model to a scoped Stream that may emit Mess
                update
 ```
 
-This inverts the usual "subscribe to an event source" framing. The thing you are subscribed to is the Model, not the `WebSocket`, not the timer, not the document event. External event sources are what your Effect happens to USE during the subscription’s lifetime; they are not the thing being subscribed to. The common shape plugs an external source into the Stream’s queue so events flow back into `update` as Messages (timer ticks, document keydowns, `WebSocket` frames, system theme changes). Some Subscriptions emit no Messages and just maintain DOM state for the subscription’s lifetime (setting `user-select: none` while a drag is active, applying `aria-hidden` to the document root while a modal is open). Both are valid uses of the same primitive because both are scoped Effect activity gated by a Model condition. See [documentDragStyles](https://github.com/foldkit/foldkit/blob/477db0e12f9599e80e6c9970366281963acd1fd2/packages/ui/src/dragAndDrop/index.ts#L663-L689) for the DOM-state-only shape in production.
+The Subscription is attached to the Model condition, not to the external source used inside its Stream. A timer, document listener, system theme observer, or `WebSocket` supplies events during that lifetime. Those events flow back into update as Messages.
 
-For events tied to a specific element’s existence (scroll listeners, IntersectionObservers, ResizeObservers on a particular element), use [Mount](/core/mount). Mount provides the element handle directly and binds the scope to element lifetime. For stateful long-lived handles your Commands consume (the `WebSocket` connection itself, a camera stream, a third-party library instance), use [ManagedResource](/core/managed-resources). ManagedResource is Subscription’s sibling: same Model-gated lifetime, both dispatch Messages. The discriminator is whether other parts of the program need a typed handle to the underlying resource. Subscription’s Messages flow from inside the body of work during the subscribed lifetime (timer ticks, document keydowns, `WebSocket` frames as they arrive). ManagedResource dispatches Messages at lifecycle transitions (`onAcquired`, `onReleased`, `onAcquireError`) AND exposes the acquired value as a typed handle Commands access via `yield*`.
+A Subscription may also maintain scoped DOM state without emitting Messages. For example: it can apply `user-select: none` while a drag is active, then restore the previous value when dragging ends. The production [documentDragStyles](https://github.com/foldkit/foldkit/blob/477db0e12f9599e80e6c9970366281963acd1fd2/packages/ui/src/dragAndDrop/index.ts#L663-L689) Subscription uses this shape.
 
-Because the Stream factory is an Effect, it can do DOM side effects directly when the work must be synchronous with the event itself. Calling `preventDefault` on a keydown listener is the canonical case: routing the event through `update` would arrive after the browser had committed the default. Do the DOM mutation in a synchronous Effect that runs in the same call stack as the browser’s event dispatch. `Stream.mapEffect` with `Effect.sync` is the typical shape when you also want to transform the event into a Message; `Stream.tap` is the typical shape when the mutation is the entire point and no Message follows.
+Choose the lifecycle primitive by what owns the work:
+
+| Primitive                                  | Lifetime owner                                      | Use it for                                                                                    |
+| ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Subscription                               | A dependency record derived from the Model          | Ongoing event streams or scoped work that does not expose a handle                            |
+| [Mount](/core/mount)                       | One rendered element                                | Listeners, observers, or imperative work that needs that element                              |
+| [ManagedResource](/core/managed-resources) | A Model condition, with a typed handle for Commands | A `WebSocket`, camera stream, or third-party instance that other parts of the program consume |
+
+Subscription callbacks can perform synchronous browser work when the event requires it. `preventDefault()` is the common case. The mapper in `Subscription.fromEvent` runs inside the browser's event dispatch, so it can suppress the default action before returning a Message.
 
 ## Auto-Counter Example
 
-In the [restaurant analogy](/core/architecture#the-restaurant-analogy), a Subscription is a standing order: “keep the coffee coming for table 5.” The waiter doesn’t keep walking back to repeat the order. The kitchen knows to keep pouring until the table says stop.
-
-Commands handle one-off side effects: a slip to the kitchen that comes back with a single result. Subscriptions handle the ongoing kind. Here’s how we add auto-counting to the counter: when `isAutoCounting` is `true`, a stream ticks every second, and when it flips to `false`, the stream stops.
+Commands describe one-shot work that produces one result. Subscriptions describe ongoing work. In the counter, a Subscription emits `Ticked` once per second while `isAutoCounting` is `true` and stops when it becomes `false`.
 
 ::Snippet{name="counterAutoCount" label="subscription example"}
 
-Each entry is built by calling `entry` with two arguments. The first is a field map describing the dependency shape (the same shape you would pass to `S.Struct`). The second is an object with two callbacks:
+`Subscription.make<Model, Message>()` receives a function that builds a named record of entries. Each call to `entry` takes two arguments:
 
-- `modelToDependencies` extracts the dependencies from the Model.
-- `dependenciesToStream` creates a Stream of Messages from those dependencies.
+- A field map defining the dependency Schema, in the same shape passed to `S.Struct`.
+- An object containing `modelToDependencies` and `dependenciesToStream`.
 
-Foldkit structurally compares the dependencies between Model updates. The stream is only restarted when the dependencies actually change, not on every Model update.
+`modelToDependencies` extracts the values that control the entry. `dependenciesToStream` creates its Stream. Foldkit compares the extracted record structurally by default, so unrelated Model updates do not restart the timer.
 
-When `isAutoCounting` changes from `false` to `true`, the stream starts ticking. When it changes back to `false`, the stream stops. Foldkit handles all the lifecycle management for you.
+When `isAutoCounting` changes to `true`, the new Stream starts ticking. When it changes back to `false`, the active scope closes and the timer stops.
 
-Defining `subscriptions` is only half of it. The value does nothing until you pass it to `makeApplication`. The field is optional, so leaving it out is not a type error: the streams simply never start, and the app runs as though the Subscription were not there.
+Defining `subscriptions` is only half of the setup. Pass the record to `makeApplication` or no streams start. The field is optional, so omitting it still produces a valid application without Subscription behavior.
 
 ::Snippet{name="counterEntryWithSubscriptions" label="subscription wiring"}
 
-For a more complex example consuming a `WebSocket` message stream, see the [websocket-chat example](/example-apps/websocket-chat). For a full real-world application, check out [Typing Terminal](https://typingterminal.com) ([source](https://github.com/foldkit/foldkit/tree/main/packages/typing-game)).
+The [websocket-chat example](/example-apps/websocket-chat) shows a more involved event stream. [Typing Terminal](https://typingterminal.com) and its [source](https://github.com/foldkit/foldkit/tree/main/packages/typing-game) show Subscriptions inside a complete application.
 
 ## Animation Frames
 
-For Subscriptions tied to the browser’s paint clock, `Subscription.animationFrame` is a ready-made helper. It emits a Message every `requestAnimationFrame` tick with the inter-frame delta in milliseconds, and tears the loop down when its `isActive` gate returns `false`. The helper returns a complete Subscription entry (its dependencies are `{ isActive: boolean }`), so it slots into `Subscription.make` as a single line alongside any other entries.
+`Subscription.animationFrame` is a ready-made entry for work tied to the browser's paint clock. It emits a Message on each `requestAnimationFrame` tick while its `isActive` function returns `true`, and supplies the inter-frame delta in milliseconds.
 
-Reach for it whenever you want smooth, time-based motion driven by Model updates: physics simulations, generative art, parallax scrolling, custom interpolations. The `deltaTime` payload makes simulation speed independent of frame rate. Multiply per-second velocities by it and motion stays consistent on 60Hz, 120Hz, or after a tab regains focus.
+The helper returns a complete entry with `{ isActive: boolean }` dependencies. Place it directly in the record passed to `Subscription.make`:
 
 ::Snippet{name="subscriptionAnimationFrame" label="animation frame example"}
 
-For discrete game ticks (where the simulation steps once every N ms regardless of refresh rate), reach for `Stream.tick` instead. Wall-clock cadence and display-coupled cadence are different problems: `Stream.tick` suits the first, `Subscription.animationFrame` the second. The [snake example](/example-apps/snake) uses `Stream.tick` for its game cadence; the [canvas-art example](/example-apps/canvas-art) uses `Subscription.animationFrame` for per-frame physics.
+Use the delta to make motion independent of refresh rate. Convert the milliseconds to seconds before multiplying a per-second velocity, so the simulation behaves consistently at 60Hz, 120Hz, and after a background tab regains focus.
+
+Use `Stream.tick` for discrete wall-clock steps that should occur every N milliseconds. `Subscription.animationFrame` follows the display; `Stream.tick` follows elapsed time. The [canvas-art example](/example-apps/canvas-art) uses animation frames for per-frame physics, while the [snake example](/example-apps/snake) uses `Stream.tick` for game cadence.
 
 ## DOM Events
 
-For DOM events that are not tied to a specific element in your rendered tree (global keyboard shortcuts on `window`, media-query changes, `document` visibility), `Subscription.fromEvent` builds the `addEventListener` and `removeEventListener` lifecycle for you. It returns a Stream that registers the listener when the scope opens and removes it when the scope closes, so you never hand-roll the `Effect.acquireRelease` yourself.
+`Subscription.fromEvent` handles DOM events that are not tied to one element in the rendered tree, such as window shortcuts, media-query changes, or document visibility. It registers the listener when the Stream scope opens and removes it when the scope closes.
 
-Because `fromEvent` is a Stream rather than a complete entry, you gate it the same way as any other Stream. Wrap it in `Stream.when` inside an `entry` to bind it to a Model condition, or pass it to `Subscription.persistent` for a listener that runs for the whole Subscriptions record. Here is a global keyboard shortcut gated on `isListening`:
+The helper returns a Stream, not a complete entry. Wrap it in `Stream.when` inside an entry to gate it on the Model, or pass it to `Subscription.persistent` for a listener that lives with the whole Subscriptions record.
 
 ::Snippet{name="subscriptionFromEvent" label="DOM event subscription example"}
 
-The `toMessage` mapper runs synchronously in the same call stack as the browser’s event dispatch, so calling `event.preventDefault()` inside it works. Pass the `target` as a thunk when it may not exist until the scope opens, or directly for always-present globals like `window` and `document`. For events tied to a specific rendered element, reach for [Mount](/core/mount) instead, which hands you the element directly.
+The `toMessage` mapper runs synchronously in the same call stack as the browser event, so it may call `event.preventDefault()`. Pass `target` as a thunk if the target may not exist until the scope opens. Pass always-present globals such as `window` and `document` directly.
 
-When only some events should become Messages, use `Subscription.fromEventFilterMap`. Its `toMessage` returns `Option.some(message)` to emit a Message or `Option.none()` to ignore the event.
+Use `Subscription.fromEventFilterMap` when only some events should dispatch. Its mapper returns `Option.some(message)` to emit or `Option.none()` to ignore the event. For a listener attached to one rendered element, use [Mount](/core/mount) instead.
 
-## Advanced
+## Keep a Stream Alive Across Dependency Changes {#advanced}
 
-Consider an auto-scroll Subscription for a drag-and-drop interface. It depends on both `isDragging` (should the scroll loop run?) and `clientY` (where is the pointer?). The stream should start when dragging begins and stop when it ends, but `clientY` changes on every pixel of mouse movement, and by default every change restarts the stream, destroying the `requestAnimationFrame` loop each time.
+The default structural comparison restarts an entry whenever any dependency changes. That is usually the right behavior. It becomes wasteful when one field controls the lifetime while another changes frequently and must remain available to a long-running callback.
+
+Auto-scroll during drag and drop is one example. `isDragging` should start and stop the animation loop. `clientY` changes with every pointer movement, but restarting the loop for every pixel would destroy and recreate it continuously.
 
 ::Snippet{name="subscriptionEquivalence" label="advanced subscription example"}
 
 ### Custom Equivalence
 
-The `keepAliveEquivalence` field overrides the default structural comparison with an `Equivalence` from Effect, letting you choose which fields are allowed to change without restarting the stream. `Equivalence.Struct({ isDragging: Equivalence.Boolean })` means two snapshots are equal if they have the same `isDragging` value, regardless of `clientY`. The stream starts once when dragging begins and stops when it ends. It never restarts in between.
+`keepAliveEquivalence` replaces the default structural comparison with an Effect `Equivalence`. In the example, `Equivalence.Struct({ isDragging: Equivalence.Boolean })` compares only `isDragging`. The Stream starts when dragging begins, stays alive while `clientY` changes, and stops when dragging ends.
 
 ### Reading Live Dependencies
 
-If the stream doesn’t restart when `clientY` changes, how does the rAF loop read the latest pointer position? The second argument to `dependenciesToStream` is `readDependencies`: a function that returns the current dependencies synchronously, reflecting the latest Model state without restarting the stream.
+The second argument to `dependenciesToStream` is `readDependencies`. It synchronously returns the latest dependency record, including fields that `keepAliveEquivalence` excluded from the restart decision. The animation callback can therefore read the newest `clientY` on every frame without restarting its Stream.
 
-Inside the `requestAnimationFrame` loop, `readDependencies()` returns the latest snapshot every frame. This is the bridge between the stream lifecycle (which gates on the dependencies that trigger restarts) and browser callbacks (which need synchronous access to the latest state).
+Most entries should use the first `dependencies` argument directly. Reach for `readDependencies` only when a long-lived callback needs current values that should not control its lifetime. The [Drag and Drop](/ui/drag-and-drop) component and [Kanban example](/example-apps/kanban) show this pattern in context.
 
-In most Subscriptions, use the dependencies passed as the first argument directly. The stream restarts whenever they change, so they’re always current. `readDependencies` is for the case where `keepAliveEquivalence` has excluded fast-changing fields from the restart decision, and you need to read those fields inside a long-lived callback. For a real-world example, see the [Drag and Drop](/ui/drag-and-drop) component and the [Kanban example](/example-apps/kanban).
+## Lifting Subscriptions
 
-When a parent Submodel embeds children that emit Subscriptions, the parent owns the wrap into its own Message type. `Subscription.lift` handles this composition in one call, and its optional `when` lets the parent gate on a parent fact the child cannot see, such as the route a page sits behind. `when` is written by the parent and reads the parent Model, as one predicate for the whole record or as a map naming the entries to gate. See [Subscription Organization](/patterns/subscription-organization) for the full pattern.
+When a parent embeds a Submodel with Subscriptions, the parent must lift the child's Messages into its own Message type. `Subscription.lift` composes the entire record in one call.
 
-You’ve now seen how state changes flow through update, how one-off side effects work as Commands, how view code reaches the live DOM with Mount, and how ongoing streams are managed with Subscriptions. But where do the first Model and Commands come from? That’s `init`.
+The optional `when` field lets the parent add a condition the child cannot see, such as whether the child's page is the active route. One predicate can gate the whole record, or a map can gate selected entries. The child continues to own its own dependencies. See [Subscription Organization](/patterns/subscription-organization) for the complete composition pattern.
+
+The application now has state transitions, one-shot Commands, element-scoped Mounts, and ongoing Subscriptions. The remaining question is where the first Model and startup Commands come from. [Init & Flags](/core/init-and-flags) defines that boundary.

--- a/packages/website/src/page/core/update.md
+++ b/packages/website/src/page/core/update.md
@@ -1,21 +1,19 @@
 # Update
 
-## Overview
+## One Function Defines Every Transition {#overview}
 
-The update function is the heart of your application logic. It’s a pure function that takes the current Model and a Message, and returns a new Model along with any Commands to execute.
+The update function receives the current Model and a Message, then returns the next Model and any Commands for the runtime to execute. It is the only place application state changes.
 
-In the [restaurant analogy](/core/architecture#the-restaurant-analogy), the update function is the waiter. Something happens (a customer flags them down, the kitchen rings the bell) and the waiter decides what to do next. Update the notebook, maybe write a slip for the kitchen. The waiter doesn’t cook the food or serve it directly. They take in what happened and decide on next steps.
+Update is pure. Given the same Model and Message, it returns the same result. It does not mutate state, call browser APIs, start timers, or make requests. That makes a transition direct to test: pass in the inputs and assert on the returned values.
 
-Pure means predictable: given the same Model and the same Message, update always returns the same result. No hidden state, no ambient mutation, no surprises. This makes every state transition easy to reason about and trivial to test: pass in a Model and a Message, assert on the output.
-
-Foldkit uses [Effect.Match](https://effect.website/docs/code-style/pattern-matching/) for exhaustive pattern matching on Messages. The TypeScript compiler will error if you forget to handle a Message type.
-
-Add a new Message to your app and forget to handle it here? The compiler tells you. No forgotten cases, no `default` branches silently swallowing new Messages (unless you explicitly opt into a catch-all).
+Use [Effect's `Match`](https://effect.website/docs/code-style/pattern-matching/) and `M.tagsExhaustive` to handle the Message union. If you add a Message and omit its branch, TypeScript reports the missing case. No `default` branch silently absorbs a new variant.
 
 ::Snippet{name="counterUpdate" label="update example"}
 
-Each branch builds the next Model with [evo](/best-practices/immutability#immutable-updates), which evolves the Model you already have instead of rebuilding it. Every field you name takes a function from its current value to its next one, and fields you leave out keep their existing references. The counter has a single field today, so there’s nothing else to carry, but the shape stays the same as the Model grows.
+Each branch describes one transition. `ClickedDecrement` and `ClickedIncrement` transform the current count. `ClickedReset` replaces it with zero. All three return an empty Commands array because this version of the counter has no side effects.
 
-Notice that update returns a tuple: the new Model and an array of Commands. Commands represent side effects: HTTP requests, timers, browser API calls. Each Command carries a name for tracing and testing. For the counter, the Commands array is always empty. But when we add a delayed reset on the [Commands](/core/commands) page, that will change.
+The branches build their next Model with [evo](/best-practices/immutability#immutable-updates). Each named field receives a function from its current value to its next value. Omitted fields keep their existing values and references, so the same update style continues to work as the Model grows.
 
-Before we get to side effects, there’s one more piece of the counter to understand: the view function, which turns your Model into what the user sees on screen.
+Update returns a tuple containing the next Model and an array of Commands. A Command describes one side effect, such as an HTTP request, timer, or browser API call. The [Commands](/core/commands) page adds a delayed reset and puts that second tuple element to work.
+
+First, the [view function](/core/view) completes the basic loop by turning the Model into what the user sees.

--- a/packages/website/src/page/core/view.md
+++ b/packages/website/src/page/core/view.md
@@ -1,22 +1,22 @@
 # View
 
-## Overview
+## Model In, HTML Out {#overview}
 
-The view function turns your Model into HTML. The user doesn’t see the Model directly. They see what view renders from it.
+The view function turns the Model into HTML. Given the same Model, it produces the same output. It does not modify state or run Effects.
 
-In the [restaurant analogy](/core/architecture#the-restaurant-analogy), the waiter’s notebook says “table 3: salmon, ready.” The view is what’s actually on the table: the plate in front of the customer.
+Event attributes complete the loop. They produce Messages for the runtime to dispatch, and update decides what those Messages mean. The view remains a pure description of what the user should see and which facts an interaction can report.
 
-Given the same Model, view always produces the same HTML. It never modifies state directly. Instead, it dispatches Messages through event handlers, feeding them back into the loop.
+In the [restaurant analogy](/core/architecture#the-restaurant-analogy), view is the meal on the table. The Model records the current facts; view presents them.
 
 ::Snippet{name="counterView" label="view example"}
 
 :::Info{label="No hook rules"}
-In React, functional components can hold local state and run effects via hooks, which come with ordering rules you have to follow. In Foldkit, view is guaranteed pure: no hooks, no effects, no local state. It’s a function from Model to Html.
+React functional components can hold local state and run effects through hooks, which introduces ordering rules. A Foldkit view has neither hooks nor local state. It is a function from Model to Html.
 :::
 
 ## The Document
 
-A `makeApplication` view returns a `Document` rather than bare HTML. A Document is everything the runtime needs to render one frame: the body to patch into the container, plus the document-level state that should track the Model.
+A `makeApplication` view returns a `Document`, not bare HTML. The Document contains the body to patch into the application container and the document-level state that should track the Model.
 
 | Field       | Type                       | Required | What the runtime does with it                                                                  |
 | ----------- | -------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
@@ -27,47 +27,45 @@ A `makeApplication` view returns a `Document` rather than bare HTML. A Document 
 | `canonical` | `string`                   | No       | Syncs it to `<link rel="canonical">`, creating the tag if absent. Defaults to the current URL. |
 | `ogUrl`     | `string`                   | No       | Syncs it to `<meta property="og:url">`, creating the tag if absent. Defaults to `canonical`.   |
 
-Every field is a function of the Model, exactly like `body`. There is no imperative `setTitle` and no separate head-management API: you return the values you want and the runtime makes the document match on each render.
+Every field is a function of the Model, just like `body`. There is no imperative `setTitle` or separate head-management API. Return the values you want, and the runtime makes the document match after each render.
 
-A `makeElement` view returns `Html` directly instead of a `Document`. An embedded app does not own the page, so it has no title or document metadata to declare, and the rest of this section does not apply to it. Everything on this page outside this section applies to both. See [Runtime](/core/runtime#make-element) for which of the two to reach for.
+A `makeElement` view returns `Html` directly. An embedded app does not own the page, so it cannot declare the title or document metadata. Everything outside this section applies to both kinds of view. See [Runtime](/core/runtime#make-element) for when to use each one.
 
-### Language and direction
+### Language and Direction
 
-`lang` and `dir` sync to the `<html>` element. Drive them from the Model when the app switches language at runtime, the same way `title` tracks the current page.
+`lang` and `dir` sync to the `<html>` element. Drive them from the Model when the application can switch languages at runtime, just as `title` tracks the current page.
 
 ::Snippet{name="documentLanguage" label="Localized document example"}
 
-`dir` takes `'Ltr'`, `'Rtl'`, or `'Auto'`, which the runtime writes as the lowercase `dir` attribute values. `Auto` hands the decision to the browser's first-strong-character heuristic. `foldkit/html` exports `TextDirection` as a Schema, so a Model that stores the direction rather than deriving it can drop the field straight into an `S.Struct`.
+`dir` accepts `'Ltr'`, `'Rtl'`, or `'Auto'`. The runtime writes the corresponding lowercase attribute value. `Auto` delegates to the browser's first-strong-character heuristic. If the Model stores direction rather than deriving it, use the `TextDirection` Schema exported by `foldkit/html`.
 
-Neither field has a default. When a view omits one, the runtime does not touch that attribute, leaving whatever value it currently holds, so a view that never sets it leaves the `lang` from your `index.html` in place. That is the right behavior for an app that ships in one language, and it means adding these fields never changes an existing app.
+Neither field has a default. If view omits one, the runtime leaves the existing attribute alone. An application that never sets `lang` therefore keeps the value from `index.html`.
 
-The runtime can only sync after the first render, so the served HTML still decides what a crawler sees on first paint. When the language is known per request, stamp `<html lang>` in the HTML shell and let the runtime keep it in sync from there. The runtime sync is what a screen reader picks up when a user flips the language switcher, which is the part a static shell cannot do.
+The runtime can only synchronize these fields after the first render. Served HTML still determines what a crawler sees on first paint. If language is known per request, stamp `<html lang>` into the HTML shell and let the runtime keep it current after startup. Use the `Lang` attribute on an individual element when only one passage differs from the page language.
 
-To mark up a passage in a different language from the page, use the `Lang` attribute on that element instead. `Document.lang` is only the root.
+### Canonical and Share URLs
 
-### Canonical and share URLs
+`canonical` and `ogUrl` keep `<link rel="canonical">` and `<meta property="og:url">` current as the route changes. If both are omitted, they resolve to the current URL. If only `canonical` is set, `ogUrl` uses the same value.
 
-`canonical` and `ogUrl` keep `<link rel="canonical">` and `<meta property="og:url">` current as you navigate, so a platform share menu copies the link for the route the user is actually on rather than the one the page was first served as.
+Set them explicitly when the address bar does not identify the page you want indexed or shared. For example: later pages in a paginated list may point to the first page as canonical.
 
-Set neither and both fall back to the current URL, which is what a routed app usually wants. The two are chained rather than independent: `canonical` falls back to the current URL, and `ogUrl` falls back to the resolved `canonical`, so setting `canonical` alone moves both. Set them explicitly when the canonical URL differs from the address bar, such as a paginated list whose later pages should point back at the first.
-
-On a server render this default is the full request URL, query string included, so set `canonical` explicitly when the query is not part of the page's identity, such as tracking parameters or a session token. Left to the default, a crawler indexes every query variant as its own canonical page.
+On a server render, the default is the full request URL, including its query string. Set `canonical` explicitly when a query parameter is not part of the page's identity, such as a tracking parameter or session token. Otherwise, a crawler can treat each query variant as a separate canonical page.
 
 ## Typed HTML Helpers
 
-Foldkit’s HTML functions are typed to your Message type. This ensures event handlers only accept valid Messages from your application. Every view receives `h`, the typed Html builder, alongside the Model: the runtime passes one to your root view, and `Submodel.defineView` passes one to each child view. Reach for `h.div`, `h.OnClick`, and the rest off it:
+Every view receives `h`, an `HtmlBuilder` typed to the application's Message union. Elements, attributes, and handlers all come from this builder:
 
 ::Snippet{name="htmlHelpers" label="HTML helpers example"}
 
-This gives you strong type safety: if you try to pass an invalid Message to `h.OnClick`, TypeScript catches it at compile time.
+The Message type follows the builder. If `h.OnClick` receives a Message outside the application union, TypeScript rejects it. The root runtime supplies its builder, and `Submodel.defineView` supplies one for each child view.
 
-An element builder takes attributes first and children second. Children are optional, so an element that has none omits the argument rather than spelling out an empty array: `h.div([h.Class('divider')])`. Attributes stay required, which leaves `h.div([])` as the spelling for an element with neither. `h.keyed` has the same shape with the key ahead of the pair, so a childless keyed row is `h.keyed('li')(row.id, [h.Class('h-8')])`. Void elements like `h.img` and `h.br` take attributes only and reject a children argument outright, so sibling elements sitting at different arities is normal rather than a sign that one of them is wrong. The `foldkit/no-empty-children-array` [lint rule](/tooling/oxlint-plugin#no-empty-children-array) catches a trailing `[]` that carries no information.
+Element builders take attributes first and optional children second. Omit the children argument when there are no children: `h.div([h.Class('divider')])`. Attributes remain required, so `h.div([])` represents an element with neither attributes nor children. `h.keyed` follows the same rule, with the key before the attributes and children. Void elements such as `h.img` and `h.br` accept attributes only. The `foldkit/no-empty-children-array` [lint rule](/tooling/oxlint-plugin#no-empty-children-array) catches a trailing `[]` that carries no information.
 
-Application code cannot construct a builder; `h` only enters a view as a parameter. That is what keeps the typing truthful. The builder is supplied by the render frame it will dispatch into, so its Message type cannot disagree with the boundary that routes its handlers. When you extract a view helper, take `h: HtmlBuilder<Message>` as its last parameter and let callers thread theirs through. A helper meant to work under any parent takes `ParentMessage` as a function generic with `h: HtmlBuilder<ParentMessage>`, staying decoupled from any particular parent and composing through the callbacks the parent supplies.
+Application code cannot construct a builder. It only enters through a view parameter, which keeps its Message type aligned with the boundary that dispatches its handlers. Extracted view helpers should take `h: HtmlBuilder<Message>` as their last parameter. A helper that works under any parent can introduce a `ParentMessage` generic and accept `h: HtmlBuilder<ParentMessage>`.
 
-Where no builder is in scope, typically module scope, `foldkit/html` exports `inertHtml`. It is typed `HtmlBuilder<never>`: elements and styling attributes work, and no event handler can be constructed with it, so nothing built with it can dispatch a Message. Inert describes what the result can do, not how it is computed; the markup is still free to vary with runtime data. Its attributes are `Attribute<never>` and flow into any Message universe, which is what lets library code hand out handler-free attribute bundles. Import it aliased as `ih`, which reads as the inert counterpart to `h` and keeps the two distinguishable at every call site. Inside a view, use the view's own `h` rather than reaching past it.
+At module scope, where no view builder exists, `foldkit/html` exports `inertHtml`. It is an `HtmlBuilder<never>`, so it can build elements and styling attributes but cannot express a Foldkit event handler. Its `Attribute<never>` values can be used with any Message type, which lets a library publish reusable, handler-free attribute bundles. Import it as `ih` to distinguish it from the live builder passed to view. Markup built with `ih` may still vary with runtime data; inert means that it cannot dispatch a Message. Inside a view, use the builder supplied to that view.
 
-Inert to Foldkit's dispatch, not to the browser. A raw DOM attribute still does whatever the browser makes of it, which is how the [crash view](/core/crash-view) gets a working reload button with `h.Attribute('onclick', 'location.reload()')`. What `never` rules out is a Message reaching `update`, not every possible behavior.
+Inert HTML is inert to Foldkit dispatch, not to the browser. A raw DOM attribute can still trigger browser behavior. The [crash view](/core/crash-view), for example, uses `h.Attribute('onclick', 'location.reload()')` because its `HtmlBuilder<never>` cannot dispatch into a stopped update loop.
 
 :::Warning{label="Raw HTML, script sources, and script attributes need trusted content"}
 Several inputs run whatever you pass them, in the browser and in server-rendered HTML alike, and Foldkit does not sanitize them:
@@ -86,42 +84,50 @@ Only ever pass content you control to these. A value built from user input, a UR
 
 ## Event Handling
 
-When the customer flags the waiter, that’s a Message. In the view, event handlers work the same way. Instead of imperative callbacks that modify state, you pass a Message, or a function that maps an event to a Message.
+Event attributes return Messages instead of mutating state. Pass a Message directly for a simple event, or use a function that translates event data into a Message:
 
 ::Snippet{name="eventHandling" label="event handling example"}
 
-For simple events like clicks, you pass the Message directly. For events that carry data (like input changes), you pass a function that receives the event and returns a Message. This keeps your view declarative. It describes what Messages should be sent, not how to handle them.
+`h.OnClick` takes a Message. `h.OnInput` takes a function because the input value becomes part of the Message. Both remain declarative: view reports what happened, and update decides what follows.
 
 ## Complex Handlers
 
-The examples above are short, but handlers are not limited to one-liners. The rule is that a handler is a pure translator from event data to a Message, not that it stays small. For example, a keydown translator can branch on the key, read Model-derived state from view scope, and return `Option<Message>` so it dispatches only when the event means something:
+A handler can do more than return a one-line Message. The constraint is purity, not size. It may branch on event data, read Model-derived state from view scope, and return `Option<Message>` when only some events should dispatch:
 
 ::Snippet{name="eventHandlingComplex" label="complex handler example"}
 
-Returning `Some` claims the key: the framework suppresses the browser’s default action and dispatches the Message. Returning `None` leaves the key to the browser. The next section covers why `OnKeyDownPreventDefault` runs that suppression for you.
+For `OnKeyDownPreventDefault`, returning `Some` claims the key. Foldkit suppresses the browser's default action and dispatches the Message. Returning `None` leaves the key to the browser.
 
-A handler never runs Effects: the runtime is the only Effect executor, and anything effectful belongs in a Command returned from update. A handler also never decides consequences: it classifies the event into a fact, like Enter with an active result meaning `SelectedResult`, and update decides what follows from that fact.
-
-When a translator grows, extract it to a named pure function and pass it to the attribute, as the example above does with `handleResultsKeyDown`. Foldkit’s own Listbox does the same: its keydown handler matches on Escape, Enter, Space, the navigation keys, and printable typeahead keys, with Model-derived state in scope, all as one pure function handed to `OnKeyDownPreventDefault`.
+Handlers never run Effects or decide consequences. The example classifies Enter with an active result as `SelectedResult`; update decides what selection changes. When a translator grows, extract it to a named pure function and pass that function to the attribute.
 
 ## Event Handler Side Effects
 
-Foldkit runs your side effects for you. Your view only declares attributes and returns Messages. Usually Foldkit defers those effects to lifecycle primitives like Commands, Subscriptions, and Mounts, which run after the current event has returned. A few effects cannot wait that long. The browser only honors them when they run synchronously, inside the originating user-gesture event handler, and a deferred primitive runs a frame too late. Foldkit handles those from inside the event attribute itself. It is still Foldkit running the effect, not your view.
+Most side effects can run after the browser event returns, through a Command, Subscription, or Mount. A few browser APIs only work synchronously inside the originating user gesture. Foldkit exposes dedicated attributes for those cases, so the framework still owns the effect and the view callback stays pure.
 
-Two cases show up in practice. `event.preventDefault()` must run synchronously to suppress a default browser action like form submission or scroll. `.focus()` on iOS Safari only opens the on-screen keyboard if it runs inside the gesture; the same call from a Command resolves a frame later and the keyboard never appears.
+Two constraints account for most uses. `event.preventDefault()` must run before the browser commits its default action. On iOS Safari, `.focus()` must run during the gesture to open the on-screen keyboard.
 
-Foldkit exposes these as attribute primitives. `OnKeyDownPreventDefault` takes a function returning `Option<Message>`. When the function returns `Some`, the framework calls `preventDefault` and dispatches the Message. `OnClickFocus` takes a selector and a Message; it synchronously focuses the element matching the selector and then dispatches.
-
-The clipboard family follows the same rule. `OnPastePreventDefault` hands your function the clipboard’s text/plain payload. Returning `Some` suppresses the browser’s default insertion and dispatches the Message carrying the pasted content; `None` lets the browser paste normally. `OnCopyText` and `OnCutText` go the other way: they write Model-derived text to the clipboard and call `preventDefault` inside the gesture, since the clipboard is only writable there. The cut variant also dispatches a Message so update can remove the cut content from the Model.
+`OnKeyDownPreventDefault` lets a translator decide whether to claim a key event. `OnPastePreventDefault` passes the clipboard's `text/plain` payload to its translator; `Some` suppresses the default insertion and dispatches the Message, while `None` leaves the paste alone. `OnCopyText` and `OnCutText` write Model-derived text to the clipboard and suppress the browser's default payload; the cut variant also dispatches a Message. `OnClickFocus` synchronously focuses the element matching a selector, then dispatches its Message.
 
 ::Snippet{name="eventHandlerSideEffects" label="event handler side effects example"}
 
-The iOS keyboard case has one wrinkle. The element you focus has to be in the page at the instant of the tap. A search field inside a dialog is not: while the dialog is closed its input is not rendered, and opening the dialog does not help because that happens a frame later, after the gesture has ended.
+The iOS keyboard case has one extra constraint: the target must already exist when the user taps. An input inside a closed dialog does not. Keep an always-present, visually hidden text input as a keyboard warmup and point `OnClickFocus` at it. The same attribute dispatches the Message that opens the dialog. Update can then return a `Dom.focus` Command to move focus to the real input after it mounts, while iOS keeps the keyboard open.
 
-:::Info{label="Focus a stand-in, then hand off"}
-Keep an always-present, visually hidden text input (the “keyboard warmup”) and point OnClickFocus at it. The tap focuses the warmup (which opens the keyboard) and dispatches a Message. update’s branch for that Message opens the dialog and returns a Dom.focus Command pointed at the real input. It runs once the dialog has mounted, so focus lands on the real input, and iOS keeps the keyboard up as focus moves between the two text inputs.
+These attributes are narrow browser-integration primitives, not a general escape hatch. Use them only when the browser requires synchronous work inside a gesture. Anything that can wait belongs in the normal lifecycle, usually a Command.
+
+## Trusted Content Boundaries
+
+Typed builders prevent a handler from dispatching the wrong Message. They do not sanitize content that you explicitly ask the browser to interpret as HTML, script, or an executable resource.
+
+:::Warning{label="Raw HTML, script sources, and script attributes need trusted content"}
+Several inputs run whatever you pass them, in the browser and in server-rendered HTML alike:
+
+- `h.InnerHTML` and `h.Srcdoc` render their strings as raw HTML.
+- A raw `onclick`-style attribute runs its string as script.
+- The `src` of a `<script>` or `<iframe>`, and the `data` of an `<object>`, load and run whatever they point at, including an `http(s)` or `data:` URL.
+
+Only pass content you control to these APIs. User input, a URL parameter, or an API response can become a cross-site scripting vector. Build ordinary markup with `h` instead, or sanitize the value before it reaches one of these sinks.
 :::
 
-These are ordinary declarative attributes, not an escape hatch into imperative code. Foldkit still owns the side effect and runs it inside the framework’s handler, so your callbacks stay pure and your Messages stay facts. Reach for them only when the browser requires a synchronous side effect inside the gesture. Anything that can wait belongs in the normal lifecycle, usually a Command.
+`h.Href`, `h.Src`, `h.Action`, and `h.Formaction` neutralize `javascript:` and `vbscript:` URLs, including control-character obfuscation, to an empty value. This blocks the classic scheme-based injection on a link or form. It does not make every URL safe. A `<script>` or `<iframe>` still executes an `http(s)` or `data:` source, so any URL that loads code must be trusted.
 
-So far everything has been synchronous. The user clicks a button, update produces a new Model, the view rerenders. But real apps need side effects: HTTP requests, timers, browser APIs. That’s where Commands come in.
+The basic loop is now complete: a Message reaches update, update returns a Model, and view renders it. The next step is side effects. [Commands](/core/commands) describe one-shot work for the runtime to execute.

--- a/packages/website/src/page/fieldValidation.md
+++ b/packages/website/src/page/fieldValidation.md
@@ -8,7 +8,14 @@ Foldkit models field validation as data in your Model, not scattered logic acros
 
 ::Snippet{name="fieldValidationMakeRules" label="makeRules example"}
 
-The four states: `NotValidated` for fields the user hasn’t interacted with yet, `Validating` for async checks in flight, `Valid` when all rules pass, and `Invalid` when one or more rules fail. Every state carries the current `value`, and `Invalid` additionally carries an `errors` array.
+Every state carries the current `value`. `Invalid` also carries a non-empty `errors` array.
+
+| Variant        | Meaning                                    |
+| -------------- | ------------------------------------------ |
+| `NotValidated` | Validation has not run.                    |
+| `Validating`   | An async check is in flight.               |
+| `Valid`        | Every applicable rule passed.              |
+| `Invalid`      | One or more rules failed, with the errors. |
 
 The Schema you pass `Field` should match what the control actually holds as the user edits, not the type you parse it into: `Field(S.String)` for text inputs, `Field(S.Array(S.String))` for a multi-select. A scalar like a checkbox’s boolean usually stays plain `S.Boolean` in the Model; wrap it in `Field` only when it needs the validation lifecycle. Values you reach by parsing text, like numbers and dates, stay `Field(S.String)`: a half-typed entry is still a string, so parse it into its domain type on submit. Validation rules stay separate, in the `Rules` bundle.
 
@@ -30,15 +37,21 @@ Call `validate(rules)(value)` to validate a value against a bundle of rules. It 
 
 ::Snippet{name="fieldValidationApply" label="validate example"}
 
-Use `validateAll(rules)` when you want to collect every failing rule into the `errors` array rather than stopping at the first failure.
+Empty values follow the bundle’s requiredness before any rules run. An empty required value becomes `Invalid` with the required message; an empty optional value becomes `NotValidated`. A non-empty value becomes `Valid` when every rule passes or `Invalid` when one fails.
+
+Use `validateAll(rules)` when you want to collect every failing rule into the `errors` array rather than stopping at the first failure. Requiredness behaves the same way in both functions.
 
 ## Displaying Validation State
 
-Match exhaustively on the four tags to derive border colors, status indicators, and error messages. For a single field, use `isValid(rules)(state)`. If the rules are required, only `Valid` passes; if optional, `NotValidated` also passes. For form-level submit gates, pass `[state, rules]` pairs to `allValid`. A single call gates fields of one value type, so a form that mixes types calls `allValid` per type and combines the results with `&&`.
+Match exhaustively on the four tags to derive border colors, status indicators, and error messages. For a single-field submit gate, use `isValid(rules)(state)`. If the rules are required, only `Valid` passes; if they are optional, `NotValidated` also passes. `Validating` and `Invalid` never pass.
+
+For a form-level gate, pass `[state, rules]` pairs to `allValid`. A single call gates fields of one value type, so a form that mixes types calls `allValid` per type and combines the results with `&&`.
 
 ::Snippet{name="fieldValidationView" label="validation view example"}
 
 Because `Field` is a discriminated union, the exhaustive match ensures you handle every state.
+
+Use `isInvalid(state)` or `anyInvalid(states)` when you specifically need to know whether validation has produced errors. They check for the `Invalid` tag. A required `NotValidated` field and a `Validating` field are not invalid, but they still fail an `isValid` submit gate.
 
 ## Async Validation
 
@@ -66,7 +79,9 @@ Keep cross-field logic in update only when the check genuinely needs more than o
 
 ## Built-in Rules
 
-Required-ness is not a rule. It’s a `makeRules` option: pass `required: message` to make the field required, omit it for an optional field. It treats an empty string or empty array as missing; any other value, including a boolean `false`, counts as present, so to require that a checkbox is checked, use a custom rule like `[(checked) => checked, message]`.
+Requiredness is not a rule. It is a `makeRules` option: pass `required: message` to make the field required, or omit it for an optional field. By default, Foldkit treats an empty string or empty array as missing. Whitespace and every other value, including the boolean `false`, count as present.
+
+Pass an `isEmpty` predicate to `makeRules` when your control needs a different definition of empty. To require that a checkbox is checked, use a custom rule such as `[(checked) => checked, message]`; unchecked is a present but invalid boolean value, not an absent one.
 
 | Rule                                 | Description                          |
 | ------------------------------------ | ------------------------------------ |

--- a/packages/website/src/page/gettingStarted.md
+++ b/packages/website/src/page/gettingStarted.md
@@ -2,80 +2,75 @@
 
 Built on Effect. Architected like Elm. Written in TypeScript. Let’s get your first application running.
 
-:::Info{label="New to Foldkit?"}
-If you’d like to learn about Foldkit’s architecture before starting a project, head to [Architecture](/core/architecture).
-:::
+## Create a Project {#quick-start}
 
-## Requirements
+Before you begin, install Node.js 22.22.2 or newer and make sure the package manager you want to use is available. The [create-foldkit-app](https://github.com/foldkit/foldkit/tree/main/packages/create-foldkit-app) scaffolder is the recommended way to start.
 
-`create-foldkit-app` requires Node.js 22.22.2 or newer.
-
-Foldkit is built on the Effect v4 release candidate and pins its `effect` peer dependency to an exact version: `effect@4.0.0-rc.109`. Stable Effect v3 does not satisfy the pin, so adding Foldkit to a project that already uses Effect v3 will produce peer dependency conflicts, and upgrading Foldkit can require upgrading the Effect release candidate in lockstep. Projects scaffolded with `create-foldkit-app` get the correct versions automatically.
-
-To add Foldkit to an existing project instead of scaffolding a new one, install it together with its pinned peer dependency:
-
-```sh
-npm install foldkit effect@4.0.0-rc.109
-```
-
-`@effect/platform-browser` is a separate package, pinned to the same version when you need it. `@foldkit/devtools` declares it as a peer dependency, and Effect's browser services such as `BrowserKeyValueStore` and `BrowserCrypto` come from it:
-
-```sh
-npm install @effect/platform-browser@4.0.0-rc.109
-```
-
-## Quick Start
-
-[Create Foldkit app](https://github.com/foldkit/foldkit/tree/main/packages/create-foldkit-app) is the recommended way to get started. You’ll pick a rendering mode (a browser-only SPA, static generation, or [server rendering](/core/server-rendering)), an [example](/example-apps) to start from when scaffolding a SPA, and the package manager you’d like to use.
+Run the scaffolder:
 
 ```sh
 npx create-foldkit-app@latest
 ```
 
-Once the project is created, navigate to the project directory and start the dev server. Each command below is the same step for a different package manager, so pick the one you use:
+The CLI asks for a project name, a rendering mode, and a package manager. If you choose a browser-only SPA, it also asks which [example](/example-apps) you want to start from. The other rendering modes create their own starter applications:
+
+- **SPA:** renders entirely in the browser.
+- **[Static generation](/core/server-rendering#build-time-ssg):** prerenders routes to static HTML, then hydrates them in the browser.
+- **[Server rendering](/core/server-rendering):** renders each request on a Node server, then hydrates it in the browser.
+
+The scaffolder creates the project and installs its dependencies. Move into the new directory, then start the development server with the package manager you selected:
 
 ```sh
-pnpm dev
+cd your-project
 ```
+
+- pnpm: `pnpm dev`
+- npm: `npm run dev`
+- Yarn: `yarn dev`
+- Bun: `bun dev`
+
+Vite prints a local URL when the server is ready. Open it in your browser, and your first Foldkit application is running.
+
+## Find Your Way Around {#project-structure}
+
+The exact files depend on the rendering mode and starter example. A small browser-only SPA such as Counter begins with these pieces:
+
+- `src/main.ts`: pure application definitions
+- `src/entry.ts`: runtime bootstrap referenced by `index.html`
+- `src/styles.css`: Tailwind CSS entry point
+- `index.html`: HTML entry point
+- `vite.config.ts`: Vite configuration with `@foldkit/vite-plugin`
+- `tsconfig.json`: TypeScript configuration
+- `.oxlintrc.json`: Oxlint configuration
+- `.prettierrc`: Prettier configuration
+- `AGENTS.md`: conventions for AI coding assistants working on the project
+
+In a small starter, `src/main.ts` holds the Model, Messages, update, init, and view. Larger examples move those definitions into focused modules as the application grows.
+
+For the Counter starter, `src/entry.ts` imports the application definitions and starts the runtime with `Runtime.makeApplication` and `Runtime.run`. Other starters may compose the application from several modules or start a different host, but they keep runtime startup separate from the pure definitions. That separation lets tests import the application without starting a runtime as a side effect.
+
+The generated project also includes `lint` and `format` scripts. Run them with your selected package manager. For example: `pnpm lint` and `pnpm format`. See [Oxlint Plugin](/tooling/oxlint-plugin) for the Foldkit-specific rules.
+
+## Add Foldkit to an Existing Project {#requirements}
+
+Skip this section if you used `create-foldkit-app`. Scaffolded projects already receive compatible package versions.
+
+Foldkit currently uses the Effect v4 release candidate and pins its `effect` peer dependency to an exact version: `effect@4.0.0-rc.109`. Stable Effect v3 does not satisfy that pin. Adding Foldkit to an Effect v3 project produces peer dependency conflicts. When Foldkit moves to a new release candidate, an existing project may need to upgrade Effect at the same time.
+
+Install Foldkit together with its pinned peer dependency:
 
 ```sh
-npm run dev
+npm install foldkit effect@4.0.0-rc.109
 ```
+
+`@effect/platform-browser` is a separate package pinned to the same version. Install it when you use `@foldkit/devtools`, which declares it as a peer dependency, or when you need Effect browser services such as `BrowserKeyValueStore` and `BrowserCrypto`:
 
 ```sh
-yarn dev
+npm install @effect/platform-browser@4.0.0-rc.109
 ```
 
-```sh
-bun dev
-```
+## Where to Go Next
 
-:::Info{label="Coming from React or Elm?"}
-If you know React, the [Coming from React](/react/coming-from-react) guide maps your existing knowledge onto Foldkit. If you know Elm, see [Foldkit vs Elm: Side by Side](/elm/foldkit-vs-elm-side-by-side).
-:::
-
-## Project Structure
-
-A new Foldkit project has the following structure:
-
-| File             | Description                                   |
-| ---------------- | --------------------------------------------- |
-| `src/main.ts`    | Your application code                         |
-| `src/entry.ts`   | Runtime bootstrap, referenced from index.html |
-| `src/styles.css` | Tailwind CSS entry point                      |
-| `index.html`     | HTML entry point                              |
-| `vite.config.ts` | Vite configuration with Foldkit HMR plugin    |
-| `tsconfig.json`  | TypeScript configuration                      |
-| `.oxlintrc.json` | Oxlint configuration                          |
-| `.prettierrc`    | Prettier configuration                        |
-| `AGENTS.md`      | AI coding assistant conventions               |
-
-The generated project includes `pnpm lint` and `pnpm format`. See [Oxlint Plugin](/tooling/oxlint-plugin) for the Foldkit-specific oxlint rules.
-
-`src/main.ts` holds the pure definitions for your application: Model, Messages, update, init, and view. `src/entry.ts` imports them and boots the runtime with `Runtime.makeApplication` and `Runtime.run`. Some starter examples keep `main.ts` in one file, while others split the Model, Messages, update, and view into separate modules.
-
-When you’re ready to dig in, head to [Architecture](/core/architecture) to understand how the pieces fit together.
-
-:::Info{label="Using AI?"}
-Foldkit’s architecture makes AI-assisted development uniquely effective. See [AI](/ai/overview) for setup.
-:::
+- Read [Architecture](/core/architecture) to understand the Model, Message, update, and view loop.
+- If you know React, use [Coming from React](/react/coming-from-react) to map familiar ideas onto Foldkit. If you know Elm, compare the two in [Foldkit vs Elm: Side by Side](/elm/foldkit-vs-elm-side-by-side).
+- For AI-assisted development, follow the setup in [AI](/ai/overview).

--- a/packages/website/src/page/ui/calendarPage.md
+++ b/packages/website/src/page/ui/calendarPage.md
@@ -1,146 +1,195 @@
 # Calendar
 
-## Overview
+## An Inline Calendar You Render {#overview}
 
-An accessible inline calendar grid built to the WAI-ARIA grid pattern. Calendar manages the 2D keyboard navigation state machine and renders a 6×7 grid of days with full screen-reader support. Use it standalone for scheduling UIs and event calendars, or as the foundation of a date picker.
+Calendar provides the state machine, ARIA wiring, and derived data for an inline calendar. You provide the markup and styling through `toView`. Use it in scheduling interfaces and event calendars, or as the calendar inside a date picker.
 
-The calendar heading is a button: clicking it switches the day grid into a 3×4 months grid. Clicking the year heading from there switches into a paged 3×4 years grid (prev/next page through 12-year windows). Selecting a year drills back to the months grid for that year; selecting a month drills back to the days grid for that month.
+The Calendar moves among three grids:
 
-Calendar uses the Submodel pattern: initialize with `Calendar.init()`, store the Model in your parent, wire Messages through [`Update.foldChild`](/core/submodel#fold-child), and render with `Calendar.view()`. The update function returns `[Model, Commands, Option<OutMessage>]`. The parent owns the selected date: store it in your Model, pass it back as `maybeSelectedDate`, and fold the `SelectedDate` OutMessage into that field. The OutMessage lets the parent handle meaningful events, for example date selection or month changes.
+- **Days:** a fixed 6×7 grid with locale-aware weekday headings.
+- **Months:** 12 cells for choosing a month, arranged in three columns.
+- **Years:** 12 cells for choosing a year, arranged in three columns and paged in 12-year windows.
+
+The heading moves from Days to Months, then from Months to Years. Selecting a year returns to Months for that year. Selecting a month returns to Days for that month.
+
+Calendar owns navigation state, including the visible month, active grid, and keyboard cursor. The parent owns the selected date. This keeps the domain value in the parent Model while Calendar handles the interaction state around it.
+
+## Wire Calendar into a Parent
+
+Initialize the Calendar with `Calendar.init()`, store its Model in your parent Model, and delegate its Messages with [`Update.foldChild`](/core/submodel#fold-child). Render it through `h.submodel` with `Calendar.view`.
+
+Pass the parent-owned selection into `viewInputs.maybeSelectedDate` on every render. When Calendar emits `SelectedDate`, fold that OutMessage into the parent's selected-date field. `Calendar.update` returns `[Model, Commands, Option<OutMessage>]`, so the same fold can handle `ChangedViewMonth` when your application needs month-scoped data.
 
 :::Info{label="See it in an app"}
-Check out how Calendar is wired up in a [real Foldkit app](https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/ui/view/calendar.ts).
+See the complete Calendar integration in the [UI Showcase](https://github.com/foldkit/foldkit/blob/main/examples/ui-showcase/src/ui/view/calendar.ts).
 :::
 
-## Examples
+## Try It {#examples}
 
-A basic calendar with today highlighted. Click a day to select it, or tab into the grid and use the arrow keys. Navigation follows the full WAI-ARIA pattern including Home/End, PageUp/Down, and Shift+PageUp/Down for year jumps.
+This Calendar highlights today and lets the parent store a selected date. Click a day, or tab into the grid and navigate with the keyboard. The snippet shows the parent Model, `Update.foldChild`, OutMessage handling, and all three view modes.
 
 ::Demo{name="basic"}
 
 ::Snippet{name="uiCalendarBasic" label="basic calendar example"}
 
-## Styling
+## Render and Style the Calendar {#styling}
 
-Calendar is headless. Your `toView` callback controls all markup and styling. The attribute groups carry ARIA and event wiring; data attributes on day cells let you style state variants with CSS selectors like `data-[today]:` and `group-data-[selected]:`.
+Calendar is headless. Its `toView` callback receives attribute groups for the current mode. Spread those attributes onto your elements, then add your own classes and structure.
 
-| Attribute            | Condition                                                                                                                                                                     |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data-today`         | Present on the cell representing "today": the day cell in Days mode, the current month cell in Months mode, the current year cell in Years mode.                              |
-| `data-selected`      | Present on the calendar's currently-centered cell: the selected date in Days mode, the centered month (viewMonth) in Months mode, the centered year (viewYear) in Years mode. |
-| `data-focused`       | Present on the cell at the keyboard cursor position while the grid has DOM focus.                                                                                             |
-| `data-outside-month` | (Days mode only.) Present on cells that fall outside the currently-viewed month (leading/trailing grid rows).                                                                 |
-| `data-disabled`      | Present on cells disabled by min/max, disabledDaysOfWeek, or disabledDates.                                                                                                   |
+State data attributes let styles follow Calendar state without rebuilding that logic in the view:
+
+| Attribute            | Present when                                                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `data-today`         | The cell represents today, today's month, or today's year.                                                                |
+| `data-selected`      | The cell represents the parent-owned selected date in Days mode, `viewMonth` in Months mode, or `viewYear` in Years mode. |
+| `data-focused`       | The cell is at the keyboard cursor while the grid has DOM focus.                                                          |
+| `data-outside-month` | A Days-mode cell falls outside the visible month.                                                                         |
+| `data-disabled`      | A day violates a date constraint, or a month or year falls entirely outside the configured minimum and maximum.           |
+
+For example: `group-data-[selected]:` can style a button from the state attributes on its containing grid cell.
 
 ## Keyboard Interaction
 
-The grid container receives DOM focus, and navigation happens via `aria-activedescendant`. Screen readers announce the focused cell without moving browser focus. Disabled dates are skipped during navigation with a bounded cap so fully-disabled ranges terminate cleanly.
+The grid container holds DOM focus. `aria-activedescendant` points to the cell at the keyboard cursor, so assistive technology can announce movement without moving focus among the buttons.
 
-| Key                                 | Description                                                                                                                                                        |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ArrowLeft / ArrowRight`            | Move the focus cursor by one cell. Days: ±1 day. Months: ±1 month (wraps across years). Years: ±1 year (wraps across pages).                                       |
-| `ArrowUp / ArrowDown`               | Move the focus cursor by one row. Days: ±1 week (7 days). Months: ±1 row (3 months). Years: ±1 row (3 years).                                                      |
-| `Home / End`                        | (Days mode only.) Move focus to the start / end of the current week (based on locale.firstDayOfWeek).                                                              |
-| `PageUp / PageDown`                 | Days: ±1 month. Months: ±1 year. Years: ±1 window (12 years).                                                                                                      |
-| `Shift + PageUp / Shift + PageDown` | (Days mode only.) Move focus by one year.                                                                                                                          |
-| `Enter / Space`                     | Commit the focus cursor. Days: select the date. Months: jump the calendar to that month and drill back to Days. Years: jump to that year and drill back to Months. |
+In Days mode, navigation clamps to `minDate` and `maxDate` and skips disabled dates. The search is bounded, so a fully disabled range terminates cleanly. Disabled month and year cells cannot be committed.
+
+| Key                             | Behavior                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `ArrowLeft` / `ArrowRight`      | Move one day, month, or year, according to the current mode.                                      |
+| `ArrowUp` / `ArrowDown`         | Move one row: seven days in Days mode, three months in Months mode, or three years in Years mode. |
+| `Home` / `End`                  | In Days mode, move to the start or end of the current week using `locale.firstDayOfWeek`.         |
+| `PageUp` / `PageDown`           | Move one month in Days mode, one year in Months mode, or one 12-year window in Years mode.        |
+| `Shift` + `PageUp` / `PageDown` | In Days mode, move one year.                                                                      |
+| `Enter` / `Space`               | Select the date in Days mode, open the month in Months mode, or open the year in Years mode.      |
 
 ## Accessibility
 
-The grid renders with `role="grid"` and an explicit `aria-label` that leads with a non-numeric word ("Calendar, April 2026") so VoiceOver doesn't pattern-match the grid's row position into a date literal. Each row has `role="row"`, column headers have `role="columnheader"`, and day cells have `role="gridcell"` with `aria-selected` set on the chosen date. Day buttons carry a full accessible name via `aria-label` (e.g. "Monday, April 13, 2026"), and disabled days get `aria-disabled="true"`.
+Each mode renders a grid with an accessible name and uses `aria-activedescendant` for its keyboard cursor. The Days grid is labeled with a leading word, such as `Calendar, April 2026`, so VoiceOver does not interpret its row position as a date literal.
+
+Rows use `role="row"`. Weekday headings use `role="columnheader"`. Cells use `role="gridcell"` and expose selection state through `aria-selected`. Day buttons receive full accessible names, such as `Monday, April 13, 2026`, and disabled cells use `aria-disabled="true"`.
 
 ## API Reference
 
 ### InitConfig {#init-config}
 
-Configuration object passed to `Calendar.init()`.
+Pass this configuration to `Calendar.init()`:
 
-| Name                 | Type                          | Default                | Description                                                                                                                                                                                       |
-| -------------------- | ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                 | `string`                      | —                      | Unique ID for the calendar instance.                                                                                                                                                              |
-| `today`              | `CalendarDate`                | —                      | The current calendar date. Typically fetched at the app boundary via Calendar.today.local and threaded through flags.                                                                             |
-| `initialViewDate`    | `CalendarDate`                | —                      | Seeds the month the calendar opens onto. When set, the view starts on the month containing this date. The parent owns the selection itself; pass your initial selected date here to open onto it. |
-| `locale`             | `LocaleConfig`                | `defaultEnglishLocale` | Month and day names plus the first day of the week. Import from foldkit/calendar.                                                                                                                 |
-| `minDate`            | `CalendarDate`                | —                      | Earliest selectable date. Dates before minDate are marked disabled and skipped by keyboard navigation.                                                                                            |
-| `maxDate`            | `CalendarDate`                | —                      | Latest selectable date. Dates after maxDate are marked disabled and skipped by keyboard navigation.                                                                                               |
-| `disabledDaysOfWeek` | `ReadonlyArray<DayOfWeek>`    | `[]`                   | Days of the week to disable (e.g. ["Saturday", "Sunday"] for weekday-only selection).                                                                                                             |
-| `disabledDates`      | `ReadonlyArray<CalendarDate>` | `[]`                   | Explicit list of disabled dates (e.g. holidays). Pre-compute for complex rules.                                                                                                                   |
+| Name                 | Type                          | Default                | Description                                                                                                                              |
+| -------------------- | ----------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                 | `string`                      | —                      | Unique ID for this Calendar instance.                                                                                                    |
+| `today`              | `CalendarDate`                | —                      | Current date used for highlighting and as the fallback focus target. Resolve it at the application boundary with `Calendar.today.local`. |
+| `initialViewDate`    | `CalendarDate`                | `today`                | Date whose month opens first. Pass the initial parent-owned selection to open on that value.                                             |
+| `locale`             | `LocaleConfig`                | `defaultEnglishLocale` | Month names, weekday names, and the first day of the week. Import the type and default from `foldkit/calendar`.                          |
+| `minDate`            | `CalendarDate`                | —                      | Earliest selectable date. Earlier dates are disabled and skipped during Days-mode keyboard navigation.                                   |
+| `maxDate`            | `CalendarDate`                | —                      | Latest selectable date. Later dates are disabled and skipped during Days-mode keyboard navigation.                                       |
+| `disabledDaysOfWeek` | `ReadonlyArray<DayOfWeek>`    | `[]`                   | Weekdays to disable across every month. For example: `['Saturday', 'Sunday']`.                                                           |
+| `disabledDates`      | `ReadonlyArray<CalendarDate>` | `[]`                   | Individual dates to disable. Precompute the array for more complex rules.                                                                |
 
 ### Model
 
-The calendar state managed as a Submodel field in your parent Model.
+Store the Calendar Model as a field in the parent Model. It contains interaction and constraint state, not the selected date.
 
-| Name                 | Type                            | Default  | Description                                                                                                   |
-| -------------------- | ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| `id`                 | `string`                        | —        | The calendar instance ID.                                                                                     |
-| `today`              | `CalendarDate`                  | —        | Cached "today" used for the data-today highlight and as the fallback focus target.                            |
-| `viewYear`           | `number`                        | —        | The year currently rendered in the grid.                                                                      |
-| `viewMonth`          | `number`                        | —        | The month (1-12) currently rendered in the grid.                                                              |
-| `maybeFocusedDate`   | `Option<CalendarDate>`          | —        | The keyboard cursor position, referenced by aria-activedescendant on the grid.                                |
-| `isGridFocused`      | `boolean`                       | —        | Whether the grid container has DOM focus. Used to apply focused styling only when visually appropriate.       |
-| `locale`             | `LocaleConfig`                  | —        | The locale for month/day names and first day of the week.                                                     |
-| `maybeMinDate`       | `Option<CalendarDate>`          | —        | Lower bound for selectable dates.                                                                             |
-| `maybeMaxDate`       | `Option<CalendarDate>`          | —        | Upper bound for selectable dates.                                                                             |
-| `disabledDaysOfWeek` | `ReadonlyArray<DayOfWeek>`      | —        | Days of the week disabled across every month.                                                                 |
-| `disabledDates`      | `ReadonlyArray<CalendarDate>`   | —        | Explicit dates marked as disabled.                                                                            |
-| `viewMode`           | `'Days' \| 'Months' \| 'Years'` | `'Days'` | Which grid the calendar is currently showing. Drives the `_tag` of the CalendarAttributes passed to `toView`. |
+| Name                 | Type                            | Description                                            |
+| -------------------- | ------------------------------- | ------------------------------------------------------ |
+| `id`                 | `string`                        | Calendar instance ID.                                  |
+| `today`              | `CalendarDate`                  | Date used for the today marker and fallback focus.     |
+| `viewYear`           | `number`                        | Year centered by the Calendar.                         |
+| `viewMonth`          | `number`                        | Month centered by the Calendar, from 1 through 12.     |
+| `viewMode`           | `'Days' \| 'Months' \| 'Years'` | Grid currently displayed.                              |
+| `maybeFocusedDate`   | `Option<CalendarDate>`          | Keyboard cursor used by `aria-activedescendant`.       |
+| `isGridFocused`      | `boolean`                       | Whether the grid container has DOM focus.              |
+| `locale`             | `LocaleConfig`                  | Month names, weekday names, and first day of the week. |
+| `maybeMinDate`       | `Option<CalendarDate>`          | Lower selection bound.                                 |
+| `maybeMaxDate`       | `Option<CalendarDate>`          | Upper selection bound.                                 |
+| `disabledDaysOfWeek` | `ReadonlyArray<DayOfWeek>`      | Weekdays disabled across every month.                  |
+| `disabledDates`      | `ReadonlyArray<CalendarDate>`   | Individually disabled dates.                           |
 
-### ViewConfig {#view-config}
+### ViewInputs {#view-config}
 
-Configuration object passed to `Calendar.view()`.
+Pass these fields under `viewInputs` when `h.submodel` renders `Calendar.view`. The surrounding `h.submodel` configuration separately receives `slotId`, `model`, `view`, and `toParentMessage`.
 
-| Name                       | Type                                                | Default                    | Description                                                                                                                                                                                                         |
-| -------------------------- | --------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                    | `Calendar.Model`                                    | —                          | The calendar state from your parent Model.                                                                                                                                                                          |
-| `maybeSelectedDate`        | `Option<CalendarDate>`                              | —                          | The parent-owned selected date. The calendar reads it to render the selected-day marker; it does not store the selection itself. Fold the SelectedDate OutMessage into this field and pass it back on every render. |
-| `toParentMessage`          | `(childMessage: Calendar.Message) => ParentMessage` | —                          | Wraps Calendar Messages in your parent Message type for Submodel delegation (navigation, keyboard, picker-mode transitions).                                                                                        |
-| `toView`                   | `(attributes: CalendarAttributes) => Html`          | —                          | Callback that receives a discriminated CalendarAttributes whose variant matches the calendar viewMode (Days, Months, or Years). Pattern-match on \_tag to render each grid.                                         |
-| `previousMonthLabel`       | `string`                                            | `'Previous month'`         | Accessible label for the previous-month navigation button (Days mode).                                                                                                                                              |
-| `nextMonthLabel`           | `string`                                            | `'Next month'`             | Accessible label for the next-month navigation button (Days mode).                                                                                                                                                  |
-| `previousYearsPageLabel`   | `string`                                            | `'Previous 12 years'`      | Accessible label for the previous-page button in the years grid.                                                                                                                                                    |
-| `nextYearsPageLabel`       | `string`                                            | `'Next 12 years'`          | Accessible label for the next-page button in the years grid.                                                                                                                                                        |
-| `daysHeadingButtonLabel`   | `string`                                            | `'Switch to month picker'` | Accessible label for the heading button in Days mode. Clicked to drill into the months grid.                                                                                                                        |
-| `monthsHeadingButtonLabel` | `string`                                            | `'Switch to year picker'`  | Accessible label for the heading button in Months mode. Clicked to drill into the years grid.                                                                                                                       |
+| Name                       | Type                                       | Default                    | Description                                                                                                |
+| -------------------------- | ------------------------------------------ | -------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `maybeSelectedDate`        | `Option<CalendarDate>`                     | —                          | Parent-owned selection used to derive selected-cell state. Pass it on every render.                        |
+| `toView`                   | `(attributes: CalendarAttributes) => Html` | —                          | Renders the current grid from the mode-specific attribute bundle. Match on `_tag` with `M.tagsExhaustive`. |
+| `previousMonthLabel`       | `string`                                   | `'Previous month'`         | Accessible label for the previous-month button in Days mode.                                               |
+| `nextMonthLabel`           | `string`                                   | `'Next month'`             | Accessible label for the next-month button in Days mode.                                                   |
+| `previousYearsPageLabel`   | `string`                                   | `'Previous 12 years'`      | Accessible label for the previous-page button in Years mode.                                               |
+| `nextYearsPageLabel`       | `string`                                   | `'Next 12 years'`          | Accessible label for the next-page button in Years mode.                                                   |
+| `daysHeadingButtonLabel`   | `string`                                   | `'Switch to month picker'` | Accessible label for the heading button in Days mode.                                                      |
+| `monthsHeadingButtonLabel` | `string`                                   | `'Switch to year picker'`  | Accessible label for the heading button in Months mode.                                                    |
 
 ### CalendarAttributes {#calendar-attributes}
 
-Attribute groups and derived data provided to the `toView` callback.
+`CalendarAttributes` is a discriminated union. Its `_tag` always matches `model.viewMode`. Every variant contains these fields:
 
-| Name                                    | Type                                                                       | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| --------------------------------------- | -------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `_tag`                                  | `'Days' \| 'Months' \| 'Years'`                                            | —       | Discriminator matching model.viewMode. Use M.tagsExhaustive to render each variant. The fields below describe the union of variants. Only the fields documented for the current \_tag are present.                                                                                                                                                                                                                                                                                                                                                       |
-| `root`                                  | `ReadonlyArray<Attribute<Message>>`                                        | —       | (All modes.) Spread onto the outermost wrapper. Includes the root id.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `grid`                                  | `ReadonlyArray<Attribute<Message>>`                                        | —       | (All modes.) Spread onto the grid container. Includes role="grid", tabindex, aria-label, aria-activedescendant, and keyboard/focus handlers.                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `heading`                               | `{ id: string; text: string }`                                             | —       | (All modes.) Heading id and text. In Days mode the text is "September 2019"; in Months mode "2019"; in Years mode "2016–2027" (the visible window).                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `headingButton`                         | `ReadonlyArray<Attribute<Message>>`                                        | —       | (Days, Months only.) Spread onto a `<button>` wrapping heading.text. Clicking dispatches ClickedHeading and drills one level deeper. Years mode is terminal and omits this field.                                                                                                                                                                                                                                                                                                                                                                        |
-| `previousMonthButton / nextMonthButton` | `ReadonlyArray<Attribute<Message>>`                                        | —       | (Days only.) Prev/next month navigation. Click handlers dispatch ClickedPreviousMonthButton / ClickedNextMonthButton.                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `previousPageButton / nextPageButton`   | `ReadonlyArray<Attribute<Message>>`                                        | —       | (Years only.) Page through 12-year windows. Click handlers dispatch PagedYears with direction -1 or 1.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `headerRow / columnHeaders`             | `ReadonlyArray<Attribute<Message>> + ReadonlyArray<ColumnHeader<Message>>` | —       | (Days only.) Row attributes (role="row") and seven column headers (role="columnheader") in locale-aware order.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `weeks`                                 | `ReadonlyArray<Week<Message>>`                                             | —       | (Days only.) Six week rows. Each Week carries its own row attributes (role="row", aria-rowindex) and seven DayCells. DayCells carry cellAttributes (role="gridcell", aria-colindex), buttonAttributes (type="button", aria-label, click), the day label string, and state flags (isToday, isSelected, isFocused, isInViewMonth, isDisabled).                                                                                                                                                                                                             |
-| `cells`                                 | `ReadonlyArray<MonthCell<Message>> \| ReadonlyArray<YearCell<Message>>`    | —       | (Months, Years.) Twelve cells. In Months mode each cell carries the month number (1-12), the full localized name (label, e.g. "September"), and the localized abbreviation (shortLabel, e.g. "Sep"). Render whichever fits, never substring label to abbreviate. In Years mode each cell carries a year from the current 12-year window. Both expose cellAttributes (role="gridcell", aria-selected), buttonAttributes (click dispatches SelectedMonth/SelectedYear), and state flags (isSelected, isFocused, isCurrentMonth/isCurrentYear, isDisabled). |
+| Name      | Type                            | Description                                                                                |
+| --------- | ------------------------------- | ------------------------------------------------------------------------------------------ |
+| `_tag`    | `'Days' \| 'Months' \| 'Years'` | Discriminator for exhaustive rendering with `M.tagsExhaustive`.                            |
+| `root`    | `ReadonlyArray<ChildAttribute>` | Attributes for the outermost Calendar element, including its ID.                           |
+| `grid`    | `ReadonlyArray<ChildAttribute>` | Grid semantics, keyboard and focus handlers, accessible name, and active-descendant state. |
+| `heading` | `{ id: string; text: string }`  | Heading ID and localized text for the current month, year, or 12-year window.              |
+
+The remaining fields depend on the variant.
+
+#### Days
+
+| Name                                     | Type                            | Description                                                              |
+| ---------------------------------------- | ------------------------------- | ------------------------------------------------------------------------ |
+| `previousMonthButton`, `nextMonthButton` | `ReadonlyArray<ChildAttribute>` | Attributes for the month-navigation buttons.                             |
+| `headingButton`                          | `ReadonlyArray<ChildAttribute>` | Attributes for the heading button that opens Months mode.                |
+| `headerRow`                              | `ReadonlyArray<ChildAttribute>` | Attributes for the weekday-header row.                                   |
+| `columnHeaders`                          | `ReadonlyArray<ColumnHeader>`   | Seven locale-ordered weekday headings. Each has `name` and `attributes`. |
+| `weeks`                                  | `ReadonlyArray<Week>`           | Six rows. Each has `attributes` and seven `DayCell` values.              |
+
+Each `DayCell` contains `date`, `label`, `cellAttributes`, `buttonAttributes`, and the state flags `isSelected`, `isFocused`, `isToday`, `isInViewMonth`, and `isDisabled`.
+
+#### Months
+
+| Name            | Type                            | Description                                                                                                       |
+| --------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `headingButton` | `ReadonlyArray<ChildAttribute>` | Attributes for the heading button that opens Years mode.                                                          |
+| `cells`         | `ReadonlyArray<MonthCell>`      | Twelve month cells with `month`, localized `label` and `shortLabel`, cell and button attributes, and state flags. |
+
+Use `shortLabel` when space is tight. Do not derive an abbreviation by slicing `label`, which is not safe across locales.
+
+#### Years
+
+| Name                                   | Type                            | Description                                                                          |
+| -------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------ |
+| `previousPageButton`, `nextPageButton` | `ReadonlyArray<ChildAttribute>` | Attributes for paging through 12-year windows.                                       |
+| `cells`                                | `ReadonlyArray<YearCell>`       | Twelve year cells with `year`, `label`, cell and button attributes, and state flags. |
+
+Month cells expose `isSelected`, `isFocused`, `isCurrentMonth`, and `isDisabled`. Year cells expose `isSelected`, `isFocused`, `isCurrentYear`, and `isDisabled`.
 
 ### OutMessage {#out-message}
 
-Messages emitted to the parent through the third element of `[Model, Commands, Option<OutMessage>]`. Parents fold the OutMessage in the `foldOutMessage` of their [`Update.foldChild`](/core/submodel#fold-child) config.
+Calendar returns an optional OutMessage as the third element of `[Model, Commands, Option<OutMessage>]`. Match on its tag in the `foldOutMessage` of your [`Update.foldChild`](/core/submodel#fold-child) configuration.
 
-| Name               | Type                              | Default | Description                                                                                                                                                                                                                                                                                |
-| ------------------ | --------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `SelectedDate`     | `{ date: CalendarDate }`          | —       | Emitted when the user commits a date (click / Enter / Space). Fold it in the `foldOutMessage` of your Calendar fold to lift the date into domain state.                                                                                                                                    |
-| `ChangedViewMonth` | `{ year: number; month: number }` | —       | Emitted when navigation changes the visible month (prev/next buttons, heading-drill selection of a different month, arrow keys crossing a month boundary, or a commit that crosses a month). Useful for inline-calendar consumers loading month-scoped data like holidays or availability. |
+| Name               | Payload                           | Emitted when                                                                                                                                                                       |
+| ------------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SelectedDate`     | `{ date: CalendarDate }`          | The user commits a date by click, `Enter`, or `Space`. If the date is outside the visible month, Calendar also moves the view, but emits only `SelectedDate`.                      |
+| `ChangedViewMonth` | `{ year: number; month: number }` | Navigation changes the visible month without committing a date. This includes month buttons, cross-month keyboard movement, and choosing a different month or year while drilling. |
+
+Use `SelectedDate` to update the parent-owned selection. Use `ChangedViewMonth` when an inline Calendar needs month-scoped data such as availability, holidays, or events.
 
 ### Programmatic Helpers
 
-Helpers you call from your own update handlers to drive the calendar imperatively: writing back the selection in controlled mode, focusing the grid, or updating constraints when they derive from other Model state.
+Call these helpers from parent update handlers when a domain event needs to drive Calendar state.
 
-The four `reflect*` helpers are how you implement cross-field date validation. Constraints are set at init time and updated via these helpers. They do not live on ViewConfig, because the update function needs them for keyboard-navigation disabled-skipping and commit-time validation. For an end date that must be on or after a start date, call `reflectMinDate(endCalendar, maybeStartDate)` in the handler that processes the start date change, where `maybeStartDate` is the parent-owned start-date field.
+| Name         | Type                                                                          | Behavior                                                                                                                  |
+| ------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `selectDate` | `(model: Model, date: CalendarDate) => [Model, Commands, Option<OutMessage>]` | Moves the view and cursor to the date and emits `SelectedDate`. Fold the OutMessage to update the parent-owned selection. |
+| `focusDate`  | `(model: Model, date: CalendarDate) => Model`                                 | Moves the view and cursor without selecting. Use it when an external value should determine which month opens.            |
+| `FocusGrid`  | `(args: { id: string }) => Command`                                           | Focuses the Calendar grid. A parent such as DatePicker can dispatch it after opening.                                     |
+| `dropToDays` | `(model: Model) => Model`                                                     | Returns to Days mode and reconciles the cursor with the visible month.                                                    |
 
-| Name                        | Type                                                                          | Default | Description                                                                                                                                                                                                                                                                                                   |
-| --------------------------- | ----------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `selectDate`                | `(model: Model, date: CalendarDate) => [Model, Commands, Option<OutMessage>]` | —       | Commits the given date and moves the cursor onto it, emitting SelectedDate. Use for a programmatic selection that should behave like a user pick. To move the view to a date without selecting it (opening onto an externally-sourced value), use focusDate.                                                  |
-| `focusDate`                 | `(model: Model, date: CalendarDate) => Model`                                 | —       | Moves the view and cursor to a date without changing the selection (which the parent owns). Use it to navigate to a known date, for example when the parent sets its value externally (a URL, a saved draft) so opening the calendar shows that month. Returns the model directly: no Command, no OutMessage. |
-| `FocusGrid`                 | `(args: { id: string }) => Command`                                           | —       | A Command constructor, dispatched as FocusGrid({ id }), that focuses the calendar grid container. Parent components like DatePicker dispatch it to hand focus to the grid's keyboard layer after opening.                                                                                                     |
-| `dropToDays`                | `(model: Model) => Model`                                                     | —       | Returns the calendar to Days mode regardless of current depth (Days, Months, or Years). Useful for standalone consumers that want to wire their own back-out gesture; popovered consumers like DatePicker call this internally on open and close so the picker always reopens at the day grid.                |
-| `reflectMinDate`            | `(model: Model, maybeMinDate: Option<CalendarDate>) => Model`                 | —       | Reflects the minimum selectable date onto the model without emitting an OutMessage. Pass Option.none() to remove the minimum. Use for cross-field validation when the minimum derives from other Model state. Does not reconcile the current selection if it falls below the new minimum.                     |
-| `reflectMaxDate`            | `(model: Model, maybeMaxDate: Option<CalendarDate>) => Model`                 | —       | Reflects the maximum selectable date onto the model without emitting an OutMessage. Pass Option.none() to remove the maximum. Does not reconcile the current selection.                                                                                                                                       |
-| `reflectDisabledDates`      | `(model: Model, disabledDates: ReadonlyArray<CalendarDate>) => Model`         | —       | Reflects the list of individually-disabled dates (e.g. holidays) onto the model. Pass an empty array to clear.                                                                                                                                                                                                |
-| `reflectDisabledDaysOfWeek` | `(model: Model, disabledDaysOfWeek: ReadonlyArray<DayOfWeek>) => Model`       | —       | Reflects the list of disabled days of the week (e.g. ["Saturday", "Sunday"]) onto the model. Pass an empty array to clear.                                                                                                                                                                                    |
+The reflection helpers update constraints already stored in the Calendar Model. They emit no OutMessage and do not reconcile the parent-owned selection. If a new constraint invalidates that value, update the selection explicitly in the same parent handler.
+
+| Name                        | Type                                                   | Behavior                                                             |
+| --------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------- |
+| `reflectMinDate`            | `(model: Model, Option<CalendarDate>) => Model`        | Replaces the minimum. Pass `Option.none()` to remove it.             |
+| `reflectMaxDate`            | `(model: Model, Option<CalendarDate>) => Model`        | Replaces the maximum. Pass `Option.none()` to remove it.             |
+| `reflectDisabledDates`      | `(model: Model, ReadonlyArray<CalendarDate>) => Model` | Replaces the disabled-date list. Pass an empty array to clear it.    |
+| `reflectDisabledDaysOfWeek` | `(model: Model, ReadonlyArray<DayOfWeek>) => Model`    | Replaces the disabled-weekday list. Pass an empty array to clear it. |


### PR DESCRIPTION
## Summary

- Reorganize the Getting Started and core guides around a clearer conceptual progression.
- Strengthen explanations of Commands, lifecycle primitives, data flow, validation, and calendar usage while preserving Foldkit conventions.
- Improve headings, transitions, cross-links, and examples across 23 documentation pages.
- Update the Commands table-of-contents expectation for the revised section heading.

## Validation

- `pnpm format`
- `pnpm --filter website test` (16 files, 463 tests)
- `pnpm --filter website typecheck`
- Full pre-push gate, including changeset policy, formatting, lint, dead-code checks, production builds, workspace typechecks, workspace tests, and the website browser smoke test

No changeset is required because this PR only changes the private website package.