### PR TITLE
docs: explain canary testing and require pre-push review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ If a Mount factory doesn't read or write its element, you've misidentified the c
 - Do not co-author or mention AI assistants in commit messages or release notes.
 - Use the repo's commit helper when asked to create a commit: `/commit` in Claude Code, `.agents/skills/commit-changes` in Codex.
 - Treat every pull request title and description as the final squash commit message. The title is the Conventional Commit subject, and the description is the commit body. Keep review-only boilerplate, checklists, generated commit lists, and verification details out of the description. Put verification details in a pull request comment instead.
+- After creating or amending a commit, have a separate agent review the exact committed diff before pushing it or opening a PR. Treat the review as a gate: address every finding, amend the commit, and have the amended commit reviewed again. Only push or open the PR after the latest commit passes review.
 - Squash-merge only. `gh pr merge --squash`.
 
 ## Editing Rules

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -65,6 +65,21 @@ the workflow summary prints every exact package version and the exact
 `create-foldkit-app` command. Rerunning a commit uses the same versions and
 skips artifacts that already match.
 
+For a new project, run the exact `create-foldkit-app` command from the workflow
+summary. For an existing project, install every Foldkit package the project
+uses at the version printed beside that package. For example:
+
+```sh
+pnpm add --save-exact \
+  "foldkit@0.148.2-canary.0123456789ab" \
+  "@foldkit/ui@0.148.2-canary.0123456789ab"
+pnpm add --save-exact -D "@foldkit/vite-plugin@0.16.1-canary.0123456789ab"
+```
+
+The numeric version prefix can differ between packages. The shared commit
+suffix identifies the coherent snapshot, so update every Foldkit package in the
+project together.
+
 ## create-foldkit-app inputs
 
 `create-foldkit-app` carries its scaffold sources in the package tarball. The


### PR DESCRIPTION
Document how new and existing projects consume commit-addressed canary
versions without relying on moving npm tags.

Require a separate agent to review each committed diff before it is pushed or
proposed, including another review after amendments.