### PR TITLE
docs(website): update the benchmark table from a fresh 14-implementation batch

### DIFF
--- a/packages/website/src/page/performance.md
+++ b/packages/website/src/page/performance.md
@@ -29,31 +29,30 @@ Keep `Message.match` anyway. Its signature requires a handler for every tag in t
 
 Foldkit ships a TodoMVC implementation for the [lustre-labs/benchmark](https://github.com/lustre-labs/benchmark) harness, which drives each implementation through the same TodoMVC workload and required selectors (add 100 todos, toggle each one, destroy the first one 100 times). Same-batch timings are comparable because every implementation uses the same driver, runbook, and browser batch. Foldkit registers two slots: an unoptimized view that rebuilds the entire tree on every Message with no memoization, and an optimized view that adds `createLazy` slots for the header, the footer, the filters list, and the toggle-all controls, and `createKeyedLazy` per todo item. The Model and update logic are identical in both. The implementation lives [in the Foldkit repo](https://github.com/foldkit/foldkit/tree/main/internal/lustre-benchmark), so you can run the comparison yourself.
 
-These cover every current-version framework variant in the harness plus Foldkit’s two current development slots; the legacy Lustre 4 and older Foldkit slots are excluded. The medians come from fifteen interleaved runs in one position-balanced batch, so every implementation occupied every ordinal run position once. The batch used harness commit 03fff17 and Chromium 149.0.7827.55. The relative column divides each displayed median by the fastest median from that same batch. A parenthesized label appears only where the harness registers both a baseline and a memoized slot. Solid and Alpine drive the DOM without a diff to skip, so each registers one implementation and its row carries a bare name. Absolute times depend on hardware and browser conditions; the same-run relationships are the result to compare.
+The batch covers fourteen slots: Foldkit’s two current development slots, plus the current-version variants of Elm, Gren, Lustre 5, React 19, Solid, Svelte, and Vue. The medians come from fourteen interleaved runs in one position-balanced batch, so every implementation occupied every ordinal run position once. The batch used harness commit 03fff17 and Chromium 141.0.7390.37. The relative column divides each displayed median by the fastest median from that same batch. A parenthesized label appears only where the harness registers both a baseline and a memoized slot. Solid and Vue drive the DOM without a diff to skip, so each registers one implementation and its row carries a bare name. Absolute times depend on hardware and browser conditions; the same-run relationships are the result to compare.
 
 | Implementation         | Median time | Relative to fastest |
 | ---------------------- | ----------- | ------------------- |
-| Svelte (optimized)     | 59.2ms      | 1.00×               |
-| Gren (optimized)       | 70.6ms      | 1.19×               |
-| Elm (optimized)        | 72.7ms      | 1.23×               |
-| Svelte (unoptimized)   | 79.1ms      | 1.34×               |
-| Solid                  | 86.7ms      | 1.46×               |
-| Lustre 5 (optimized)   | 97.1ms      | 1.64×               |
-| Foldkit (optimized)    | 119.3ms     | 2.02×               |
-| Vue (unoptimized)      | 134.2ms     | 2.27×               |
-| React 19 (optimized)   | 136.1ms     | 2.30×               |
-| Gren (unoptimized)     | 159.3ms     | 2.69×               |
-| Elm (unoptimized)      | 161.4ms     | 2.73×               |
-| Lustre 5 (unoptimized) | 169.0ms     | 2.85×               |
-| React 19 (unoptimized) | 198.9ms     | 3.36×               |
-| Alpine                 | 258.1ms     | 4.36×               |
-| Foldkit (unoptimized)  | 352.9ms     | 5.96×               |
+| Svelte (optimized)     | 69.4ms      | 1.00×               |
+| Svelte (unoptimized)   | 90.6ms      | 1.31×               |
+| Elm (optimized)        | 102.2ms     | 1.47×               |
+| Gren (optimized)       | 105.7ms     | 1.52×               |
+| Solid                  | 108.0ms     | 1.56×               |
+| Lustre 5 (optimized)   | 142.6ms     | 2.05×               |
+| Foldkit (optimized)    | 159.3ms     | 2.30×               |
+| React 19 (optimized)   | 169.3ms     | 2.44×               |
+| Vue                    | 188.9ms     | 2.72×               |
+| Elm (unoptimized)      | 238.4ms     | 3.44×               |
+| Gren (unoptimized)     | 238.8ms     | 3.44×               |
+| Lustre 5 (unoptimized) | 250.1ms     | 3.60×               |
+| React 19 (unoptimized) | 255.5ms     | 3.68×               |
+| Foldkit (unoptimized)  | 343.1ms     | 4.94×               |
 
 ### Reading the numbers
 
-Foldkit optimized ranks seventh of fifteen in this batch. It takes 2.02 times the fastest row, about 1.23 times optimized Lustre’s time, and 1.38 times Solid’s. Vue takes about 1.12 times Foldkit’s time, while optimized React takes about 1.14 times Foldkit’s. Per-bucket attribution puts the remaining distance in view and patch work inside animation frames rather than Message dispatch.
+Foldkit optimized ranks seventh of fourteen in this batch. It takes 2.30 times the fastest row, about 1.12 times optimized Lustre’s time, and 1.48 times Solid’s. Vue takes about 1.19 times Foldkit’s time, while optimized React takes about 1.06 times Foldkit’s. Per-bucket attribution puts the remaining distance in view and patch work inside animation frames rather than Message dispatch.
 
-Elm is the proof of what this architecture can do. Elm renders a pure view into a virtual DOM with lazy memoization, exactly Foldkit’s design, and sits near the batch leaders at 1.23 times the fastest row. Foldkit takes 1.64 times Elm’s time. That distance is runtime implementation, not architecture, which is why optimization work targets the runtime and owned differ rather than replacing the rendering model.
+Elm is the proof of what this architecture can do. Elm renders a pure view into a virtual DOM with lazy memoization, exactly Foldkit’s design, and sits near the batch leaders at 1.47 times the fastest row. Foldkit takes 1.56 times Elm’s time. That distance is runtime implementation, not architecture, which is why optimization work targets the runtime and owned differ rather than replacing the rendering model.
 
 ## Development mode is not production
 


### PR DESCRIPTION
Re-ran the lustre-labs/benchmark harness at commit 03fff17 and replaced the published medians. The previous numbers were measured before the callable constructor speedup landed, so they understated current performance.

Against the animation-frame cohort (Elm, Gren, Lustre), which schedules renders the same way Foldkit does and so shares any host timing bias, the optimized slot gained about 9 percent and the unoptimized slot about 34 percent. Foldkit holds its rank: seventh of fourteen optimized, last unoptimized.

The relative-to-fastest column moved for every row in the batch, Foldkit's included, because the batch ran on different hardware and a different Chromium build. Elm and Gren optimized moved from 1.19 and 1.23 to 1.47 and 1.52 on frozen code, so that column tracks the host rather than framework change. Per-comparator ratios within one scheduling family are what the paragraph above reports.

The methodology paragraph now names the slots the batch covers rather than claiming to cover every variant the harness registers.

Vue loses its parenthesized label. The harness registers one Vue slot, so a bare name is what the paragraph's own rule calls for.

https://claude.ai/code/session_012qSMEALNtEDWyxpKJNhqwY