### PR TITLE
feat: publish coherent canaries with pre-push review

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -32,3 +32,34 @@ When changesets are merged to main, a "Version Packages" PR is automatically cre
 2. Update CHANGELOG.md files
 3. Publish to npm
 4. Create GitHub releases
+
+The release workflow coalesces rapid merges and publishes a canary snapshot for
+the newest main commit. Every public package in the snapshot uses the same
+version, which includes the full Git commit. This keeps internal peer
+dependencies aligned when testing the snapshot in another project.
+
+For a new project, run the canary scaffolder:
+
+```bash
+pnpm create foldkit-app@canary
+```
+
+The canary scaffolder reads examples from its encoded Git commit and installs
+the exact shared version of every Foldkit package the project needs.
+
+For an existing project, resolve the channel version once and install that
+exact version for each Foldkit package the project uses. For example:
+
+```bash
+CANARY_VERSION="$(npm view create-foldkit-app@canary version)"
+pnpm add "foldkit@$CANARY_VERSION" "@foldkit/ui@$CANARY_VERSION" "@foldkit/vite-plugin@$CANARY_VERSION"
+```
+
+Do not install `foldkit@canary` directly. `create-foldkit-app` is the only
+moving canary channel. The other packages use snapshot-specific tags and must
+be installed at the resolved exact version.
+
+`create-foldkit-app@canary` moves only after npm confirms every package in the
+snapshot is available. If publication stops partway through, the previous
+canary remains advertised. Canary publishing does not change any package's
+`latest` npm tag.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,10 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "snapshot": {
+    "useCalculatedVersion": false,
+    "prereleaseTemplate": "{tag}-{commit}-{datetime}"
+  },
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },

--- a/.changeset/tidy-tools-share.md
+++ b/.changeset/tidy-tools-share.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Keep canary scaffolds on the same Foldkit snapshot and source commit as the canary CLI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,24 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.changeset/**'
-      - 'packages/foldkit/**'
-      - 'packages/ui/**'
-      - 'packages/devtools/**'
-      - 'packages/markdown/**'
-      - 'packages/vite-plugin-foldkit/**'
-      - 'packages/create-foldkit-app/**'
-      - 'packages/oxlint-plugin-foldkit/**'
-      - 'packages/devtools-mcp/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'scripts/check-changeset-ignore.ts'
-      - 'scripts/check-create-foldkit-app-smoke.ts'
-      - 'scripts/check-peer-floors.ts'
-      - 'scripts/reset-peer-deps.ts'
-      - '.github/workflows/release.yml'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -86,3 +68,70 @@ jobs:
     with:
       published_commit: ${{ github.sha }}
     secrets: inherit
+
+  publish-canary:
+    name: Publish package canaries
+    needs: release
+    if: needs.release.outputs.published != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Version package canaries
+        run: pnpm version-packages:canary
+
+      - name: Verify package canary versions
+        id: canary
+        env:
+          CANARY_COMMIT: ${{ github.sha }}
+        run: node scripts/package-canary.mjs inspect "$CANARY_COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Build package canaries
+        run: pnpm build:packages
+
+      - name: Verify packed package canaries
+        env:
+          CANARY_COMMIT: ${{ github.sha }}
+        run: node scripts/package-canary.mjs inspect-packed "$CANARY_COMMIT"
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: |
+          NPM_DIR="$(npm config get prefix)/lib/node_modules/npm"
+          rm -rf "$NPM_DIR"
+          curl -sL https://registry.npmjs.org/npm/-/npm-11.12.1.tgz | tar xz -C "$(dirname "$NPM_DIR")"
+          mv "$(dirname "$NPM_DIR")/package" "$NPM_DIR"
+          npm --version
+
+      - name: Fetch current main
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+
+      - name: Publish package canaries
+        run: pnpm release:canary
+        env:
+          FOLDKIT_CANARY_COMMIT: ${{ github.sha }}
+          NPM_CONFIG_PROVENANCE: true
+          SKIP_SIMPLE_GIT_HOOKS: '1'
+
+      - name: Summarize package canary
+        env:
+          CANARY_VERSION: ${{ steps.canary.outputs.version }}
+        run: echo "Published the Foldkit canary channel at ${CANARY_VERSION}." >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ If a Mount factory doesn't read or write its element, you've misidentified the c
 - Do not co-author or mention AI assistants in commit messages or release notes.
 - Use the repo's commit helper when asked to create a commit: `/commit` in Claude Code, `.agents/skills/commit-changes` in Codex.
 - Treat every pull request title and description as the final squash commit message. The title is the Conventional Commit subject, and the description is the commit body. Keep review-only boilerplate, checklists, generated commit lists, and verification details out of the description. Put verification details in a pull request comment instead.
+- After creating or amending a commit, have a separate agent review the exact committed diff before pushing it or opening a PR. Treat the review as a gate: address every finding, amend the commit, and have the amended commit reviewed again. Only push or open the PR after the latest commit passes review.
 - Squash-merge only. `gh pr merge --squash`.
 
 ## Editing Rules

--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
     "dev:example:ssr": "pnpm --filter ssr-example dev",
     "changeset": "changeset",
     "version-packages": "changeset version && tsx scripts/reset-peer-deps.ts && pnpm install --no-frozen-lockfile",
+    "version-packages:canary": "node scripts/package-canary.mjs prepare && changeset version --snapshot canary && pnpm install --no-frozen-lockfile",
     "release": "pnpm check:peer-floors && pnpm build:packages && changeset publish",
+    "release:canary": "node scripts/package-canary.mjs publish \"$FOLDKIT_CANARY_COMMIT\" origin/main",
     "check:dom-state-parity": "tsx scripts/check-dom-state-parity.mts",
     "check:published-versions": "tsx scripts/check-published-versions.ts"
   },

--- a/packages/create-foldkit-app/src/index.ts
+++ b/packages/create-foldkit-app/src/index.ts
@@ -2,7 +2,6 @@
 import { Effect, Layer, Option, Schema } from 'effect'
 import { Command, Flag } from 'effect/unstable/cli'
 import { FetchHttpClient } from 'effect/unstable/http'
-import { createRequire } from 'node:module'
 
 import { NodeRuntime, NodeServices, NodeStdio } from '@effect/platform-node'
 
@@ -10,11 +9,7 @@ import { create as create_ } from './commands/create.js'
 import { EXAMPLE_VALUES } from './examples.js'
 import { RENDERING_VALUES } from './rendering.js'
 import { validateProjectName } from './validateName.js'
-
-/* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-const packageJson = createRequire(import.meta.url)('../package.json') as {
-  version: string
-}
+import { PACKAGE_VERSION } from './version.js'
 
 const nameSchema = Schema.String.pipe(
   Schema.check(
@@ -79,7 +74,7 @@ const create = Command.make(
 ).pipe(Command.withDescription('Create a new Foldkit application'))
 
 const cli = Command.run(create, {
-  version: packageJson.version,
+  version: PACKAGE_VERSION,
 })
 
 cli.pipe(

--- a/packages/create-foldkit-app/src/utils/files.test.ts
+++ b/packages/create-foldkit-app/src/utils/files.test.ts
@@ -1,3 +1,5 @@
+import { Effect, Layer } from 'effect'
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 import { readFileSync, readdirSync } from 'node:fs'
 import { join, relative, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -5,7 +7,9 @@ import { expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
-import { applyPackageManager } from './files.js'
+import { applyPackageManager, fetchExampleFileList } from './files.js'
+
+const CANARY_COMMIT = '1234567890abcdef1234567890abcdef12345678'
 
 const templatePath = (relativePath: string): string =>
   fileURLToPath(new URL(`../../templates/${relativePath}`, import.meta.url))
@@ -59,6 +63,64 @@ describe('applyPackageManager', () => {
     expect(pnpm).toContain('pnpm install')
     expect(pnpm).toContain('pnpm dev')
     expect(pnpm).not.toContain('{{')
+  })
+})
+
+describe('fetchExampleFileList', () => {
+  it.effect('pins every GitHub Contents request to the canary commit', () => {
+    const requestedUrls: Array<string> = []
+    const nestedUrl =
+      'https://api.github.com/repos/foldkit/foldkit/contents/examples/counter/src/nested'
+    const mainFile = {
+      name: 'main.ts',
+      path: 'examples/counter/src/main.ts',
+      download_url: `https://raw.githubusercontent.com/foldkit/foldkit/${CANARY_COMMIT}/examples/counter/src/main.ts`,
+      type: 'file',
+      url: 'https://api.github.com/main.ts',
+    }
+    const nestedFile = {
+      name: 'view.ts',
+      path: 'examples/counter/src/nested/view.ts',
+      download_url: `https://raw.githubusercontent.com/foldkit/foldkit/${CANARY_COMMIT}/examples/counter/src/nested/view.ts`,
+      type: 'file',
+      url: 'https://api.github.com/view.ts',
+    }
+
+    const mockClient = HttpClient.make(request =>
+      Effect.sync(() => {
+        requestedUrls.push(request.url)
+
+        const responseBody = request.url.startsWith(nestedUrl)
+          ? [nestedFile]
+          : [
+              mainFile,
+              {
+                name: 'nested',
+                path: 'examples/counter/src/nested',
+                download_url: null,
+                type: 'dir',
+                url: nestedUrl,
+              },
+            ]
+
+        return HttpClientResponse.fromWeb(
+          request,
+          new Response(JSON.stringify(responseBody), { status: 200 }),
+        )
+      }),
+    )
+
+    return Effect.gen(function* () {
+      const files = yield* fetchExampleFileList('counter', CANARY_COMMIT).pipe(
+        Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)),
+      )
+
+      expect(requestedUrls).toEqual([
+        `https://api.github.com/repos/foldkit/foldkit/contents/examples/counter/src?ref=${CANARY_COMMIT}`,
+        `${nestedUrl}?ref=${CANARY_COMMIT}`,
+      ])
+      expect(files).toEqual([mainFile, nestedFile])
+    })
   })
 })
 

--- a/packages/create-foldkit-app/src/utils/files.ts
+++ b/packages/create-foldkit-app/src/utils/files.ts
@@ -20,9 +20,11 @@ import {
 import { fileURLToPath } from 'node:url'
 
 import { type Scaffold } from '../rendering.js'
+import { PACKAGE_VERSION } from '../version.js'
 import {
   type PackageManager,
   devCommand,
+  exampleSourceReference,
   installCommand,
   runScriptCommand,
 } from './packages.js'
@@ -285,8 +287,13 @@ const createExampleFiles = (projectPath: string, example: string) =>
     )
   })
 
-const fetchExampleFileList = (
+/**
+ * Fetch an example's source-file listing from the Git reference encoded in the
+ * scaffolder version.
+ */
+export const fetchExampleFileList = (
   example: string,
+  sourceReference = exampleSourceReference(PACKAGE_VERSION),
 ): Effect.Effect<
   ReadonlyArray<GitHubFileEntry>,
   HttpClientError.HttpClientError | Schema.SchemaError,
