### PR TITLE
perf(foldkit): speed up callable constructors

### DIFF
--- a/.changeset/fast-callable-constructors.md
+++ b/.changeset/fast-callable-constructors.md
@@ -1,0 +1,10 @@
+---
+'foldkit': patch
+'@foldkit/vite-plugin': patch
+---
+
+Speed up callable tagged constructors whose type-side fields can be copied directly, such as primitives, literals, and unions of those identity types. Structs, Arrays, child Messages, checked fields, contextual fields, opaque schemas, oneOf unions, schemas that redefine `_tag`, and other composite fields continue through Schema validation. In a warmed Node 22.22.3 benchmark on Effect 4.0.0-rc.109, `ClickedReset()` fell from 177.8 ns to 30.5 ns per call and `ClickedItem({ id })` fell from 257.5 ns to 73.7 ns per call.
+
+The Vite plugin now includes SchemaAST in its forced Effect prebundle for this runtime dependency.
+
+The fast path assumes typed object inputs whose provided payload fields are own data properties. Primitive inputs, payload accessors, and inherited payload fields fall back to Schema validation. Both paths ignore an inherited `_tag`. Calls that bypass TypeScript can now construct eligible variants with wrong primitive field types or missing required fields. Stateful accessor Proxy traps are outside the fast-path equivalence boundary. Decode untrusted input through the Schema as before.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Match the implementation style to the subsystem and the behavior being modeled. 
 - Capitalize Schema literal strings: `S.Literals(['Horizontal', 'Vertical'])`.
 - Capitalize namespace imports: `import * as Command from './command'`.
 - Use `const`. Only use `let` when mutation is truly unavoidable. Always brace control flow.
+- Use blank lines to show the phases of non-trivial control flow. For example: separate setup, fallback guards, value reads, branching, writes, and the final return instead of presenting them as one uninterrupted block. Do not separate statements that form one operation.
 - Extract magic numbers to named constants.
 - Never use nested ternaries. Use `Match.value`, an `if`/`else` chain, or a named helper.
 - Prefer explicit `if`/`else` when both branches return. Early-return reads as "A is exceptional, B is the default"; reserve it for true guards.

