### PR TITLE
fix(website): center the Subscription page diagram

### DIFF
--- a/packages/website/src/markdown/diagram.test.ts
+++ b/packages/website/src/markdown/diagram.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest'
+
+import { dedentDiagram } from './diagram'
+
+describe('dedentDiagram', () => {
+  test('removes the left margin every line shares', () => {
+    const content = [
+      '      Model',
+      '        |',
+      '        v',
+      '     update',
+    ].join('\n')
+
+    expect(dedentDiagram(content)).toBe(
+      [' Model', '   |', '   v', 'update'].join('\n'),
+    )
+  })
+
+  test('leaves a diagram that already starts at the left edge untouched', () => {
+    const content = ['Model', '  |', '  v', 'update'].join('\n')
+
+    expect(dedentDiagram(content)).toBe(content)
+  })
+
+  test('ignores empty and whitespace-only lines when measuring the margin', () => {
+    const content = ['    Model', '', '  ', '    update'].join('\n')
+
+    expect(dedentDiagram(content)).toBe(['Model', '', '', 'update'].join('\n'))
+  })
+
+  test('returns content with no drawn lines unchanged', () => {
+    expect(dedentDiagram('   \n  ')).toBe('   \n  ')
+  })
+})

--- a/packages/website/src/markdown/diagram.ts
+++ b/packages/website/src/markdown/diagram.ts
@@ -1,0 +1,27 @@
+import { Array, Order, String, pipe } from 'effect'
+
+const indentWidth = (line: string): number =>
+  line.length - String.trimStart(line).length
+
+/**
+ * Strips the left margin every line of a diagram shares. A `pre` sizes itself
+ * to its widest line, so indentation the author used to lay the drawing out
+ * becomes part of the figure's width, and centering that figure leaves the
+ * drawing sitting right of center with empty space beside it.
+ */
+export const dedentDiagram = (content: string): string => {
+  const lines = String.split(content, '\n')
+
+  const drawnLines = Array.filter(lines, line =>
+    String.isNonEmpty(String.trim(line)),
+  )
+
+  return Array.match(drawnLines, {
+    onEmpty: () => content,
+    onNonEmpty: drawn => {
+      const margin = Array.min(Array.map(drawn, indentWidth), Order.Number)
+
+      return pipe(lines, Array.map(String.slice(margin)), Array.join('\n'))
+    },
+  })
+}

--- a/packages/website/src/page/core/subscriptions.md
+++ b/packages/website/src/page/core/subscriptions.md
@@ -7,36 +7,36 @@ A Subscription describes ongoing work whose lifetime comes from the Model. Each 
 The first dependency value opens the Stream's initial scope. After every Model update, Foldkit compares the latest dependencies with the previous value. Equivalent dependencies keep the current Stream alive. A change closes its scope, runs any registered `Effect.acquireRelease` finalizers, and opens a fresh scope with the new dependencies.
 
 ```diagram
-                             Model
-                               | modelToDependencies(model)
-                               v
-                          Dependencies
-                               |
-                +--------------+---------------+
-                |                              |
-           first value                   later value
-                |                              |
-                |                              v
-                |                   compare with previous
-                |                              |
-                |                 +------------+-----------+
-                |                 |                        |
-                |              changed                equivalent
-                |                 |                        |
-                |                 v                        v
-                |         close old scope         keep current scope
-                |          run finalizers                  |
-                |                 |                        |
-                +-----------------+                        |
-                                  v                        |
-                           open fresh scope                |
-                                  |                        |
-                                  +------------+-----------+
-                                               v
-                                    active Stream<Message>
-                                               |
-                                               v
-                                             update
+                  Model
+                    | modelToDependencies(model)
+                    v
+               Dependencies
+                    |
+     +--------------+---------------+
+     |                              |
+first value                   later value
+     |                              |
+     |                              v
+     |                   compare with previous
+     |                              |
+     |                 +------------+-----------+
+     |                 |                        |
+     |              changed                equivalent
+     |                 |                        |
+     |                 v                        v
+     |         close old scope         keep current scope
+     |          run finalizers                  |
+     |                 |                        |
+     +-----------------+                        |
+                       v                        |
+                open fresh scope                |
+                       |                        |
+                       +------------+-----------+
+                                    v
+                         active Stream<Message>
+                                    |
+                                    v
+                                  update
 ```
 
 The Subscription is attached to the Model condition, not to the external source used inside its Stream. A timer, document listener, system theme observer, or `WebSocket` supplies events during that lifetime. Those events flow back into update as Messages.

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -4,6 +4,7 @@ import { twMerge } from 'tailwind-merge'
 
 import { Icon } from './icon'
 import { type TableOfContentsEntry } from './main'
+import { dedentDiagram } from './markdown/diagram'
 import { ClickedCopyLink, type Message } from './message'
 
 /**
@@ -300,7 +301,7 @@ export const diagram = (content: string): Html =>
         'mb-4 mx-auto w-fit max-w-full text-[#403d4a] dark:text-[#E0DEE6] text-sm p-4 overflow-x-auto rounded-lg bg-gray-100 dark:bg-[#1c1a20] border border-gray-200 dark:border-gray-700/50',
       ),
     ],
-    [content],
+    [dedentDiagram(content)],
   )
 
 /**


### PR DESCRIPTION
The Subscription diagram was authored with every line indented eleven
columns. A `pre` sizes itself to its widest line, so that margin became
part of the figure's width: the box was 616px wide for a 522px drawing,
and centering the box left the drawing sitting right of center with
empty space beside it.

`diagram` now strips the left margin its lines share, so any diagram
hugs its drawing no matter how the source was laid out. The Subscription
diagram's source is dedented too, matching the other four diagrams on
the site, which all start at column zero.