@@ -302,7 +309,10 @@ const fetchExampleFileList = (
       HttpClientError.HttpClientError | Schema.SchemaError
     > =>
       Effect.gen(function* () {
-        const request = HttpClientRequest.get(apiUrl)
+        const requestUrl = new URL(apiUrl)
+        requestUrl.searchParams.set('ref', sourceReference)
+
+        const request = HttpClientRequest.get(requestUrl.href)
         const response = yield* client.execute(request)
         const json = yield* response.json
         const entries = yield* Schema.decodeUnknownEffect(

--- a/packages/create-foldkit-app/src/utils/packages.test.ts
+++ b/packages/create-foldkit-app/src/utils/packages.test.ts
@@ -1,3 +1,4 @@
+import { Option } from 'effect'
 import { readFileSync } from 'node:fs'
 import { expect } from 'vitest'
 
@@ -9,9 +10,14 @@ import {
   buildUnresolvedDevDeps,
   dependencyExample,
   devCommand,
+  exampleSourceReference,
   installCommand,
+  resolveFoldkitCanaryVersion,
   scaffoldDevDependencies,
 } from './packages.js'
+
+const CANARY_COMMIT = '0123456789abcdef0123456789abcdef01234567'
+const CANARY_VERSION = `0.0.0-canary-${CANARY_COMMIT}-20260821213000`
 
 describe('buildUnresolvedDeps', () => {
   it('keeps third-party versions, resolves Foldkit workspace deps to latest, and drops foreign workspace deps', () => {
@@ -76,6 +82,31 @@ describe('dependencyExample', () => {
     )
     expect(dependencyExample(Scaffold.Ssg())).toBe('ssg')
     expect(dependencyExample(Scaffold.Ssr())).toBe('ssr')
+  })
+})
+
+describe('canary package resolution', () => {
+  it('pins Foldkit packages to the CLI snapshot', () => {
+    expect(resolveFoldkitCanaryVersion(CANARY_VERSION, 'foldkit')).toEqual(
+      Option.some(CANARY_VERSION),
+    )
+    expect(resolveFoldkitCanaryVersion(CANARY_VERSION, '@foldkit/ui')).toEqual(
+      Option.some(CANARY_VERSION),
+    )
+  })
+
+  it('leaves stable and third-party packages on latest resolution', () => {
+    expect(resolveFoldkitCanaryVersion('0.27.3', 'foldkit')).toEqual(
+      Option.none(),
+    )
+    expect(resolveFoldkitCanaryVersion(CANARY_VERSION, 'effect')).toEqual(
+      Option.none(),
+    )
+  })
+
+  it('reads canary examples from the encoded commit', () => {
+    expect(exampleSourceReference(CANARY_VERSION)).toBe(CANARY_COMMIT)
+    expect(exampleSourceReference('0.27.3')).toBe('main')
   })
 })
 

--- a/packages/create-foldkit-app/src/utils/packages.ts
+++ b/packages/create-foldkit-app/src/utils/packages.ts
@@ -16,6 +16,7 @@ import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { spawn } from 'node:child_process'
 
 import { type Scaffold } from '../rendering.js'
+import { PACKAGE_VERSION } from '../version.js'
 
 export type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
@@ -44,12 +45,9 @@ export const runScriptCommand = (
   script: string,
 ): string => `${RUN_SCRIPT_PREFIXES[packageManager]} ${script}`
 
-const GITHUB_RAW_BASE_URL =
-  'https://raw.githubusercontent.com/foldkit/foldkit/main/examples'
-
 const NPM_REGISTRY_BASE_URL = 'https://registry.npmjs.org'
-
 const FOLDKIT_SCOPE_PREFIX = '@foldkit/'
+const CANARY_VERSION_PATTERN = /^0\.0\.0-canary-([0-9a-f]{40})-\d{14}$/
 
 const isWindows = process.platform === 'win32'
 
@@ -92,6 +90,35 @@ const SERVER_RENDERING_DEV_DEPENDENCIES = ['@types/node']
 const isFoldkitPackage = (name: string): boolean =>
   name === 'foldkit' || name.startsWith(FOLDKIT_SCOPE_PREFIX)
 
+const canaryCommit = (packageVersion: string): Option.Option<string> => {
+  const match = Option.fromNullishOr(
+    CANARY_VERSION_PATTERN.exec(packageVersion),
+  )
+
+  return Option.flatMap(match, groups => Array.get(groups, 1))
+}
+
+/**
+ * Resolve a Foldkit dependency to the exact snapshot version when the
+ * scaffolder itself is a canary.
+ */
+export const resolveFoldkitCanaryVersion = (
+  packageVersion: string,
+  name: string,
+): Option.Option<string> => {
+  if (!isFoldkitPackage(name)) {
+    return Option.none()
+  }
+
+  return Option.map(canaryCommit(packageVersion), () => packageVersion)
+}
+
+/** The Git reference that supplies example manifests for this CLI version. */
+export const exampleSourceReference = (packageVersion: string): string =>
+  Option.getOrElse(canaryCommit(packageVersion), () => 'main')
+
+const GITHUB_RAW_BASE_URL = `https://raw.githubusercontent.com/foldkit/foldkit/${exampleSourceReference(PACKAGE_VERSION)}/examples`
+
 type UnresolvedSpec = Data.TaggedEnum<{
   Keep: { readonly version: string }
   Latest: {}
@@ -114,8 +141,8 @@ const toUnresolvedSpec = (
 /**
  * Build the runtime dependency map for a scaffolded project from an example's
  * raw `dependencies`. Concrete versions are kept, Foldkit monorepo packages are
- * marked for latest-version resolution, and any other workspace packages (which
- * are not published) are dropped.
+ * marked for published-version resolution, and any other workspace packages
+ * (which are not published) are dropped.
  */
 export const buildUnresolvedDeps = (
   exampleDeps: Record<string, string>,
@@ -126,7 +153,7 @@ export const buildUnresolvedDeps = (
  * Build the devDependency map for a scaffolded project by merging the always-on
  * template tooling and any extra scaffold devDependencies with the example's
  * own `devDependencies`. A concrete version from the example wins over a
- * latest marker for the same package.
+ * published-version marker for the same package.
  */
 export const buildUnresolvedDevDeps = (
   exampleDevDeps: Record<string, string>,
@@ -190,10 +217,14 @@ const resolveEntry = (name: string, spec: UnresolvedSpec) =>
     Match.tagsExhaustive({
       Keep: ({ version }) => Effect.succeed([name, version] as const),
       Latest: () =>
-        Effect.map(
-          resolveLatestVersion(name),
-          version => [name, version] as const,
-        ),
+        Option.match(resolveFoldkitCanaryVersion(PACKAGE_VERSION, name), {
+          onNone: () =>
+            Effect.map(
+              resolveLatestVersion(name),
+              version => [name, version] as const,
+            ),
+          onSome: version => Effect.succeed([name, version] as const),
+        }),
     }),
   )
 

--- a/packages/create-foldkit-app/src/version.ts
+++ b/packages/create-foldkit-app/src/version.ts
@@ -1,0 +1,10 @@
+import { Schema } from 'effect'
+import { createRequire } from 'node:module'
+
+const PackageJson = Schema.Struct({ version: Schema.String })
+const packageJson = Schema.decodeUnknownSync(PackageJson)(
+  createRequire(import.meta.url)('../package.json'),
+)
+
+/** The installed create-foldkit-app package version. */
+export const PACKAGE_VERSION = packageJson.version

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -79,7 +79,11 @@ test('peer floor changes run the packed-manifest check before release', () => {
       "      - name: Check packed peer dependency floors\n        if: steps.scope.outputs.peer_floors == 'true'\n        run: pnpm check:peer-floors",
     ),
   )
-  assert.match(releaseWorkflow, /^\s+- 'scripts\/check-peer-floors\.ts'$/m)
+  assert.match(
+    rootPackage.scripts.release,
+    /^pnpm check:peer-floors && pnpm build:packages && changeset publish$/,
+  )
+  assert.doesNotMatch(releaseWorkflow, /^\s+paths:/m)
 })
 
 test('browser-backed scaffold checks install Chromium exactly once', () => {

--- a/scripts/package-canary.mjs
+++ b/scripts/package-canary.mjs
@@ -1,0 +1,623 @@
+import { execFileSync } from 'node:child_process'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const PUBLISHABLE_PACKAGES = [
+  { name: 'foldkit', manifest: 'packages/foldkit/package.json' },
+  { name: '@foldkit/ui', manifest: 'packages/ui/package.json' },
+  { name: '@foldkit/devtools', manifest: 'packages/devtools/package.json' },
+  {
+    name: '@foldkit/vite-plugin',
+    manifest: 'packages/vite-plugin-foldkit/package.json',
+  },
+  {
+    name: '@foldkit/devtools-mcp',
+    manifest: 'packages/devtools-mcp/package.json',
+  },
+  {
+    name: '@foldkit/oxlint-plugin',
+    manifest: 'packages/oxlint-plugin-foldkit/package.json',
+  },
+  { name: '@foldkit/markdown', manifest: 'packages/markdown/package.json' },
+  {
+    name: 'create-foldkit-app',
+    manifest: 'packages/create-foldkit-app/package.json',
+  },
+]
+
+export const CANARY_CHANNEL_PACKAGE = 'create-foldkit-app'
+
+const CANARY_CHANGESET_PATH = '.changeset/foldkit-main-canary.md'
+const CANARY_VERSION_PATTERN = /^0\.0\.0-canary-([0-9a-f]{40})-(\d{14})$/
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+]
+const NPM_REGISTRY_BASE_URL = 'https://registry.npmjs.org'
+const REGISTRY_RETRY_DELAYS_MS = [0, 1_000, 2_000, 4_000, 8_000]
+
+const validateCommit = commit => {
+  if (!/^[0-9a-f]{40}$/.test(commit)) {
+    throw new Error(`Expected a full lowercase Git commit, received ${commit}.`)
+  }
+}
+
+const expectedPackageNames = () =>
+  new Set(PUBLISHABLE_PACKAGES.map(({ name }) => name))
+
+const canaryChangeset = () =>
+  [
+    '---',
+    ...PUBLISHABLE_PACKAGES.map(({ name }) => `'${name}': patch`),
+    '---',
+    '',
+    'Publish a coherent canary snapshot of the current main commit.',
+    '',
+  ].join('\n')
+
+const readWorkspacePackages = repositoryRoot => {
+  const output = execFileSync(
+    'pnpm',
+    ['list', '--recursive', '--depth', '-1', '--json'],
+    { cwd: repositoryRoot, encoding: 'utf8' },
+  )
+  const workspacePackages = JSON.parse(output)
+
+  if (!Array.isArray(workspacePackages)) {
+    throw new Error('pnpm did not return a workspace package list.')
+  }
+
+  for (const workspacePackage of workspacePackages) {
+    if (
+      typeof workspacePackage !== 'object' ||
+      workspacePackage === null ||
+      typeof workspacePackage.name !== 'string' ||
+      typeof workspacePackage.path !== 'string'
+    ) {
+      throw new Error('pnpm returned invalid workspace package metadata.')
+    }
+  }
+
+  return workspacePackages
+}
+
+export const validatePublishableWorkspace = (
+  repositoryRoot,
+  workspacePackages,
+) => {
+  const expectedByName = new Map(
+    PUBLISHABLE_PACKAGES.map(packageDefinition => [
+      packageDefinition.name,
+      packageDefinition,
+    ]),
+  )
+  const publicWorkspacePackages = workspacePackages.filter(
+    workspacePackage => workspacePackage.private !== true,
+  )
+  const publicByName = new Map(
+    publicWorkspacePackages.map(workspacePackage => [
+      workspacePackage.name,
+      workspacePackage,
+    ]),
+  )
+
+  const missingPackages = [...expectedByName.keys()].filter(
+    name => !publicByName.has(name),
+  )
+  const unexpectedPackages = [...publicByName.keys()].filter(
+    name => !expectedByName.has(name),
+  )
+
+  if (
+    missingPackages.at(0) !== undefined ||
+    unexpectedPackages.at(0) !== undefined
+  ) {
+    throw new Error(
+      `Canary package set does not match the public workspace. Missing: ${missingPackages.join(', ') || 'none'}. Unexpected: ${unexpectedPackages.join(', ') || 'none'}.`,
+    )
+  }
+
+  for (const [name, packageDefinition] of expectedByName) {
+    const workspacePackage = publicByName.get(name)
+
+    if (workspacePackage === undefined) {
+      throw new Error(`The public workspace package ${name} is missing.`)
+    }
+
+    const workspaceManifest = relative(
+      repositoryRoot,
+      resolve(workspacePackage.path, 'package.json'),
+    ).replaceAll('\\', '/')
+
+    if (workspaceManifest !== packageDefinition.manifest) {
+      throw new Error(
+        `${name} is at ${workspaceManifest}, not ${packageDefinition.manifest}.`,
+      )
+    }
+  }
+}
+
+const validateRepositoryPackages = repositoryRoot =>
+  validatePublishableWorkspace(
+    repositoryRoot,
+    readWorkspacePackages(repositoryRoot),
+  )
+
+export const preparePackageCanary = (
+  repositoryRoot,
+  workspacePackages = readWorkspacePackages(repositoryRoot),
+) => {
+  validatePublishableWorkspace(repositoryRoot, workspacePackages)
+
+  mkdirSync(resolve(repositoryRoot, '.changeset'), { recursive: true })
+
+  writeFileSync(
+    resolve(repositoryRoot, CANARY_CHANGESET_PATH),
+    canaryChangeset(),
+    { flag: 'wx' },
+  )
+}
+
+const readPackageManifests = repositoryRoot =>
+  PUBLISHABLE_PACKAGES.map(({ name, manifest }) => {
+    const parsed = JSON.parse(
+      readFileSync(resolve(repositoryRoot, manifest), 'utf8'),
+    )
+
+    if (parsed.name !== name) {
+      throw new Error(
+        `${manifest} declares ${String(parsed.name)}, not ${name}.`,
+      )
+    }
+
+    return parsed
+  })
+
+const packPackageCanary = (repositoryRoot, outputDirectory) =>
+  PUBLISHABLE_PACKAGES.map(packageDefinition => {
+    const packageDirectory = resolve(
+      repositoryRoot,
+      dirname(packageDefinition.manifest),
+    )
+
+    const packed = execFileSync(
+      'pnpm',
+      ['pack', '--pack-destination', outputDirectory],
+      { cwd: packageDirectory, encoding: 'utf8' },
+    )
+
+    const tarballOutput = packed.trim().split('\n').at(-1)
+
+    if (tarballOutput === undefined || tarballOutput === '') {
+      throw new Error(`pnpm pack produced no tarball for ${packageDirectory}.`)
+    }
+
+    const tarball = resolve(packageDirectory, tarballOutput)
+    const packedManifest = execFileSync(
+      'tar',
+      ['-xzOf', tarball, 'package/package.json'],
+      { encoding: 'utf8' },
+    )
+
+    return {
+      ...packageDefinition,
+      packageManifest: JSON.parse(packedManifest),
+      tarball,
+    }
+  })
+
+const withPackedPackageCanary = async (repositoryRoot, useArtifacts) => {
+  const outputDirectory = mkdtempSync(join(tmpdir(), 'foldkit-canary-pack-'))
+
+  try {
+    const artifacts = packPackageCanary(repositoryRoot, outputDirectory)
+
+    return await useArtifacts(artifacts)
+  } finally {
+    rmSync(outputDirectory, { recursive: true, force: true })
+  }
+}
+
+const validatePackageSet = packageManifests => {
+  const expectedNames = expectedPackageNames()
+  const manifestsByName = new Map(
+    packageManifests.map(manifest => [manifest.name, manifest]),
+  )
+
+  if (
+    manifestsByName.size !== expectedNames.size ||
+    [...expectedNames].some(name => !manifestsByName.has(name))
+  ) {
+    throw new Error('The canary does not include every published package.')
+  }
+
+  return expectedNames
+}
+
+export const validatePackageCanary = (expectedCommit, packageManifests) => {
+  validateCommit(expectedCommit)
+
+  validatePackageSet(packageManifests)
+
+  const canaryVersionPattern = new RegExp(
+    `^0\\.0\\.0-canary-${expectedCommit}-\\d{14}$`,
+  )
+  const canaryVersions = new Set(
+    packageManifests.map(manifest => manifest.version),
+  )
+
+  if (
+    canaryVersions.size !== 1 ||
+    [...canaryVersions].some(version => !canaryVersionPattern.test(version))
+  ) {
+    throw new Error(
+      `Published packages do not share a canary version for ${expectedCommit}.`,
+    )
+  }
+
+  const canaryVersion = [...canaryVersions].at(0)
+
+  if (canaryVersion === undefined) {
+    throw new Error('The canary contains no published packages.')
+  }
+
+  return canaryVersion
+}
+
+export const validatePackedPackageCanary = (
+  expectedCommit,
+  packageManifests,
+) => {
+  const canaryVersion = validatePackageCanary(expectedCommit, packageManifests)
+  const expectedNames = expectedPackageNames()
+
+  for (const manifest of packageManifests) {
+    for (const field of DEPENDENCY_FIELDS) {
+      const dependencies = manifest[field] ?? {}
+
+      for (const [dependency, range] of Object.entries(dependencies)) {
+        if (typeof range === 'string' && range.startsWith('workspace:')) {
+          throw new Error(
+            `${manifest.name} leaves ${dependency} at unsupported ${range}.`,
+          )
+        }
+
+        const isCanaryDependency =
+          typeof range === 'string' && range.includes('0.0.0-canary-')
+
+        if (!expectedNames.has(dependency) && !isCanaryDependency) {
+          continue
+        }
+
+        if (range !== canaryVersion) {
+          throw new Error(
+            `${manifest.name} points ${dependency} at ${range}, not ${canaryVersion}.`,
+          )
+        }
+      }
+    }
+  }
+
+  return canaryVersion
+}
+
+export const verifyCurrentCanaryCommit = (
+  repositoryRoot,
+  expectedCommit,
+  currentReference,
+) => {
+  validateCommit(expectedCommit)
+
+  const currentCommit = execFileSync(
+    'git',
+    ['rev-parse', '--verify', `${currentReference}^{commit}`],
+    { cwd: repositoryRoot, encoding: 'utf8' },
+  ).trim()
+
+  validateCommit(currentCommit)
+
+  if (currentCommit !== expectedCommit) {
+    throw new Error(
+      `Refusing to publish stale canary ${expectedCommit}; ${currentReference} is ${currentCommit}.`,
+    )
+  }
+
+  return currentCommit
+}
+
+export const packageCanaryTag = (name, canaryVersion) => {
+  if (!CANARY_VERSION_PATTERN.test(canaryVersion)) {
+    throw new Error(`Invalid canary version ${canaryVersion}.`)
+  }
+
+  if (name === CANARY_CHANNEL_PACKAGE) {
+    return 'canary'
+  }
+
+  return canaryVersion.slice('0.0.0-'.length)
+}
+
+export const orderPackageCanaryArtifacts = artifacts => {
+  const channelArtifact = artifacts.find(
+    artifact => artifact.packageManifest.name === CANARY_CHANNEL_PACKAGE,
+  )
+
+  if (channelArtifact === undefined) {
+    throw new Error(`The canary is missing ${CANARY_CHANNEL_PACKAGE}.`)
+  }
+
+  return [
+    ...artifacts.filter(
+      artifact => artifact.packageManifest.name !== CANARY_CHANNEL_PACKAGE,
+    ),
+    channelArtifact,
+  ]
+}
+
+const registryPackagesByName = registryPackages =>
+  new Map(
+    registryPackages.map(registryPackage => [
+      registryPackage.name,
+      registryPackage,
+    ]),
+  )
+
+export const validateStableLatestTags = registryPackages => {
+  const packagesByName = registryPackagesByName(registryPackages)
+
+  for (const name of expectedPackageNames()) {
+    const registryPackage = packagesByName.get(name)
+    const latest = registryPackage?.tags.latest
+
+    if (
+      registryPackage === undefined ||
+      typeof latest !== 'string' ||
+      CANARY_VERSION_PATTERN.test(latest) ||
+      !Object.hasOwn(registryPackage.versions, latest)
+    ) {
+      throw new Error(
+        `${name} must have an existing stable latest version before canary publishing.`,
+      )
+    }
+  }
+}
+
+const validatePublishedArtifact = (registryPackage, name, canaryVersion) => {
+  const tag = packageCanaryTag(name, canaryVersion)
+
+  if (!Object.hasOwn(registryPackage.versions, canaryVersion)) {
+    throw new Error(`${name}@${canaryVersion} is not available on npm.`)
+  }
+
+  if (registryPackage.tags[tag] !== canaryVersion) {
+    throw new Error(`${name}@${tag} does not point to ${canaryVersion} on npm.`)
+  }
+}
+
+export const validatePublishedPackageCanary = (
+  canaryVersion,
+  registryPackages,
+) => {
+  validateStableLatestTags(registryPackages)
+
+  const packagesByName = registryPackagesByName(registryPackages)
+
+  for (const name of expectedPackageNames()) {
+    const registryPackage = packagesByName.get(name)
+
+    if (registryPackage === undefined) {
+      throw new Error(`${name} is missing from the npm registry response.`)
+    }
+
+    validatePublishedArtifact(registryPackage, name, canaryVersion)
+  }
+}
+
+const fetchRegistryPackage = async name => {
+  const encodedName = encodeURIComponent(name)
+  const response = await fetch(
+    `${NPM_REGISTRY_BASE_URL}/${encodedName}?canary=${Date.now()}`,
+    { cache: 'no-store' },
+  )
+
+  if (response.status === 404) {
+    return { name, tags: {}, versions: {} }
+  }
+
+  if (!response.ok) {
+    throw new Error(`npm returned ${response.status} for ${name}.`)
+  }
+
+  const packument = await response.json()
+
+  if (
+    typeof packument !== 'object' ||
+    packument === null ||
+    typeof packument['dist-tags'] !== 'object' ||
+    packument['dist-tags'] === null ||
+    typeof packument.versions !== 'object' ||
+    packument.versions === null
+  ) {
+    throw new Error(`npm returned invalid package metadata for ${name}.`)
+  }
+
+  return {
+    name,
+    tags: packument['dist-tags'],
+    versions: packument.versions,
+  }
+}
+
+const fetchRegistryPackages = names =>
+  Promise.all(names.map(fetchRegistryPackage))
+
+const pause = milliseconds =>
+  new Promise(resolvePause => setTimeout(resolvePause, milliseconds))
+
+const waitForRegistry = async (names, validateRegistryPackages) => {
+  let latestError = new Error('npm registry validation did not run.')
+
+  for (const delay of REGISTRY_RETRY_DELAYS_MS) {
+    if (delay !== 0) {
+      await pause(delay)
+    }
+
+    try {
+      const registryPackages = await fetchRegistryPackages(names)
+
+      validateRegistryPackages(registryPackages)
+
+      return registryPackages
+    } catch (error) {
+      latestError = error instanceof Error ? error : new Error(String(error))
+    }
+  }
+
+  throw latestError
+}
+
+const waitForPublishedArtifact = (name, canaryVersion) =>
+  waitForRegistry([name], registryPackages => {
+    const registryPackage = registryPackages.at(0)
+
+    if (registryPackage === undefined) {
+      throw new Error(`npm returned no package metadata for ${name}.`)
+    }
+
+    validatePublishedArtifact(registryPackage, name, canaryVersion)
+  })
+
+const publishPackageArtifact = async (
+  repositoryRoot,
+  artifact,
+  canaryVersion,
+) => {
+  const name = artifact.packageManifest.name
+  const tag = packageCanaryTag(name, canaryVersion)
+
+  try {
+    execFileSync(
+      'npm',
+      ['publish', artifact.tarball, '--tag', tag, '--access', 'public'],
+      {
+        cwd: resolve(repositoryRoot, dirname(artifact.manifest)),
+        stdio: 'inherit',
+      },
+    )
+  } catch (publishError) {
+    try {
+      await waitForPublishedArtifact(name, canaryVersion)
+
+      return
+    } catch {
+      throw publishError
+    }
+  }
+
+  await waitForPublishedArtifact(name, canaryVersion)
+}
+
+export const inspectPackageCanary = (repositoryRoot, expectedCommit) => {
+  validateRepositoryPackages(repositoryRoot)
+
+  return validatePackageCanary(
+    expectedCommit,
+    readPackageManifests(repositoryRoot),
+  )
+}
+
+export const inspectPackedPackageCanary = (repositoryRoot, expectedCommit) => {
+  validateRepositoryPackages(repositoryRoot)
+
+  return withPackedPackageCanary(repositoryRoot, artifacts =>
+    validatePackedPackageCanary(
+      expectedCommit,
+      artifacts.map(({ packageManifest }) => packageManifest),
+    ),
+  )
+}
+
+export const publishPackageCanary = (
+  repositoryRoot,
+  expectedCommit,
+  currentReference,
+) => {
+  validateRepositoryPackages(repositoryRoot)
+
+  return withPackedPackageCanary(repositoryRoot, async artifacts => {
+    const canaryVersion = validatePackedPackageCanary(
+      expectedCommit,
+      artifacts.map(({ packageManifest }) => packageManifest),
+    )
+    const packageNames = artifacts.map(
+      ({ packageManifest }) => packageManifest.name,
+    )
+
+    await waitForRegistry(packageNames, validateStableLatestTags)
+
+    verifyCurrentCanaryCommit(repositoryRoot, expectedCommit, currentReference)
+
+    for (const artifact of orderPackageCanaryArtifacts(artifacts)) {
+      await publishPackageArtifact(repositoryRoot, artifact, canaryVersion)
+    }
+
+    await waitForRegistry(packageNames, registryPackages =>
+      validatePublishedPackageCanary(canaryVersion, registryPackages),
+    )
+
+    return canaryVersion
+  })
+}
+
+const entryPath = process.argv.at(1)
+
+if (
+  entryPath !== undefined &&
+  import.meta.url === pathToFileURL(resolve(entryPath)).href
+) {
+  const command = process.argv.at(2)
+
+  if (command === 'prepare') {
+    preparePackageCanary(process.cwd())
+  } else if (command === 'inspect' || command === 'inspect-packed') {
+    const expectedCommit = process.argv.at(3)
+
+    if (expectedCommit === undefined) {
+      throw new Error('Pass the canary commit to inspect.')
+    }
+
+    const canaryVersion =
+      command === 'inspect'
+        ? inspectPackageCanary(process.cwd(), expectedCommit)
+        : await inspectPackedPackageCanary(process.cwd(), expectedCommit)
+
+    process.stdout.write(`version=${canaryVersion}\n`)
+  } else if (command === 'publish') {
+    const expectedCommit = process.argv.at(3)
+    const currentReference = process.argv.at(4)
+
+    if (expectedCommit === undefined || currentReference === undefined) {
+      throw new Error('Pass the canary commit and current Git reference.')
+    }
+
+    const canaryVersion = await publishPackageCanary(
+      process.cwd(),
+      expectedCommit,
+      currentReference,
+    )
+
+    process.stdout.write(`version=${canaryVersion}\n`)
+  } else {
+    throw new Error('Pass prepare, inspect, inspect-packed, or publish.')
+  }
+}

--- a/scripts/package-canary.test.mjs
+++ b/scripts/package-canary.test.mjs
@@ -1,0 +1,374 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { test } from 'node:test'
+
+import {
+  CANARY_CHANNEL_PACKAGE,
+  PUBLISHABLE_PACKAGES,
+  orderPackageCanaryArtifacts,
+  packageCanaryTag,
+  preparePackageCanary,
+  validatePackageCanary,
+  validatePackedPackageCanary,
+  validatePublishableWorkspace,
+  validatePublishedPackageCanary,
+  validateStableLatestTags,
+  verifyCurrentCanaryCommit,
+} from './package-canary.mjs'
+
+const COMMIT = '0123456789abcdef0123456789abcdef01234567'
+const VERSION = `0.0.0-canary-${COMMIT}-20260821213000`
+const STABLE_VERSION = '0.148.2'
+
+const packageNames = () => PUBLISHABLE_PACKAGES.map(({ name }) => name)
+
+const manifests = () => packageNames().map(name => ({ name, version: VERSION }))
+
+const workspacePackages = repositoryRoot => [
+  {
+    name: 'foldkit-monorepo',
+    path: repositoryRoot,
+    private: true,
+  },
+  ...PUBLISHABLE_PACKAGES.map(({ name, manifest }) => ({
+    name,
+    path: resolve(repositoryRoot, dirname(manifest)),
+    private: false,
+  })),
+]
+
+const registryPackages = () =>
+  packageNames().map(name => ({
+    name,
+    tags: {
+      latest: STABLE_VERSION,
+      [packageCanaryTag(name, VERSION)]: VERSION,
+    },
+    versions: {
+      [STABLE_VERSION]: {},
+      [VERSION]: {},
+    },
+  }))
+
+const git = (repositoryRoot, args) =>
+  execFileSync('git', args, { cwd: repositoryRoot, encoding: 'utf8' }).trim()
+
+test('the canary allowlist matches the public workspace', () => {
+  const repositoryRoot = '/workspace/foldkit'
+
+  assert.doesNotThrow(() =>
+    validatePublishableWorkspace(
+      repositoryRoot,
+      workspacePackages(repositoryRoot),
+    ),
+  )
+})
+
+test('an unlisted public workspace package is rejected', () => {
+  const repositoryRoot = '/workspace/foldkit'
+  const packages = [
+    ...workspacePackages(repositoryRoot),
+    {
+      name: '@foldkit/new-package',
+      path: resolve(repositoryRoot, 'packages/new-package'),
+      private: false,
+    },
+  ]
+
+  assert.throws(
+    () => validatePublishableWorkspace(repositoryRoot, packages),
+    /Unexpected: @foldkit\/new-package/,
+  )
+})
+
+test('prepare writes one temporary changeset for the complete package set', () => {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'foldkit-canary-test-'))
+
+  try {
+    preparePackageCanary(repositoryRoot, workspacePackages(repositoryRoot))
+
+    const changeset = readFileSync(
+      resolve(repositoryRoot, '.changeset/foldkit-main-canary.md'),
+      'utf8',
+    )
+
+    for (const name of packageNames()) {
+      assert.match(changeset, new RegExp(`^'${name}': patch$`, 'm'))
+    }
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true })
+  }
+})
+
+test('a coherent package canary returns its shared version', () => {
+  assert.equal(validatePackageCanary(COMMIT, manifests()), VERSION)
+})
+
+test('a package omitted from the canary is rejected', () => {
+  assert.throws(
+    () => validatePackageCanary(COMMIT, manifests().slice(1)),
+    /does not include every published package/,
+  )
+})
+
+test('a canary from another commit is rejected', () => {
+  assert.throws(
+    () => validatePackageCanary('f'.repeat(40), manifests()),
+    /do not share a canary version/,
+  )
+})
+
+test('mixed package canary versions are rejected', () => {
+  const packageManifests = manifests()
+  const finalManifest = packageManifests.at(-1)
+
+  assert.ok(finalManifest !== undefined)
+
+  finalManifest.version = `0.0.0-canary-${COMMIT}-20260821213001`
+
+  assert.throws(
+    () => validatePackageCanary(COMMIT, packageManifests),
+    /do not share a canary version/,
+  )
+})
+
+test('a stale packed internal canary dependency is rejected', () => {
+  const packageManifests = manifests()
+  const uiManifest = packageManifests.find(({ name }) => name === '@foldkit/ui')
+
+  assert.ok(uiManifest !== undefined)
+
+  uiManifest.peerDependencies = {
+    foldkit: `0.0.0-canary-${COMMIT}-20260821212959`,
+  }
+
+  assert.throws(
+    () => validatePackedPackageCanary(COMMIT, packageManifests),
+    /not 0.0.0-canary/,
+  )
+})
+
+test('a stable packed internal dependency is rejected', () => {
+  const packageManifests = manifests()
+  const uiManifest = packageManifests.find(({ name }) => name === '@foldkit/ui')
+
+  assert.ok(uiManifest !== undefined)
+
+  uiManifest.peerDependencies = { foldkit: '^0.5.0' }
+
+  assert.throws(
+    () => validatePackedPackageCanary(COMMIT, packageManifests),
+    /not 0.0.0-canary/,
+  )
+})
+
+test('a workspace protocol is rejected from packed packages', () => {
+  const packageManifests = manifests()
+  const uiManifest = packageManifests.find(({ name }) => name === '@foldkit/ui')
+
+  assert.ok(uiManifest !== undefined)
+
+  uiManifest.devDependencies = { '@private/build-helper': 'workspace:*' }
+
+  assert.throws(
+    () => validatePackedPackageCanary(COMMIT, packageManifests),
+    /leaves @private\/build-helper at unsupported workspace:\*/,
+  )
+})
+
+test('the source check allows workspace ranges that packing will resolve', () => {
+  const packageManifests = manifests()
+  const uiManifest = packageManifests.find(({ name }) => name === '@foldkit/ui')
+
+  assert.ok(uiManifest !== undefined)
+
+  uiManifest.devDependencies = { '@foldkit/vite-plugin': 'workspace:*' }
+
+  assert.equal(validatePackageCanary(COMMIT, packageManifests), VERSION)
+})
+
+test('a stale main commit is refused', () => {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'foldkit-canary-git-'))
+
+  try {
+    git(repositoryRoot, ['init'])
+    git(repositoryRoot, ['config', 'user.name', 'Foldkit Test'])
+    git(repositoryRoot, ['config', 'user.email', 'test@foldkit.dev'])
+
+    const trackedFile = resolve(repositoryRoot, 'tracked.txt')
+    writeFileSync(trackedFile, 'first\n')
+    git(repositoryRoot, ['add', 'tracked.txt'])
+    git(repositoryRoot, ['commit', '-m', 'first'])
+
+    const staleCommit = git(repositoryRoot, ['rev-parse', 'HEAD'])
+
+    writeFileSync(trackedFile, 'second\n')
+    git(repositoryRoot, ['add', 'tracked.txt'])
+    git(repositoryRoot, ['commit', '-m', 'second'])
+
+    const currentCommit = git(repositoryRoot, ['rev-parse', 'HEAD'])
+
+    git(repositoryRoot, [
+      'update-ref',
+      'refs/remotes/origin/main',
+      currentCommit,
+    ])
+
+    assert.equal(
+      verifyCurrentCanaryCommit(repositoryRoot, currentCommit, 'origin/main'),
+      currentCommit,
+    )
+    assert.throws(
+      () =>
+        verifyCurrentCanaryCommit(repositoryRoot, staleCommit, 'origin/main'),
+      /Refusing to publish stale canary/,
+    )
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true })
+  }
+})
+
+test('the moving canary channel publishes after immutable snapshots', () => {
+  const artifacts = packageNames().map(name => ({
+    packageManifest: { name },
+  }))
+  const orderedArtifacts = orderPackageCanaryArtifacts(artifacts)
+  const channelArtifact = orderedArtifacts.at(-1)
+
+  assert.equal(channelArtifact?.packageManifest.name, CANARY_CHANNEL_PACKAGE)
+
+  for (const artifact of orderedArtifacts.slice(0, -1)) {
+    assert.equal(
+      packageCanaryTag(artifact.packageManifest.name, VERSION),
+      VERSION.slice('0.0.0-'.length),
+    )
+  }
+
+  assert.equal(packageCanaryTag(CANARY_CHANNEL_PACKAGE, VERSION), 'canary')
+})
+
+test('every package needs an existing stable latest version', () => {
+  assert.doesNotThrow(() => validateStableLatestTags(registryPackages()))
+
+  const packages = registryPackages()
+  const foldkit = packages.find(({ name }) => name === 'foldkit')
+
+  assert.ok(foldkit !== undefined)
+
+  foldkit.tags = {}
+
+  assert.throws(
+    () => validateStableLatestTags(packages),
+    /must have an existing stable latest version/,
+  )
+})
+
+test('the advertised channel requires every exact package version', () => {
+  assert.doesNotThrow(() =>
+    validatePublishedPackageCanary(VERSION, registryPackages()),
+  )
+
+  const packages = registryPackages()
+  const uiPackage = packages.find(({ name }) => name === '@foldkit/ui')
+
+  assert.ok(uiPackage !== undefined)
+
+  uiPackage.tags[packageCanaryTag('@foldkit/ui', VERSION)] = STABLE_VERSION
+
+  assert.throws(
+    () => validatePublishedPackageCanary(VERSION, packages),
+    /does not point to/,
+  )
+})
+
+test('the release workflow keeps stable and canary publication separate', () => {
+  const repositoryRoot = resolve(import.meta.dirname, '..')
+
+  const workflow = readFileSync(
+    resolve(repositoryRoot, '.github/workflows/release.yml'),
+    'utf8',
+  )
+  const rootPackage = JSON.parse(
+    readFileSync(resolve(repositoryRoot, 'package.json'), 'utf8'),
+  )
+  const changesetConfig = JSON.parse(
+    readFileSync(resolve(repositoryRoot, '.changeset/config.json'), 'utf8'),
+  )
+
+  assert.equal(
+    changesetConfig.snapshot.prereleaseTemplate,
+    '{tag}-{commit}-{datetime}',
+  )
+  assert.equal(changesetConfig.snapshot.useCalculatedVersion, false)
+
+  assert.equal(
+    rootPackage.scripts['version-packages:canary'],
+    'node scripts/package-canary.mjs prepare && changeset version --snapshot canary && pnpm install --no-frozen-lockfile',
+  )
+  assert.equal(
+    rootPackage.scripts['release:canary'],
+    'node scripts/package-canary.mjs publish "$FOLDKIT_CANARY_COMMIT" origin/main',
+  )
+  assert.equal(
+    rootPackage.scripts.release,
+    'pnpm check:peer-floors && pnpm build:packages && changeset publish',
+  )
+
+  assert.doesNotMatch(workflow, /^\s+paths:/m)
+
+  const deployWebsiteIndex = workflow.indexOf('  deploy-website:')
+  const publishCanaryIndex = workflow.indexOf('  publish-canary:')
+
+  const deployWebsiteJob = workflow.slice(
+    deployWebsiteIndex,
+    publishCanaryIndex,
+  )
+  const publishCanaryJob = workflow.slice(publishCanaryIndex)
+
+  assert.ok(deployWebsiteIndex >= 0)
+  assert.ok(publishCanaryIndex > deployWebsiteIndex)
+  assert.match(
+    deployWebsiteJob,
+    /needs: release\n\s+if: needs\.release\.outputs\.published == 'true'/,
+  )
+  assert.match(publishCanaryJob, /name: Publish package canaries/)
+  assert.match(
+    publishCanaryJob,
+    /permissions:\n\s+contents: read\n\s+id-token: write/,
+  )
+  assert.match(
+    publishCanaryJob,
+    /needs: release\n\s+if: needs\.release\.outputs\.published != 'true'/,
+  )
+  assert.match(publishCanaryJob, /fetch-depth: 0/)
+  assert.match(publishCanaryJob, /NPM_CONFIG_PROVENANCE: true/)
+  assert.match(
+    publishCanaryJob,
+    /FOLDKIT_CANARY_COMMIT: \$\{\{ github\.sha \}\}/,
+  )
+  assert.match(
+    publishCanaryJob,
+    /git fetch --no-tags origin main:refs\/remotes\/origin\/main/,
+  )
+  assert.match(publishCanaryJob, /run: pnpm release:canary/)
+  assert.doesNotMatch(publishCanaryJob, /changeset publish/)
+
+  const prepareIndex = workflow.indexOf('Version package canaries')
+  const verifySourceIndex = workflow.indexOf('Verify package canary versions')
+  const buildIndex = workflow.indexOf('Build package canaries')
+  const verifyPackedIndex = workflow.indexOf('Verify packed package canaries')
+  const fetchMainIndex = workflow.indexOf('Fetch current main')
+  const publishIndex = workflow.indexOf(
+    'Publish package canaries',
+    prepareIndex,
+  )
+
+  assert.ok(prepareIndex < verifySourceIndex)
+  assert.ok(verifySourceIndex < buildIndex)
+  assert.ok(buildIndex < verifyPackedIndex)
+  assert.ok(verifyPackedIndex < fetchMainIndex)
+  assert.ok(fetchMainIndex < publishIndex)
+})


### PR DESCRIPTION
Publish every public package under a commit-addressed snapshot for the newest
main commit.

Expose the snapshot through create-foldkit-app@canary only after npm confirms
every exact package version. Reject stale workflow runs and keep canary
scaffolds on the encoded source commit and shared version.

Require a separate-agent review of each committed diff before it is pushed or
proposed, including a fresh review after amendments.
