### PR TITLE
fix(foldkit): make the runtime boot key nameable

### DIFF
--- a/.changeset/nameable-runtime-boot-key.md
+++ b/.changeset/nameable-runtime-boot-key.md
@@ -1,0 +1,9 @@
+---
+'foldkit': patch
+---
+
+Let a consumer export a program whose type comes from `makeElement` or `makeApplication`.
+
+`MakeRuntimeReturn` has a hidden field that carries Flags, Resources and Kind. Its key was a `unique symbol` that Foldkit did not export. TypeScript had to write that key into the `.d.ts` file, but it had no name for it, so it failed with `TS4023: ... has or is using name 'RuntimeBootTypeId' ... but cannot be named`. This hit any package that builds a program in one module and exports it, as soon as that package turned on declaration emit.
+
+The key is now a normal property, `'~foldkit/RuntimeBoot'`. Consumers need to do nothing. The field is still internal and still has no runtime representation.

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -1432,8 +1432,6 @@ export type ElementInit<
 
 type BootMode = 'Fresh' | 'Hydrate'
 
-declare const RuntimeBootTypeId: unique symbol
-
 /** Client-only startup input for an application that declares Flags. Pass it
  *  to `run` or `embed`; `hydrate` instead decodes the exact Flags value
  *  embedded by the server render.
@@ -1459,7 +1457,7 @@ export type MakeRuntimeReturn<
   runtimeId: string
   start: (hmrModel?: unknown) => Effect.Effect<void>
   ports: P
-  [RuntimeBootTypeId]?: Readonly<{
+  '~foldkit/RuntimeBoot'?: Readonly<{
     Flags: (flags: Flags) => Flags
     Resources: (resources: Resources) => Resources
     Kind: Kind

--- a/scripts/check-packed-ssr-consumer.ts
+++ b/scripts/check-packed-ssr-consumer.ts
@@ -179,6 +179,7 @@ const CONSUMER_FIXTURES: ReadonlyArray<ConsumerFixture> = [
   { path: 'src/entry.server.ts' },
   { path: 'src/vite-env.d.ts' },
   { path: 'src/packed-types.ts' },
+  { path: 'src/inferred-program.ts' },
   { path: 'tsconfig.json' },
 ]
 
@@ -276,6 +277,13 @@ const writeConsumerProject = (
 // were documented as shipping from there while the packed declarations omitted
 // them, which nothing inside the workspace could show: a source path resolves
 // them whether or not the barrel re-exports them.
+//
+// The fixture also sets `declaration`, so it covers a consumer that exports a
+// program whose type comes from `makeElement` or `makeApplication`. If a type
+// that foldkit exports has a key the consumer cannot write, that consumer
+// cannot write its own `.d.ts` file at all, and TypeScript reports TS4023.
+// `noEmit` still reports it, but only while `declaration` is set. Without
+// `declaration` the check never runs.
 const assertPackedTypesResolve = (projectDir: string): void => {
   const result = spawnSync('npx', ['tsc', '--noEmit'], {
     cwd: projectDir,
@@ -283,11 +291,12 @@ const assertPackedTypesResolve = (projectDir: string): void => {
   })
   assertConsumer(
     result.status === 0,
-    'a consumer importing the documented types from ' +
-      '`foldkit/experimental/server` does not typecheck against the packed ' +
-      `declarations:\n${result.stdout}${result.stderr}`,
+    'a consumer cannot compile against the packed declarations. It either ' +
+      'imports the documented types from `foldkit/experimental/server`, or ' +
+      'exports a program built with `makeElement` or `makeApplication`:' +
+      `\n${result.stdout}${result.stderr}`,
   )
-  log('Packed declarations carry the documented render option types')
+  log('Packed declarations compile, and a consumer can write its own')
 }
 
 // ASSERTIONS ON THE BUILT ARTIFACTS

--- a/scripts/fixtures/packed-ssr-consumer/src/inferred-program.ts
+++ b/scripts/fixtures/packed-ssr-consumer/src/inferred-program.ts
@@ -1,0 +1,47 @@
+import { Schema as S } from 'effect'
+import { Runtime } from 'foldkit'
+import type { Document, Html, HtmlBuilder } from 'foldkit/html'
+import { m } from 'foldkit/message'
+
+const InferredModel = S.Struct({ count: S.Number })
+type InferredModel = typeof InferredModel.Type
+
+const Ticked = m('Ticked')
+type InferredMessage = typeof Ticked.Type
+
+type InferredStep = readonly [InferredModel, ReadonlyArray<never>]
+
+const init = (): InferredStep => [{ count: 0 }, []]
+
+const update = (model: InferredModel): InferredStep => [model, []]
+
+const elementView = (
+  model: InferredModel,
+  h: HtmlBuilder<InferredMessage>,
+): Html => h.div([], [String(model.count)])
+
+const applicationView = (
+  model: InferredModel,
+  h: HtmlBuilder<InferredMessage>,
+): Document => ({
+  title: `Count ${model.count}`,
+  body: h.div([], [String(model.count)]),
+})
+
+export const makeInferredElement = (container: HTMLElement) =>
+  Runtime.makeElement({
+    Model: InferredModel,
+    init,
+    update,
+    view: elementView,
+    container,
+  })
+
+export const makeInferredApplication = (container: HTMLElement | null) =>
+  Runtime.makeApplication({
+    Model: InferredModel,
+    init,
+    update,
+    view: applicationView,
+    container,
+  })

--- a/scripts/fixtures/packed-ssr-consumer/tsconfig.json
+++ b/scripts/fixtures/packed-ssr-consumer/tsconfig.json
@@ -2,11 +2,12 @@
   "compilerOptions": {
     "strict": true,
     "noEmit": true,
+    "declaration": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "target": "es2022",
     "lib": ["esnext", "dom"],
     "types": []
   },
-  "include": ["src/packed-types.ts"]
+  "include": ["src/packed-types.ts", "src/inferred-program.ts"]
 }


### PR DESCRIPTION
## Summary

- key the `MakeRuntimeReturn` phantom field with a normal property, `'~foldkit/RuntimeBoot'`, instead of a `unique symbol` that is not exported
- let a consumer export a program whose type comes from `makeElement` or `makeApplication`. This failed with TS4023 before
- set `declaration` in the packed consumer fixture, so TypeScript runs the declaration check there
- add a fixture module that exports one inferred element program and one inferred application program

## Why

`MakeRuntimeReturn` has a hidden field that carries Flags, Resources and Kind. Its key was a `unique symbol` that Foldkit did not export. TypeScript had to write that key into the `.d.ts` file, but it had no name for it, so it reported TS4023. This was reported against `foldkit@0.148.1`, where it broke every call site in a downstream package after the upgrade.

Exporting the symbol does not help. TypeScript names a symbol by the place where it is declared. A re-export through a namespace adds no name there, so the error stays. The `~scope/Name` style follows Effect, which keys its own type-level fields the same way: `"~effect/Brand"` holds the brand keys, and `"~effect/data/Option"` holds the variance markers.

The old gate could not have caught this. TypeScript only checks declaration emit when `declaration` is set, and the fixture did not set it.

## Verification

- the reporter's repro now writes a valid `.d.ts` with plain TypeScript. `Flags`, `Resources` and `Kind` are still correct
- put the old key back, and TS4023 returns on the same line
- put the old key back, and the packed gate fails against the tarball, naming both exports
- the packed Chromium gate passed from start to finish
- the foldkit tests pass, 2305 of them
- workspace typecheck, Prettier, Oxlint and Knip all pass
- the pre-push suite passed when the branch was pushed

The changeset is a patch. No consumer could write the old key, so no consumer could depend on it.
