### PR TITLE
fix(website): extend mobile Safari through safe area

### DIFF
--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -84,6 +84,7 @@
   }
 
   html {
+    @apply bg-cream dark:bg-gray-900;
     color-scheme: light;
     scroll-padding-top: calc(var(--header-height) + var(--mobile-toc-height));
   }
@@ -94,7 +95,7 @@
   }
 
   body {
-    @apply text-base leading-relaxed font-light tracking-[0.01em] text-gray-800 dark:text-gray-200 bg-cream dark:bg-gray-900;
+    @apply text-base leading-relaxed font-light tracking-[0.01em] text-gray-800 dark:text-gray-200;
   }
 
   strong {

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -171,7 +171,7 @@ export const docsFooterView = (
   h.footer(
     [
       h.Class(
-        'px-4 py-6 md:px-6 mt-6 border-t border-gray-300 dark:border-gray-800',
+        'px-4 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] md:px-6 mt-6 border-t border-gray-300 dark:border-gray-800',
       ),
     ],
     [

--- a/packages/website/src/view/landing.ts
+++ b/packages/website/src/view/landing.ts
@@ -104,7 +104,7 @@ const landingFooter = (currentYear: number): Html =>
   ih.footer(
     [
       ih.Class(
-        'px-6 py-8 md:px-12 lg:px-20 border-t border-gray-300 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-400',
+        'px-6 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom,0px))] md:px-12 lg:px-20 border-t border-gray-300 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-400',
       ),
     ],
     [


### PR DESCRIPTION
## Summary

- paint the root canvas with the active theme so Safari fills the area beneath its floating controls
- add the bottom safe-area inset to the landing, newsletter, docs, and blog footers
- keep footer content clear of the home indicator while preserving existing spacing elsewhere

## Testing

- pnpm format
- pnpm --filter website build
- website theme-color tests
- full repository pre-push gate, including build, typecheck, unit tests, and website E2E