### PR TITLE
fix(release): finalize GitHub releases independently

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: main
+          ref: ${{ inputs.published_commit || 'main' }}
 
       - name: Match package source to published versions
         id: authorization
@@ -67,13 +67,19 @@ jobs:
         run: |
           target=$(git rev-parse HEAD)
           if [ -n "${PUBLISHED_COMMIT}" ]; then
-            if ! git merge-base --is-ancestor "${PUBLISHED_COMMIT}" "${target}"; then
-              echo "the published commit ${PUBLISHED_COMMIT} is not an ancestor of latest main ${target}" >&2
+            expected=$(git rev-parse --verify "${PUBLISHED_COMMIT}^{commit}")
+            if [ "${target}" != "${expected}" ]; then
+              echo "the checked-out website commit ${target} is not the published commit ${expected}" >&2
+              exit 1
+            fi
+
+            if ! git merge-base --is-ancestor "${expected}" refs/remotes/origin/main; then
+              echo "the published website commit ${expected} is not on main" >&2
               exit 1
             fi
           fi
 
-          result=$(node scripts/plan-website-deploy.mjs "${target}")
+          result=$(node scripts/plan-website-deploy.mjs "${target}" "${PUBLISHED_COMMIT:+--allow-historical-target}")
           echo "${result}"
           deploy=${result#deploy=}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,10 @@ on:
       - 'scripts/build-public-packages.mjs'
       - 'scripts/check-playground-ssg-build.ts'
       - 'scripts/coherent-release.mjs'
+      - 'scripts/finalize-github-release.mjs'
       - 'scripts/example-bridge.js'
       - 'scripts/lib/coherent-release.mjs'
+      - 'scripts/lib/github-release.mjs'
       - 'scripts/lib/package-version.mjs'
       - 'scripts/lib/workspace-packages.mjs'
       - 'scripts/reset-peer-deps.ts'
@@ -40,17 +42,56 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
-  release:
-    name: Version or upload stable packages
+  version:
+    name: Create or update the Version Packages pull request
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
-      published: ${{ steps.changesets.outputs.published }}
+      has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify changeset ignore list
+        run: pnpm check:changeset-ignore
+
+      - name: Smoke test create-foldkit-app
+        run: pnpm check:create-foldkit-app-smoke
+
+      - name: Create or update the Version Packages pull request
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm version-packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  stable:
+    name: Upload and verify stable packages
+    if: github.event_name == 'push' && needs.version.outputs.has_changesets == 'false'
+    needs: version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -76,20 +117,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Verify changeset ignore list
-        run: pnpm check:changeset-ignore
-
-      - name: Smoke test create-foldkit-app
-        run: pnpm check:create-foldkit-app-smoke
-
-      - name: Create Release Pull Request or upload and verify packages
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          version: pnpm version-packages
-          publish: pnpm release
+      - name: Upload and verify stable packages
+        run: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           SKIP_SIMPLE_GIT_HOOKS: '1'
 
@@ -139,16 +169,40 @@ jobs:
     secrets: inherit
 
   finalize:
-    name: Verify stable promotion
+    name: Finalize the promoted stable release
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout the promoted release
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.published_commit }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify the promoted release commit
+        env:
+          PUBLISHED_COMMIT: ${{ inputs.published_commit }}
+        run: |
+          if [[ ! "${PUBLISHED_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "published_commit must be a full lowercase Git commit SHA" >&2
+            exit 1
+          fi
+
+          resolved=$(git rev-parse --verify "${PUBLISHED_COMMIT}^{commit}")
+          checked_out=$(git rev-parse HEAD)
+
+          if [ "${PUBLISHED_COMMIT}" != "${resolved}" ] || [ "${checked_out}" != "${resolved}" ]; then
+            echo "the checked-out commit ${checked_out} is not the exact published commit ${PUBLISHED_COMMIT}" >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "${resolved}" refs/remotes/origin/main; then
+            echo "the published commit ${resolved} is not on main" >&2
+            exit 1
+          fi
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -164,6 +218,12 @@ jobs:
 
       - name: Verify every stable package and latest tag
         run: pnpm release:verify-latest
+
+      - name: Create matching Git tags and GitHub Releases
+        run: pnpm release:finalize-github
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PUBLISHED_COMMIT: ${{ inputs.published_commit }}
 
   deploy-website:
     name: Deploy the promoted website

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,9 @@ set exists. It also keeps a long-lived npm token out of GitHub Actions.
 3. Check that the stable job passed. The last upload is not enough. The job
    fetches the complete public package set from npm and checks each internal
    dependency and peer range against the versions in this release. Changesets
-   receives its `New tag:` output only after that complete check passes.
+   only creates the Version Packages pull request. The coherent uploader runs
+   in a separate workflow step, so its output cannot be mistaken for
+   Changesets' tag-push protocol.
 
 4. Check out the release commit and sign in to npm with 2FA. Run:
 
@@ -49,7 +51,12 @@ set exists. It also keeps a long-lived npm token out of GitHub Actions.
    ```
 
    The dispatch verifies every registry version and every `latest` tag from
-   scratch. Only then can the production website deployment start.
+   scratch. It derives the packages versioned by the release commit, creates
+   their missing Git tags at that exact commit, and creates each GitHub Release
+   from the matching changelog section. Matching tags and Releases are skipped
+   on a retry. A tag at another commit or conflicting Release metadata stops
+   finalization before it creates anything new. Only then can the matching
+   production website deployment start.
 
 ## Package canaries
 
@@ -132,10 +139,11 @@ workflow so npm generates provenance for each public tarball.
 
 The production website does not deploy when the quarantine upload finishes.
 The finalization dispatch first proves that every intended version is on npm
-and every `latest` tag points to it. The existing website gate then checks the
-playground versions, normal npm peer resolution, package-source release tags,
-the generated SSG project, and the live SSR and SSG playgrounds before the
-deployment completes.
+and every `latest` tag points to it, then finishes the GitHub release metadata.
+The website workflow checks out that exact release commit. Its existing gate
+then checks the playground versions, normal npm peer resolution, package-source
+release tags, the generated SSG project, and the live SSR and SSG playgrounds
+before the deployment completes.
 
 Website-only pushes still use the normal production deployment workflow. Its
 package-source authorization prevents unreleased package work from reaching

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "version-packages": "changeset version && tsx scripts/reset-peer-deps.ts && pnpm install --no-frozen-lockfile",
     "release": "pnpm check:peer-floors && node scripts/coherent-release.mjs stable",
     "release:canary": "node scripts/coherent-release.mjs canary",
+    "release:finalize-github": "node scripts/finalize-github-release.mjs",
     "release:promote": "node scripts/coherent-release.mjs promote",
     "release:verify-latest": "node scripts/coherent-release.mjs verify-latest",
     "check:dom-state-parity": "tsx scripts/check-dom-state-parity.mts",

--- a/scripts/deploy-website-workflow.test.mjs
+++ b/scripts/deploy-website-workflow.test.mjs
@@ -422,6 +422,25 @@ test('production deployment requires the complete promoted npm snapshot', () => 
   )
 })
 
+test('stable finalization deploys the exact published website commit', () => {
+  assert.match(
+    productionWorkflow,
+    /ref: \$\{\{ inputs\.published_commit \|\| 'main' \}\}/,
+  )
+  assert.match(
+    productionWorkflow,
+    /node scripts\/plan-website-deploy\.mjs "\$\{target\}" "\$\{PUBLISHED_COMMIT:\+--allow-historical-target\}"/,
+  )
+  assert.match(
+    productionWorkflow,
+    /git merge-base --is-ancestor "\$\{expected\}" refs\/remotes\/origin\/main/,
+  )
+  assert.match(
+    productionWorkflow,
+    /target: \$\{\{ needs\.authorize\.outputs\.target \}\}/,
+  )
+})
+
 test('the registry-backed SSG playground build runs only for production', () => {
   assert.match(
     buildWorkflow,

--- a/scripts/finalize-github-release.mjs
+++ b/scripts/finalize-github-release.mjs
@@ -1,0 +1,54 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  GitHubRepository,
+  finalizeGitHubReleases,
+  releasePackagesForCommit,
+} from './lib/github-release.mjs'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+const fail = message => {
+  throw new Error(message)
+}
+
+const requiredEnvironment = name => {
+  const value = process.env[name]
+
+  if (value === undefined || value === '') {
+    return fail(`${name} is required to finalize a release`)
+  }
+
+  return value
+}
+
+const main = async () => {
+  const publishedCommit = requiredEnvironment('PUBLISHED_COMMIT')
+  const repository = requiredEnvironment('GITHUB_REPOSITORY')
+  const token = requiredEnvironment('GITHUB_TOKEN')
+  const release = releasePackagesForCommit({
+    root: REPO_ROOT,
+    publishedCommit,
+  })
+  const github = new GitHubRepository({ repository, token })
+  const result = await finalizeGitHubReleases({
+    packages: release.packages,
+    commit: release.commit,
+    github,
+  })
+
+  console.log(
+    `Created ${String(result.createdTags.length)} Git tags and ${String(result.createdReleases.length)} GitHub Releases for ${release.commit}.`,
+  )
+  console.log(
+    `Kept ${String(result.existingTags.length)} matching Git tags and ${String(result.existingReleases.length)} matching GitHub Releases.`,
+  )
+}
+
+main().catch(error => {
+  const message = error instanceof Error ? error.stack : String(error)
+
+  console.error(`[github-release] FAIL ${message}`)
+  process.exitCode = 1
+})

--- a/scripts/lib/coherent-release.mjs
+++ b/scripts/lib/coherent-release.mjs
@@ -519,6 +519,11 @@ const remoteTags = root => {
 
 const packageTag = pkg => `${pkg.packageJson.name}@${pkg.packageJson.version}`
 
+export const uploadedPackageMessage = (channel, pkg) =>
+  channel === 'stable'
+    ? `Uploaded and verified ${packageTag(pkg)}`
+    : packageTag(pkg)
+
 export const packagesForChannel = (packages, channel, commit) =>
   channel === 'canary' ? canaryPackageJsons(packages, commit) : packages
 
@@ -685,11 +690,7 @@ export const runCoherentUpload = async ({
     )
 
     for (const pkg of packagesToPack) {
-      log(
-        channel === 'stable'
-          ? `New tag: ${packageTag(pkg)}`
-          : `${pkg.packageJson.name}@${pkg.packageJson.version}`,
-      )
+      log(uploadedPackageMessage(channel, pkg))
     }
 
     return { packages: releasePackages, ...result }

--- a/scripts/lib/coherent-release.test.mjs
+++ b/scripts/lib/coherent-release.test.mjs
@@ -11,6 +11,7 @@ import {
   uploadArtifacts,
   uploadPlannedArtifacts,
   uploadTag,
+  uploadedPackageMessage,
   verifyRegistrySnapshot,
 } from './coherent-release.mjs'
 
@@ -427,6 +428,15 @@ test('canary versions and internal references are commit-addressed', () => {
     }),
     packages,
   )
+})
+
+test('stable upload output does not use Changesets reserved tag protocol', () => {
+  const pkg = packageFor('foldkit', '1.2.3')
+  const message = uploadedPackageMessage('stable', pkg)
+
+  assert.equal(message, 'Uploaded and verified foldkit@1.2.3')
+  assert.doesNotMatch(message, /^New tag:/)
+  assert.equal(uploadedPackageMessage('canary', pkg), 'foldkit@1.2.3')
 })
 
 test('registry verification requires exact internal canary references', async () => {

--- a/scripts/lib/github-release.mjs
+++ b/scripts/lib/github-release.mjs
@@ -1,0 +1,366 @@
+import { spawnSync } from 'node:child_process'
+import { relative, resolve } from 'node:path'
+
+import {
+  publicWorkspacePackages,
+  readWorkspacePackages,
+} from './workspace-packages.mjs'
+
+const fail = message => {
+  throw new Error(message)
+}
+
+const packageTag = ({ name, version }) => `${name}@${version}`
+
+const parsePackageManifest = (contents, path) => {
+  const packageJson = JSON.parse(contents)
+
+  if (
+    typeof packageJson !== 'object' ||
+    packageJson === null ||
+    typeof packageJson.name !== 'string' ||
+    typeof packageJson.version !== 'string'
+  ) {
+    return fail(`${path} does not contain a package name and version`)
+  }
+
+  return packageJson
+}
+
+const repositoryPath = (root, path) => {
+  const result = relative(resolve(root), resolve(path))
+
+  if (result.startsWith('..')) {
+    return fail(`${path} is outside ${root}`)
+  }
+
+  return result
+}
+
+export const extractReleaseNotes = (changelog, version) => {
+  const lines = changelog.replaceAll('\r\n', '\n').split('\n')
+  const heading = `## ${version}`
+  const headingIndex = lines.findIndex(line => line === heading)
+
+  if (headingIndex === -1) {
+    return fail(`changelog has no ${heading} section`)
+  }
+
+  const remainingLines = lines.slice(headingIndex + 1)
+  const nextHeadingIndex = remainingLines.findIndex(line =>
+    line.startsWith('## '),
+  )
+  const sectionLines =
+    nextHeadingIndex === -1
+      ? remainingLines
+      : remainingLines.slice(0, nextHeadingIndex)
+
+  return sectionLines.join('\n').trim()
+}
+
+export class GitRepository {
+  constructor(root) {
+    this.root = root
+  }
+
+  run(args) {
+    return spawnSync('git', args, {
+      cwd: this.root,
+      encoding: 'utf8',
+    })
+  }
+
+  resolveCommit(ref) {
+    const result = this.run(['rev-parse', '--verify', `${ref}^{commit}`])
+
+    if (result.status !== 0) {
+      return fail(result.stderr.trim() || `could not resolve ${ref}`)
+    }
+
+    return result.stdout.trim()
+  }
+
+  parentCommit(commit) {
+    return this.resolveCommit(`${commit}^`)
+  }
+
+  readFileAt(commit, path) {
+    const result = this.run(['show', `${commit}:${path}`])
+
+    if (result.status !== 0) {
+      return undefined
+    }
+
+    return result.stdout
+  }
+}
+
+export const releasePackagesForCommit = ({
+  root,
+  publishedCommit,
+  git = new GitRepository(root),
+  workspacePackages = readWorkspacePackages(root),
+}) => {
+  const commit = git.resolveCommit(publishedCommit)
+  const head = git.resolveCommit('HEAD')
+
+  if (head !== commit) {
+    return fail(
+      `published commit ${commit} is not the checked-out commit ${head}`,
+    )
+  }
+
+  const parent = git.parentCommit(commit)
+  const packages = []
+
+  for (const workspacePackage of publicWorkspacePackages(workspacePackages)) {
+    const manifestPath = repositoryPath(root, workspacePackage.manifestPath)
+    const currentContents = git.readFileAt(commit, manifestPath)
+
+    if (currentContents === undefined) {
+      return fail(`${manifestPath} is missing from published commit ${commit}`)
+    }
+
+    const currentPackageJson = parsePackageManifest(
+      currentContents,
+      manifestPath,
+    )
+    const previousContents = git.readFileAt(parent, manifestPath)
+
+    if (previousContents !== undefined) {
+      const previousPackageJson = parsePackageManifest(
+        previousContents,
+        `${manifestPath} at ${parent}`,
+      )
+
+      if (
+        previousPackageJson.name === currentPackageJson.name &&
+        previousPackageJson.version === currentPackageJson.version
+      ) {
+        continue
+      }
+    }
+
+    const changelogPath = repositoryPath(
+      root,
+      resolve(workspacePackage.dir, 'CHANGELOG.md'),
+    )
+    const changelog = git.readFileAt(commit, changelogPath)
+
+    if (changelog === undefined) {
+      return fail(`${changelogPath} is missing from published commit ${commit}`)
+    }
+
+    const releasePackage = {
+      name: currentPackageJson.name,
+      version: currentPackageJson.version,
+      notes: extractReleaseNotes(changelog, currentPackageJson.version),
+    }
+
+    packages.push({
+      ...releasePackage,
+      tag: packageTag(releasePackage),
+    })
+  }
+
+  if (packages.at(0) === undefined) {
+    return fail(`${commit} did not version any public packages`)
+  }
+
+  return { commit, packages }
+}
+
+export class GitHubRepository {
+  constructor({ repository, token }) {
+    const match = repository.match(/^([^/]+)\/([^/]+)$/)
+
+    if (match === null) {
+      return fail(`invalid GitHub repository ${repository}`)
+    }
+
+    if (token === '') {
+      return fail('GITHUB_TOKEN is required to finalize a release')
+    }
+
+    const [, owner, name] = match
+
+    this.baseUrl = `https://api.github.com/repos/${owner}/${name}`
+    this.token = token
+  }
+
+  async request(method, path, body) {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${this.token}`,
+        'content-type': 'application/json',
+        'user-agent': 'foldkit-release-finalizer',
+        'x-github-api-version': '2022-11-28',
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
+
+    if (method === 'GET' && response.status === 404) {
+      return undefined
+    }
+
+    const text = await response.text()
+    const responseBody = text === '' ? undefined : JSON.parse(text)
+
+    if (!response.ok) {
+      const detail = responseBody?.message ?? text
+
+      return fail(
+        `GitHub answered ${String(response.status)} for ${method} ${path}${detail === '' ? '' : `: ${String(detail)}`}`,
+      )
+    }
+
+    return responseBody
+  }
+
+  async tagCommit(tag) {
+    const ref = await this.request(
+      'GET',
+      `/git/ref/tags/${encodeURIComponent(tag)}`,
+    )
+
+    if (ref === undefined) {
+      return undefined
+    }
+
+    let object = ref.object
+    const seen = new Set()
+
+    while (object?.type === 'tag') {
+      if (seen.has(object.sha)) {
+        return fail(`GitHub tag ${tag} contains a tag object cycle`)
+      }
+
+      seen.add(object.sha)
+
+      const tagObject = await this.request('GET', `/git/tags/${object.sha}`)
+
+      if (tagObject === undefined) {
+        return fail(`GitHub tag ${tag} points to missing object ${object.sha}`)
+      }
+
+      object = tagObject.object
+    }
+
+    if (object?.type !== 'commit' || typeof object.sha !== 'string') {
+      return fail(`GitHub tag ${tag} does not resolve to a commit`)
+    }
+
+    return object.sha
+  }
+
+  createTag(tag, commit) {
+    return this.request('POST', '/git/refs', {
+      ref: `refs/tags/${tag}`,
+      sha: commit,
+    })
+  }
+
+  releaseForTag(tag) {
+    return this.request('GET', `/releases/tags/${encodeURIComponent(tag)}`)
+  }
+
+  createRelease(releasePackage, commit) {
+    return this.request('POST', '/releases', {
+      tag_name: releasePackage.tag,
+      target_commitish: commit,
+      name: releasePackage.tag,
+      body: releasePackage.notes,
+      draft: false,
+      prerelease: false,
+    })
+  }
+}
+
+const validateExistingRelease = (releasePackage, release) => {
+  const conflicts = []
+  const body = release.body ?? ''
+
+  if (release.tag_name !== releasePackage.tag) {
+    conflicts.push(`tag_name=${String(release.tag_name)}`)
+  }
+
+  if (release.name !== releasePackage.tag) {
+    conflicts.push(`name=${String(release.name)}`)
+  }
+
+  if (body !== releasePackage.notes) {
+    conflicts.push('body differs from the matching changelog section')
+  }
+
+  if (release.draft !== false) {
+    conflicts.push(`draft=${String(release.draft)}`)
+  }
+
+  if (release.prerelease !== false) {
+    conflicts.push(`prerelease=${String(release.prerelease)}`)
+  }
+
+  if (conflicts.at(0) !== undefined) {
+    return fail(
+      `${releasePackage.tag} has conflicting GitHub Release metadata: ${conflicts.join(', ')}`,
+    )
+  }
+}
+
+export const finalizeGitHubReleases = async ({ packages, commit, github }) => {
+  const plan = []
+
+  for (const releasePackage of packages) {
+    const tagCommit = await github.tagCommit(releasePackage.tag)
+
+    if (tagCommit !== undefined && tagCommit !== commit) {
+      return fail(
+        `${releasePackage.tag} points to ${tagCommit}, expected ${commit}`,
+      )
+    }
+
+    const release = await github.releaseForTag(releasePackage.tag)
+
+    if (release !== undefined) {
+      validateExistingRelease(releasePackage, release)
+    }
+
+    plan.push({
+      releasePackage,
+      isTagMissing: tagCommit === undefined,
+      isReleaseMissing: release === undefined,
+    })
+  }
+
+  const createdTags = []
+  const existingTags = []
+  const createdReleases = []
+  const existingReleases = []
+
+  for (const entry of plan) {
+    const { releasePackage } = entry
+
+    if (entry.isTagMissing) {
+      await github.createTag(releasePackage.tag, commit)
+      createdTags.push(releasePackage.tag)
+    } else {
+      existingTags.push(releasePackage.tag)
+    }
+
+    if (entry.isReleaseMissing) {
+      await github.createRelease(releasePackage, commit)
+      createdReleases.push(releasePackage.tag)
+    } else {
+      existingReleases.push(releasePackage.tag)
+    }
+  }
+
+  return {
+    createdTags,
+    existingTags,
+    createdReleases,
+    existingReleases,
+  }
+}

--- a/scripts/lib/github-release.test.mjs
+++ b/scripts/lib/github-release.test.mjs
@@ -1,0 +1,335 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  GitHubRepository,
+  extractReleaseNotes,
+  finalizeGitHubReleases,
+  releasePackagesForCommit,
+} from './github-release.mjs'
+
+const COMMIT = '0123456789abcdef0123456789abcdef01234567'
+const PARENT = 'fedcba9876543210fedcba9876543210fedcba98'
+const ROOT = '/repo'
+
+const workspacePackage = (name, version, directory, extra = {}) => ({
+  dir: `${ROOT}/${directory}`,
+  manifestPath: `${ROOT}/${directory}/package.json`,
+  packageJson: { name, version, ...extra },
+})
+
+const releasePackage = (name, version, notes = `${name} notes`) => ({
+  name,
+  version,
+  tag: `${name}@${version}`,
+  notes,
+})
+
+const releaseMetadata = pkg => ({
+  tag_name: pkg.tag,
+  name: pkg.tag,
+  body: pkg.notes,
+  draft: false,
+  prerelease: false,
+})
+
+class FakeGit {
+  constructor(files, head = COMMIT) {
+    this.files = files
+    this.head = head
+  }
+
+  resolveCommit(ref) {
+    if (ref === 'HEAD') {
+      return this.head
+    }
+
+    if (ref === 'release-input') {
+      return COMMIT
+    }
+
+    throw new Error(`unexpected ref ${ref}`)
+  }
+
+  parentCommit(commit) {
+    assert.equal(commit, COMMIT)
+
+    return PARENT
+  }
+
+  readFileAt(commit, path) {
+    return this.files.get(`${commit}:${path}`)
+  }
+}
+
+class FakeGitHub {
+  constructor() {
+    this.tags = new Map()
+    this.releases = new Map()
+    this.createdTags = []
+    this.createdReleases = []
+    this.releaseFailure = undefined
+  }
+
+  async tagCommit(tag) {
+    return this.tags.get(tag)
+  }
+
+  async releaseForTag(tag) {
+    return this.releases.get(tag)
+  }
+
+  async createTag(tag, commit) {
+    this.createdTags.push({ tag, commit })
+    this.tags.set(tag, commit)
+  }
+
+  async createRelease(pkg, commit) {
+    this.createdReleases.push({ tag: pkg.tag, commit })
+
+    if (this.releaseFailure === pkg.tag) {
+      throw new Error(`simulated Release failure for ${pkg.tag}`)
+    }
+
+    this.releases.set(pkg.tag, releaseMetadata(pkg))
+  }
+}
+
+test('release notes are the exact matching changelog section', () => {
+  const changelog = `# foldkit
+
+## 2.0.0
+
+### Minor Changes
+
+- New release
+
+## 1.0.0
+
+- Old release
+`
+
+  assert.equal(
+    extractReleaseNotes(changelog, '2.0.0'),
+    '### Minor Changes\n\n- New release',
+  )
+  assert.equal(extractReleaseNotes('# pkg\n\n## 2.0.0\n\n', '2.0.0'), '')
+  assert.throws(
+    () => extractReleaseNotes(changelog, '3.0.0'),
+    /changelog has no ## 3.0.0 section/,
+  )
+})
+
+test('release packages come only from versions changed by the exact commit', () => {
+  const changed = workspacePackage('foldkit', '2.0.0', 'packages/foldkit')
+  const unchanged = workspacePackage(
+    '@foldkit/markdown',
+    '1.0.0',
+    'packages/markdown',
+  )
+  const privatePackage = workspacePackage(
+    'website',
+    '1.0.0',
+    'packages/website',
+    { private: true },
+  )
+  const files = new Map([
+    [
+      `${COMMIT}:packages/foldkit/package.json`,
+      JSON.stringify(changed.packageJson),
+    ],
+    [
+      `${PARENT}:packages/foldkit/package.json`,
+      JSON.stringify({ name: 'foldkit', version: '1.0.0' }),
+    ],
+    [
+      `${COMMIT}:packages/foldkit/CHANGELOG.md`,
+      '# foldkit\n\n## 2.0.0\n\n- Exact notes\n\n## 1.0.0\n',
+    ],
+    [
+      `${COMMIT}:packages/markdown/package.json`,
+      JSON.stringify(unchanged.packageJson),
+    ],
+    [
+      `${PARENT}:packages/markdown/package.json`,
+      JSON.stringify(unchanged.packageJson),
+    ],
+  ])
+
+  const result = releasePackagesForCommit({
+    root: ROOT,
+    publishedCommit: 'release-input',
+    git: new FakeGit(files),
+    workspacePackages: [changed, unchanged, privatePackage],
+  })
+
+  assert.equal(result.commit, COMMIT)
+  assert.deepEqual(result.packages, [
+    {
+      name: 'foldkit',
+      version: '2.0.0',
+      tag: 'foldkit@2.0.0',
+      notes: '- Exact notes',
+    },
+  ])
+})
+
+test('release package discovery rejects a different checked-out commit', () => {
+  assert.throws(
+    () =>
+      releasePackagesForCommit({
+        root: ROOT,
+        publishedCommit: 'release-input',
+        git: new FakeGit(new Map(), PARENT),
+        workspacePackages: [],
+      }),
+    new RegExp(
+      `published commit ${COMMIT} is not the checked-out commit ${PARENT}`,
+    ),
+  )
+})
+
+test('partial tag and Release creation resumes without recreating completed work', async () => {
+  const packages = [
+    releasePackage('foldkit', '2.0.0'),
+    releasePackage('@foldkit/ui', '2.0.0'),
+  ]
+  const github = new FakeGitHub()
+  github.releaseFailure = '@foldkit/ui@2.0.0'
+
+  await assert.rejects(
+    finalizeGitHubReleases({ packages, commit: COMMIT, github }),
+    /simulated Release failure/,
+  )
+
+  assert.deepEqual(
+    github.createdTags.map(entry => entry.tag),
+    ['foldkit@2.0.0', '@foldkit/ui@2.0.0'],
+  )
+  assert.deepEqual(
+    github.createdReleases.map(entry => entry.tag),
+    ['foldkit@2.0.0', '@foldkit/ui@2.0.0'],
+  )
+
+  github.releaseFailure = undefined
+  github.createdTags = []
+  github.createdReleases = []
+
+  const retry = await finalizeGitHubReleases({
+    packages,
+    commit: COMMIT,
+    github,
+  })
+
+  assert.deepEqual(github.createdTags, [])
+  assert.deepEqual(github.createdReleases, [
+    { tag: '@foldkit/ui@2.0.0', commit: COMMIT },
+  ])
+  assert.deepEqual(retry.existingTags, ['foldkit@2.0.0', '@foldkit/ui@2.0.0'])
+  assert.deepEqual(retry.existingReleases, ['foldkit@2.0.0'])
+})
+
+test('a conflicting tag stops the complete plan before any mutation', async () => {
+  const packages = [
+    releasePackage('foldkit', '2.0.0'),
+    releasePackage('@foldkit/ui', '2.0.0'),
+  ]
+  const github = new FakeGitHub()
+  github.tags.set('@foldkit/ui@2.0.0', PARENT)
+
+  await assert.rejects(
+    finalizeGitHubReleases({ packages, commit: COMMIT, github }),
+    new RegExp(`points to ${PARENT}, expected ${COMMIT}`),
+  )
+
+  assert.deepEqual(github.createdTags, [])
+  assert.deepEqual(github.createdReleases, [])
+})
+
+test('conflicting Release metadata stops before any mutation', async () => {
+  const packages = [
+    releasePackage('foldkit', '2.0.0'),
+    releasePackage('@foldkit/ui', '2.0.0'),
+  ]
+  const github = new FakeGitHub()
+  github.tags.set('@foldkit/ui@2.0.0', COMMIT)
+  github.releases.set('@foldkit/ui@2.0.0', {
+    ...releaseMetadata(packages.at(1)),
+    body: 'wrong notes',
+  })
+
+  await assert.rejects(
+    finalizeGitHubReleases({ packages, commit: COMMIT, github }),
+    /conflicting GitHub Release metadata.*body differs/,
+  )
+
+  assert.deepEqual(github.createdTags, [])
+  assert.deepEqual(github.createdReleases, [])
+})
+
+test('new tags and Releases target the exact published commit', async () => {
+  const pkg = releasePackage('foldkit', '2.0.0')
+  const github = new FakeGitHub()
+
+  await finalizeGitHubReleases({ packages: [pkg], commit: COMMIT, github })
+
+  assert.deepEqual(github.createdTags, [
+    { tag: 'foldkit@2.0.0', commit: COMMIT },
+  ])
+  assert.deepEqual(github.createdReleases, [
+    { tag: 'foldkit@2.0.0', commit: COMMIT },
+  ])
+})
+
+test('GitHub requests create lightweight tags and Releases at the exact commit', async () => {
+  const pkg = releasePackage('@foldkit/ui', '2.0.0')
+  const github = new GitHubRepository({
+    repository: 'foldkit/foldkit',
+    token: 'test-token',
+  })
+  const requests = []
+  github.request = async (method, path, body) => {
+    requests.push({ method, path, body })
+  }
+
+  await github.createTag(pkg.tag, COMMIT)
+  await github.createRelease(pkg, COMMIT)
+
+  assert.deepEqual(requests, [
+    {
+      method: 'POST',
+      path: '/git/refs',
+      body: { ref: 'refs/tags/@foldkit/ui@2.0.0', sha: COMMIT },
+    },
+    {
+      method: 'POST',
+      path: '/releases',
+      body: {
+        tag_name: '@foldkit/ui@2.0.0',
+        target_commitish: COMMIT,
+        name: '@foldkit/ui@2.0.0',
+        body: '@foldkit/ui notes',
+        draft: false,
+        prerelease: false,
+      },
+    },
+  ])
+})
+
+test('matching tags and Releases are idempotent no-ops', async () => {
+  const pkg = releasePackage('foldkit', '2.0.0')
+  const github = new FakeGitHub()
+  github.tags.set(pkg.tag, COMMIT)
+  github.releases.set(pkg.tag, releaseMetadata(pkg))
+
+  const result = await finalizeGitHubReleases({
+    packages: [pkg],
+    commit: COMMIT,
+    github,
+  })
+
+  assert.deepEqual(github.createdTags, [])
+  assert.deepEqual(github.createdReleases, [])
+  assert.deepEqual(result.existingTags, [pkg.tag])
+  assert.deepEqual(result.existingReleases, [pkg.tag])
+})

--- a/scripts/plan-website-deploy.mjs
+++ b/scripts/plan-website-deploy.mjs
@@ -25,6 +25,8 @@ const SHARED_PACKAGE_INPUTS = [
 ]
 
 const TARGET = process.argv.at(2) ?? 'HEAD'
+const isHistoricalTargetAllowed =
+  process.argv.at(3) === '--allow-historical-target'
 
 const git = args =>
   spawnSync('git', args, {
@@ -52,6 +54,7 @@ const remoteMain = git([
   'refs/remotes/origin/main^{commit}',
 ])
 if (
+  !isHistoricalTargetAllowed &&
   remoteMain.status === 0 &&
   resolvedTarget.stdout.trim() !== remoteMain.stdout.trim()
 ) {

--- a/scripts/plan-website-deploy.test.mjs
+++ b/scripts/plan-website-deploy.test.mjs
@@ -94,6 +94,16 @@ const planTarget = (repo, target) =>
     encoding: 'utf8',
   })
 
+const planReleaseTarget = (repo, target) =>
+  spawnSync(
+    process.execPath,
+    [SCRIPT_PATH, target, '--allow-historical-target'],
+    {
+      cwd: repo,
+      encoding: 'utf8',
+    },
+  )
+
 test('allows a website-only commit after the package set was released', () => {
   const repo = makeReleasedRepo()
   try {
@@ -165,6 +175,25 @@ test('refuses an older target after a newer website commit exists', () => {
     assert.equal(result.status, 0, result.stderr)
     assert.equal(result.stdout.trim(), 'deploy=false')
     assert.match(result.stderr, /not the checked-out latest deployment target/)
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+})
+
+test('allows an exact historical release target during finalization', () => {
+  const repo = makeReleasedRepo()
+
+  try {
+    const released = run(repo, 'git', ['rev-parse', 'HEAD'])
+
+    write(repo, 'packages/website/page.ts', 'export const page = true\n')
+    commit(repo, 'update website')
+    run(repo, 'git', ['checkout', '-q', released])
+
+    const result = planReleaseTarget(repo, released)
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout.trim(), 'deploy=true')
   } finally {
     rmSync(repo, { recursive: true, force: true })
   }

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -16,15 +16,54 @@ const canaryWorkflow = readFileSync(
 const rootPackage = JSON.parse(
   readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
 )
+const coherentPublisher = readFileSync(
+  resolve(REPO_ROOT, 'scripts/lib/coherent-release.mjs'),
+  'utf8',
+)
 
-test('stable publication uses the coherent uploader instead of Changesets publish', () => {
+const job = (name, nextName) =>
+  workflow.slice(
+    workflow.indexOf(`\n  ${name}:`),
+    workflow.indexOf(`\n  ${nextName}:`),
+  )
+
+test('Changesets only versions packages and cannot parse publisher output', () => {
   assert.equal(
     rootPackage.scripts.release,
     'pnpm check:peer-floors && node scripts/coherent-release.mjs stable',
   )
   assert.doesNotMatch(rootPackage.scripts.release, /changeset publish/)
-  assert.match(workflow, /publish: pnpm release/)
-  assert.match(workflow, /NPM_CONFIG_PROVENANCE: true/)
+  assert.match(
+    workflow,
+    /uses: changesets\/action@v1\n\s+with:\n\s+version: pnpm version-packages/,
+  )
+  assert.doesNotMatch(workflow, /publish: pnpm release/)
+
+  const versionJob = job('version', 'stable')
+  const stableJob = job('stable', 'canary')
+
+  assert.match(
+    versionJob,
+    /permissions:\n\s+contents: write\n\s+pull-requests: write/,
+  )
+  assert.doesNotMatch(versionJob, /id-token: write/)
+  assert.doesNotMatch(versionJob, /run: pnpm release/)
+  assert.match(
+    versionJob,
+    /outputs:\n\s+has_changesets: \$\{\{ steps\.changesets\.outputs\.hasChangesets \}\}/,
+  )
+
+  assert.match(
+    stableJob,
+    /if: github\.event_name == 'push' && needs\.version\.outputs\.has_changesets == 'false'/,
+  )
+  assert.match(stableJob, /\n    needs: version\n/)
+  assert.match(stableJob, /permissions:\n\s+contents: read\n\s+id-token: write/)
+  assert.doesNotMatch(stableJob, /contents: write|pull-requests: write/)
+  assert.doesNotMatch(stableJob, /changesets\/action/)
+  assert.match(stableJob, /run: pnpm release/)
+  assert.doesNotMatch(coherentPublisher, /New tag:/)
+  assert.match(stableJob, /NPM_CONFIG_PROVENANCE: true/)
 })
 
 test('canaries publish from the trusted release workflow and use exact snapshots', () => {
@@ -36,6 +75,13 @@ test('canaries publish from the trusted release workflow and use exact snapshots
   assert.match(workflow, /^\s+- 'packages\/\*\*'$/m)
   assert.match(workflow, /^\s+- 'examples\/\*\*'$/m)
   assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/)
+
+  const canaryJob = workflow.slice(
+    workflow.indexOf('\n  canary:'),
+    workflow.indexOf('\n  deploy-website-canary:'),
+  )
+
+  assert.doesNotMatch(canaryJob, /release:finalize-github|GitHub Releases/)
 })
 
 test('website canaries deploy only after their package snapshot is verified', () => {
@@ -69,10 +115,43 @@ test('website canaries deploy only after their package snapshot is verified', ()
 test('website deployment waits for a separately verified latest promotion', () => {
   const finalize = workflow.indexOf('finalize:')
   const deploy = workflow.indexOf('deploy-website:')
+  const finalizeJob = job('finalize', 'deploy-website')
 
   assert.ok(finalize > 0)
   assert.ok(deploy > finalize)
   assert.match(workflow, /run: pnpm release:verify-latest/)
+  assert.match(
+    workflow,
+    /Verify every stable package and latest tag[\s\S]+Create matching Git tags and GitHub Releases/,
+  )
+  assert.match(workflow, /run: pnpm release:finalize-github/)
+  assert.match(
+    workflow,
+    /PUBLISHED_COMMIT: \$\{\{ inputs\.published_commit \}\}/,
+  )
+  assert.match(
+    workflow,
+    /published_commit must be a full lowercase Git commit SHA/,
+  )
+  assert.match(
+    workflow,
+    /git merge-base --is-ancestor "\$\{resolved\}" refs\/remotes\/origin\/main/,
+  )
+  assert.match(
+    workflow,
+    /ref: \$\{\{ inputs\.published_commit \}\}\n\s+fetch-depth: 0\n\s+persist-credentials: false/,
+  )
+  assert.match(
+    finalizeJob,
+    /- name: Create matching Git tags and GitHub Releases\n\s+run: pnpm release:finalize-github\n\s+env:\n\s+GITHUB_TOKEN: \$\{\{ github\.token \}\}/,
+  )
+  assert.deepEqual(
+    finalizeJob
+      .split('\n')
+      .filter(line => /GITHUB_TOKEN|github\.token/.test(line)),
+    ['          GITHUB_TOKEN: ${{ github.token }}'],
+  )
+  assert.match(workflow, /finalize:[\s\S]+permissions:\n\s+contents: write/)
   assert.match(workflow, /needs: finalize/)
   assert.doesNotMatch(workflow, /needs: release\n\s+if: needs\.release/)
 })


### PR DESCRIPTION
## What changed

- Limit changesets/action to Version Packages pull request creation.
- Run the coherent stable uploader in a separate step and remove the reserved New tag output.
- After every intended npm version and latest tag is verified, derive the packages versioned by the exact release commit, create their missing Git tags, create GitHub Releases from matching changelog sections, and deploy that same website commit.
- Keep canary publication and its commit-addressed package snapshots unchanged.

## Failure model

The 0.149.0 upload completed coherently on npm, but the custom publisher printed the Changesets New tag protocol without creating local refs. changesets/action parsed those lines as its own publish result, tried to push nonexistent tags, and stopped before GitHub Releases were created. The publisher now runs outside that parser, and its output no longer contains the reserved prefix.

GitHub finalization preflights the complete release set before any mutation. A matching tag or Release is skipped. A tag at another commit or Release metadata that differs from the package tag, title, changelog body, draft state, or prerelease state stops the run before new resources are created. If an API call fails after writes begin, a retry keeps completed resources and resumes from the first missing tag or Release. The finalizer never publishes an npm package or changes an npm dist-tag.

## Authentication constraints

Stable uploads still use the commit-addressed holding tag through npm trusted publishing with OIDC provenance. npm OIDC does not authorize dist-tag mutation, so latest promotion remains an interactive 2FA operation. This change adds no npm token, secret, or weaker credential. The finalizer uses the workflow GitHub token with contents write only after the input is verified as a full commit SHA on main.

## Stable and canary coherence

Stable consumers see the new snapshot only after interactive latest promotion. Git tags, GitHub Releases, and the production website are created only after the complete latest snapshot and internal dependency graph pass registry verification. The website checks out the same published commit, including on a later retry. Canary continues to upload exact commit-addressed versions under its non-consumer holding tag and does not create stable tags or GitHub Releases.

## Verification

- Audited all six recovered 0.149.0 Release bodies against their changelog sections. All matched, so no metadata was changed and publication or promotion was not rerun.
- Ran formatting, lint, dead-code analysis, script typechecking, Changesets status, all 118 script tests, all workspace builds and typechecks, package tests, and website browser smoke tests.
- Mutation-tested the Changesets publish interface, reserved stdout prefix, workspace version discovery, conflicting tag and Release gates, partial-failure retry skips, exact commit targets, changelog extraction, main ancestry validation, and exact website checkout. Each focused test failed under its mutation and passed after restoration.