### PR TITLE
feat(foldkit): add messages() for declaring a Message union

### DIFF
--- a/.changeset/messages-union-helper.md
+++ b/.changeset/messages-union-helper.md
@@ -1,0 +1,20 @@
+---
+'foldkit': minor
+---
+
+Add `messages` to `foldkit/message`, which declares a whole Message union from one record of fields per variant instead of naming each variant once as a constructor and again in the union list.
+
+The result is a `Schema.TaggedUnion`, so it decodes, nests in a Model, and carries `cases`, `guards`, and `isAnyOf`. Each variant hangs off it as a callable constructor that is itself a schema, which is what `Command.define` needs for its `messages` list. Matching is unaffected, since the values are ordinary tagged objects that `Match` handles as before, including `M.tag` over several tags and `M.tags` with an `M.orElse` fallback.
+
+`m` is unchanged. Reach for it for a single variant, and for a variant shared across two unions, such as a Submodel OutMessage built from some of its own Messages.
+
+```typescript
+export const Message = messages({
+  ClickedReset: {},
+  ChangedCount: { count: S.Number },
+})
+export type Message = typeof Message.Type
+
+Message.ClickedReset() // { _tag: 'ClickedReset' }
+Message.ChangedCount({ count: 1 }) // { _tag: 'ChangedCount', count: 1 }
+```

