### PR TITLE
refactor: persist saved values through toCodecJson

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Skills for building Foldkit apps \u2014 app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/examples/auth/src/command.ts
+++ b/examples/auth/src/command.ts
@@ -5,7 +5,7 @@ import { Command } from 'foldkit'
 import { BrowserKeyValueStore } from '@effect/platform-browser'
 
 import { SESSION_STORAGE_KEY } from './constant'
-import { Session } from './domain/session'
+import { Session, SessionJsonString } from './domain/session'
 import { Message } from './message'
 
 export const SaveSession = Command.define('SaveSession', {
@@ -16,7 +16,7 @@ export const SaveSession = Command.define('SaveSession', {
       const store = yield* KeyValueStore.KeyValueStore
       yield* store.set(
         SESSION_STORAGE_KEY,
-        S.encodeSync(S.fromJsonString(Session))(session),
+        S.encodeSync(SessionJsonString)(session),
       )
       return Message.SucceededSaveSession()
     }).pipe(

--- a/examples/auth/src/domain/session.ts
+++ b/examples/auth/src/domain/session.ts
@@ -7,3 +7,5 @@ export const Session = S.Struct({
 })
 
 export type Session = typeof Session.Type
+
+export const SessionJsonString = S.fromJsonString(S.toCodecJson(Session))

--- a/examples/auth/src/main.ts
+++ b/examples/auth/src/main.ts
@@ -6,7 +6,7 @@ import { Url } from 'foldkit/url'
 import { BrowserKeyValueStore } from '@effect/platform-browser'
 
 import { SESSION_STORAGE_KEY } from './constant'
-import { Session } from './domain/session'
+import { Session, SessionJsonString } from './domain/session'
 import { Message } from './message'
 import { LoggedIn, LoggedOut, Model } from './model'
 import { DashboardRoute, LoginRoute, urlToAppRoute } from './route'
@@ -24,7 +24,7 @@ export const flags: Effect.Effect<Flags> = Effect.gen(function* () {
     Option.fromNullishOr(yield* store.get(SESSION_STORAGE_KEY)),
   )
 
-  const decodeSession = S.decodeEffect(S.fromJsonString(Session))
+  const decodeSession = S.decodeEffect(SessionJsonString)
   const session = yield* decodeSession(sessionJson)
 
   return Flags.make({ maybeSession: Option.some(session) })

--- a/examples/kanban/src/command.ts
+++ b/examples/kanban/src/command.ts
@@ -7,7 +7,7 @@ import { BrowserCrypto, BrowserKeyValueStore } from '@effect/platform-browser'
 import { ADD_CARD_INPUT_ID, STORAGE_KEY } from './constant'
 import { Column } from './domain'
 import { Message } from './message'
-import { SavedBoard } from './model'
+import { SavedBoardJsonString } from './model'
 
 export const GenerateCardId = Command.define('GenerateCardId', {
   args: { columnId: S.String, title: S.String },
@@ -28,7 +28,7 @@ export const SaveBoard = Command.define('SaveBoard', {
       const store = yield* KeyValueStore.KeyValueStore
       yield* store.set(
         STORAGE_KEY,
-        S.encodeSync(S.fromJsonString(SavedBoard))({ columns }),
+        S.encodeSync(SavedBoardJsonString)({ columns }),
       )
       return Message.CompletedSaveBoard()
     }).pipe(

--- a/examples/kanban/src/main.ts
+++ b/examples/kanban/src/main.ts
@@ -7,7 +7,7 @@ import { DragAndDrop } from '@foldkit/ui'
 
 import { DEFAULT_COLUMNS, STORAGE_KEY } from './constant'
 import { Message } from './message'
-import { Model, SavedBoard } from './model'
+import { Model, SavedBoard, SavedBoardJsonString } from './model'
 import { subscriptions } from './subscription'
 import { update } from './update'
 import { view } from './view'
@@ -24,7 +24,7 @@ export const flags: Effect.Effect<Flags> = Effect.gen(function* () {
   const json = yield* Effect.fromOption(
     Option.fromNullishOr(yield* store.get(STORAGE_KEY)),
   )
-  const decoded = yield* S.decodeEffect(S.fromJsonString(SavedBoard))(json)
+  const decoded = yield* S.decodeEffect(SavedBoardJsonString)(json)
   return Flags.make({ maybeSavedBoard: Option.some(decoded) })
 }).pipe(
   Effect.catch(() =>

--- a/examples/kanban/src/model.ts
+++ b/examples/kanban/src/model.ts
@@ -10,6 +10,8 @@ export const SavedBoard = S.Struct({
 
 export type SavedBoard = typeof SavedBoard.Type
 
+export const SavedBoardJsonString = S.fromJsonString(S.toCodecJson(SavedBoard))
+
 export const Model = S.Struct({
   columns: S.Array(Column.Column),
   dragAndDrop: DragAndDrop.Model,

--- a/examples/todo/src/main.ts
+++ b/examples/todo/src/main.ts
@@ -36,6 +36,8 @@ type Todo = typeof Todo.Type
 const Todos = S.Array(Todo)
 type Todos = typeof Todos.Type
 
+const TodosJsonString = S.fromJsonString(S.toCodecJson(Todos))
+
 const Filter = S.Literals(['All', 'Active', 'Completed'])
 type Filter = typeof Filter.Type
 
@@ -302,10 +304,7 @@ export const SaveTodos = Command.define('SaveTodos', {
   execute: ({ todos }) =>
     Effect.gen(function* () {
       const store = yield* KeyValueStore.KeyValueStore
-      yield* store.set(
-        TODOS_STORAGE_KEY,
-        S.encodeSync(S.fromJsonString(Todos))(todos),
-      )
+      yield* store.set(TODOS_STORAGE_KEY, S.encodeSync(TodosJsonString)(todos))
       return Message.SucceededSaveTodos({ todos })
     }).pipe(
       Effect.catch(() => Effect.succeed(Message.FailedSaveTodos())),
@@ -672,7 +671,7 @@ export const flags: Effect.Effect<Flags> = Effect.gen(function* () {
     Option.fromNullishOr(yield* store.get(TODOS_STORAGE_KEY)),
   )
 
-  const decodeTodos = S.decodeEffect(S.fromJsonString(Todos))
+  const decodeTodos = S.decodeEffect(TodosJsonString)
   const todos = yield* decodeTodos(todosJson)
 
   return { todos: Option.some(todos) }

--- a/packages/typing-game/client/src/page/room/command.ts
+++ b/packages/typing-game/client/src/page/room/command.ts
@@ -11,7 +11,7 @@ import {
 } from '../../constant'
 import { RoomsClient } from '../../rpc'
 import { Message } from './message'
-import { RoomPlayerSession } from './model'
+import { RoomPlayerSession, RoomPlayerSessionJsonString } from './model'
 
 export const FetchRoom = Command.define('FetchRoom', {
   args: { roomId: S.String },
@@ -35,7 +35,7 @@ export const LoadSession = Command.define('LoadSession', {
       const sessionJson = yield* Effect.fromOption(
         Option.fromNullishOr(maybeSessionJson),
       )
-      const decodeSession = S.decodeEffect(S.fromJsonString(RoomPlayerSession))
+      const decodeSession = S.decodeEffect(RoomPlayerSessionJsonString)
 
       return yield* decodeSession(sessionJson).pipe(
         Effect.map(session =>
@@ -147,7 +147,7 @@ export const SavePlayerSession = Command.define('SavePlayerSession', {
   execute: ({ session }) =>
     Effect.gen(function* () {
       const store = yield* KeyValueStore.KeyValueStore
-      const encodeSession = S.encodeEffect(S.fromJsonString(RoomPlayerSession))
+      const encodeSession = S.encodeEffect(RoomPlayerSessionJsonString)
       const sessionJson = yield* encodeSession(session)
       yield* store.set(ROOM_PLAYER_SESSION_KEY, sessionJson)
       return Message.CompletedSavePlayerSession()

--- a/packages/typing-game/client/src/page/room/model.ts
+++ b/packages/typing-game/client/src/page/room/model.ts
@@ -9,6 +9,10 @@ export const RoomPlayerSession = S.Struct({
 })
 export type RoomPlayerSession = typeof RoomPlayerSession.Type
 
+export const RoomPlayerSessionJsonString = S.fromJsonString(
+  S.toCodecJson(RoomPlayerSession),
+)
+
 export const RoomAsyncData = AsyncData.Schema(Shared.Room, S.String)
 export type RoomAsyncData = typeof RoomAsyncData.schema.Type
 

--- a/packages/website/src/snippet/flagsDefinition.ts
+++ b/packages/website/src/snippet/flagsDefinition.ts
@@ -11,6 +11,8 @@ const Todo = S.Struct({
 
 const Todos = S.Array(Todo)
 
+const TodosJsonString = S.fromJsonString(S.toCodecJson(Todos))
+
 const Flags = S.Struct({
   todos: S.Option(Todos),
 })
@@ -23,7 +25,7 @@ const flags: Effect.Effect<Flags> = Effect.gen(function* () {
     Option.fromNullishOr(yield* store.get('todos')),
   )
 
-  const decodeTodos = S.decodeEffect(S.fromJsonString(Todos))
+  const decodeTodos = S.decodeEffect(TodosJsonString)
   const todos = yield* decodeTodos(todosJson)
 
   return Flags.make({ todos: Option.some(todos) })

--- a/skills/generate-program/architecture.md
+++ b/skills/generate-program/architecture.md
@@ -224,6 +224,14 @@ For a fresh browser boot, Flags are produced by an `Effect<Flags>`. The runtime 
 - Getting the current time
 - Reading browser capabilities (`navigator.language`, `matchMedia`)
 
+When Flags restore a value that a Command saved to storage, define the persistence Schema once next to the saved Schema and use it for both decode and encode:
+
+```ts
+export const SavedBoardJsonString = S.fromJsonString(S.toCodecJson(SavedBoard))
+```
+
+`toCodecJson` turns the domain value into canonical JSON, then `fromJsonString` stringifies it. Leave it out and a field like `S.Option` writes Effect's runtime shape (`{_id:"Option",_tag:"None"}`) to storage. The next boot fails to decode it, the Flags `Effect.catch` falls back to the empty value, and the user's saved data looks gone. For a Schema that is already JSON-native, `toCodecJson` changes nothing on the wire, so composing it every time costs nothing.
+
 Declare the `Flags` Schema on `Runtime.makeApplication`, then pass the Effect to `Runtime.run`:
 
 ```ts


### PR DESCRIPTION
Todo, kanban, auth, and the typing-game room session saved a domain value with `S.fromJsonString(Schema)`, which only works while the saved Schema is JSON-native. Pixel-art already used `S.fromJsonString(S.toCodecJson(Schema))`, and that split is what agents copy from the examples.

An app that adds an `S.Option` (or `Date`, `Map`, `Set`) field to a saved Schema and keeps the old composition encodes Effect's runtime shape into storage (`{"_id":"Option","_tag":"Some","value":"x"}`). The next boot fails to decode it, the Flags `Effect.catch` falls back to the empty value, and the saved data looks gone.

Each saved Schema now has a `JsonString` sibling composed once next to it, used for both encode and decode:

- `examples/todo/src/main.ts`: `TodosJsonString`
- `examples/kanban/src/model.ts`: `SavedBoardJsonString`, used by `command.ts` and `main.ts`
- `examples/auth/src/domain/session.ts`: `SessionJsonString`
- `packages/typing-game/client/src/page/room/model.ts`: `RoomPlayerSessionJsonString`
- `packages/website/src/snippet/flagsDefinition.ts`: the Flags snippet now teaches the same composition
- `skills/generate-program/architecture.md`: the Flags section spells out the persistence composition and what goes wrong without it, with the plugin version bumped so users pick it up

Protocol and devtools frames are left alone. Those values are already JSON-shaped on the wire.

Verification: `toCodecJson` is a no-op on the wire for these JSON-native Schemas, so existing saved data keeps loading. Confirmed against the real codecs with a scratch test: encoding `Todos` produces the identical string under both compositions, and a string written by the old composition decodes under the new one. The same test with an `S.Option` field shows the two diverge (`{"_id":"Option",...}` versus `{"_tag":"Some",...}`), which is the failure this change prevents. Full `pnpm check`, `pnpm lint`, and `pnpm test` pass, and the pre-push suite ran on the pushed commit.

Fixes #1138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgRKJj8PrYUaueVozNJgGt)_