### PR TITLE
fix(website): deploy canaries with matching packages

### DIFF
--- a/.github/workflows/deploy-website-canary.yml
+++ b/.github/workflows/deploy-website-canary.yml
@@ -1,29 +1,23 @@
 name: Deploy Website Canary
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/website/**'
-      - 'packages/foldkit/**'
-      - 'packages/ui/**'
-      - 'packages/devtools/**'
-      - 'packages/markdown/**'
-      - 'packages/vite-plugin-foldkit/**'
-      - 'examples/**'
-      - 'scripts/build-examples.ts'
-      - 'scripts/check-playground-ssg-build.ts'
-      - 'scripts/example-bridge.js'
-      - 'scripts/restore-website-fonts.sh'
-      - 'scripts/website-vercel-config.mjs'
-      - '.npmrc'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'tsconfig.base.json'
-      - '.github/workflows/deploy-website-build.yml'
-      - '.github/workflows/deploy-website-canary.yml'
+  workflow_call:
+    inputs:
+      target:
+        description: Commit whose verified package snapshot to deploy
+        required: true
+        type: string
+    secrets:
+      VERCEL_TOKEN:
+        required: true
+      VERCEL_ORG_ID:
+        required: true
+      VERCEL_WEBSITE_CANARY_PROJECT_ID:
+        required: true
+      ABC_FAVORIT_BOOK_WOFF2_BASE64:
+        required: true
+      ABC_FAVORIT_LIGHT_WOFF2_BASE64:
+        required: true
 
 concurrency:
   group: deploy-website-canary
@@ -36,7 +30,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy-website-build.yml
     with:
-      target: ${{ github.sha }}
+      target: ${{ inputs.target }}
       channel: canary
       hostname: canary.foldkit.dev
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,21 @@ on:
       - 'scripts/check-changeset-ignore.mjs'
       - 'scripts/check-create-foldkit-app-smoke.ts'
       - 'scripts/check-peer-floors.ts'
+      - 'scripts/build-examples.ts'
       - 'scripts/build-public-packages.mjs'
+      - 'scripts/check-playground-ssg-build.ts'
       - 'scripts/coherent-release.mjs'
+      - 'scripts/example-bridge.js'
       - 'scripts/lib/coherent-release.mjs'
+      - 'scripts/lib/package-version.mjs'
       - 'scripts/lib/workspace-packages.mjs'
       - 'scripts/reset-peer-deps.ts'
+      - 'scripts/restore-website-fonts.sh'
+      - 'scripts/website-vercel-config.mjs'
+      - '.npmrc'
+      - 'tsconfig.base.json'
+      - '.github/workflows/deploy-website-build.yml'
+      - '.github/workflows/deploy-website-canary.yml'
       - '.github/workflows/release.yml'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -120,6 +130,13 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
           SKIP_SIMPLE_GIT_HOOKS: '1'
+
+  deploy-website-canary:
+    needs: canary
+    uses: ./.github/workflows/deploy-website-canary.yml
+    with:
+      target: ${{ github.sha }}
+    secrets: inherit
 
   finalize:
     name: Verify stable promotion

--- a/knip.json
+++ b/knip.json
@@ -9,7 +9,10 @@
         "scripts/fixtures/host-parity/vite.config.ts"
       ],
       "project": ["scripts/**"],
-      "ignoreFiles": ["scripts/fixtures/packed-ssr-consumer/**"]
+      "ignoreFiles": [
+        "scripts/fixtures/packed-ssr-consumer/**",
+        "scripts/lib/package-version.d.mts"
+      ]
     },
     "packages/foldkit": {
       "entry": [

--- a/packages/website/scripts/exampleBuildScripts.test.ts
+++ b/packages/website/scripts/exampleBuildScripts.test.ts
@@ -3,6 +3,7 @@ import { dirname, extname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
+import { canaryVersion } from '../../../scripts/lib/package-version.mjs'
 import { EXAMPLE_FILE_EXTENSIONS, EXAMPLE_SOURCE_ROOTS } from '../vite.config'
 import {
   INCLUDED_EXTENSIONS,
@@ -13,6 +14,7 @@ import {
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 
 const SERVER_RENDERED_EXAMPLES = ['ssr', 'ssg']
+const CANARY_COMMIT = '0123456789abcdef0123456789abcdef01234567'
 
 const buildScriptOf = (slug: string): string => {
   const manifest: Readonly<{ scripts: Readonly<Record<string, string>> }> =
@@ -95,6 +97,48 @@ describe('server-rendered example build scripts', () => {
         if (dependencies[name] !== undefined) {
           expect(dependencies[name], `${slug}: ${name}`).toBe(version)
         }
+      }
+    }
+  })
+
+  it('pins canary playground dependencies to the commit-addressed snapshot', async () => {
+    const previousCanaryCommit = process.env['VITE_FOLDKIT_CANARY_COMMIT']
+    delete process.env['VITE_FOLDKIT_CANARY_COMMIT']
+
+    const stableVersions = await loadPlaygroundWorkspacePackageVersions()
+    process.env['VITE_FOLDKIT_CANARY_COMMIT'] = CANARY_COMMIT
+
+    try {
+      const bySlug = await loadPlaygroundFiles()
+
+      for (const [slug, { files }] of Object.entries(bySlug)) {
+        const source = files['package.json']
+        if (source === undefined) {
+          throw new Error(`the ${slug} playground omits package.json`)
+        }
+
+        const manifest: Readonly<{
+          dependencies?: Readonly<Record<string, string>>
+          devDependencies?: Readonly<Record<string, string>>
+        }> = JSON.parse(source)
+        const dependencies = {
+          ...(manifest.dependencies ?? {}),
+          ...(manifest.devDependencies ?? {}),
+        }
+
+        for (const [name, stableVersion] of Object.entries(stableVersions)) {
+          if (dependencies[name] !== undefined) {
+            expect(dependencies[name], `${slug}: ${name}`).toBe(
+              canaryVersion(stableVersion, CANARY_COMMIT),
+            )
+          }
+        }
+      }
+    } finally {
+      if (previousCanaryCommit === undefined) {
+        delete process.env['VITE_FOLDKIT_CANARY_COMMIT']
+      } else {
+        process.env['VITE_FOLDKIT_CANARY_COMMIT'] = previousCanaryCommit
       }
     }
   })

--- a/packages/website/scripts/playgroundFilesPlugin.ts
+++ b/packages/website/scripts/playgroundFilesPlugin.ts
@@ -4,6 +4,7 @@ import { dirname, extname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Plugin } from 'vite'
 
+import { canaryVersion } from '../../../scripts/lib/package-version.mjs'
 import { exampleSlugs } from '../src/page/example/meta'
 
 const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url))
@@ -131,6 +132,17 @@ const rewriteWorkspaceSpec =
     }
     return versions[name] ?? specifier
   }
+
+const versionForDeployment = (
+  version: string,
+  canaryCommit: string | undefined,
+): string => {
+  if (canaryCommit === undefined) {
+    return version
+  } else {
+    return canaryVersion(version, canaryCommit)
+  }
+}
 
 const rewriteDependencyMap = (
   dependencies: DependencySpec | undefined,
@@ -338,13 +350,18 @@ export const playgroundFilesPlugin = (): Plugin => ({
 export const loadPlaygroundWorkspacePackageVersions = async (): Promise<
   Readonly<Record<string, string>>
 > => {
+  const canaryCommit = process.env['VITE_FOLDKIT_CANARY_COMMIT']
   const entries = await Promise.all(
     Object.entries(WORKSPACE_PACKAGE_JSON_PATHS).map(
       async ([name, packageJsonPath]) => {
         const packageJson: { version: string } = JSON.parse(
           await readFile(packageJsonPath, 'utf-8'),
         )
-        return [name, packageJson.version] as const
+
+        return [
+          name,
+          versionForDeployment(packageJson.version, canaryCommit),
+        ] as const
       },
     ),
   )

--- a/scripts/lib/coherent-release.mjs
+++ b/scripts/lib/coherent-release.mjs
@@ -6,11 +6,14 @@ import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
 import semver from 'semver'
 
+import { canaryVersion } from './package-version.mjs'
 import {
   assertCompleteReleaseSet,
   publicWorkspacePackages,
   readWorkspacePackages,
 } from './workspace-packages.mjs'
+
+export { canaryVersion }
 
 export const REGISTRY = 'https://registry.npmjs.org'
 
@@ -76,20 +79,6 @@ export class NpmRegistry {
 
     return response.json()
   }
-}
-
-export const canaryVersion = (version, commit) => {
-  const parsed = semver.parse(version)
-
-  if (parsed === null) {
-    return fail(`cannot create a canary from invalid version ${version}`)
-  }
-
-  if (!/^[0-9a-f]{7,40}$/i.test(commit)) {
-    return fail(`cannot create a canary from invalid commit ${commit}`)
-  }
-
-  return `${parsed.major}.${parsed.minor}.${parsed.patch}-canary.${commit.slice(0, 12)}`
 }
 
 const internalDependencyFields = [

--- a/scripts/lib/package-version.d.mts
+++ b/scripts/lib/package-version.d.mts
@@ -1,0 +1,1 @@
+export declare const canaryVersion: (version: string, commit: string) => string

--- a/scripts/lib/package-version.mjs
+++ b/scripts/lib/package-version.mjs
@@ -1,0 +1,19 @@
+import semver from 'semver'
+
+const fail = message => {
+  throw new Error(message)
+}
+
+export const canaryVersion = (version, commit) => {
+  const parsed = semver.parse(version)
+
+  if (parsed === null) {
+    return fail(`cannot create a canary from invalid version ${version}`)
+  }
+
+  if (!/^[0-9a-f]{7,40}$/i.test(commit)) {
+    return fail(`cannot create a canary from invalid commit ${commit}`)
+  }
+
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}-canary.${commit.slice(0, 12)}`
+}

--- a/scripts/plan-ci.mjs
+++ b/scripts/plan-ci.mjs
@@ -119,9 +119,12 @@ const website =
       '.github/workflows/deploy-website-build.yml',
       '.github/workflows/deploy-website-canary.yml',
       '.github/workflows/deploy-website.yml',
+      '.github/workflows/release.yml',
       'scripts/build-examples.ts',
       'scripts/check-playground-ssg-build.ts',
       'scripts/example-bridge.js',
+      'scripts/lib/package-version.d.mts',
+      'scripts/lib/package-version.mjs',
       'scripts/website-vercel-config.mjs',
     ],
     prefixes: [

--- a/scripts/plan-ci.test.mjs
+++ b/scripts/plan-ci.test.mjs
@@ -220,6 +220,9 @@ test('website deployment infrastructure selects the website scope', () => {
   for (const file of [
     '.github/workflows/deploy-website-build.yml',
     '.github/workflows/deploy-website-canary.yml',
+    '.github/workflows/release.yml',
+    'scripts/lib/package-version.d.mts',
+    'scripts/lib/package-version.mjs',
     'scripts/website-vercel-config.mjs',
   ]) {
     assert.equal(planCiForFile(file)['website'], 'true', file)

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -9,6 +9,10 @@ const workflow = readFileSync(
   resolve(REPO_ROOT, '.github/workflows/release.yml'),
   'utf8',
 )
+const canaryWorkflow = readFileSync(
+  resolve(REPO_ROOT, '.github/workflows/deploy-website-canary.yml'),
+  'utf8',
+)
 const rootPackage = JSON.parse(
   readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
 )
@@ -32,6 +36,34 @@ test('canaries publish from the trusted release workflow and use exact snapshots
   assert.match(workflow, /^\s+- 'packages\/\*\*'$/m)
   assert.match(workflow, /^\s+- 'examples\/\*\*'$/m)
   assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/)
+})
+
+test('website canaries deploy only after their package snapshot is verified', () => {
+  const packageCanary = workflow.indexOf('\n  canary:')
+  const websiteCanary = workflow.indexOf('\n  deploy-website-canary:')
+
+  assert.ok(packageCanary > 0)
+  assert.ok(websiteCanary > packageCanary)
+  assert.match(
+    workflow,
+    /deploy-website-canary:\n\s+needs: canary\n\s+uses: \.\/\.github\/workflows\/deploy-website-canary\.yml\n\s+with:\n\s+target: \$\{\{ github\.sha \}\}/,
+  )
+  assert.match(canaryWorkflow, /workflow_call:/)
+  assert.doesNotMatch(canaryWorkflow, /\n  push:/)
+
+  for (const path of [
+    '.npmrc',
+    'scripts/build-examples.ts',
+    'scripts/check-playground-ssg-build.ts',
+    'scripts/example-bridge.js',
+    'scripts/restore-website-fonts.sh',
+    'scripts/website-vercel-config.mjs',
+    'tsconfig.base.json',
+    '.github/workflows/deploy-website-build.yml',
+    '.github/workflows/deploy-website-canary.yml',
+  ]) {
+    assert.match(workflow, new RegExp(`^\\s+- '${path}'$`, 'm'), path)
+  }
 })
 
 test('website deployment waits for a separately verified latest promotion', () => {


### PR DESCRIPTION
Canary websites embedded stable package versions while shipping example source
from main, so unreleased APIs failed in live playgrounds.

Use the publisher's shared commit-addressed version helper for playground
manifests. Make package upload and registry verification a prerequisite for the
website deployment so every requested snapshot exists before smoke testing.