### PR TITLE
feat(website): make foldkit.dev agent-ready

### DIFF
--- a/.github/workflows/deploy-website-build.yml
+++ b/.github/workflows/deploy-website-build.yml
@@ -112,7 +112,7 @@ jobs:
           DEPLOYMENT_CHANNEL: ${{ inputs.channel }}
         run: |
           mkdir -p .vercel/output/static
-          cp -r packages/website/dist/* .vercel/output/static/
+          cp -r packages/website/dist/. .vercel/output/static/
           node scripts/website-vercel-config.mjs "${DEPLOYMENT_CHANNEL}"
 
       - name: Deploy immutable website build

--- a/packages/website/public/.well-known/mcp
+++ b/packages/website/public/.well-known/mcp
@@ -1,0 +1,20 @@
+{
+  "name": "Foldkit",
+  "description": "Foldkit is a TypeScript frontend framework built on Effect. Its first-party MCP server connects an agent to a running Foldkit application in development.",
+  "website": "https://foldkit.dev",
+  "documentation": "https://foldkit.dev/ai/mcp",
+  "servers": [
+    {
+      "name": "foldkit-devtools",
+      "package": "@foldkit/devtools-mcp",
+      "registry": "https://www.npmjs.com/package/@foldkit/devtools-mcp",
+      "description": "Exposes a running Foldkit app to agents: read the current or any historical Model, inspect the Message history with diffs and Command lifecycle, replay to past states, discover the Message Schema as JSON Schema, and dispatch Schema-validated Messages.",
+      "transport": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@foldkit/devtools-mcp"]
+      },
+      "setup": "Run `npx @foldkit/devtools-mcp init` in a Foldkit project root to write the .mcp.json entry. Projects scaffolded with create-foldkit-app ship with it pre-wired. Requires the app's dev server running with devToolsMcpPort configured in @foldkit/vite-plugin."
+    }
+  ]
+}

--- a/packages/website/public/404.json
+++ b/packages/website/public/404.json
@@ -1,0 +1,19 @@
+{
+  "error": {
+    "code": "not_found",
+    "status": 404,
+    "message": "Nothing exists at this path on foldkit.dev.",
+    "hints": [
+      "Every page is listed with a short description at https://foldkit.dev/llms.txt.",
+      "Fetch any documentation page as Markdown by appending .md to its URL, or by requesting the page URL with Accept: text/markdown.",
+      "The machine-readable endpoints are described at https://foldkit.dev/openapi.json."
+    ],
+    "links": {
+      "llms": "https://foldkit.dev/llms.txt",
+      "llmsFull": "https://foldkit.dev/llms-full.txt",
+      "sitemap": "https://foldkit.dev/sitemap.xml",
+      "openapi": "https://foldkit.dev/openapi.json",
+      "docs": "https://foldkit.dev/get-started/getting-started"
+    }
+  }
+}

--- a/packages/website/public/404.md
+++ b/packages/website/public/404.md
@@ -1,0 +1,13 @@
+# 404 Not Found
+
+Nothing exists at this path on foldkit.dev.
+
+Useful entry points:
+
+- Page index for agents: https://foldkit.dev/llms.txt
+- Every docs page in one Markdown file: https://foldkit.dev/llms-full.txt
+- Sitemap: https://foldkit.dev/sitemap.xml
+- Machine-readable endpoint descriptions: https://foldkit.dev/openapi.json
+- Getting started: https://foldkit.dev/get-started/getting-started.md
+
+Every documentation page is available as Markdown by appending `.md` to its URL, or by requesting the page URL with `Accept: text/markdown`.

--- a/packages/website/public/openapi.json
+++ b/packages/website/public/openapi.json
@@ -1,0 +1,211 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Foldkit Documentation Content API",
+    "version": "1.0.0",
+    "summary": "Read-only content endpoints for the Foldkit documentation site.",
+    "description": "Foldkit is a TypeScript frontend framework built on Effect. This API describes the machine-readable surface of foldkit.dev: a Markdown variant of every documentation page, an agent-oriented page index, a single-file docs concatenation, the sitemap, and the blog feed. Every endpoint is a public, unauthenticated GET. Unknown paths return HTTP 404 with a JSON body when requested with Accept: application/json. The framework itself is consumed as npm packages (foldkit, @foldkit/ui) and scaffolded with `npm create foldkit-app@latest`, not through this HTTP API.",
+    "contact": {
+      "name": "Foldkit",
+      "url": "https://github.com/foldkit/foldkit/issues"
+    },
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    }
+  },
+  "externalDocs": {
+    "description": "Foldkit documentation",
+    "url": "https://foldkit.dev"
+  },
+  "servers": [
+    {
+      "url": "https://foldkit.dev",
+      "description": "Production documentation site"
+    }
+  ],
+  "paths": {
+    "/llms.txt": {
+      "get": {
+        "operationId": "getLlmsIndex",
+        "summary": "Agent-oriented page index",
+        "description": "Lists every documentation page with a one-line description, grouped by section, in the llms.txt format. Includes guidance on when to use Foldkit and links to the other developer resources. Use this as the entry point for discovering pages, then fetch each page's Markdown variant.",
+        "responses": {
+          "200": {
+            "description": "The llms.txt index as Markdown-formatted plain text.",
+            "content": {
+              "text/plain": {
+                "schema": { "$ref": "#/components/schemas/MarkdownDocument" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/llms-full.txt": {
+      "get": {
+        "operationId": "getLlmsFull",
+        "summary": "Every documentation page in one file",
+        "description": "The Markdown content of every documentation page concatenated into a single file, each section preceded by its source URL. Suited to loading the full documentation into one context window.",
+        "responses": {
+          "200": {
+            "description": "The concatenated documentation as Markdown-formatted plain text.",
+            "content": {
+              "text/plain": {
+                "schema": { "$ref": "#/components/schemas/MarkdownDocument" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/{page}.md": {
+      "get": {
+        "operationId": "getPageMarkdown",
+        "summary": "One documentation page as Markdown",
+        "description": "The Markdown variant of a single documentation page. The page parameter is the page's URL path without the leading slash and may contain slashes, for example `get-started/getting-started` or `core/model`. Valid page paths are enumerated in /llms.txt and /sitemap.xml. The same document is returned when the page's HTML URL is requested with an Accept header containing text/markdown.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "path",
+            "required": true,
+            "description": "The page's URL path without the leading slash, for example `core/model`. May contain slashes. The homepage is `index`.",
+            "schema": {
+              "type": "string",
+              "examples": ["index", "get-started/getting-started", "core/model"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The page content as Markdown.",
+            "content": {
+              "text/markdown": {
+                "schema": { "$ref": "#/components/schemas/MarkdownDocument" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/sitemap.xml": {
+      "get": {
+        "operationId": "getSitemap",
+        "summary": "Sitemap",
+        "description": "Every page URL on the site in the sitemaps.org XML format.",
+        "responses": {
+          "200": {
+            "description": "The sitemap as XML.",
+            "content": {
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/XmlDocument" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/blog/rss.xml": {
+      "get": {
+        "operationId": "getBlogFeed",
+        "summary": "Blog RSS feed",
+        "description": "The Foldkit blog as an RSS 2.0 feed, including the full article content of each post.",
+        "responses": {
+          "200": {
+            "description": "The blog feed as RSS XML.",
+            "content": {
+              "application/rss+xml": {
+                "schema": { "$ref": "#/components/schemas/XmlDocument" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "operationId": "getOpenApiDescription",
+        "summary": "This document",
+        "description": "The OpenAPI 3.1 description of the site's machine-readable endpoints.",
+        "responses": {
+          "200": {
+            "description": "This OpenAPI document as JSON.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "NotFound": {
+        "description": "Nothing exists at the requested path. The body names the error and links the discovery endpoints. Requests without Accept: application/json receive the same information as Markdown instead.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "MarkdownDocument": {
+        "type": "string",
+        "description": "A Markdown document."
+      },
+      "XmlDocument": {
+        "type": "string",
+        "description": "An XML document."
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "The structured error body returned for unknown paths.",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "status", "message"],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "A stable machine-readable error code.",
+                "examples": ["not_found"]
+              },
+              "status": {
+                "type": "integer",
+                "description": "The HTTP status of the response.",
+                "examples": [404]
+              },
+              "message": {
+                "type": "string",
+                "description": "What went wrong, in one sentence."
+              },
+              "hints": {
+                "type": "array",
+                "description": "How to find the resource you were probably looking for.",
+                "items": { "type": "string" }
+              },
+              "links": {
+                "type": "object",
+                "description": "Discovery endpoints, keyed by name.",
+                "additionalProperties": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/website/public/robots.txt
+++ b/packages/website/public/robots.txt
@@ -5,6 +5,8 @@ Content-Signal: ai-train=yes, search=yes, ai-input=yes
 Sitemap: https://foldkit.dev/sitemap.xml
 
 # Agent-friendly digests. Every page is also available as Markdown by
-# appending `.md` to its URL (e.g. https://foldkit.dev/get-started/getting-started.md).
+# appending `.md` to its URL (e.g. https://foldkit.dev/get-started/getting-started.md)
+# or by requesting the page URL with `Accept: text/markdown`.
 # https://foldkit.dev/llms.txt
 # https://foldkit.dev/llms-full.txt
+# https://foldkit.dev/openapi.json

--- a/packages/website/scripts/agentSurface.test.ts
+++ b/packages/website/scripts/agentSurface.test.ts
@@ -1,0 +1,144 @@
+import { Array, Option, Record, pipe } from 'effect'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const PUBLIC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../public')
+
+const readPublicFile = (relativePath: string): string =>
+  readFileSync(resolve(PUBLIC_DIR, relativePath), 'utf8')
+
+type OpenApiOperation = Readonly<{
+  operationId?: string
+  summary?: string
+  description?: string
+  responses?: Record<string, unknown>
+}>
+
+describe('openapi.json', () => {
+  const spec = JSON.parse(readPublicFile('openapi.json'))
+
+  const operations: ReadonlyArray<readonly [string, OpenApiOperation]> = pipe(
+    Record.toEntries(spec.paths as Record<string, Record<string, unknown>>),
+    Array.flatMap(([path, methods]) =>
+      pipe(
+        Record.toEntries(methods),
+        Array.map(
+          ([method, operation]) =>
+            /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+            [
+              `${method.toUpperCase()} ${path}`,
+              operation as OpenApiOperation,
+            ] as const,
+        ),
+      ),
+    ),
+  )
+
+  it('declares OpenAPI 3.1 with the production server', () => {
+    expect(spec.openapi).toBe('3.1.0')
+    expect(spec.servers).toEqual([
+      expect.objectContaining({ url: 'https://foldkit.dev' }),
+    ])
+  })
+
+  it('gives every operation a unique operationId, a summary, and a description', () => {
+    expect(operations.length).toBeGreaterThan(0)
+
+    for (const [label, operation] of operations) {
+      expect(operation.operationId, label).toBeTruthy()
+      expect(operation.summary, label).toBeTruthy()
+      expect(operation.description, label).toBeTruthy()
+    }
+
+    const ids = Array.map(operations, ([, operation]) => operation.operationId)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('types every response and documents the JSON 404 body', () => {
+    for (const [label, operation] of operations) {
+      const responses = Record.toEntries(operation.responses ?? {})
+      expect(responses.length, label).toBeGreaterThan(0)
+      expect(
+        Array.some(responses, ([status]) => status === '404'),
+        label,
+      ).toBe(true)
+    }
+
+    expect(
+      spec.components.schemas.ErrorResponse.properties.error.required,
+    ).toEqual(['code', 'status', 'message'])
+  })
+
+  it('covers the machine-readable surface the site actually serves', () => {
+    const paths = Record.keys(spec.paths)
+    for (const expected of [
+      '/llms.txt',
+      '/llms-full.txt',
+      '/{page}.md',
+      '/sitemap.xml',
+      '/blog/rss.xml',
+      '/openapi.json',
+    ]) {
+      expect(paths).toContain(expected)
+    }
+  })
+})
+
+describe('404 bodies', () => {
+  it('the JSON 404 matches the ErrorResponse contract in openapi.json', () => {
+    const body = JSON.parse(readPublicFile('404.json'))
+
+    expect(body.error.code).toBe('not_found')
+    expect(body.error.status).toBe(404)
+    expect(body.error.message.length).toBeGreaterThan(0)
+    expect(body.error.hints.length).toBeGreaterThan(0)
+    expect(body.error.links.llms).toBe('https://foldkit.dev/llms.txt')
+    expect(body.error.links.openapi).toBe('https://foldkit.dev/openapi.json')
+  })
+
+  it('the markdown 404 points agents at the discovery endpoints', () => {
+    const body = readPublicFile('404.md')
+
+    expect(body).toContain('# 404 Not Found')
+    expect(body).toContain('https://foldkit.dev/llms.txt')
+    expect(body).toContain('https://foldkit.dev/sitemap.xml')
+    expect(body).toContain('https://foldkit.dev/openapi.json')
+    expect(body).toContain('`.md`')
+  })
+})
+
+describe('.well-known/mcp', () => {
+  it('names the published MCP server and its transport', () => {
+    const manifest = JSON.parse(readPublicFile('.well-known/mcp'))
+
+    const maybeServer = Array.head(
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      manifest.servers as Array<{
+        package: string
+        transport: { type: string; command: string }
+        registry: string
+      }>,
+    )
+    expect(Option.isSome(maybeServer)).toBe(true)
+    if (Option.isSome(maybeServer)) {
+      expect(maybeServer.value.package).toBe('@foldkit/devtools-mcp')
+      expect(maybeServer.value.transport.type).toBe('stdio')
+      expect(maybeServer.value.transport.command).toBe('npx')
+      expect(maybeServer.value.registry).toContain('npmjs.com')
+    }
+    expect(manifest.documentation).toBe('https://foldkit.dev/ai/mcp')
+  })
+})
+
+describe('robots.txt', () => {
+  it('keeps the agent digest pointers current', () => {
+    const robots = readPublicFile('robots.txt')
+
+    expect(robots).toContain('https://foldkit.dev/llms.txt')
+    expect(robots).toContain('https://foldkit.dev/llms-full.txt')
+    expect(robots).toContain('https://foldkit.dev/openapi.json')
+    expect(robots).toContain('Sitemap: https://foldkit.dev/sitemap.xml')
+  })
+})

--- a/packages/website/scripts/markdown.test.ts
+++ b/packages/website/scripts/markdown.test.ts
@@ -230,6 +230,34 @@ describe('buildLlmsIndex', () => {
     const tabsIndex = output.indexOf('[Tabs]')
     expect(dialogIndex).toBeLessThan(tabsIndex)
   })
+
+  it('tells agents when to use Foldkit and how to work with the site', () => {
+    const output = buildLlmsIndex([
+      indexEntry('/manifesto', 'Manifesto', 'Why Foldkit exists.', 'Docs'),
+    ])
+
+    expect(output).toContain('When to use Foldkit:')
+    expect(output).toContain('Not a fit for:')
+    expect(output).toContain('npm create foldkit-app@latest')
+    expect(output).toContain('Accept: text/markdown')
+  })
+
+  it('lists the developer resources before the page sections', () => {
+    const output = buildLlmsIndex([
+      indexEntry('/manifesto', 'Manifesto', 'Why Foldkit exists.', 'Docs'),
+    ])
+
+    const resourcesIndex = output.indexOf('## Developer Resources')
+    const docsIndex = output.indexOf('## Docs')
+    expect(resourcesIndex).toBeGreaterThan(-1)
+    expect(resourcesIndex).toBeLessThan(docsIndex)
+
+    expect(output).toContain('https://foldkit.dev/openapi.json')
+    expect(output).toContain('https://foldkit.dev/llms-full.txt')
+    expect(output).toContain('https://foldkit.dev/sitemap.xml')
+    expect(output).toContain('@foldkit/devtools-mcp')
+    expect(output).toContain('https://github.com/foldkit/foldkit')
+  })
 })
 
 const fullEntry = (

--- a/packages/website/scripts/markdown.ts
+++ b/packages/website/scripts/markdown.ts
@@ -336,6 +336,31 @@ const renderIndexSection = (
   return `## ${section}\n\n${Array_.join(lines, '\n')}`
 }
 
+const WHEN_TO_USE = `When to use Foldkit:
+
+- Building a browser single-page application in TypeScript around The Elm Architecture: one Schema-defined Model, Messages as facts, a pure update function, and side effects confined to Commands.
+- Extending a codebase that already uses Effect-TS, since Foldkit shares its idioms (Effect, Schema, Match, Option) and its ecosystem.
+- Applications where agents write or audit significant code. Explicit state transitions and Messages-as-data make programs inspectable, and the Story and Scene test frameworks drive them without a browser.
+- Not a fit for: server-only projects with no browser UI, teams staying on React and JSX idioms, or codebases avoiding the Effect ecosystem.
+
+How an agent works with Foldkit:
+
+- Scaffold a new application with \`npm create foldkit-app@latest\` (pnpm, yarn, and bun equivalents work too).
+- Fetch any page below as Markdown by appending \`.md\` to its URL, or by requesting the page URL with \`Accept: text/markdown\`.
+- Connect to a running app through the DevTools MCP server (\`npx @foldkit/devtools-mcp init\`) to inspect the Model, replay history, and dispatch Messages.
+- Install the repository skills from ${SITE_URL}/ai/skills for architecture guidance, program generation, and application audits.`
+
+const DEVELOPER_RESOURCES_SECTION = `## Developer Resources
+
+- [llms-full.txt](${SITE_URL}/llms-full.txt): Every documentation page concatenated into one Markdown file.
+- [openapi.json](${SITE_URL}/openapi.json): OpenAPI 3.1 description of this site's machine-readable content endpoints.
+- [Sitemap](${SITE_URL}/sitemap.xml): Every page URL on the site.
+- [AI overview](${SITE_URL}/ai/overview): How Foldkit's explicit architecture supports coding agents, and the resources available to them.
+- [Agent skills](${SITE_URL}/ai/skills): Installable repository skills for architecture guidance, program generation, and application audits.
+- [DevTools MCP server](${SITE_URL}/ai/mcp): Connect an agent to a running Foldkit application. Published on npm as @foldkit/devtools-mcp.
+- [GitHub repository](https://github.com/foldkit/foldkit): Source code, issues, and discussions.
+- [Blog RSS feed](${SITE_URL}/blog/rss.xml): Release announcements and deep dives.`
+
 export const buildLlmsIndex = (
   entries: ReadonlyArray<LlmsIndexEntry>,
 ): string => {
@@ -353,9 +378,9 @@ export const buildLlmsIndex = (
     ),
   )
 
-  const header = `# Foldkit\n\n> ${SITE_BLURB}\n\nThis index lists every page on the Foldkit documentation site with a short description. Every page is also available as Markdown by appending \`.md\` to its URL (e.g. ${SITE_URL}/get-started/getting-started.md). A single-file concatenation of every page is available at ${SITE_URL}/llms-full.txt.`
+  const header = `# Foldkit\n\n> ${SITE_BLURB}\n\nThis index lists every page on the Foldkit documentation site with a short description. Every page is also available as Markdown by appending \`.md\` to its URL (e.g. ${SITE_URL}/get-started/getting-started.md). A single-file concatenation of every page is available at ${SITE_URL}/llms-full.txt.\n\n${WHEN_TO_USE}`
 
-  return `${header}\n\n${Array_.join(sectionBlocks, '\n\n')}\n`
+  return `${header}\n\n${DEVELOPER_RESOURCES_SECTION}\n\n${Array_.join(sectionBlocks, '\n\n')}\n`
 }
 
 // FULL

--- a/packages/website/scripts/og-image.test.ts
+++ b/packages/website/scripts/og-image.test.ts
@@ -6,10 +6,11 @@ import {
   BlogPostRoute,
   ExamplesRoute,
   HomeRoute,
+  NotFoundRoute,
   PlaygroundRoute,
 } from '../src/route'
 import { blogPosts } from './blogPosts'
-import { injectMetaTags } from './og-image'
+import { ORGANIZATION_SCHEMA, injectMetaTags } from './og-image'
 
 const resolveApiModuleName = (slug: string) => slug
 
@@ -191,6 +192,40 @@ describe('injectMetaTags', () => {
       expect(html).toContain('property="og:type" content="website"')
       expect(html).toContain('"@type":"SoftwareApplication"')
       expect(html).not.toContain('article:published_time')
+    })
+
+    it('describes the Foldkit Organization with a contact point', () => {
+      expect(ORGANIZATION_SCHEMA['@type']).toBe('Organization')
+      expect(ORGANIZATION_SCHEMA.url).toBe('https://foldkit.dev')
+      expect(ORGANIZATION_SCHEMA.logo).toBe('https://foldkit.dev/logo.svg')
+      expect(ORGANIZATION_SCHEMA.sameAs).toContain(
+        'https://github.com/foldkit/foldkit',
+      )
+      expect(ORGANIZATION_SCHEMA.contactPoint.contactType).toBe(
+        'technical support',
+      )
+      expect(ORGANIZATION_SCHEMA.contactPoint.url).toBe(
+        'https://github.com/foldkit/foldkit/issues',
+      )
+      expect(html).toContain('"@type":"Organization"')
+      expect(html).toContain('"contactPoint"')
+    })
+  })
+
+  describe('the prerendered 404 page', () => {
+    const html = injectMetaTags(
+      baseHtml,
+      NotFoundRoute({ path: '/404' }),
+      '/404',
+      resolveApiModuleName,
+    )
+
+    it('titles the page and points its social card at the 404 slug', () => {
+      expect(html).toContain('<title>Page Not Found | Foldkit</title>')
+      expect(html).toContain(
+        'property="og:image" content="https://foldkit.dev/og/404.png"',
+      )
+      expect(html).toContain('rel="canonical" href="https://foldkit.dev/404"')
     })
   })
 })

--- a/packages/website/scripts/og-image.ts
+++ b/packages/website/scripts/og-image.ts
@@ -403,6 +403,29 @@ const generatedOgImageAlt = (metadata: PageMetadata): string => {
   }
 }
 
+const ORGANIZATION_ID = `${SITE_URL}/#organization`
+
+export const ORGANIZATION_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  '@id': ORGANIZATION_ID,
+  name: 'Foldkit',
+  url: SITE_URL,
+  logo: `${SITE_URL}/logo.svg`,
+  description:
+    'Foldkit is an open source TypeScript frontend framework built on Effect, developed in the open on GitHub.',
+  sameAs: [
+    'https://github.com/foldkit/foldkit',
+    'https://www.npmjs.com/package/foldkit',
+  ],
+  contactPoint: {
+    '@type': 'ContactPoint',
+    contactType: 'technical support',
+    url: 'https://github.com/foldkit/foldkit/issues',
+    availableLanguage: 'English',
+  },
+}
+
 const SOFTWARE_APPLICATION_SCHEMA = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
@@ -412,7 +435,7 @@ const SOFTWARE_APPLICATION_SCHEMA = {
   description:
     'Foldkit is a TypeScript frontend framework built on Effect. One Schema-defined Model, explicit effects, typed routing, server rendering, and accessible UI components.',
   url: SITE_URL,
-  author: { '@type': 'Organization', name: 'Foldkit' },
+  author: { '@id': ORGANIZATION_ID },
   programmingLanguage: 'TypeScript',
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   license: 'https://opensource.org/licenses/MIT',
@@ -423,6 +446,7 @@ const WEBSITE_SCHEMA = {
   '@type': 'WebSite',
   name: 'Foldkit',
   url: SITE_URL,
+  publisher: { '@id': ORGANIZATION_ID },
   description:
     'Foldkit is a TypeScript frontend framework built on Effect. One Schema-defined Model, explicit effects, typed routing, server rendering, and accessible UI components.',
 }
@@ -431,6 +455,7 @@ const jsonLdTag = (schema: Record<string, unknown>): string =>
   `<script type="application/ld+json">${JSON.stringify(schema)}</script>`
 
 const HOMEPAGE_JSON_LD = [
+  jsonLdTag(ORGANIZATION_SCHEMA),
   jsonLdTag(SOFTWARE_APPLICATION_SCHEMA),
   jsonLdTag(WEBSITE_SCHEMA),
 ].join('\n    ')

--- a/packages/website/scripts/prerender.test.ts
+++ b/packages/website/scripts/prerender.test.ts
@@ -1,13 +1,16 @@
 import { Option } from 'effect'
 import { describe, expect, it } from 'vitest'
 
-import { SECTION_ORDER } from './markdown'
+import { SECTION_ORDER, shouldExportMarkdown } from './markdown'
 import { routeToMetadata } from './metadata'
 import {
+  NOT_FOUND_OUTPUT_PATH,
+  NOT_FOUND_ROUTE,
   STATIC_ROUTES,
   buildBlogRssFeed,
   enumerateRoutes,
   extractPostArticleHtml,
+  routeToUrlPath,
   toFeedArticleHtml,
 } from './prerender'
 
@@ -28,6 +31,20 @@ describe('enumerateRoutes', () => {
       _tag: 'ApiModule',
       moduleSlug: 'runtime',
     })
+  })
+})
+
+describe('the 404 page', () => {
+  it('prerenders at /404 into a root-level 404.html', () => {
+    expect(NOT_FOUND_ROUTE._tag).toBe('NotFound')
+    expect(routeToUrlPath(NOT_FOUND_ROUTE)).toBe('/404')
+    expect(NOT_FOUND_OUTPUT_PATH).toBe('404.html')
+  })
+
+  it('stays out of the sitemap routes and the markdown exports', () => {
+    const routes = enumerateRoutes(['html'])
+    expect(routes.filter(route => route._tag === 'NotFound')).toEqual([])
+    expect(shouldExportMarkdown(NOT_FOUND_ROUTE)).toBe(false)
   })
 })
 

--- a/packages/website/scripts/prerender.ts
+++ b/packages/website/scripts/prerender.ts
@@ -82,6 +82,7 @@ import {
   HomeRoute,
   ManifestoRoute,
   NewsletterRoute,
+  NotFoundRoute,
   PatternsInformingSubmodelsRoute,
   PatternsSubscriptionOrganizationRoute,
   PerformanceRoute,
@@ -430,7 +431,7 @@ export const routeToUrlPath = (route: AppRoute): string =>
       Newsletter: () => newsletterRouter(),
       Blog: () => blogRouter(),
       BlogPost: ({ postSlug }) => blogPostRouter({ postSlug }),
-      NotFound: () => '/',
+      NotFound: ({ path }) => path,
     }),
   )
 
@@ -696,6 +697,41 @@ const prerenderPlaygroundShells = (
     )
   })
 
+// NOT FOUND PAGE
+
+// NOTE: the static host serves this file with a real 404 status for every
+// unknown path (see scripts/website-vercel-config.mjs). Without it, unknown
+// paths answer 200 with the app shell and agents conclude every path exists.
+export const NOT_FOUND_ROUTE = NotFoundRoute({ path: '/404' })
+
+export const NOT_FOUND_OUTPUT_PATH = '404.html'
+
+const prerenderNotFoundPage = (
+  serverEntry: typeof ServerEntry,
+  baseHtml: string,
+  resolveApiModuleName: ApiModuleNameResolver,
+) =>
+  Effect.gen(function* () {
+    const captured = yield* renderRoutePage(serverEntry, NOT_FOUND_ROUTE)
+    const injectedHtml = Server.injectIntoTemplate(
+      baseHtml,
+      captured.application,
+    )
+    const outputHtml = injectMetaTags(
+      injectedHtml,
+      NOT_FOUND_ROUTE,
+      routeToUrlPath(NOT_FOUND_ROUTE),
+      resolveApiModuleName,
+    )
+
+    const fs = yield* FileSystem.FileSystem
+    yield* fs.writeFileString(
+      resolve(DIST_DIR, NOT_FOUND_OUTPUT_PATH),
+      outputHtml,
+    )
+    yield* Console.log(`  ✓ /${NOT_FOUND_OUTPUT_PATH}`)
+  })
+
 // SITEMAP
 
 const SITE_URL = 'https://foldkit.dev'
@@ -899,7 +935,11 @@ const program = Effect.scoped(
     const routes = enumerateRoutes(apiModuleSlugs)
 
     yield* generateOgImages(
-      Array.appendAll(routes, PLAYGROUND_ROUTES),
+      pipe(
+        routes,
+        Array.appendAll(PLAYGROUND_ROUTES),
+        Array.append(NOT_FOUND_ROUTE),
+      ),
       routeToUrlPath,
       DIST_DIR,
       resolveApiModuleName,
@@ -914,6 +954,8 @@ const program = Effect.scoped(
       baseHtml,
       resolveApiModuleName,
     )
+
+    yield* prerenderNotFoundPage(serverEntry, baseHtml, resolveApiModuleName)
 
     const results = yield* Effect.forEach(
       routes,

--- a/scripts/deploy-website-workflow.test.mjs
+++ b/scripts/deploy-website-workflow.test.mjs
@@ -41,6 +41,133 @@ const isolationHeadersFor = (config, pathname) =>
     ),
   )
 
+// NOTE: a minimal model of Vercel's routing phases: initial routes run in order
+// (accumulating headers from `continue` routes, stopping on a redirect or a
+// rewrite), the filesystem serves exact files and directory indexes, and the
+// routes after `handle: filesystem` decide what a missing file becomes.
+const DEPLOYED_FILES = new Set([
+  'index.html',
+  'index.md',
+  '404.html',
+  '404.md',
+  '404.json',
+  'core/model/index.html',
+  'core/model.md',
+  'newsletter/index.html',
+  'playground/index.html',
+  'playground/counter/index.html',
+  'get-started/getting-started/index.html',
+  'get-started/getting-started.md',
+  'llms.txt',
+  'llms-full.txt',
+  'sitemap.xml',
+  'openapi.json',
+  '.well-known/mcp',
+  'blog/rss.xml',
+])
+
+const splitPhases = routes => {
+  const filesystemIndex = routes.findIndex(
+    route => route.handle === 'filesystem',
+  )
+  assert.notEqual(filesystemIndex, -1)
+  return {
+    initial: routes.slice(0, filesystemIndex),
+    postFilesystem: routes.slice(filesystemIndex + 1),
+  }
+}
+
+const routeMatches = (route, pathname, accept) => {
+  if (typeof route.src !== 'string') {
+    return false
+  }
+  if (!new RegExp(route.src).test(pathname)) {
+    return false
+  }
+  if (route.has === undefined) {
+    return true
+  }
+  return route.has.every(
+    condition =>
+      condition.type === 'header' &&
+      condition.key === 'accept' &&
+      new RegExp(condition.value).test(accept),
+  )
+}
+
+const applyDest = (route, pathname) => {
+  const captures = new RegExp(route.src).exec(pathname)
+  return route.dest.replace(/\$(\d)/g, (_, index) => captures[Number(index)])
+}
+
+const filesystemFileFor = pathname => {
+  const relative = pathname.replace(/^\//, '')
+  const directory = relative.replace(/\/$/, '')
+  if (directory === '' && DEPLOYED_FILES.has('index.html')) {
+    return 'index.html'
+  }
+  if (DEPLOYED_FILES.has(relative)) {
+    return relative
+  }
+  if (DEPLOYED_FILES.has(`${directory}/index.html`)) {
+    return `${directory}/index.html`
+  }
+  return undefined
+}
+
+const resolveRequest = (config, pathname, accept = '*/*') => {
+  const { initial, postFilesystem } = splitPhases(config.routes)
+  const headers = {}
+  let currentPath = pathname
+
+  for (const route of initial) {
+    if (!routeMatches(route, currentPath, accept)) {
+      continue
+    }
+    Object.assign(headers, route.headers)
+    if (route.status !== undefined && route.dest === undefined) {
+      return {
+        kind: 'redirect',
+        status: route.status,
+        location: route.headers.Location,
+      }
+    }
+    if (route.dest !== undefined) {
+      currentPath = applyDest(route, currentPath)
+      break
+    }
+    if (route.continue !== true) {
+      break
+    }
+  }
+
+  const initialMatch = filesystemFileFor(currentPath)
+  if (initialMatch !== undefined) {
+    return { kind: 'file', servedFile: initialMatch, status: 200, headers }
+  }
+
+  for (const route of postFilesystem) {
+    if (!routeMatches(route, currentPath, accept)) {
+      continue
+    }
+    Object.assign(headers, route.headers)
+    if (route.dest !== undefined) {
+      const servedFile = filesystemFileFor(applyDest(route, currentPath))
+      assert.notEqual(
+        servedFile,
+        undefined,
+        `Fallback dest ${route.dest} names a file the build does not emit.`,
+      )
+      return { kind: 'file', servedFile, status: route.status ?? 200, headers }
+    }
+    if (route.continue !== true) {
+      break
+    }
+  }
+
+  return { kind: 'miss', status: 404, headers }
+}
+
 test('the deployed playground and Monaco workers share an embedder policy', () => {
   assert.deepEqual(isolationHeadersFor(productionConfig, '/playground/ssr'), {
     'Cross-Origin-Embedder-Policy': 'credentialless',
@@ -64,6 +191,164 @@ test('the deployed playground and Monaco workers share an embedder policy', () =
   assert.equal(
     workerEmbedderRoutes.every(route => route.continue === true),
     true,
+  )
+})
+
+test('unknown paths return a real 404 in the format the client asked for', () => {
+  const asAgent = resolveRequest(
+    productionConfig,
+    '/some-path-that-does-not-exist',
+  )
+  assert.equal(asAgent.status, 404)
+  assert.equal(asAgent.servedFile, '404.md')
+  assert.equal(asAgent.headers['Content-Type'], 'text/markdown; charset=utf-8')
+
+  const asBrowser = resolveRequest(
+    productionConfig,
+    '/some-path-that-does-not-exist',
+    'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  )
+  assert.equal(asBrowser.status, 404)
+  assert.equal(asBrowser.servedFile, '404.html')
+
+  const asJsonClient = resolveRequest(
+    productionConfig,
+    '/some-path-that-does-not-exist',
+    'application/json',
+  )
+  assert.equal(asJsonClient.status, 404)
+  assert.equal(asJsonClient.servedFile, '404.json')
+  assert.equal(
+    asJsonClient.headers['Content-Type'],
+    'application/json; charset=utf-8',
+  )
+})
+
+test('every 404 variant tells caches the response depends on Accept', () => {
+  for (const accept of ['*/*', 'text/html', 'application/json']) {
+    const result = resolveRequest(productionConfig, '/nope', accept)
+    assert.equal(result.status, 404)
+    assert.match(result.headers.Vary, /Accept\b/)
+  }
+})
+
+test('Accept: text/markdown negotiates the markdown variant of a page', () => {
+  const page = resolveRequest(productionConfig, '/core/model', 'text/markdown')
+  assert.equal(page.status, 200)
+  assert.equal(page.servedFile, 'core/model.md')
+  assert.equal(page.headers['Content-Type'], 'text/markdown; charset=utf-8')
+  assert.match(page.headers.Vary, /Accept\b/)
+
+  const home = resolveRequest(productionConfig, '/', 'text/markdown')
+  assert.equal(home.servedFile, 'index.md')
+  assert.equal(home.headers['Content-Type'], 'text/markdown; charset=utf-8')
+
+  const trailingSlash = resolveRequest(
+    productionConfig,
+    '/core/model/',
+    'text/markdown',
+  )
+  assert.equal(trailingSlash.servedFile, 'core/model.md')
+})
+
+test('HTML page responses carry Vary: Accept so caches keep variants apart', () => {
+  const page = resolveRequest(productionConfig, '/core/model', 'text/html')
+  assert.equal(page.status, 200)
+  assert.equal(page.servedFile, 'core/model/index.html')
+  assert.match(page.headers.Vary, /Accept\b/)
+
+  const markdownFile = resolveRequest(productionConfig, '/core/model.md')
+  assert.equal(markdownFile.servedFile, 'core/model.md')
+  assert.equal(
+    markdownFile.headers['Content-Type'],
+    'text/markdown; charset=utf-8',
+  )
+  assert.match(markdownFile.headers.Vary, /Accept\b/)
+})
+
+test('pages without a markdown variant fall back to HTML instead of 404', () => {
+  for (const pathname of ['/newsletter', '/newsletter/']) {
+    const newsletter = resolveRequest(
+      productionConfig,
+      pathname,
+      'text/markdown',
+    )
+    assert.equal(newsletter.status, 200, pathname)
+    assert.equal(newsletter.servedFile, 'newsletter/index.html', pathname)
+  }
+
+  const playground = resolveRequest(
+    productionConfig,
+    '/playground/counter',
+    'text/markdown',
+  )
+  assert.equal(playground.status, 200)
+  assert.equal(playground.servedFile, 'playground/counter/index.html')
+})
+
+test('a nonexistent .md path answers a browser with HTML, not markdown', () => {
+  const result = resolveRequest(
+    productionConfig,
+    '/renamed-page.md',
+    'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  )
+  assert.equal(result.status, 404)
+  assert.equal(result.servedFile, '404.html')
+  assert.equal(result.headers['Content-Type'], 'text/html; charset=utf-8')
+})
+
+test('/404 never answers 200, whatever format the client asks for', () => {
+  const asAgent = resolveRequest(productionConfig, '/404', 'text/markdown')
+  assert.equal(asAgent.status, 404)
+  assert.equal(asAgent.servedFile, '404.md')
+
+  const asBrowser = resolveRequest(productionConfig, '/404', 'text/html')
+  assert.equal(asBrowser.status, 404)
+  assert.equal(asBrowser.servedFile, '404.html')
+})
+
+test('unknown playground slugs still load the shared editor shell', () => {
+  const result = resolveRequest(productionConfig, '/playground/unknown-slug')
+  assert.equal(result.status, 200)
+  assert.equal(result.servedFile, 'playground/index.html')
+})
+
+test('the developer portal path redirects to the AI overview', () => {
+  const result = resolveRequest(productionConfig, '/developers')
+  assert.equal(result.kind, 'redirect')
+  assert.equal(result.status, 308)
+  assert.equal(result.location, '/ai/overview')
+  assert.equal(
+    resolveRequest(productionConfig, '/developers/').location,
+    '/ai/overview',
+  )
+})
+
+test('the MCP manifest and OpenAPI description are served as JSON', () => {
+  const manifest = resolveRequest(productionConfig, '/.well-known/mcp')
+  assert.equal(manifest.status, 200)
+  assert.equal(manifest.servedFile, '.well-known/mcp')
+  assert.equal(
+    manifest.headers['Content-Type'],
+    'application/json; charset=utf-8',
+  )
+
+  const spec = resolveRequest(productionConfig, '/openapi.json')
+  assert.equal(spec.status, 200)
+  assert.equal(spec.servedFile, 'openapi.json')
+})
+
+test('the homepage advertises the OpenAPI description in its Link header', () => {
+  assert.match(
+    headersFor(productionConfig, '/').Link,
+    /<\/openapi\.json>; rel="service-desc"/,
+  )
+})
+
+test('the deploy workflow copies dotfiles like .well-known into the Vercel output', () => {
+  assert.match(
+    buildWorkflow,
+    /cp -r packages\/website\/dist\/\. \.vercel\/output\/static\//,
   )
 })
 

--- a/scripts/website-vercel-config.mjs
+++ b/scripts/website-vercel-config.mjs
@@ -15,6 +15,25 @@ const sharedResponseHeaders = channel => {
   }
 }
 
+const NEGOTIATED_VARY = 'Accept, Accept-Encoding'
+
+const markdownResponseHeaders = {
+  'Content-Type': 'text/markdown; charset=utf-8',
+  Vary: NEGOTIATED_VARY,
+}
+
+const acceptsMediaType = mediaType => [
+  { type: 'header', key: 'accept', value: `.*${mediaType}.*` },
+]
+
+// NOTE: Newsletter and the playground editor render as HTML only; every other
+// extensionless page has a prerendered `.md` sibling. Excluding the two here
+// lets an `Accept: text/markdown` request for them fall back to HTML instead
+// of turning an existing page into a 404. `/404` is excluded so the error
+// document is never served with a 200 status.
+const MARKDOWN_PAGE_PATTERN =
+  '^/(?!playground(?:/|$)|newsletter(?:/|$)|404(?:/|$))([^.]+?)/?$'
+
 export const websiteVercelConfig = channel => {
   if (channel !== 'production' && channel !== 'canary') {
     throw new Error(`Unknown website deployment channel: ${channel}`)
@@ -34,7 +53,22 @@ export const websiteVercelConfig = channel => {
       {
         src: '^/$',
         headers: {
-          Link: '</sitemap.xml>; rel="sitemap", </get-started/manifesto>; rel="about", </get-started/getting-started>; rel="help", </example-apps>; rel="related", </ai/overview>; rel="describedby"',
+          Link: '</sitemap.xml>; rel="sitemap", </get-started/manifesto>; rel="about", </get-started/getting-started>; rel="help", </example-apps>; rel="related", </ai/overview>; rel="describedby", </openapi.json>; rel="service-desc"',
+        },
+        continue: true,
+      },
+      {
+        src: '^/.+\\.md$',
+        headers: {
+          ...markdownResponseHeaders,
+          'Cache-Control': 'public, max-age=0, must-revalidate',
+        },
+        continue: true,
+      },
+      {
+        src: '^/\\.well-known/mcp$',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
         },
         continue: true,
       },
@@ -69,8 +103,14 @@ export const websiteVercelConfig = channel => {
         src: '^/([^.]*)$',
         headers: {
           'Cache-Control': 'public, max-age=0, must-revalidate',
+          Vary: NEGOTIATED_VARY,
         },
         continue: true,
+      },
+      {
+        src: '^/developers/?$',
+        status: 308,
+        headers: { Location: '/ai/overview' },
       },
       {
         src: '^/manifesto$',
@@ -207,6 +247,18 @@ export const websiteVercelConfig = channel => {
         status: 308,
         headers: { Location: '/blog/foldkit-has-server-rendering.md' },
       },
+      {
+        src: '^/$',
+        has: acceptsMediaType('text/markdown'),
+        dest: '/index.md',
+        headers: markdownResponseHeaders,
+      },
+      {
+        src: MARKDOWN_PAGE_PATTERN,
+        has: acceptsMediaType('text/markdown'),
+        dest: '/$1.md',
+        headers: markdownResponseHeaders,
+      },
       { handle: 'filesystem' },
       {
         src: '/',
@@ -214,7 +266,32 @@ export const websiteVercelConfig = channel => {
         dest: '/example-apps-embed/$slug/index.html',
       },
       { src: '/playground/(.*)', dest: '/playground/index.html' },
-      { src: '/(.*)', dest: '/index.html' },
+      {
+        src: '/(.*)',
+        has: acceptsMediaType('application/json'),
+        dest: '/404.json',
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          Vary: NEGOTIATED_VARY,
+        },
+      },
+      {
+        src: '/(.*)',
+        has: acceptsMediaType('text/html'),
+        dest: '/404.html',
+        status: 404,
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          Vary: NEGOTIATED_VARY,
+        },
+      },
+      {
+        src: '/(.*)',
+        dest: '/404.md',
+        status: 404,
+        headers: markdownResponseHeaders,
+      },
     ],
   }
 }


### PR DESCRIPTION
Unknown paths currently answer 200 with the app shell, so agents probing for resources conclude every path exists. Serve a real 404 instead: prerender the NotFound view to 404.html, and answer unknown paths with status 404 as HTML for browsers, as a Markdown pointer to llms.txt and the sitemap by default, and as a structured JSON error for clients that ask for application/json. The 404 page itself is excluded from negotiation, so /404 answers status 404 in every format.

Negotiate Markdown on page URLs: a request with `Accept: text/markdown` receives the page's prerendered `.md` sibling with a text/markdown content type, and both variants carry `Vary: Accept, Accept-Encoding` so caches keep them apart. Newsletter and the playground, which have no Markdown sibling, fall back to HTML, trailing-slash forms included.

Describe the machine-readable surface in an OpenAPI 3.1 document at /openapi.json, publish an MCP discovery manifest at /.well-known/mcp for @foldkit/devtools-mcp, and redirect /developers to /ai/overview. Extend llms.txt with when-to-use guidance and a Developer Resources section, expand the homepage Organization JSON-LD with a logo, sameAs links, and a contact point, and advertise the OpenAPI document in the homepage Link header and robots.txt.

The deploy workflow now copies dist with the dot form so dotted paths like .well-known reach the Vercel output.