### PR TITLE
fix(foldkit): make the machine edge guard key nameable

### DIFF
--- a/.changeset/nameable-edge-guard-key.md
+++ b/.changeset/nameable-edge-guard-key.md
@@ -1,0 +1,9 @@
+---
+'foldkit': patch
+---
+
+Let a consumer export a Machine Edge built with `to` or `when` from `foldkit/experimental/machine`.
+
+`Edge` has a hidden field that carries the guard value type. Its key was a `unique symbol` that Foldkit did not export. TypeScript had to write that key into the consumer's `.d.ts` file, but it had no name for it, so it failed with `TS4023: ... has or is using name 'EdgeGuardValueTypeId' ... but cannot be named`. This hit any package that builds an Edge in one module and exports it, as soon as that package turned on declaration emit. `When`, `Otherwise`, and `TransitionTable` embed `Edge`, so exporting any of them hit the same error.
+
+The key is now a normal property, `'~foldkit/EdgeGuardValue'`, following the same fix as the runtime boot key. Consumers need to do nothing. The field is still internal and still has no runtime representation.

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -19,8 +19,6 @@ export type Variant<Union extends Tagged, Tag extends TagOf<Union>> = Extract<
 
 // EDGE
 
-declare const EdgeGuardValueTypeId: unique symbol
-
 /**
  * The single argument an Edge's `build` and `commands` callbacks receive:
  * the source state, the triggering Message, and the guard value produced by
@@ -66,7 +64,7 @@ export type Edge<
       input: EdgeInput<SourceState, TriggerMessage, unknown>,
     ) => ReadonlyArray<Command<Message, never, R>>
   >
-  readonly [EdgeGuardValueTypeId]?: GuardValue
+  readonly '~foldkit/EdgeGuardValue'?: GuardValue
 }>
 
 /** A guarded Edge that fires only when its guard passes. Construct with {@link when}. */

--- a/scripts/check-packed-ssr-consumer.ts
+++ b/scripts/check-packed-ssr-consumer.ts
@@ -179,6 +179,7 @@ const CONSUMER_FIXTURES: ReadonlyArray<ConsumerFixture> = [
   { path: 'src/vite-env.d.ts' },
   { path: 'src/packed-types.ts' },
   { path: 'src/inferred-program.ts' },
+  { path: 'src/inferred-machine-edge.ts' },
   { path: 'tsconfig.json' },
 ]
 
@@ -278,9 +279,10 @@ const writeConsumerProject = (
 // them whether or not the barrel re-exports them.
 //
 // The fixture also sets `declaration`, so it covers a consumer that exports a
-// program whose type comes from `makeElement` or `makeApplication`. If a type
-// that foldkit exports has a key the consumer cannot write, that consumer
-// cannot write its own `.d.ts` file at all, and TypeScript reports TS4023.
+// program whose type comes from `makeElement` or `makeApplication`, or a
+// Machine Edge built with `to` or `when`. If a type that foldkit exports has a
+// key the consumer cannot write, that consumer cannot write its own `.d.ts`
+// file at all, and TypeScript reports TS4023.
 // `noEmit` still reports it, but only while `declaration` is set. Without
 // `declaration` the check never runs.
 const assertPackedTypesResolve = (projectDir: string): void => {
@@ -290,9 +292,10 @@ const assertPackedTypesResolve = (projectDir: string): void => {
   })
   assertConsumer(
     result.status === 0,
-    'a consumer cannot compile against the packed declarations. It either ' +
-      'imports the documented types from `foldkit/experimental/server`, or ' +
-      'exports a program built with `makeElement` or `makeApplication`:' +
+    'a consumer cannot compile against the packed declarations. It imports ' +
+      'the documented types from `foldkit/experimental/server`, exports a ' +
+      'program built with `makeElement` or `makeApplication`, or exports a ' +
+      'Machine Edge built with `to` or `when`:' +
       `\n${result.stdout}${result.stderr}`,
   )
   log('Packed declarations compile, and a consumer can write its own')

--- a/scripts/fixtures/packed-ssr-consumer/src/inferred-machine-edge.ts
+++ b/scripts/fixtures/packed-ssr-consumer/src/inferred-machine-edge.ts
@@ -1,0 +1,32 @@
+import { Option } from 'effect'
+import { to, when } from 'foldkit/experimental/machine'
+import { defineMessageUnion } from 'foldkit/message'
+import { defineTaggedUnion } from 'foldkit/schema'
+
+const MachineState = defineTaggedUnion({ Idle: {}, Running: {} })
+type MachineState = typeof MachineState.Type
+type IdleState = typeof MachineState.Idle.Type
+
+const MachineMessage = defineMessageUnion({ Started: {} })
+type MachineMessage = typeof MachineMessage.Type
+
+export const startEdge = to<
+  MachineState,
+  MachineMessage,
+  IdleState,
+  MachineMessage,
+  'Running'
+>('Running', () => MachineState.Running())
+
+export const guardedStartEdge = when<
+  MachineState,
+  MachineMessage,
+  IdleState,
+  MachineMessage,
+  Option.Option<number>,
+  'Running'
+>(
+  state => Option.some(state._tag.length),
+  'Running',
+  () => MachineState.Running(),
+)

--- a/scripts/fixtures/packed-ssr-consumer/tsconfig.json
+++ b/scripts/fixtures/packed-ssr-consumer/tsconfig.json
@@ -9,5 +9,9 @@
     "lib": ["esnext", "dom"],
     "types": []
   },
-  "include": ["src/packed-types.ts", "src/inferred-program.ts"]
+  "include": [
+    "src/packed-types.ts",
+    "src/inferred-program.ts",
+    "src/inferred-machine-edge.ts"
+  ]
 }


### PR DESCRIPTION
Edge kept its guard value type under a unique symbol key that Foldkit does not export. TypeScript cannot name that key in a consumer's declaration file, so a package exporting an Edge built with `to` or `when` failed declaration emit with TS4023. `When`, `Otherwise`, and `TransitionTable` embed `Edge`, so exporting any of them failed the same way.

Key the field with the normal property `'~foldkit/EdgeGuardValue'`, matching the runtime boot key fix, and cover the defect in the packed consumer gate with a fixture that exports one plain and one guarded Edge.
