### PR TITLE
fix(website): center the Subscription page diagram

### DIFF
--- a/packages/website/src/page/core/subscriptions.md
+++ b/packages/website/src/page/core/subscriptions.md
@@ -7,36 +7,36 @@ A Subscription describes ongoing work whose lifetime comes from the Model. Each 
 The first dependency value opens the Stream's initial scope. After every Model update, Foldkit compares the latest dependencies with the previous value. Equivalent dependencies keep the current Stream alive. A change closes its scope, runs any registered `Effect.acquireRelease` finalizers, and opens a fresh scope with the new dependencies.
 
 ```diagram
-                             Model
-                               | modelToDependencies(model)
-                               v
-                          Dependencies
-                               |
-                +--------------+---------------+
-                |                              |
-           first value                   later value
-                |                              |
-                |                              v
-                |                   compare with previous
-                |                              |
-                |                 +------------+-----------+
-                |                 |                        |
-                |              changed                equivalent
-                |                 |                        |
-                |                 v                        v
-                |         close old scope         keep current scope
-                |          run finalizers                  |
-                |                 |                        |
-                +-----------------+                        |
-                                  v                        |
-                           open fresh scope                |
-                                  |                        |
-                                  +------------+-----------+
-                                               v
-                                    active Stream<Message>
-                                               |
-                                               v
-                                             update
+                  Model
+                    | modelToDependencies(model)
+                    v
+               Dependencies
+                    |
+     +--------------+---------------+
+     |                              |
+first value                   later value
+     |                              |
+     |                              v
+     |                   compare with previous
+     |                              |
+     |                 +------------+-----------+
+     |                 |                        |
+     |              changed                equivalent
+     |                 |                        |
+     |                 v                        v
+     |         close old scope         keep current scope
+     |          run finalizers                  |
+     |                 |                        |
+     +-----------------+                        |
+                       v                        |
+                open fresh scope                |
+                       |                        |
+                       +------------+-----------+
+                                    v
+                         active Stream<Message>
+                                    |
+                                    v
+                                  update
 ```
 
 The Subscription is attached to the Model condition, not to the external source used inside its Stream. A timer, document listener, system theme observer, or `WebSocket` supplies events during that lifetime. Those events flow back into update as Messages.


### PR DESCRIPTION
The diagram on `/core/subscriptions` sat right of center with empty space beside it.

Every line of its ASCII art was indented eleven columns in the markdown source. A `pre` sizes itself to its widest line, so that margin became part of the figure's width. `diagram` styles the block `mx-auto w-fit`, which centered a box eleven columns wider than the drawing inside it.

Dedenting the source fixes it. The other four `diagram` blocks on the site already start at column zero, which is why the architecture page looked right.

Measured in Chromium at a 1440px viewport:

| | before | after |
| --- | --- | --- |
| figure width | 616.1px | 521.9px |
| left / right gap | 65.1 / 65.1 (box centered, drawing not) | 112.2 / 112.2 |

The architecture diagram is unchanged at 402.1px with 223.0 / 223.0 gaps, confirming nothing else moved.

No changeset: `website` is in the changeset ignore list.

---
_Generated by [Claude Code](https://claude.ai/code/session_012HBdvX6Y2JeR4w4HS6H9g8)_