### PR TITLE
docs(website): standardize ASCII diagrams

### DIFF
--- a/packages/website/src/page/core/architecture.md
+++ b/packages/website/src/page/core/architecture.md
@@ -18,15 +18,23 @@ Every Foldkit app repeats the same cycle:
 The complete cycle looks like this:
 
 ```diagram
-Message ──▶ update ──▶ Model ──▶ view ──▶ Browser
-  ▲          │          │          │          │
-  │          │          │          │          └─ events ─────┐
-  │          │          │          └─ Mounts ────────────────┤
-  │          │          ├─ Subscriptions ────────────────────┤
-  │          │          └─ ManagedResources ─────────────────┤
-  │          └─ Commands ────────────────────────────────────┤
-  │                                                          ▼
-  └────────────────────────── Runtime ◀──────────────────────┘
++------> update -> Commands -----------+
+|         |                            |
+|         v                            |
+|       Model -> Subscriptions --------+
+|         |                            |
+|         +-> ManagedResources --------+
+|         |                            |
+|         v                            |
+|       view -> Mounts ----------------+
+|         |                            |
+|         v                            |
+|       Browser -> events -------------+
+|                                      v
+|                                   Runtime
+|                                      |
+|                                      v
++<--------------------------------- Message
 ```
 
 Five sources report through the Runtime: Commands, the Browser, Mounts, Subscriptions, and ManagedResources. When one produces a Message, the Runtime dispatches it back into `update`.

--- a/packages/website/src/page/core/serverRendering.md
+++ b/packages/website/src/page/core/serverRendering.md
@@ -25,21 +25,21 @@ For an application with Flags, here is the handoff from server input to a live a
        SERVER OR BUILD                      BROWSER
 
 request or build input                 live Foldkit app
-         │                                     ▲
-         ▼                                     │
+         |                                     ^
+         v                                     |
        Flags                           adopts matching DOM
-         │                                     ▲
-         ▼                                     │
+         |                                     ^
+         v                                     |
         init                                same view
-         │                                     ▲
-         ▼                                     │
+         |                                     ^
+         v                                     |
        Model                          equivalent Model
-         │                                     ▲
-         ▼                                     │
+         |                                     ^
+         v                                     |
         view                               same init
-         │                                     ▲
-         ▼                                     │
-HTML + serialized Flags ────────▶ Runtime.hydrate reads Flags
+         |                                     ^
+         v                                     |
+HTML + serialized Flags --------> Runtime.hydrate reads Flags
 ```
 
 Once the live application takes over, it behaves like any other Foldkit application. Routing, update, Commands, and Subscriptions run in the browser. A handled navigation does not ask the delivery host to render another document, though the application's Commands may still request data. The server renders the document again only on a full page load, such as a reload or a link the runtime does not handle.

--- a/packages/website/src/page/core/subscriptions.md
+++ b/packages/website/src/page/core/subscriptions.md
@@ -8,34 +8,34 @@ The first dependency value opens the Stream's initial scope. After every Model u
 
 ```diagram
                              Model
-                               │ modelToDependencies(model)
-                               ▼
+                               | modelToDependencies(model)
+                               v
                           Dependencies
-                               │
-                ┌──────────────┴───────────────┐
-                │                              │
+                               |
+                +--------------+---------------+
+                |                              |
            first value                   later value
-                │                              │
-                │                              ▼
-                │                   compare with previous
-                │                              │
-                │                 ┌────────────┴───────────┐
-                │                 │                        │
-                │              changed                equivalent
-                │                 │                        │
-                │                 ▼                        ▼
-                │         close old scope         keep current scope
-                │          run finalizers                  │
-                │                 │                        │
-                └─────────────────┤                        │
-                                  ▼                        │
-                           open fresh scope                │
-                                  │                        │
-                                  └────────────┬───────────┘
-                                               ▼
+                |                              |
+                |                              v
+                |                   compare with previous
+                |                              |
+                |                 +------------+-----------+
+                |                 |                        |
+                |              changed                equivalent
+                |                 |                        |
+                |                 v                        v
+                |         close old scope         keep current scope
+                |          run finalizers                  |
+                |                 |                        |
+                +-----------------+                        |
+                                  v                        |
+                           open fresh scope                |
+                                  |                        |
+                                  +------------+-----------+
+                                               v
                                     active Stream<Message>
-                                               │
-                                               ▼
+                                               |
+                                               v
                                              update
 ```
 

--- a/packages/website/src/page/patterns/subscriptionOrganization.md
+++ b/packages/website/src/page/patterns/subscriptionOrganization.md
@@ -15,21 +15,21 @@ page/settings/themeMenu/
   subscription.ts
   Subscription.make
   Stream<ThemeMenu.Message>
-               │
+               |
        Subscription.lift
  wraps with GotThemeMenuMessage
-               ▼
+               v
 page/settings/
   subscription.ts
   Stream<Settings.Message>
-               │
+               |
        Subscription.lift
    wraps with GotSettingsMessage
-               ▼
+               v
 subscription.ts (root)
   Stream<Message>
-               │
-               ▼
+               |
+               v
             Runtime
 ```
 