--- a/packages/foldkit/src/schema/index.test.ts
+++ b/packages/foldkit/src/schema/index.test.ts
@@ -1,0 +1,857 @@
+import { Effect, Option, Schema as S } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { m } from './index.js'
+
+const ClickedReset = m('ClickedReset')
+const ClickedItem = m('ClickedItem', { id: S.String })
+const ExplicitTagField = m('ExplicitTagField', {
+  _tag: S.Literal('ExplicitTagField'),
+})
+
+const expectSameObjectStructure = (actual: object, expected: object): void => {
+  expect(Object.getPrototypeOf(actual)).toBe(Object.getPrototypeOf(expected))
+  expect(Reflect.ownKeys(actual)).toStrictEqual(Reflect.ownKeys(expected))
+  expect(Object.getOwnPropertySymbols(actual)).toStrictEqual([])
+  expect(Object.getOwnPropertyDescriptors(actual)).toStrictEqual(
+    Object.getOwnPropertyDescriptors(expected),
+  )
+}
+
+const getError = (construct: () => unknown, cleanup?: () => void): Error => {
+  try {
+    construct()
+  } catch (error) {
+    if (error instanceof Error) {
+      return error
+    }
+    throw error
+  } finally {
+    cleanup?.()
+  }
+  throw new Error('Expected construction to fail')
+}
+
+describe('makeCallable', () => {
+  it('keeps the wrapped Schema properties and prototype transparent', () => {
+    const schema = S.TaggedStruct('ClickedItem', { id: S.String })
+
+    expect('make' in ClickedItem).toBe(true)
+    expect(ClickedItem.ast).toBeDefined()
+    expect(Object.getPrototypeOf(ClickedItem)).toBe(
+      Object.getPrototypeOf(schema),
+    )
+  })
+
+  it('matches make when the fields explicitly define _tag', () => {
+    const input = { _tag: 'ExplicitTagField' }
+    const made = Reflect.apply(ExplicitTagField.make, undefined, [input])
+    const constructed = Reflect.apply(ExplicitTagField, undefined, [input])
+
+    expect(constructed).toStrictEqual(made)
+    expectSameObjectStructure(constructed, made)
+    expect(() => Reflect.apply(ExplicitTagField.make, undefined, [{}])).toThrow(
+      'Schema validation failed',
+    )
+    expect(() => Reflect.apply(ExplicitTagField, undefined, [{}])).toThrow(
+      'Schema validation failed',
+    )
+  })
+
+  it('matches make and a literal for correct input', () => {
+    const literal = { _tag: 'ClickedItem', id: 'item-1' }
+    const made = ClickedItem.make({ id: 'item-1' })
+    const constructed = ClickedItem({ id: 'item-1' })
+
+    expect(constructed).toStrictEqual(made)
+    expectSameObjectStructure(made, literal)
+    expectSameObjectStructure(constructed, literal)
+  })
+
+  it('matches make for a declared __proto__ field', () => {
+    const ChangedPrototypeLabel = m('ChangedPrototypeLabel', {
+      ['__proto__']: S.String,
+    })
+    const input = { ['__proto__']: 'label' }
+    const literal = { _tag: 'ChangedPrototypeLabel', ['__proto__']: 'label' }
+    const made = ChangedPrototypeLabel.make(input)
+    const constructed = ChangedPrototypeLabel(input)
+
+    expect(constructed).toStrictEqual(made)
+    expectSameObjectStructure(constructed, literal)
+  })
+
+  it('builds a fresh no-payload object on every call', () => {
+    expect(ClickedReset()).not.toBe(ClickedReset())
+  })
+
+  it('accepts a wrong field type that make rejects', () => {
+    const input = { id: 1 }
+
+    expect(() => Reflect.apply(ClickedItem.make, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+    expect(Reflect.apply(ClickedItem, undefined, [input])).toStrictEqual({
+      _tag: 'ClickedItem',
+      id: 1,
+    })
+  })
+
+  it('falls back to make for primitive inputs', () => {
+    const inputs: ReadonlyArray<unknown> = ['item-1', 1, true]
+    for (const input of inputs) {
+      const makeError = getError(() =>
+        Reflect.apply(ClickedItem.make, undefined, [input]),
+      )
+      const callableError = getError(() =>
+        Reflect.apply(ClickedItem, undefined, [input]),
+      )
+
+      expect(callableError.constructor).toBe(makeError.constructor)
+      expect(callableError.message).toBe(makeError.message)
+      expect(callableError.cause).toStrictEqual(makeError.cause)
+    }
+  })
+
+  it('copies an undefined field when make rejects a missing required field', () => {
+    expect(() => Reflect.apply(ClickedItem.make, undefined, [{}])).toThrow(
+      'Schema validation failed',
+    )
+    expect(Reflect.apply(ClickedItem, undefined, [{}])).toStrictEqual({
+      _tag: 'ClickedItem',
+      id: undefined,
+    })
+  })
+
+  it('guards a null payload before constructing a no-payload value', () => {
+    const payload: unknown = null
+    const previousCallableResult = Reflect.apply(ClickedReset.make, undefined, [
+      payload ?? {},
+    ])
+
+    expect(Reflect.apply(ClickedReset, undefined, [payload])).toStrictEqual(
+      previousCallableResult,
+    )
+  })
+
+  it('guards a null payload before reading declared fields', () => {
+    expect(() => Reflect.apply(ClickedItem.make, undefined, [null])).toThrow(
+      'Schema validation failed',
+    )
+    expect(Reflect.apply(ClickedItem, undefined, [null])).toStrictEqual({
+      _tag: 'ClickedItem',
+      id: undefined,
+    })
+  })
+
+  it('strips extra string and symbol keys exactly like make', () => {
+    const extraSymbol = Symbol('extra')
+    const input = { id: 'item-1', extra: true, [extraSymbol]: true }
+    const made = Reflect.apply(ClickedItem.make, undefined, [input])
+    const constructed = Reflect.apply(ClickedItem, undefined, [input])
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed).toStrictEqual({ _tag: 'ClickedItem', id: 'item-1' })
+    expectSameObjectStructure(constructed, made)
+  })
+
+  it('falls back for an explicit accessor tag', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      '_tag',
+    )
+    const restoreDescriptor = () => {
+      if (originalDescriptor === undefined) {
+        Reflect.deleteProperty(Object.prototype, '_tag')
+      } else {
+        Object.defineProperty(Object.prototype, '_tag', originalDescriptor)
+      }
+    }
+    const makeInput = () => {
+      const input = { id: 'item-1' }
+      Object.defineProperty(input, '_tag', {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          Object.defineProperty(Object.prototype, '_tag', {
+            configurable: true,
+            set: () => undefined,
+          })
+          return 'ClickedItem'
+        },
+      })
+      return input
+    }
+
+    try {
+      const made = ClickedItem.make(makeInput())
+      restoreDescriptor()
+      const constructed = ClickedItem(makeInput())
+
+      expect(constructed).toStrictEqual(made)
+      expect(Object.hasOwn(constructed, '_tag')).toBe(false)
+    } finally {
+      restoreDescriptor()
+    }
+  })
+
+  it('matches make write ordering for an explicit undefined tag', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      '_tag',
+    )
+    const restoreDescriptor = () => {
+      if (originalDescriptor === undefined) {
+        Reflect.deleteProperty(Object.prototype, '_tag')
+      } else {
+        Object.defineProperty(Object.prototype, '_tag', originalDescriptor)
+      }
+    }
+    const installDeletingSetter = () => {
+      Object.defineProperty(Object.prototype, '_tag', {
+        configurable: true,
+        set: () => {
+          Reflect.deleteProperty(Object.prototype, '_tag')
+        },
+      })
+    }
+
+    try {
+      installDeletingSetter()
+      const made = Reflect.apply(ClickedItem.make, undefined, [
+        { _tag: undefined, id: 'item-1' },
+      ])
+      restoreDescriptor()
+      installDeletingSetter()
+      const constructed = Reflect.apply(ClickedItem, undefined, [
+        { _tag: undefined, id: 'item-1' },
+      ])
+
+      expect(constructed).toStrictEqual(made)
+      expect(constructed).toStrictEqual({
+        _tag: 'ClickedItem',
+        id: 'item-1',
+      })
+    } finally {
+      restoreDescriptor()
+    }
+  })
+
+  it('observes direct properties in the same order as make', () => {
+    const ChangedIndex = m('ChangedIndex', { 0: S.Number })
+    const makeInput = () => {
+      const input = { 0: 1, _tag: 'ChangedIndex' }
+      return new Proxy(input, {
+        get: (target, name, receiver) => {
+          if (name === '_tag') {
+            target[0] = 2
+          }
+          return Reflect.get(target, name, receiver)
+        },
+      })
+    }
+    const made = Reflect.apply(ChangedIndex.make, undefined, [makeInput()])
+    const constructed = Reflect.apply(ChangedIndex, undefined, [makeInput()])
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed).toStrictEqual({ 0: 1, _tag: 'ChangedIndex' })
+  })
+
+  it('falls back for accessor fields before reading them', () => {
+    const getterError = new Error('id getter')
+    const makeInput = () => ({
+      get id(): string {
+        throw getterError
+      },
+    })
+    const makeError = getError(() => ClickedItem.make(makeInput()))
+    const callableError = getError(() => ClickedItem(makeInput()))
+
+    expect(callableError.message).toBe(makeError.message)
+    expect(callableError.cause).toStrictEqual(makeError.cause)
+  })
+
+  it('falls back for fields inherited from the input prototype', () => {
+    class Row {
+      get id(): string {
+        return 'item-1'
+      }
+    }
+
+    const inheritedDataInput: { readonly id: string } = Object.create({
+      id: 'item-1',
+    })
+
+    expect(() => ClickedItem.make(new Row())).toThrow(
+      'Schema validation failed',
+    )
+    expect(() => ClickedItem(new Row())).toThrow('Schema validation failed')
+    expect(() => ClickedItem.make(inheritedDataInput)).toThrow(
+      'Schema validation failed',
+    )
+    expect(() => ClickedItem(inheritedDataInput)).toThrow(
+      'Schema validation failed',
+    )
+  })
+
+  it('falls back for an explicitly wrong top-level tag', () => {
+    const input = { _tag: 'Bogus', id: 'item-1' }
+
+    expect(() => Reflect.apply(ClickedItem.make, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+    expect(() => Reflect.apply(ClickedItem, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+  })
+
+  it('matches make for data-property Proxies without duplicate reads', () => {
+    const makeInput = () => {
+      const log: Array<string> = []
+      let idDescriptorCount = 0
+      const input = new Proxy(
+        { id: 'item-1' },
+        {
+          get: (target, name, receiver) => {
+            log.push(`get:${String(name)}`)
+            if (name === 'id' && idDescriptorCount > 1) {
+              return 'item-2'
+            }
+            return Reflect.get(target, name, receiver)
+          },
+          getOwnPropertyDescriptor: (target, name) => {
+            log.push(`descriptor:${String(name)}`)
+            if (name === 'id') {
+              idDescriptorCount += 1
+            }
+            return Reflect.getOwnPropertyDescriptor(target, name)
+          },
+        },
+      )
+      return { input, log }
+    }
+    const madeInput = makeInput()
+    const callableInput = makeInput()
+    const made = ClickedItem.make(madeInput.input)
+    const constructed = ClickedItem(callableInput.input)
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed.id).toBe('item-1')
+    expect(callableInput.log).toStrictEqual(madeInput.log)
+  })
+
+  it('checks the value read from an explicit Proxy tag', () => {
+    const makeInput = () =>
+      new Proxy(
+        { _tag: 'ClickedItem', id: 'item-1' },
+        {
+          get: (target, name, receiver) =>
+            name === '_tag' ? 'Bogus' : Reflect.get(target, name, receiver),
+        },
+      )
+
+    expect(() =>
+      Reflect.apply(ClickedItem.make, undefined, [makeInput()]),
+    ).toThrow('Schema validation failed')
+    expect(() => Reflect.apply(ClickedItem, undefined, [makeInput()])).toThrow(
+      'Schema validation failed',
+    )
+  })
+
+  it('falls back to make for a checked field', () => {
+    const ChangedName = m('ChangedName', { name: S.NonEmptyString })
+    const input = { name: '' }
+
+    expect(() => Reflect.apply(ChangedName.make, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+    expect(() => Reflect.apply(ChangedName, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+  })
+
+  it('finds a check nested inside a Struct field', () => {
+    const ChangedProfile = m('ChangedProfile', {
+      profile: S.Struct({ name: S.NonEmptyString }),
+    })
+    const input = { profile: { name: '' } }
+
+    expect(() =>
+      Reflect.apply(ChangedProfile.make, undefined, [input]),
+    ).toThrow('Schema validation failed')
+    expect(() => Reflect.apply(ChangedProfile, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+  })
+
+  it('finds checks nested inside union members, tuple elements, and array rest', () => {
+    const ChangedUnion = m('ChangedUnion', {
+      value: S.Union([S.NonEmptyString, S.Number]),
+    })
+    const ChangedTuple = m('ChangedTuple', {
+      value: S.Tuple([S.NonEmptyString]),
+    })
+    const ChangedArray = m('ChangedArray', {
+      value: S.Array(S.NonEmptyString),
+    })
+
+    expect(() =>
+      Reflect.apply(ChangedUnion, undefined, [{ value: '' }]),
+    ).toThrow('Schema validation failed')
+    expect(() =>
+      Reflect.apply(ChangedTuple, undefined, [{ value: [''] }]),
+    ).toThrow('Schema validation failed')
+    expect(() =>
+      Reflect.apply(ChangedArray, undefined, [{ value: [''] }]),
+    ).toThrow('Schema validation failed')
+  })
+
+  it('keeps an unchecked primitive union on the fast path', () => {
+    const ChangedValue = m('ChangedValue', {
+      value: S.Union([S.String, S.Number]),
+    })
+    const input = { value: true }
+
+    expect(() => Reflect.apply(ChangedValue.make, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+    expect(Reflect.apply(ChangedValue, undefined, [input])).toStrictEqual({
+      _tag: 'ChangedValue',
+      value: true,
+    })
+  })
+
+  it('keeps every identity leaf category on the fast path', () => {
+    const uniqueSymbol = Symbol('unique')
+    const otherSymbol = Symbol('other')
+    const ChangedSymbol = m('ChangedSymbol', { value: S.Symbol })
+    const ChangedUniqueSymbol = m('ChangedUniqueSymbol', {
+      value: S.UniqueSymbol(uniqueSymbol),
+    })
+    const ChangedObject = m('ChangedObject', { value: S.ObjectKeyword })
+    const ChangedEnum = m('ChangedEnum', {
+      value: S.Enum({ Selected: 'Selected' }),
+    })
+    const ChangedTemplate = m('ChangedTemplate', {
+      value: S.TemplateLiteral(['item-', S.String]),
+    })
+
+    expect(
+      Reflect.apply(ChangedSymbol, undefined, [{ value: 'not a symbol' }]),
+    ).toHaveProperty('value', 'not a symbol')
+    expect(
+      Reflect.apply(ChangedUniqueSymbol, undefined, [{ value: otherSymbol }]),
+    ).toHaveProperty('value', otherSymbol)
+    expect(
+      Reflect.apply(ChangedObject, undefined, [{ value: 'not an object' }]),
+    ).toHaveProperty('value', 'not an object')
+    expect(
+      Reflect.apply(ChangedEnum, undefined, [{ value: 'Other' }]),
+    ).toHaveProperty('value', 'Other')
+    expect(
+      Reflect.apply(ChangedTemplate, undefined, [{ value: 1 }]),
+    ).toHaveProperty('value', 1)
+  })
+
+  it('falls back for suspended fields', () => {
+    const ChangedValue = m('ChangedValue', {
+      value: S.suspend(() => S.String),
+    })
+    const input = { value: 1 }
+
+    expect(() => Reflect.apply(ChangedValue.make, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+    expect(() => Reflect.apply(ChangedValue, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+  })
+
+  it('rebuilds plain Struct and Array fields like make', () => {
+    const ChangedProfiles = m('ChangedProfiles', {
+      profile: S.Struct({ name: S.String }),
+      profiles: S.Array(S.Struct({ name: S.String })),
+    })
+    const profile = { name: 'Ada', extra: true }
+    const nestedProfile = { name: 'Grace', extra: true }
+    const profiles = [nestedProfile]
+    const input = { profile, profiles }
+    const made = ChangedProfiles.make(input)
+    const constructed = ChangedProfiles(input)
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed.profile).not.toBe(profile)
+    expect(constructed.profiles).not.toBe(profiles)
+    expect(constructed.profiles.at(0)).not.toBe(nestedProfile)
+  })
+
+  it('preserves empty Struct identity like make', () => {
+    const ChangedValue = m('ChangedValue', { value: S.Struct({}) })
+    const value = { extra: true }
+    const made = ChangedValue.make({ value })
+    const constructed = ChangedValue({ value })
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed.value).toBe(value)
+  })
+
+  it('rebuilds Array subclasses as plain Arrays like make', () => {
+    class ProfileList extends globalThis.Array<{ name: string }> {}
+
+    const ChangedProfiles = m('ChangedProfiles', {
+      profiles: S.Array(S.Struct({ name: S.String })),
+    })
+    const profiles = new ProfileList()
+    profiles.push({ name: 'Ada' })
+    const made = ChangedProfiles.make({ profiles })
+    const constructed = ChangedProfiles({ profiles })
+
+    expect(constructed).toStrictEqual(made)
+    expect(Object.getPrototypeOf(constructed.profiles)).toBe(Array.prototype)
+  })
+
+  it('rebuilds Arrays from numeric indexes without using a custom iterator', () => {
+    const ChangedValues = m('ChangedValues', { values: S.Array(S.String) })
+    const values = ['first', 'second']
+    values[Symbol.iterator] = function* () {
+      yield 'iterator value'
+      return undefined
+    }
+    values.at = () => 'overridden at value'
+    const made = ChangedValues.make({ values })
+    const constructed = ChangedValues({ values })
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed.values).toStrictEqual(['first', 'second'])
+  })
+
+  it('snapshots Array length before reading its items', () => {
+    const ChangedValues = m('ChangedValues', { values: S.Array(S.Unknown) })
+    const makeValues = () => {
+      const values = new globalThis.Array<unknown>(3)
+      Object.defineProperty(values, 0, {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          values.length = 1
+          return 'first'
+        },
+      })
+      return values
+    }
+    const made = ChangedValues.make({ values: makeValues() })
+    const constructed = ChangedValues({ values: makeValues() })
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed.values).toStrictEqual(['first', undefined, undefined])
+  })
+
+  it('writes Array items without reading Array.prototype.push', () => {
+    const ChangedValues = m('ChangedValues', { values: S.Array(S.Unknown) })
+    const originalPush = globalThis.Array.prototype.push
+    const makeValues = () => {
+      const values = ['first', 'second']
+      Object.defineProperty(values, 0, {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          globalThis.Array.prototype.push = () => 0
+          return 'first'
+        },
+      })
+      return values
+    }
+
+    try {
+      const made = ChangedValues.make({ values: makeValues() })
+      globalThis.Array.prototype.push = originalPush
+      const constructed = ChangedValues({ values: makeValues() })
+
+      expect(constructed).toStrictEqual(made)
+      expect(constructed.values).toStrictEqual(['first', 'second'])
+    } finally {
+      globalThis.Array.prototype.push = originalPush
+    }
+  })
+
+  it('throws when an Array item cannot be assigned', () => {
+    const ChangedValues = m('ChangedValues', { values: S.Array(S.Unknown) })
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis.Array.prototype,
+      0,
+    )
+    const restoreDescriptor = () => {
+      if (originalDescriptor === undefined) {
+        Reflect.deleteProperty(globalThis.Array.prototype, 0)
+      } else {
+        Object.defineProperty(globalThis.Array.prototype, 0, originalDescriptor)
+      }
+    }
+    const makeValues = () => {
+      const values = new globalThis.Array<unknown>(1)
+      Object.defineProperty(values, 0, {
+        configurable: true,
+        enumerable: true,
+        get: () => {
+          Object.defineProperty(globalThis.Array.prototype, 0, {
+            configurable: true,
+            value: 'blocked',
+            writable: false,
+          })
+          return 'first'
+        },
+      })
+      return values
+    }
+    const makeError = getError(
+      () => ChangedValues.make({ values: makeValues() }),
+      restoreDescriptor,
+    )
+    const callableError = getError(
+      () => ChangedValues({ values: makeValues() }),
+      restoreDescriptor,
+    )
+
+    expect(makeError).toBeInstanceOf(Error)
+    expect(callableError).toBeInstanceOf(Error)
+  })
+
+  it('assigns raw object fields before constructing nested values', () => {
+    const ChangedChild = m('ChangedChild', {
+      child: S.Struct({ name: S.String }),
+    })
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      'child',
+    )
+    const restoreDescriptor = () => {
+      if (originalDescriptor === undefined) {
+        Reflect.deleteProperty(Object.prototype, 'child')
+      } else {
+        Object.defineProperty(Object.prototype, 'child', originalDescriptor)
+      }
+    }
+    const makeInput = () => ({
+      child: {
+        get name() {
+          Object.defineProperty(Object.prototype, 'child', {
+            configurable: true,
+            set: () => undefined,
+          })
+          return 'Ada'
+        },
+      },
+    })
+
+    try {
+      const made = ChangedChild.make(makeInput())
+      restoreDescriptor()
+      const constructed = ChangedChild(makeInput())
+
+      expect(constructed).toStrictEqual(made)
+      expect(constructed).toStrictEqual({
+        _tag: 'ChangedChild',
+        child: { name: 'Ada' },
+      })
+    } finally {
+      restoreDescriptor()
+    }
+  })
+
+  it('falls back for structural unions', () => {
+    const ChangedValue = m('ChangedValue', {
+      value: S.Union([
+        S.Struct({ name: S.String }),
+        S.Struct({ count: S.Number }),
+      ]),
+    })
+    const value = { name: 'Ada', extra: true }
+    const input = { value }
+    const made = ChangedValue.make(input)
+    const constructed = ChangedValue(input)
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed.value).not.toBe(value)
+  })
+
+  it('falls back for oneOf unions', () => {
+    const ChangedValue = m('ChangedValue', {
+      value: S.Union([S.String, S.String], { mode: 'oneOf' }),
+    })
+    const input = { value: 'value' }
+
+    expect(() => ChangedValue.make(input)).toThrow('Schema validation failed')
+    expect(() => ChangedValue(input)).toThrow('Schema validation failed')
+  })
+
+  it('falls back for index signatures', () => {
+    const ChangedValues = m('ChangedValues', {
+      values: S.Record(S.String, S.String),
+    })
+    const values = { first: 'one' }
+    const input = { values }
+    const made = ChangedValues.make(input)
+    const constructed = ChangedValues(input)
+
+    expect(constructed).toStrictEqual(made)
+    expect(constructed.values).not.toBe(values)
+  })
+
+  it('falls back for Declaration fields', () => {
+    const DeclaredString = S.declare(
+      (input): input is string => typeof input === 'string',
+      { expected: 'string declaration' },
+    )
+    const ChangedDeclaredValue = m('ChangedDeclaredValue', {
+      value: DeclaredString,
+    })
+    const SelectedValue = m('SelectedValue', {
+      value: S.Option(S.String),
+    })
+    const invalidInput = { value: 1 }
+    const option = Option.some('selected')
+    const made = SelectedValue.make({ value: option })
+    const constructed = SelectedValue({ value: option })
+
+    expect(() =>
+      Reflect.apply(ChangedDeclaredValue, undefined, [invalidInput]),
+    ).toThrow('Schema validation failed')
+    expect(constructed).toStrictEqual(made)
+    expect(constructed.value).not.toBe(option)
+  })
+
+  it('falls back to make for field context', () => {
+    const ChangedLabel = m('ChangedLabel', {
+      label: S.optionalKey(S.String),
+    })
+
+    expect(Reflect.apply(ChangedLabel, undefined, [{}])).toStrictEqual({
+      _tag: 'ChangedLabel',
+    })
+  })
+
+  it('falls back for value-shaping parse options', () => {
+    const profile = S.Struct({ name: S.String }).annotate({
+      parseOptions: { onExcessProperty: 'preserve' },
+    })
+    const ChangedProfile = m('ChangedProfile', { profile })
+    const input = { profile: { name: 'Ada', extra: true } }
+
+    expect(ChangedProfile(input)).toStrictEqual(ChangedProfile.make(input))
+    expect(ChangedProfile(input).profile).toHaveProperty('extra', true)
+  })
+
+  it('falls back for child Message fields', () => {
+    const ChildMessage = m('ChildMessage')
+    const GotChildMessage = m('GotChildMessage', { message: ChildMessage })
+    const input = { message: { _tag: 'Bogus' } }
+
+    expect(() =>
+      Reflect.apply(GotChildMessage.make, undefined, [input]),
+    ).toThrow('Schema validation failed')
+    expect(() => Reflect.apply(GotChildMessage, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+  })
+
+  it('applies a missing child Message tag like make', () => {
+    const ChildMessage = m('ChildMessage')
+    const GotChildMessage = m('GotChildMessage', { message: ChildMessage })
+    const input = { message: {} }
+
+    expect(GotChildMessage(input)).toStrictEqual(GotChildMessage.make(input))
+  })
+
+  it('falls back for custom child tag constructor defaults', () => {
+    let defaultCount = 0
+    const CustomChild = S.Struct({
+      _tag: S.Literal('CustomChild').pipe(
+        S.withConstructorDefault(
+          Effect.sync((): 'CustomChild' => {
+            defaultCount += 1
+            return 'CustomChild'
+          }),
+        ),
+      ),
+    })
+    const WrappedChild = m('WrappedChild', { child: CustomChild })
+    const missingTagInput = { child: {} }
+    const undefinedTagInput = { child: { _tag: undefined } }
+    const bogusTagInput = { child: { _tag: 'Bogus' } }
+
+    expect(WrappedChild(missingTagInput)).toStrictEqual(
+      WrappedChild.make(missingTagInput),
+    )
+    expect(
+      Reflect.apply(WrappedChild, undefined, [undefinedTagInput]),
+    ).toStrictEqual(
+      Reflect.apply(WrappedChild.make, undefined, [undefinedTagInput]),
+    )
+    expect(() =>
+      Reflect.apply(WrappedChild, undefined, [bogusTagInput]),
+    ).toThrow('Schema validation failed')
+    expect(defaultCount).toBe(4)
+  })
+
+  it('falls back for child Message unions', () => {
+    const SelectedChild = m('SelectedChild', { id: S.String })
+    const ResetChild = m('ResetChild')
+    const ChildMessage = S.Union([SelectedChild, ResetChild])
+    const GotChildMessage = m('GotChildMessage', { message: ChildMessage })
+    const missingTagInput = { message: { id: 'child-1', extra: true } }
+    const undefinedTagInput = { message: { _tag: undefined } }
+    const bogusTagInput = { message: { _tag: 'Bogus' } }
+
+    expect(GotChildMessage(missingTagInput)).toStrictEqual(
+      GotChildMessage.make(missingTagInput),
+    )
+    expect(
+      Reflect.apply(GotChildMessage, undefined, [undefinedTagInput]),
+    ).toStrictEqual(
+      Reflect.apply(GotChildMessage.make, undefined, [undefinedTagInput]),
+    )
+    expect(() =>
+      Reflect.apply(GotChildMessage.make, undefined, [bogusTagInput]),
+    ).toThrow('Schema validation failed')
+    expect(() =>
+      Reflect.apply(GotChildMessage, undefined, [bogusTagInput]),
+    ).toThrow('Schema validation failed')
+  })
+
+  it('uses child Message union parsing when omitted tags are ambiguous', () => {
+    const SelectedText = m('SelectedText', { value: S.String })
+    const SelectedCount = m('SelectedCount', { value: S.Number })
+    const ChildMessage = S.Union([SelectedText, SelectedCount])
+    const GotChildMessage = m('GotChildMessage', {
+      message: ChildMessage,
+    })
+    const input = { message: { value: 1 } }
+
+    expect(GotChildMessage(input)).toStrictEqual(GotChildMessage.make(input))
+    expect(GotChildMessage(input).message._tag).toBe('SelectedCount')
+  })
+
+  it('falls back for encoded child Message schemas', () => {
+    const SelectedCount = m('SelectedCount', { count: S.NumberFromString })
+    const ResetCount = m('ResetCount')
+    const ChildMessage = S.Union([SelectedCount, ResetCount])
+    const GotSelectedCountMessage = m('GotSelectedCountMessage', {
+      message: SelectedCount,
+    })
+    const GotChildMessage = m('GotChildMessage', { message: ChildMessage })
+    const input = { message: { _tag: 'Bogus', count: 1 } }
+
+    expect(() =>
+      Reflect.apply(GotSelectedCountMessage.make, undefined, [input]),
+    ).toThrow('Schema validation failed')
+    expect(() =>
+      Reflect.apply(GotChildMessage.make, undefined, [input]),
+    ).toThrow('Schema validation failed')
+    expect(() =>
+      Reflect.apply(GotSelectedCountMessage, undefined, [input]),
+    ).toThrow('Schema validation failed')
+    expect(() => Reflect.apply(GotChildMessage, undefined, [input])).toThrow(
+      'Schema validation failed',
+    )
+  })
+})

--- a/packages/foldkit/src/schema/index.ts
+++ b/packages/foldkit/src/schema/index.ts
@@ -1,4 +1,4 @@
-import { Schema as S, Types } from 'effect'
+import { Match as M, Schema as S, SchemaAST, Types } from 'effect'
 
 /** A `TaggedStruct` schema that can be called directly as a constructor: `Foo({ count: 1 })` instead of `Foo.make({ count: 1 })`. */
 export type CallableTaggedStruct<
@@ -15,13 +15,143 @@ export type CallableTaggedStruct<
         S.Struct.Type<{ readonly _tag: S.tag<Tag> } & Fields>
       >)
 
+const assignPlainProperty = (
+  output: Record<PropertyKey, unknown>,
+  name: PropertyKey,
+  value: unknown,
+): void => {
+  if (name === '__proto__') {
+    Object.defineProperty(output, name, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    })
+  } else {
+    output[name] = value
+  }
+}
+
+const isDirectlyCopyable = (ast: SchemaAST.AST): boolean => {
+  if (
+    ast.checks !== undefined ||
+    ast.encoding !== undefined ||
+    ast.context !== undefined ||
+    ast.annotations?.['parseOptions'] !== undefined
+  ) {
+    return false
+  }
+
+  return M.value(ast).pipe(
+    M.withReturnType<boolean>(),
+    M.tagsExhaustive({
+      Declaration: () => false,
+      Null: () => true,
+      Undefined: () => true,
+      Void: () => true,
+      Never: () => true,
+      Unknown: () => true,
+      Any: () => true,
+      String: () => true,
+      Number: () => true,
+      Boolean: () => true,
+      BigInt: () => true,
+      Symbol: () => true,
+      Literal: () => true,
+      UniqueSymbol: () => true,
+      ObjectKeyword: () => true,
+      Enum: () => true,
+      TemplateLiteral: ({ parts }) => parts.every(isDirectlyCopyable),
+      Arrays: () => false,
+      Objects: () => false,
+      Union: ({ mode, types }) =>
+        mode !== 'oneOf' && types.every(isDirectlyCopyable),
+      Suspend: () => false,
+    }),
+  )
+}
+
+const getDirectPropertyNames = (
+  propertySignatures: ReadonlyArray<SchemaAST.PropertySignature>,
+): Array<PropertyKey> | undefined => {
+  const names: Array<PropertyKey> = []
+
+  for (const { name, type } of propertySignatures) {
+    if (name !== '_tag' && !isDirectlyCopyable(SchemaAST.toType(type))) {
+      return undefined
+    }
+
+    names.push(name)
+  }
+
+  return names
+}
+
 const makeCallable = <Tag extends string, Fields extends S.Struct.Fields>(
-  schema: S.TaggedStruct<Tag, Fields>,
-): CallableTaggedStruct<Tag, Fields> =>
+  tag: Tag,
+  fields: Fields,
+): CallableTaggedStruct<Tag, Fields> => {
+  const schema = S.TaggedStruct(tag, fields)
+  const propertyNames = Object.hasOwn(fields, '_tag')
+    ? undefined
+    : getDirectPropertyNames(schema.ast.propertySignatures)
+  const make = (value: unknown) =>
+    schema.make(
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      (value ?? {}) as Parameters<typeof schema.make>[0],
+    )
+  const construct =
+    propertyNames !== undefined
+      ? (value: unknown): Record<PropertyKey, unknown> => {
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+          const input = (value ?? {}) as Record<PropertyKey, unknown>
+          if (Object(input) !== input) {
+            return make(value)
+          }
+
+          const output: Record<PropertyKey, unknown> = {}
+
+          for (const name of propertyNames) {
+            const descriptor = Object.getOwnPropertyDescriptor(input, name)
+
+            if (
+              name !== '_tag' &&
+              descriptor === undefined &&
+              Reflect.has(input, name)
+            ) {
+              return make(value)
+            }
+
+            if (descriptor !== undefined && !('value' in descriptor)) {
+              return make(value)
+            }
+
+            const inputValue =
+              descriptor === undefined ? undefined : input[name]
+
+            if (name === '_tag') {
+              if (inputValue !== undefined && inputValue !== tag) {
+                return make(value)
+              }
+
+              if (descriptor !== undefined && inputValue === undefined) {
+                assignPlainProperty(output, name, inputValue)
+              }
+
+              assignPlainProperty(output, name, tag)
+            } else {
+              assignPlainProperty(output, name, inputValue)
+            }
+          }
+
+          return output
+        }
+      : make
+
   /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-  new Proxy(function () {} as unknown as object, {
+  return new Proxy(function () {} as unknown as object, {
     apply(_target, _thisArg, argumentsList) {
-      return schema.make(argumentsList[0] ?? {})
+      return construct(argumentsList[0])
     },
     get(_target, property, receiver) {
       return Reflect.get(schema, property, receiver)
@@ -33,6 +163,7 @@ const makeCallable = <Tag extends string, Fields extends S.Struct.Fields>(
       return Reflect.getPrototypeOf(schema)
     },
   }) as unknown as CallableTaggedStruct<Tag, Fields>
+}
 
 /**
  * Wraps `Schema.TaggedStruct` to create a message variant you can call directly as a constructor.
@@ -53,7 +184,7 @@ export function m<Tag extends string, Fields extends S.Struct.Fields>(
   fields: Fields,
 ): CallableTaggedStruct<Tag, Fields>
 export function m(tag: string, fields: S.Struct.Fields = {}): any {
-  return makeCallable(S.TaggedStruct(tag, fields))
+  return makeCallable(tag, fields)
 }
 
 /**
@@ -75,7 +206,7 @@ export function r<Tag extends string, Fields extends S.Struct.Fields>(
   fields: Fields,
 ): CallableTaggedStruct<Tag, Fields>
 export function r(tag: string, fields: S.Struct.Fields = {}): any {
-  return makeCallable(S.TaggedStruct(tag, fields))
+  return makeCallable(tag, fields)
 }
 
 /**
@@ -98,5 +229,5 @@ export function ts<Tag extends string, Fields extends S.Struct.Fields>(
   fields: Fields,
 ): CallableTaggedStruct<Tag, Fields>
 export function ts(tag: string, fields: S.Struct.Fields = {}): any {
-  return makeCallable(S.TaggedStruct(tag, fields))
+  return makeCallable(tag, fields)
 }

--- a/packages/vite-plugin-foldkit/src/index.ts
+++ b/packages/vite-plugin-foldkit/src/index.ts
@@ -128,6 +128,7 @@ const FORCE_INCLUDED_EFFECT_NAMESPACES: ReadonlyArray<string> = [
   'effect/Runtime',
   'effect/Scheduler',
   'effect/Schema',
+  'effect/SchemaAST',
   'effect/SchemaIssue',
   'effect/SchemaTransformation',
   'effect/Scope',


### PR DESCRIPTION
## Summary

- precompute direct constructors only for identity-only type-side fields such as primitives, literals, and unions of those types
- keep Structs, Arrays, child Messages, checks, context, Declarations, Suspend, oneOf, and other composites on `Schema.make`
- preserve Effect property order and output shape for data records, including integer, symbol, and `__proto__` fields
- fall back for accessor properties and explicitly invalid outer tags
- add SchemaAST to the Vite forced Effect prebundle

## Why the scope is narrow

An independent adversarial review found that recursively rebuilding Structs, Arrays, defaults, and tagged unions would amount to maintaining a second Effect constructor parser. This PR deliberately keeps those cases on `Schema.make`. The original proposed behavior where a bogus child Message tag passes is not included. Child Messages validate and throw.

## Benchmarks

Node 22.22.3, Effect 4.0.0-rc.109, median of eleven warmed 1,000,000-call samples:

- `ClickedReset()`: 177.8 ns to 30.5 ns per call
- `ClickedItem({ id })`: 257.5 ns to 73.7 ns per call

## Behavioral boundary

Eligible constructors assume typed data-property call sites. Calls bypassing TypeScript can still construct wrong primitive values or omit required fields. Accessor properties and invalid outer tags fall back to `Schema.make`. Stateful accessor Proxy traps, thrown Proxy traps, and mutation of global reflection intrinsics are outside the fast-path equivalence boundary. Untrusted input remains validated through decode.

## Verification

- independent adversarial review against Effect 4.0.0-rc.109, with a go recommendation for typed data-property call sites
- complete pre-push gate, including all workspace builds, typechecks, tests, and the Chromium smoke test
- focused constructor suite: 42 passed
- full Foldkit coverage suite: 2,338 passed, 1 skipped
- Schema constructor branch coverage: 97.43%
- mutation checks for disabled fast path, shallow Struct admission, accessor fallback, property order, duplicate Proxy reads, actual tag comparison, and explicit undefined-tag write ordering