### PR TITLE
fix(release): allow Version Packages branch updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
           version: pnpm version-packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_SIMPLE_GIT_HOOKS: '1'
 
   stable:
     name: Upload and verify stable packages

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -52,6 +52,16 @@ test('Changesets only versions packages and cannot parse publisher output', () =
     versionJob,
     /outputs:\n\s+has_changesets: \$\{\{ steps\.changesets\.outputs\.hasChangesets \}\}/,
   )
+  assert.match(
+    versionJob,
+    /uses: changesets\/action@v1\n\s+with:\n\s+version: pnpm version-packages\n\s+env:\n\s+GITHUB_TOKEN: \$\{\{ secrets\.GITHUB_TOKEN \}\}\n\s+SKIP_SIMPLE_GIT_HOOKS: '1'/,
+  )
+  assert.deepEqual(
+    versionJob
+      .split('\n')
+      .filter(line => line.includes('SKIP_SIMPLE_GIT_HOOKS')),
+    ["          SKIP_SIMPLE_GIT_HOOKS: '1'"],
+  )
 
   assert.match(
     stableJob,


### PR DESCRIPTION
## Summary

- skip simple-git-hooks only while changesets/action pushes the generated Version Packages branch
- keep the bypass off the version job and every other workflow step
- add a regression test for the exact step-level placement and single occurrence

## Failure model

Release run 32608871093 successfully generated the Version Packages commit, then git push invoked Foldkit's local pre-push hook. Because Changesets had already consumed the pending changesets, changeset status rejected the generated package changes and the branch update failed.

The stable upload job was skipped, so no stable npm publication occurred. The independent canary upload and website deployment succeeded.

## Fix and retry

SKIP_SIMPLE_GIT_HOOKS is set only in the changesets/action step environment. This lets the action perform its own generated branch push without weakening developer pushes or the earlier validation steps.

Merging this PR triggers a fresh Release workflow run on main, which should update Version Packages PR #1139. Do not rerun the old failed workflow because it uses the old workflow definition.

## Verification

- removed the bypass and confirmed the workflow test failed
- moved the bypass to job scope and confirmed the workflow test failed
- restored the step-level bypass and passed all 118 script tests
- passed formatting, lint, script typechecking, builds, package tests, and browser E2E
- focused adversarial review: PASS