--- a/examples/todo/src/main.ts
+++ b/examples/todo/src/main.ts
@@ -12,7 +12,7 @@ import {
 import { KeyValueStore } from 'effect/unstable/persistence'
 import { Command, Runtime } from 'foldkit'
 import { Document, Html, HtmlBuilder } from 'foldkit/html'
-import { m } from 'foldkit/message'
+import { messages } from 'foldkit/message'
 import { ts } from 'foldkit/schema'
 import { evo } from 'foldkit/struct'
 
@@ -61,41 +61,22 @@ export type Model = typeof Model.Type
 
 // MESSAGE
 
-export const UpdatedNewTodo = m('UpdatedNewTodo', { text: S.String })
-export const UpdatedEditingTodo = m('UpdatedEditingTodo', { text: S.String })
-export const AddedTodo = m('AddedTodo')
-export const CompletedGenerateTodo = m('CompletedGenerateTodo', {
-  id: S.String,
-  timestamp: S.Number,
-  text: S.String,
+export const Message = messages({
+  UpdatedNewTodo: { text: S.String },
+  UpdatedEditingTodo: { text: S.String },
+  AddedTodo: {},
+  CompletedGenerateTodo: { id: S.String, timestamp: S.Number, text: S.String },
+  DeletedTodo: { id: S.String },
+  ToggledTodo: { id: S.String },
+  StartedEditing: { id: S.String },
+  SavedEdit: {},
+  CancelledEdit: {},
+  ToggledAll: {},
+  ClearedCompleted: {},
+  SelectedFilter: { filter: Filter },
+  SucceededSaveTodos: { todos: Todos },
+  FailedSaveTodos: {},
 })
-export const DeletedTodo = m('DeletedTodo', { id: S.String })
-export const ToggledTodo = m('ToggledTodo', { id: S.String })
-export const StartedEditing = m('StartedEditing', { id: S.String })
-export const SavedEdit = m('SavedEdit')
-export const CancelledEdit = m('CancelledEdit')
-export const ToggledAll = m('ToggledAll')
-export const ClearedCompleted = m('ClearedCompleted')
-export const SelectedFilter = m('SelectedFilter', { filter: Filter })
-export const SucceededSaveTodos = m('SucceededSaveTodos', { todos: Todos })
-export const FailedSaveTodos = m('FailedSaveTodos')
-
-export const Message = S.Union([
-  UpdatedNewTodo,
-  UpdatedEditingTodo,
-  AddedTodo,
-  CompletedGenerateTodo,
-  DeletedTodo,
-  ToggledTodo,
-  StartedEditing,
-  SavedEdit,
-  CancelledEdit,
-  ToggledAll,
-  ClearedCompleted,
-  SelectedFilter,
-  SucceededSaveTodos,
-  FailedSaveTodos,
-])
 export type Message = typeof Message.Type
 
 // FLAGS
@@ -309,20 +290,20 @@ export const update = (
 
 export const GenerateTodo = Command.define('GenerateTodo', {
   args: { text: S.String },
-  messages: [CompletedGenerateTodo],
+  messages: [Message.CompletedGenerateTodo],
   execute: ({ text }) =>
     Effect.gen(function* () {
       const id = yield* Random.nextIntBetween(0, Number.MAX_SAFE_INTEGER).pipe(
         Effect.map(value => value.toString(36)),
       )
       const timestamp = yield* Clock.currentTimeMillis
-      return CompletedGenerateTodo({ id, timestamp, text })
+      return Message.CompletedGenerateTodo({ id, timestamp, text })
     }),
 })
 
 export const SaveTodos = Command.define('SaveTodos', {
   args: { todos: Todos },
-  messages: [SucceededSaveTodos, FailedSaveTodos],
+  messages: [Message.SucceededSaveTodos, Message.FailedSaveTodos],
   execute: ({ todos }) =>
     Effect.gen(function* () {
       const store = yield* KeyValueStore.KeyValueStore
@@ -330,9 +311,9 @@ export const SaveTodos = Command.define('SaveTodos', {
         TODOS_STORAGE_KEY,
         S.encodeSync(S.fromJsonString(Todos))(todos),
       )
-      return SucceededSaveTodos({ todos })
+      return Message.SucceededSaveTodos({ todos })
     }).pipe(
-      Effect.catch(() => Effect.succeed(FailedSaveTodos())),
+      Effect.catch(() => Effect.succeed(Message.FailedSaveTodos())),
       Effect.provide(BrowserKeyValueStore.layerLocalStorage),
     ),
 })
@@ -374,7 +355,7 @@ const editingTodoView = (
         {
           id: `edit-${todo.id}`,
           value: text,
-          onInput: text => UpdatedEditingTodo({ text }),
+          onInput: text => Message.UpdatedEditingTodo({ text }),
           toView: attributes =>
             h.input([
               ...attributes.input,
@@ -388,7 +369,7 @@ const editingTodoView = (
       ),
       Button.view(
         {
-          onClick: SavedEdit(),
+          onClick: Message.SavedEdit(),
           toView: attributes =>
             h.button(
               [
@@ -404,7 +385,7 @@ const editingTodoView = (
       ),
       Button.view(
         {
-          onClick: CancelledEdit(),
+          onClick: Message.CancelledEdit(),
           toView: attributes =>
             h.button(
               [
@@ -436,7 +417,7 @@ const nonEditingTodoView = (todo: Todo, h: HtmlBuilder<Message>): Html =>
         {
           id: `todo-${todo.id}`,
           isChecked: todo.completed,
-          onToggle: () => ToggledTodo({ id: todo.id }),
+          onToggle: () => Message.ToggledTodo({ id: todo.id }),
           toView: attributes =>
             h.div(
               [h.Class('flex items-center')],
@@ -461,13 +442,13 @@ const nonEditingTodoView = (todo: Todo, h: HtmlBuilder<Message>): Html =>
           h.Class(
             `flex-1 ${todo.completed ? 'line-through text-gray-500' : 'text-gray-900'}`,
           ),
-          h.OnClick(StartedEditing({ id: todo.id })),
+          h.OnClick(Message.StartedEditing({ id: todo.id })),
         ],
         [todo.text],
       ),
       Button.view(
         {
-          onClick: DeletedTodo({ id: todo.id }),
+          onClick: Message.DeletedTodo({ id: todo.id }),
           toView: attributes =>
             h.button(
               [
@@ -490,7 +471,7 @@ const filterButtonView =
   (filter: Filter, label: string, h: HtmlBuilder<Message>): Html =>
     Button.view(
       {
-        onClick: SelectedFilter({ filter }),
+        onClick: Message.SelectedFilter({ filter }),
         toView: attributes =>
           h.button(
             [
@@ -543,7 +524,7 @@ const footerView = (
                 onNonEmpty: todos =>
                   Button.view(
                     {
-                      onClick: ToggledAll(),
+                      onClick: Message.ToggledAll(),
                       toView: attributes =>
                         h.button(
                           [
@@ -566,7 +547,7 @@ const footerView = (
               completedCount > 0
                 ? Button.view(
                     {
-                      onClick: ClearedCompleted(),
+                      onClick: Message.ClearedCompleted(),
                       toView: attributes =>
                         h.button(
                           [
@@ -614,7 +595,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
           ),
 
           h.form(
-            [h.Class('mb-6'), h.OnSubmit(AddedTodo())],
+            [h.Class('mb-6'), h.OnSubmit(Message.AddedTodo())],
             [
               h.div(
                 [h.Class('flex gap-3')],
@@ -624,7 +605,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
                       id: 'new-todo',
                       value: model.newTodoText,
                       placeholder: 'What needs to be done?',
-                      onInput: text => UpdatedNewTodo({ text }),
+                      onInput: text => Message.UpdatedNewTodo({ text }),
                       toView: attributes =>
                         h.input([
                           ...attributes.input,

--- a/examples/todo/src/scene.test.ts
+++ b/examples/todo/src/scene.test.ts
@@ -13,13 +13,11 @@ import {
 import { describe, test } from 'vitest'
 
 import {
-  CompletedGenerateTodo,
-  FailedSaveTodos,
   GenerateTodo,
+  Message,
   type Model,
   NotEditing,
   SaveTodos,
-  SucceededSaveTodos,
   update,
   view,
 } from './main'
@@ -77,14 +75,17 @@ describe('view', () => {
       Command.expectExact(GenerateTodo),
       Command.resolve(
         GenerateTodo,
-        CompletedGenerateTodo({
+        Message.CompletedGenerateTodo({
           id: 'new-1',
           timestamp: 5000,
           text: 'Write tests',
         }),
       ),
       Command.expectExact(SaveTodos),
-      Command.resolve(SaveTodos, SucceededSaveTodos({ todos: [addedTodo] })),
+      Command.resolve(
+        SaveTodos,
+        Message.SucceededSaveTodos({ todos: [addedTodo] }),
+      ),
       expect(text('Write tests')).toExist(),
       expect(label('New todo')).toHaveValue(''),
     )
@@ -100,7 +101,10 @@ describe('view', () => {
       given(modelWithTodos),
       click(label('Buy milk')),
       Command.expectExact(SaveTodos),
-      Command.resolve(SaveTodos, SucceededSaveTodos({ todos: toggledTodos })),
+      Command.resolve(
+        SaveTodos,
+        Message.SucceededSaveTodos({ todos: toggledTodos }),
+      ),
       expect(role('status')).toContainText('1 active, 2 completed'),
     )
   })
@@ -113,7 +117,10 @@ describe('view', () => {
       given(modelWithTodos),
       click(role('button', { name: 'Delete Buy milk' })),
       Command.expectExact(SaveTodos),
-      Command.resolve(SaveTodos, SucceededSaveTodos({ todos: remainingTodos })),
+      Command.resolve(
+        SaveTodos,
+        Message.SucceededSaveTodos({ todos: remainingTodos }),
+      ),
       expect(text('Buy milk')).toBeAbsent(),
       expect(text('Walk the dog')).toExist(),
     )
@@ -129,7 +136,10 @@ describe('view', () => {
       given(modelWithTodos),
       click(role('button', { name: 'Clear 1 completed' })),
       Command.expectExact(SaveTodos),
-      Command.resolve(SaveTodos, SucceededSaveTodos({ todos: activeTodos })),
+      Command.resolve(
+        SaveTodos,
+        Message.SucceededSaveTodos({ todos: activeTodos }),
+      ),
       expect(text('Done task')).toBeAbsent(),
       expect(role('status')).toContainText('2 active, 0 completed'),
     )
@@ -148,7 +158,7 @@ describe('view', () => {
       Command.expectExact(SaveTodos),
       Command.resolve(
         SaveTodos,
-        SucceededSaveTodos({ todos: allCompletedTodos }),
+        Message.SucceededSaveTodos({ todos: allCompletedTodos }),
       ),
       expect(role('status')).toContainText('0 active, 3 completed'),
     )
@@ -160,7 +170,7 @@ describe('view', () => {
       given(modelWithTodos),
       click(label('Buy milk')),
       Command.expectExact(SaveTodos),
-      Command.resolve(SaveTodos, FailedSaveTodos()),
+      Command.resolve(SaveTodos, Message.FailedSaveTodos()),
       expect(role('status')).toContainText('1 active, 2 completed'),
     )
   })

--- a/examples/todo/src/story.test.ts
+++ b/examples/todo/src/story.test.ts
@@ -3,24 +3,12 @@ import { Command, given, message, model, story } from 'foldkit/story'
 import { describe, expect, test } from 'vitest'
 
 import {
-  AddedTodo,
-  CancelledEdit,
-  ClearedCompleted,
-  CompletedGenerateTodo,
-  DeletedTodo,
   Editing,
   GenerateTodo,
+  Message,
   type Model,
   NotEditing,
   SaveTodos,
-  SavedEdit,
-  SelectedFilter,
-  StartedEditing,
-  SucceededSaveTodos,
-  ToggledAll,
-  ToggledTodo,
-  UpdatedEditingTodo,
-  UpdatedNewTodo,
   update,
 } from './main'
 
@@ -63,11 +51,11 @@ describe('update', () => {
       story(
         update,
         given({ ...emptyModel, newTodoText: 'Buy milk' }),
-        message(AddedTodo()),
+        message(Message.AddedTodo()),
         Command.expectHas(GenerateTodo),
         Command.resolve(
           GenerateTodo,
-          CompletedGenerateTodo({
+          Message.CompletedGenerateTodo({
             id: 'abc',
             timestamp: 1000,
             text: 'Buy milk',
@@ -75,7 +63,7 @@ describe('update', () => {
         ),
         Command.resolve(
           SaveTodos,
-          SucceededSaveTodos({
+          Message.SucceededSaveTodos({
             todos: [
               {
                 id: 'abc',
@@ -99,7 +87,7 @@ describe('update', () => {
       story(
         update,
         given({ ...emptyModel, newTodoText: '' }),
-        message(AddedTodo()),
+        message(Message.AddedTodo()),
         Command.expectNone(),
       )
     })
@@ -108,7 +96,7 @@ describe('update', () => {
       story(
         update,
         given({ ...emptyModel, newTodoText: '   ' }),
-        message(AddedTodo()),
+        message(Message.AddedTodo()),
         Command.expectNone(),
       )
     })
@@ -117,7 +105,7 @@ describe('update', () => {
       story(
         update,
         given(emptyModel),
-        message(UpdatedNewTodo({ text: 'Walk' })),
+        message(Message.UpdatedNewTodo({ text: 'Walk' })),
         model(model => {
           expect(model.newTodoText).toBe('Walk')
         }),
@@ -134,8 +122,11 @@ describe('update', () => {
       story(
         update,
         given(modelWithTodos),
-        message(ToggledTodo({ id: 'abc' })),
-        Command.resolve(SaveTodos, SucceededSaveTodos({ todos: toggledTodos })),
+        message(Message.ToggledTodo({ id: 'abc' })),
+        Command.resolve(
+          SaveTodos,
+          Message.SucceededSaveTodos({ todos: toggledTodos }),
+        ),
         model(model => {
           const todo = Array.findFirst(model.todos, ({ id }) => id === 'abc')
           expect(Option.map(todo, ({ completed }) => completed)).toStrictEqual(
@@ -153,8 +144,11 @@ describe('update', () => {
       story(
         update,
         given(modelWithTodos),
-        message(ToggledTodo({ id: 'ghi' })),
-        Command.resolve(SaveTodos, SucceededSaveTodos({ todos: toggledTodos })),
+        message(Message.ToggledTodo({ id: 'ghi' })),
+        Command.resolve(
+          SaveTodos,
+          Message.SucceededSaveTodos({ todos: toggledTodos }),
+        ),
         model(model => {
           const todo = Array.findFirst(model.todos, ({ id }) => id === 'ghi')
           expect(Option.map(todo, ({ completed }) => completed)).toStrictEqual(
@@ -172,10 +166,10 @@ describe('update', () => {
       story(
         update,
         given(modelWithTodos),
-        message(DeletedTodo({ id: 'abc' })),
+        message(Message.DeletedTodo({ id: 'abc' })),
         Command.resolve(
           SaveTodos,
-          SucceededSaveTodos({ todos: remainingTodos }),
+          Message.SucceededSaveTodos({ todos: remainingTodos }),
         ),
         model(model => {
           expect(model.todos).toHaveLength(2)
@@ -192,7 +186,7 @@ describe('update', () => {
       story(
         update,
         given(modelWithTodos),
-        message(StartedEditing({ id: 'abc' })),
+        message(Message.StartedEditing({ id: 'abc' })),
         model(model => {
           expect(model.editing).toStrictEqual(
             Editing({ id: 'abc', text: 'Buy milk' }),
@@ -210,7 +204,7 @@ describe('update', () => {
       story(
         update,
         given(editingModel),
-        message(UpdatedEditingTodo({ text: 'Buy oat milk' })),
+        message(Message.UpdatedEditingTodo({ text: 'Buy oat milk' })),
         model(model => {
           expect(model.editing).toStrictEqual(
             Editing({ id: 'abc', text: 'Buy oat milk' }),
@@ -232,8 +226,11 @@ describe('update', () => {
       story(
         update,
         given(editingModel),
-        message(SavedEdit()),
-        Command.resolve(SaveTodos, SucceededSaveTodos({ todos: editedTodos })),
+        message(Message.SavedEdit()),
+        Command.resolve(
+          SaveTodos,
+          Message.SucceededSaveTodos({ todos: editedTodos }),
+        ),
         model(model => {
           const todo = Array.findFirst(model.todos, ({ id }) => id === 'abc')
           expect(Option.map(todo, ({ text }) => text)).toStrictEqual(
@@ -253,7 +250,7 @@ describe('update', () => {
       story(
         update,
         given(editingModel),
-        message(SavedEdit()),
+        message(Message.SavedEdit()),
         model(model => {
           const todo = Array.findFirst(model.todos, ({ id }) => id === 'abc')
           expect(Option.map(todo, ({ text }) => text)).toStrictEqual(
@@ -274,7 +271,7 @@ describe('update', () => {
       story(
         update,
         given(editingModel),
-        message(CancelledEdit()),
+        message(Message.CancelledEdit()),
         model(model => {
           const todo = Array.findFirst(model.todos, ({ id }) => id === 'abc')
           expect(Option.map(todo, ({ text }) => text)).toStrictEqual(
@@ -296,10 +293,10 @@ describe('update', () => {
       story(
         update,
         given(modelWithTodos),
-        message(ToggledAll()),
+        message(Message.ToggledAll()),
         Command.resolve(
           SaveTodos,
-          SucceededSaveTodos({ todos: allCompletedTodos }),
+          Message.SucceededSaveTodos({ todos: allCompletedTodos }),
         ),
         model(model => {
           expect(Array.every(model.todos, ({ completed }) => completed)).toBe(
@@ -326,10 +323,10 @@ describe('update', () => {
       story(
         update,
         given(allCompletedModel),
-        message(ToggledAll()),
+        message(Message.ToggledAll()),
         Command.resolve(
           SaveTodos,
-          SucceededSaveTodos({ todos: allActiveTodos }),
+          Message.SucceededSaveTodos({ todos: allActiveTodos }),
         ),
         model(model => {
           expect(Array.every(model.todos, ({ completed }) => !completed)).toBe(
@@ -347,8 +344,11 @@ describe('update', () => {
       story(
         update,
         given(modelWithTodos),
-        message(ClearedCompleted()),
-        Command.resolve(SaveTodos, SucceededSaveTodos({ todos: activeTodos })),
+        message(Message.ClearedCompleted()),
+        Command.resolve(
+          SaveTodos,
+          Message.SucceededSaveTodos({ todos: activeTodos }),
+        ),
         model(model => {
           expect(model.todos).toHaveLength(2)
           expect(Array.every(model.todos, ({ completed }) => !completed)).toBe(
@@ -364,7 +364,7 @@ describe('update', () => {
       story(
         update,
         given(modelWithTodos),
-        message(SelectedFilter({ filter: 'Active' })),
+        message(Message.SelectedFilter({ filter: 'Active' })),
         model(model => {
           expect(model.filter).toBe('Active')
         }),

--- a/packages/foldkit/src/message/index.ts
+++ b/packages/foldkit/src/message/index.ts
@@ -1,1 +1,2 @@
-export { m } from '../schema/index.js'
+export { m, messages } from '../schema/index.js'
+export type { Messages } from '../schema/index.js'

--- a/packages/foldkit/src/message/public.ts
+++ b/packages/foldkit/src/message/public.ts
@@ -1,1 +1,2 @@
-export { m } from './index.js'
+export { m, messages } from './index.js'
+export type { Messages } from './index.js'

--- a/packages/foldkit/src/schema/index.ts
+++ b/packages/foldkit/src/schema/index.ts
@@ -56,6 +56,101 @@ export function m(tag: string, fields: S.Struct.Fields = {}): any {
   return makeCallable(S.TaggedStruct(tag, fields))
 }
 
+/** Property names the schema surface already occupies. A variant cannot use
+ *  one, because the constructor attached under that name would shadow it. */
+type ReservedVariantName =
+  | 'Encoded'
+  | 'Iso'
+  | 'Type'
+  | 'annotate'
+  | 'ast'
+  | 'cases'
+  | 'check'
+  | 'guards'
+  | 'isAnyOf'
+  | 'make'
+  | 'makeEffect'
+  | 'makeOption'
+  | 'match'
+  | 'pipe'
+  | 'rebuild'
+
+/** The union `messages` returns. A `Schema.TaggedUnion` that also carries one
+ *  callable constructor per variant, reachable by tag. */
+export type Messages<CasesByTag extends Record<string, S.Struct.Fields>> =
+  S.TaggedUnion<{
+    readonly [Tag in keyof CasesByTag & string]: S.TaggedStruct<
+      Tag,
+      CasesByTag[Tag]
+    >
+  }> & {
+    readonly [Tag in keyof CasesByTag & string]: CallableTaggedStruct<
+      Tag,
+      CasesByTag[Tag]
+    >
+  }
+
+/**
+ * Declares a whole Message union from one record of fields per variant, naming
+ * each variant once instead of once per constructor and once in the union list.
+ *
+ * The result is a `Schema.TaggedUnion`, so it decodes, nests in a Model, and
+ * carries `cases`, `guards`, and `isAnyOf`. Each variant hangs off it as a
+ * callable constructor that is itself a schema, which is what `Command.define`
+ * needs for its `messages` list.
+ *
+ * Matching is unaffected. The values are ordinary tagged objects, so `Match`
+ * keeps working, including the forms `TaggedUnion.match` cannot express, such
+ * as `M.tag` over several tags and `M.tags` with an `M.orElse` fallback.
+ *
+ * A Submodel's OutMessage is declared the same way, with variants of its own. A
+ * Message is a fact the Submodel handles; an OutMessage is a fact it reports to
+ * its parent. Sharing one variant between the two unions puts the child's
+ * internal vocabulary in the parent's contract, so declare them separately even
+ * when a pair happens to carry the same fields.
+ *
+ * `m` still declares a single variant, which is what existing code uses and
+ * what keeps an incremental migration working.
+ *
+ * A variant may not be named after the schema surface it would shadow, such as
+ * `make`, `match`, `cases`, or `ast`. Doing so is a type error.
+ *
+ * @example
+ * ```typescript
+ * export const Message = messages({
+ *   ClickedReset: {},
+ *   ChangedCount: { count: S.Number },
+ * })
+ * export type Message = typeof Message.Type
+ *
+ * Message.ClickedReset() // { _tag: 'ClickedReset' }
+ * Message.ChangedCount({ count: 1 }) // { _tag: 'ChangedCount', count: 1 }
+ * ```
+ */
+export function messages<
+  const CasesByTag extends Record<string, S.Struct.Fields>,
+>(
+  casesByTag: Extract<keyof CasesByTag, ReservedVariantName> extends never
+    ? CasesByTag
+    : never,
+): Messages<CasesByTag> {
+  const union = S.TaggedUnion(casesByTag)
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  const members = union.cases as Record<
+    string,
+    S.TaggedStruct<string, S.Struct.Fields>
+  >
+
+  const callables: Record<string, unknown> = {}
+  for (const [tag, member] of Object.entries(members)) {
+    callables[tag] = makeCallable(member)
+  }
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  return Object.assign(union, callables) as unknown as Messages<CasesByTag>
+}
+
 /**
  * Wraps `Schema.TaggedStruct` to create a route variant you can call directly as a constructor.
  * Use `r` for route types — enabling `Home()` instead of `Home.make()`.

--- a/packages/foldkit/src/schema/messages.test.ts
+++ b/packages/foldkit/src/schema/messages.test.ts
@@ -1,0 +1,110 @@
+import { Match as M, Schema as S } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { messages } from './index.js'
+
+const Message = messages({
+  ClickedReset: {},
+  ChangedCount: { count: S.Number },
+  SelectedItem: { id: S.String, label: S.String },
+})
+type Message = typeof Message.Type
+
+describe('messages', () => {
+  it('builds a callable constructor for a variant with no fields', () => {
+    expect(Message.ClickedReset()).toStrictEqual({ _tag: 'ClickedReset' })
+  })
+
+  it('builds a callable constructor for a variant with fields', () => {
+    expect(Message.ChangedCount({ count: 1 })).toStrictEqual({
+      _tag: 'ChangedCount',
+      count: 1,
+    })
+  })
+
+  it('produces the same value as the equivalent TaggedStruct constructor', () => {
+    expect(Message.SelectedItem({ id: 'a', label: 'Alpha' })).toStrictEqual(
+      S.TaggedStruct('SelectedItem', {
+        id: S.String,
+        label: S.String,
+      }).make({ id: 'a', label: 'Alpha' }),
+    )
+  })
+
+  it('decodes a member of the union', () => {
+    expect(
+      S.decodeUnknownSync(Message)({ _tag: 'ChangedCount', count: 2 }),
+    ).toStrictEqual({ _tag: 'ChangedCount', count: 2 })
+  })
+
+  it('rejects a tag the union does not declare', () => {
+    expect(() => S.decodeUnknownSync(Message)({ _tag: 'Unknown' })).toThrow()
+  })
+
+  it('rejects a member whose field has the wrong type', () => {
+    expect(() =>
+      S.decodeUnknownSync(Message)({ _tag: 'ChangedCount', count: 'two' }),
+    ).toThrow()
+  })
+
+  it('exposes each variant as a schema in its own right', () => {
+    expect(
+      S.decodeUnknownSync(Message.ChangedCount)({
+        _tag: 'ChangedCount',
+        count: 3,
+      }),
+    ).toStrictEqual({ _tag: 'ChangedCount', count: 3 })
+  })
+
+  it('carries the tagged union utilities', () => {
+    expect(Object.keys(Message.cases)).toStrictEqual([
+      'ClickedReset',
+      'ChangedCount',
+      'SelectedItem',
+    ])
+    expect(Message.guards.ClickedReset(Message.ClickedReset())).toBe(true)
+    expect(
+      Message.isAnyOf(['ClickedReset'])(Message.ChangedCount({ count: 1 })),
+    ).toBe(false)
+  })
+
+  it('works with exhaustive tag matching', () => {
+    const describeMessage = (message: Message): string =>
+      M.value(message).pipe(
+        M.withReturnType<string>(),
+        M.tagsExhaustive({
+          ClickedReset: () => 'reset',
+          ChangedCount: ({ count }) => `count ${count}`,
+          SelectedItem: ({ label }) => `selected ${label}`,
+        }),
+      )
+
+    expect(describeMessage(Message.ClickedReset())).toBe('reset')
+    expect(describeMessage(Message.ChangedCount({ count: 4 }))).toBe('count 4')
+  })
+
+  it('works with a single handler across several tags', () => {
+    const isInteraction = (message: Message): boolean =>
+      M.value(message).pipe(
+        M.tag('ClickedReset', 'SelectedItem', () => true),
+        M.orElse(() => false),
+      )
+
+    expect(isInteraction(Message.ClickedReset())).toBe(true)
+    expect(isInteraction(Message.SelectedItem({ id: 'a', label: 'A' }))).toBe(
+      true,
+    )
+    expect(isInteraction(Message.ChangedCount({ count: 1 }))).toBe(false)
+  })
+
+  it('works with partial tag matching and a fallback', () => {
+    const describeMessage = (message: Message): string =>
+      M.value(message).pipe(
+        M.tags({ ChangedCount: ({ count }) => `count ${count}` }),
+        M.orElse(() => 'other'),
+      )
+
+    expect(describeMessage(Message.ChangedCount({ count: 5 }))).toBe('count 5')
+    expect(describeMessage(Message.ClickedReset())).toBe('other')
+  })
+})


### PR DESCRIPTION
Adds `messages` to `foldkit/message`, which declares a whole Message union from one record of fields per variant. Converts `examples/todo` to it as a prototype.

## The API

```ts
export const Message = messages({
  UpdatedNewTodo: { text: S.String },
  AddedTodo: {},
  DeletedTodo: { id: S.String },
})
export type Message = typeof Message.Type

Message.AddedTodo()
Message.DeletedTodo({ id: todo.id })
```

Each variant is named once. Declaring the same union with `m` names it twice, once as a constructor and again in the `S.Union` list. In the todo example that takes the Message block from 36 lines to 17.

## Matching does not change

`messages` returns a `Schema.TaggedUnion`, and its values are ordinary tagged objects, so `Match` works on them exactly as it does on an `S.Union` of `m` variants:

```ts
M.value(message).pipe(
  M.withReturnType<UpdateResult>(),
  M.tagsExhaustive({ AddedTodo: () => [model, []], /* ... */ }),
)

// several tags, one handler
M.value(message).pipe(
  M.tag('AddedTodo', 'DeletedTodo', 'ToggledTodo', () => [model, []]),
  M.orElse(() => [model, []]),
)

// partial, with a fallback
M.value(message).pipe(
  M.tags({ DeletedTodo: ({ id }) => `deleted ${id}` }),
  M.orElse(() => 'other'),
)
```

The todo example's `update` function is untouched by the conversion, along with `MODEL`, `EditingState`, and `init`. The diff there is one import, the Message block, and 14 call sites gaining a `Message.` prefix.

## What it composes with

The union is a schema, so it decodes and nests in a Model, and it carries `cases`, `guards`, and `isAnyOf`.

Each variant is a schema too, which is what `Command.define` needs:

```ts
export const SaveTodos = Command.define('SaveTodos', {
  args: { todos: Todos },
  messages: [Message.SucceededSaveTodos, Message.FailedSaveTodos],
  execute: ({ todos }) => // ...
})
```

A Submodel's OutMessage declares the same way, with variants of its own:

```ts
export const OutMessage = messages({ Opened: {}, Closed: {} })
```

## Scope

Additive. `m`, `r`, and `ts` are unchanged, so every other example, the website, typing-game, and `@foldkit/ui` compile against the same API as before. Only `examples/todo` is converted, across three files.

## Known rough edge

A variant cannot be named after part of the schema surface it would shadow (`make`, `match`, `cases`, `ast`, and similar). That is a type error, but an unhelpful one:

```
Argument of type '{ ... }' is not assignable to parameter of type 'never'
```

It does not say that a variant name collided. A branded error type would report it properly.

## Tests

11 tests in `packages/foldkit/src/schema/messages.test.ts` cover construction with and without fields, decoding and rejection, the tagged-union utilities, and all three matching forms above. Breaking `makeCallable` inside the helper fails 7 of them, so they are wired to the behavior they claim to test.

## Open questions

**Rename support.** `Message.DeletedTodo` is a property on a mapped type rather than an imported symbol. Whether F2 rename and find-references work through it decides how much this costs against named exports, and it needs an editor to answer.

**Whether `m` keeps a job.** Nothing here requires it, since a lone variant can be declared as a one-entry `messages` call. Retiring it means moving `r` and `ts` to equivalents at the same time, and that decision is better made after converting typing-game, which is the codebase with real Submodel and OutMessage wiring.