--- a/packages/website/src/page/projectOrganization.md
+++ b/packages/website/src/page/projectOrganization.md
@@ -14,43 +14,43 @@ When one file becomes hard to navigate, separate the root pieces and give each [
 
 ```text
 src/
-├── entry.ts               Runtime bootstrap
-├── main.ts                App-level init
-├── model.ts               App-level state
-├── message.ts             App-level messages
-├── command.ts             App-level Commands
-├── route.ts               Route definitions
-├── update.ts              App-level update
-├── view.ts                App-level view
-├── subscription.ts        App-level subscriptions
-├── story.test.ts          Story tests for the app-level update
-├── scene.test.ts          Scene tests for flows that cross pages
-│
-├── page/
-│   ├── index.ts           Re-exports all pages
-│   ├── home/
-│   │   ├── index.ts       Re-exports Home module
-│   │   ├── model.ts       Home state
-│   │   ├── message.ts     Home events
-│   │   ├── command.ts     Home Commands
-│   │   ├── update.ts      Home update
-│   │   ├── view.ts        Home view
-│   │   ├── story.test.ts  Story tests for the Home update
-│   │   └── scene.test.ts  Scene tests for the Home view
-│   └── products/
-│       ├── index.ts
-│       ├── model.ts
-│       ├── message.ts
-│       ├── command.ts
-│       ├── update.ts
-│       ├── view.ts
-│       ├── story.test.ts
-│       └── scene.test.ts
-│
-└── domain/
-    ├── index.ts           Re-exports domain modules
-    ├── cart.ts            Cart type + operations
-    └── item.ts            Item type + operations
++-- entry.ts               Runtime bootstrap
++-- main.ts                App-level init
++-- model.ts               App-level state
++-- message.ts             App-level messages
++-- command.ts             App-level Commands
++-- route.ts               Route definitions
++-- update.ts              App-level update
++-- view.ts                App-level view
++-- subscription.ts        App-level subscriptions
++-- story.test.ts          Story tests for the app-level update
++-- scene.test.ts          Scene tests for flows that cross pages
+|
++-- page/
+|   +-- index.ts           Re-exports all pages
+|   +-- home/
+|   |   +-- index.ts       Re-exports Home module
+|   |   +-- model.ts       Home state
+|   |   +-- message.ts     Home events
+|   |   +-- command.ts     Home Commands
+|   |   +-- update.ts      Home update
+|   |   +-- view.ts        Home view
+|   |   +-- story.test.ts  Story tests for the Home update
+|   |   +-- scene.test.ts  Scene tests for the Home view
+|   +-- products/
+|       +-- index.ts
+|       +-- model.ts
+|       +-- message.ts
+|       +-- command.ts
+|       +-- update.ts
+|       +-- view.ts
+|       +-- story.test.ts
+|       +-- scene.test.ts
+|
++-- domain/
+    +-- index.ts           Re-exports domain modules
+    +-- cart.ts            Cart type + operations
+    +-- item.ts            Item type + operations
 ```
 
 Each feature folder owns its Model, Messages, update, view, Commands, Subscriptions, and tests. Do not create empty files only to match the diagram. Add a file when the feature has that concern.

--- a/packages/website/src/page/ui/animationPage.md
+++ b/packages/website/src/page/ui/animationPage.md
@@ -39,21 +39,21 @@ ENTER                                LEAVE
 Animation drives completion          Parent detects settlement
 
 Showed()                              Hid()
-   │                                    │
-   ▼                                    ▼
+   |                                    |
+   v                                    v
 EnterStart                           LeaveStart
-   │ rAF × 2                            │ rAF × 2
-   ▼                                    ▼
+   | rAF x 2                            | rAF x 2
+   v                                    v
 EnterAnimating                       LeaveAnimating
-   │ EndedAnimation (internal)          ├─ emits StartedLeaveAnimating
-   ▼                                    │  parent supplies leave Command
- Idle                                   │
-                                        │  Command dispatches
-                                        │  EndedAnimation
-                                        ▼
+   | EndedAnimation (internal)          +-> emits StartedLeaveAnimating
+   v                                    |   parent supplies leave Command
+ Idle                                   |
+                                        |   Command dispatches
+                                        |   EndedAnimation
+                                        v
                                        Idle
-                                        └─ emits TransitionedOut
-                                           parent handles cleanup
+                                        +-> emits TransitionedOut
+                                            parent handles cleanup
 ```
 
 The double-rAF timing (one frame to set the start state, another to trigger the animation) ensures browsers flush layout between phases so the CSS animation actually plays.


### PR DESCRIPTION
## Summary

- replace the architecture loop with a narrow vertical diagram that returns Message to the same update
- standardize every site diagram and the project layout tree on plain ASCII characters
- keep the diagrams readable on mobile with modest horizontal scrolling where needed

## Testing

- Prettier check for all six changed Markdown files
- production website build
- documentation rendering tests (206 passed)