### PR TITLE
docs(website): simplify the canary callout

### DIFF
--- a/packages/website/src/view/shared.ts
+++ b/packages/website/src/view/shared.ts
@@ -24,10 +24,6 @@ export const canaryBanner = (commit: string): Html => {
         ],
         [shortCommit],
       ),
-      ih.span(
-        [ih.Class('hidden sm:inline')],
-        [' · Playgrounds install the published release'],
-      ),
     ],
   )
 }


### PR DESCRIPTION
The callout exposed an internal package installation detail that did not
help visitors understand the preview. Keep the banner focused on the main
commit it represents.