### PR TITLE
fix(ci): skip published SSG build for canaries

### DIFF
--- a/.github/workflows/deploy-website-build.yml
+++ b/.github/workflows/deploy-website-build.yml
@@ -65,6 +65,7 @@ jobs:
         run: pnpm check:published-versions -- --wait
 
       - name: Build the exact transformed SSG playground
+        if: inputs.channel == 'production'
         run: pnpm check:playground-ssg-build
 
       - name: Build core packages

--- a/scripts/deploy-website-workflow.test.mjs
+++ b/scripts/deploy-website-workflow.test.mjs
@@ -421,3 +421,10 @@ test('production deployment requires the complete promoted npm snapshot', () => 
     /- name: Verify the complete promoted package release\n\s+if: inputs\.channel == 'production'\n\s+run: pnpm release:verify-latest/,
   )
 })
+
+test('the registry-backed SSG playground build runs only for production', () => {
+  assert.match(
+    buildWorkflow,
+    /- name: Build the exact transformed SSG playground\n\s+if: inputs\.channel == 'production'\n\s+run: pnpm check:playground-ssg-build/,
+  )
+})


### PR DESCRIPTION
Canary deployments build examples from main, which may use APIs unavailable in
the current npm release. Keep the registry-backed transformed SSG check on the
production path where the examples and published packages are aligned.