### PR TITLE
fix(release): complete stable promotion reliably

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.pnpm-store/
 dist
 coverage
 *.tsbuildinfo

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,13 +25,26 @@ set exists. It also keeps a long-lived npm token out of GitHub Actions.
    in a separate workflow step, so its output cannot be mistaken for
    Changesets' tag-push protocol.
 
-4. Check out the release commit and sign in to npm with 2FA. Run:
+4. Check out the exact release commit in a clean worktree and sign in to npm
+   with 2FA. Run:
 
    ```sh
    pnpm release:promote
    ```
 
-   The command repeats the complete registry check and reads every current
+   The command prompts once for an npm one-time password and reuses it for the
+   package tag changes. The password is not echoed or included in command-line
+   arguments. Set `NPM_CONFIG_OTP` before running the command when another
+   secure prompt already supplies it. The promoter removes that value from the
+   environment of its pnpm, Git, and GitHub subprocesses.
+
+   Before changing an npm tag, the promoter refreshes `origin/main`. It checks
+   that the clean checkout is an ancestor of current `main` and derives at
+   least one versioned public package, including its changelog section, from
+   that exact commit. A later website commit or an unpublished local commit
+   therefore stops before npm changes.
+
+   Promotion repeats the complete registry check and reads every current
    `latest` manifest before moving any tag. It computes a promotion path where
    every intermediate mixture of old and new tags satisfies all internal
    dependency and peer ranges. It prefers `create-foldkit-app` first because
@@ -40,17 +53,21 @@ set exists. It also keeps a long-lived npm token out of GitHub Actions.
    release whose ranges accept both snapshots, or keep consumers on exact
    versions until npm supports atomic multi-package promotion.
 
+   npm registry reads can briefly return an older tag after `npm dist-tag`
+   succeeds. The command waits for each planned tag change to become visible
+   before starting the next one. It then polls until the complete `latest`
+   snapshot exposes every intended version and dispatches stable finalization
+   for the exact checked-out commit.
+
    If a command or network request fails after promotion starts, run the same
-   command again. Tags already on the intended version are skipped. A tag on a
-   newer version stops the command before any tag is moved backward.
+   command again. Tags already on the intended version are skipped, so a retry
+   needs no npm one-time password when every tag is already current. A tag on a
+   newer version stops the command before any tag is moved backward. If only
+   the GitHub dispatch failed, the retry verifies npm again and retries that
+   dispatch without republishing or moving a tag.
 
-5. Finalize the release with the command printed by `release:promote`:
-
-   ```sh
-   gh workflow run release.yml -f published_commit=$(git rev-parse HEAD)
-   ```
-
-   The dispatch verifies every registry version and every `latest` tag from
+5. Follow the stable finalization run dispatched by `release:promote`. The
+   workflow verifies every registry version and every `latest` tag from
    scratch. It derives the packages versioned by the release commit, creates
    their missing Git tags at that exact commit, and creates each GitHub Release
    from the matching changelog section. Matching tags and Releases are skipped
@@ -134,6 +151,18 @@ interactive staged approval. See:
 Do not add an npm token to automate promotion without a separate security
 decision. Package upload must continue through the trusted `release.yml`
 workflow so npm generates provenance for each public tarball.
+
+A bypass-2FA granular access token is not an acceptable bridge. It would put a
+long-lived write credential in GitHub Actions, and npm has announced that these
+tokens will lose direct publishing around January 2027. See:
+
+- <https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/>
+
+Stable promotion therefore remains one local command with one interactive npm
+one-time password. The rest of the release proceeds automatically after the
+complete `latest` snapshot verifies. A zero-touch stable release can replace
+this step when npm supports OIDC-authenticated tag changes or another coherent
+multi-package promotion mechanism.
 
 ## Website deployment
 

--- a/scripts/coherent-release.mjs
+++ b/scripts/coherent-release.mjs
@@ -4,9 +4,10 @@ import { fileURLToPath } from 'node:url'
 
 import {
   NpmRegistry,
-  promoteCurrentWorkspace,
+  promoteAndFinalizeCurrentWorkspace,
   runCoherentUpload,
   verifyRegistrySnapshot,
+  waitForTaggedSnapshot,
 } from './lib/coherent-release.mjs'
 import {
   publicWorkspacePackages,
@@ -78,14 +79,12 @@ const main = async () => {
   }
 
   if (command === 'promote') {
-    const result = await promoteCurrentWorkspace({ root: REPO_ROOT })
+    const result = await promoteAndFinalizeCurrentWorkspace({ root: REPO_ROOT })
 
     console.log(
       `Promoted ${String(result.promoted.length)} packages; ${String(result.alreadyPromoted.length)} were already current.`,
     )
-    console.log(
-      `Finalize the release with: gh workflow run release.yml -f published_commit=$(git rev-parse HEAD)`,
-    )
+    console.log(`Dispatched stable finalization for ${result.publishedCommit}.`)
 
     return
   }
@@ -101,16 +100,7 @@ const main = async () => {
       new Set(workspacePackages.map(pkg => pkg.packageJson.name)),
     )
 
-    for (const pkg of packages) {
-      const packument = await registry.packument(pkg.packageJson.name)
-      const latest = packument?.['dist-tags']?.latest
-
-      if (latest !== pkg.packageJson.version) {
-        return fail(
-          `${pkg.packageJson.name}@latest is ${String(latest)}, expected ${pkg.packageJson.version}`,
-        )
-      }
-    }
+    await waitForTaggedSnapshot({ packages, tag: 'latest', registry })
 
     console.log('The complete stable package set is published and promoted.')
 

--- a/scripts/lib/coherent-release.mjs
+++ b/scripts/lib/coherent-release.mjs
@@ -4,8 +4,11 @@ import { createHash } from 'node:crypto'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
+import { createInterface } from 'node:readline/promises'
+import { Writable } from 'node:stream'
 import semver from 'semver'
 
+import { GitRepository, releasePackagesForCommit } from './github-release.mjs'
 import { canaryVersion } from './package-version.mjs'
 import {
   assertCompleteReleaseSet,
@@ -22,6 +25,8 @@ export const uploadTag = (channel, commit) =>
 
 const REGISTRY_ATTEMPTS = 30
 const REGISTRY_DELAY_MILLISECONDS = 10_000
+const REGISTRY_REQUEST_TIMEOUT_MILLISECONDS = 30_000
+const FULL_GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/
 
 const fail = message => {
   throw new Error(message)
@@ -30,20 +35,42 @@ const fail = message => {
 const encodedPackageName = name => encodeURIComponent(name)
 
 export class NpmRegistry {
-  constructor(baseUrl = REGISTRY) {
+  constructor(
+    baseUrl = REGISTRY,
+    {
+      fetchRegistry = fetch,
+      requestTimeoutMilliseconds = REGISTRY_REQUEST_TIMEOUT_MILLISECONDS,
+    } = {},
+  ) {
     this.baseUrl = baseUrl.replace(/\/$/, '')
+    this.fetchRegistry = fetchRegistry
+    this.requestTimeoutMilliseconds = requestTimeoutMilliseconds
   }
 
-  async packument(name) {
-    const response = await fetch(
-      `${this.baseUrl}/${encodedPackageName(name)}`,
-      {
+  async request(path, description) {
+    const signal = AbortSignal.timeout(this.requestTimeoutMilliseconds)
+
+    try {
+      return await this.fetchRegistry(`${this.baseUrl}/${path}`, {
         headers: {
           accept: 'application/json',
           'cache-control': 'no-cache',
         },
-      },
-    )
+        signal,
+      })
+    } catch (error) {
+      if (signal.aborted) {
+        return fail(`registry request timed out for ${description}`)
+      }
+
+      const detail = error instanceof Error ? error.message : String(error)
+
+      return fail(`registry request failed for ${description}: ${detail}`)
+    }
+  }
+
+  async packument(name) {
+    const response = await this.request(encodedPackageName(name), name)
 
     if (response.status === 404) {
       return undefined
@@ -57,14 +84,9 @@ export class NpmRegistry {
   }
 
   async version(name, version) {
-    const response = await fetch(
-      `${this.baseUrl}/${encodedPackageName(name)}/${version}`,
-      {
-        headers: {
-          accept: 'application/json',
-          'cache-control': 'no-cache',
-        },
-      },
+    const response = await this.request(
+      `${encodedPackageName(name)}/${version}`,
+      `${name}@${version}`,
     )
 
     if (response.status === 404) {
@@ -146,6 +168,171 @@ const runRequired = (command, args, options = {}) => {
   }
 
   return result
+}
+
+const environmentWithoutNpmOtp = env => {
+  const childEnvironment = { ...env }
+
+  delete childEnvironment['NPM_CONFIG_OTP']
+  delete childEnvironment['npm_config_otp']
+
+  return childEnvironment
+}
+
+export const promptForNpmOtp = async ({
+  input = process.stdin,
+  output = process.stderr,
+} = {}) => {
+  if (input.isTTY !== true || typeof input.setRawMode !== 'function') {
+    return fail(
+      'npm promotion requires an interactive terminal or NPM_CONFIG_OTP',
+    )
+  }
+
+  const hiddenOutput = new Writable({
+    write(_chunk, _encoding, complete) {
+      complete()
+    },
+  })
+  const prompt = createInterface({
+    input,
+    output: hiddenOutput,
+    terminal: true,
+    historySize: 0,
+  })
+
+  output.write('npm OTP: ')
+
+  try {
+    const otp = (await prompt.question('')).trim()
+
+    if (otp === '') {
+      return fail('npm OTP cannot be empty')
+    }
+
+    return otp
+  } finally {
+    output.write('\n')
+    prompt.close()
+  }
+}
+
+export const createNpmTagger = ({
+  env = process.env,
+  promptForOtp = promptForNpmOtp,
+  run = runRequired,
+} = {}) => {
+  const childEnvironment = environmentWithoutNpmOtp(env)
+  let otp = env['NPM_CONFIG_OTP'] ?? env['npm_config_otp']
+
+  return async (pkg, tag) => {
+    if (otp === undefined || otp === '') {
+      otp = await promptForOtp()
+    }
+
+    run(
+      'npm',
+      [
+        'dist-tag',
+        'add',
+        `${pkg.packageJson.name}@${pkg.packageJson.version}`,
+        tag,
+      ],
+      {
+        inherit: true,
+        env: { ...childEnvironment, NPM_CONFIG_OTP: otp },
+      },
+    )
+  }
+}
+
+export const resolveReleaseCommit = (
+  root,
+  run = runRequired,
+  env = process.env,
+) => {
+  const childEnvironment = environmentWithoutNpmOtp(env)
+  const status = run('git', ['status', '--short'], {
+    cwd: root,
+    env: childEnvironment,
+  })
+
+  if (status.stdout.trim() !== '') {
+    return fail('release promotion requires a clean checkout')
+  }
+
+  const result = run('git', ['rev-parse', 'HEAD'], {
+    cwd: root,
+    env: childEnvironment,
+  })
+  const commit = result.stdout.trim()
+
+  if (!FULL_GIT_COMMIT_PATTERN.test(commit)) {
+    return fail('release promotion could not resolve an exact Git commit')
+  }
+
+  return commit
+}
+
+export const verifyStableReleaseCommit = ({
+  root,
+  commit,
+  env = process.env,
+  run = runRequired,
+  workspacePackages,
+  git,
+  deriveReleasePackages = releasePackagesForCommit,
+}) => {
+  const childEnvironment = environmentWithoutNpmOtp(env)
+  const packages =
+    workspacePackages ?? readWorkspacePackages(root, { env: childEnvironment })
+  const repository = git ?? new GitRepository(root, childEnvironment)
+
+  run('git', ['fetch', 'origin', '+refs/heads/main:refs/remotes/origin/main'], {
+    cwd: root,
+    env: childEnvironment,
+  })
+
+  const branches = run(
+    'git',
+    ['branch', '--remotes', '--contains', commit, '--format=%(refname:short)'],
+    { cwd: root, env: childEnvironment },
+  )
+    .stdout.split('\n')
+    .map(branch => branch.trim())
+    .filter(branch => branch !== '')
+
+  if (!branches.includes('origin/main')) {
+    return fail(`${commit} is not an ancestor of origin/main`)
+  }
+
+  return deriveReleasePackages({
+    root,
+    publishedCommit: commit,
+    git: repository,
+    workspacePackages: packages,
+  })
+}
+
+export const dispatchReleaseFinalization = (
+  root,
+  commit,
+  run = runRequired,
+  env = process.env,
+) => {
+  if (!FULL_GIT_COMMIT_PATTERN.test(commit)) {
+    return fail('release finalization requires a full lowercase Git commit')
+  }
+
+  run(
+    'gh',
+    ['workflow', 'run', 'release.yml', '-f', `published_commit=${commit}`],
+    {
+      cwd: root,
+      inherit: true,
+      env: environmentWithoutNpmOtp(env),
+    },
+  )
 }
 
 const parsePackFilename = output => {
@@ -860,12 +1047,59 @@ const readTaggedSnapshot = async ({
   return { versions, metadataByName }
 }
 
+export const waitForTaggedSnapshot = async ({
+  packages,
+  tag,
+  registry,
+  attempts = REGISTRY_ATTEMPTS,
+  delayMilliseconds = REGISTRY_DELAY_MILLISECONDS,
+}) => {
+  let mismatches = []
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    mismatches = []
+
+    for (const pkg of packages) {
+      const { name, version } = pkg.packageJson
+
+      try {
+        const packument = await registry.packument(name)
+        const actual = packument?.['dist-tags']?.[tag]
+
+        if (actual !== version) {
+          mismatches.push(
+            `${name}@${tag} is ${String(actual)}, expected ${version}`,
+          )
+        }
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+
+        mismatches.push(`${name}@${tag} could not be read: ${detail}`)
+      }
+    }
+
+    if (Array.isArrayEmpty(mismatches)) {
+      return
+    }
+
+    if (attempt < attempts) {
+      await wait(delayMilliseconds)
+    }
+  }
+
+  return fail(
+    `registry did not expose the complete ${tag} snapshot after promotion: ${mismatches.join('; ')}`,
+  )
+}
+
 export const promoteSnapshot = async ({
   packages,
   tag,
   registry,
   addTag,
   workspacePackageNames = new Set(packages.map(pkg => pkg.packageJson.name)),
+  attempts,
+  delayMilliseconds,
 }) => {
   const targetMetadataByName = await verifyRegistrySnapshot(
     packages,
@@ -950,21 +1184,26 @@ export const promoteSnapshot = async ({
 
     await addTag(pkg, tag)
 
+    await waitForTaggedSnapshot({
+      packages: [pkg],
+      tag,
+      registry,
+      attempts,
+      delayMilliseconds,
+    })
+
     currentSnapshot.versions.set(name, version)
     currentSnapshot.metadataByName.set(name, targetMetadataByName.get(name))
     promoted.push(name)
   }
 
-  for (const pkg of packages) {
-    const packument = await registry.packument(pkg.packageJson.name)
-    const actual = packument?.['dist-tags']?.[tag]
-
-    if (actual !== pkg.packageJson.version) {
-      return fail(
-        `${pkg.packageJson.name}@${tag} is ${String(actual)}, expected ${pkg.packageJson.version}`,
-      )
-    }
-  }
+  await waitForTaggedSnapshot({
+    packages,
+    tag,
+    registry,
+    attempts,
+    delayMilliseconds,
+  })
 
   return { alreadyPromoted, promoted }
 }
@@ -983,19 +1222,26 @@ export const promoteCurrentWorkspace = async ({
     workspacePackageNames: new Set(
       workspacePackages.map(pkg => pkg.packageJson.name),
     ),
-    addTag: pkg => {
-      runRequired(
-        'npm',
-        [
-          'dist-tag',
-          'add',
-          `${pkg.packageJson.name}@${pkg.packageJson.version}`,
-          tag,
-        ],
-        { inherit: true },
-      )
-    },
+    addTag: createNpmTagger(),
   })
 
   return { packages, ...result }
+}
+
+export const promoteAndFinalizeCurrentWorkspace = async ({
+  root,
+  resolveCommit = () => resolveReleaseCommit(root),
+  verifyCommit = commit => verifyStableReleaseCommit({ root, commit }),
+  promote = () => promoteCurrentWorkspace({ root }),
+  dispatch = commit => dispatchReleaseFinalization(root, commit),
+}) => {
+  const publishedCommit = resolveCommit()
+
+  verifyCommit(publishedCommit)
+
+  const result = await promote()
+
+  await dispatch(publishedCommit)
+
+  return { ...result, publishedCommit }
 }

--- a/scripts/lib/coherent-release.test.mjs
+++ b/scripts/lib/coherent-release.test.mjs
@@ -1,18 +1,27 @@
 import assert from 'node:assert/strict'
+import { PassThrough } from 'node:stream'
 import { test } from 'node:test'
 
 import {
+  NpmRegistry,
   assertArtifactsMatchPackages,
   assertPackagesAlreadyExist,
   canaryVersion,
+  createNpmTagger,
+  dispatchReleaseFinalization,
   packagesForChannel,
   packagesToUpload,
+  promoteAndFinalizeCurrentWorkspace,
   promoteSnapshot,
+  promptForNpmOtp,
+  resolveReleaseCommit,
   uploadArtifacts,
   uploadPlannedArtifacts,
   uploadTag,
   uploadedPackageMessage,
   verifyRegistrySnapshot,
+  verifyStableReleaseCommit,
+  waitForTaggedSnapshot,
 } from './coherent-release.mjs'
 
 const packageFor = (name, version, extra = {}) => ({
@@ -608,4 +617,531 @@ test('promotion refuses every backward tag before changing any tag', async () =>
     /refusing to move foldkit@latest backward.*No tags were changed/,
   )
   assert.deepEqual(attempted, [])
+})
+
+test('promotion waits for each dependency-ordered tag to propagate', async () => {
+  const packages = [
+    packageFor('@foldkit/ui', '0.149.0', {
+      peerDependencies: { foldkit: '>=0.148.0 <0.150.0' },
+    }),
+    packageFor('foldkit', '0.149.0'),
+  ]
+  const registry = new FakeRegistry(packages)
+  registry.add(artifactFor('@foldkit/ui', '0.148.0'), {
+    peerDependencies: { foldkit: '^0.148.0' },
+  })
+  registry.add(artifactFor('@foldkit/ui', '0.149.0'), {
+    peerDependencies: { foldkit: '>=0.148.0 <0.150.0' },
+  })
+  registry.add(artifactFor('foldkit', '0.148.0'))
+  registry.add(artifactFor('foldkit', '0.149.0'))
+  registry.packuments.get('@foldkit/ui')['dist-tags'].latest = '0.148.0'
+  registry.packuments.get('foldkit')['dist-tags'].latest = '0.148.0'
+  const readPackument = registry.packument.bind(registry)
+  const promoted = []
+  let isUiPending = false
+  let pendingUiReads = 0
+
+  registry.packument = async name => {
+    const packument = await readPackument(name)
+
+    if (name === '@foldkit/ui' && isUiPending) {
+      pendingUiReads += 1
+
+      if (pendingUiReads === 2) {
+        packument['dist-tags'].latest = '0.149.0'
+        isUiPending = false
+      }
+    }
+
+    return packument
+  }
+
+  await promoteSnapshot({
+    packages,
+    tag: 'latest',
+    registry,
+    addTag: async (pkg, tag) => {
+      const name = pkg.packageJson.name
+
+      if (name === 'foldkit') {
+        assert.equal(
+          registry.packuments.get('@foldkit/ui')['dist-tags'].latest,
+          '0.149.0',
+        )
+      }
+
+      promoted.push(name)
+
+      if (name === '@foldkit/ui') {
+        isUiPending = true
+      } else {
+        registry.packuments.get(name)['dist-tags'][tag] =
+          pkg.packageJson.version
+      }
+    },
+    attempts: 2,
+    delayMilliseconds: 0,
+  })
+
+  assert.deepEqual(promoted, ['@foldkit/ui', 'foldkit'])
+  assert.equal(pendingUiReads, 2)
+})
+
+test('tag propagation verification fails after its bounded retries', async () => {
+  const packages = [packageFor('foldkit', '1.2.3')]
+  const registry = new FakeRegistry(packages)
+  registry.packuments.get('foldkit')['dist-tags'].latest = '1.2.2'
+  let reads = 0
+  const readPackument = registry.packument.bind(registry)
+
+  registry.packument = async name => {
+    reads += 1
+
+    return readPackument(name)
+  }
+
+  await assert.rejects(
+    waitForTaggedSnapshot({
+      packages,
+      tag: 'latest',
+      registry,
+      attempts: 2,
+      delayMilliseconds: 0,
+    }),
+    /registry did not expose the complete latest snapshot.*foldkit@latest is 1.2.2, expected 1.2.3/,
+  )
+  assert.equal(reads, 2)
+})
+
+test('promotion retries a transient registry read without repeating the tag change', async () => {
+  const packages = [packageFor('foldkit', '1.2.3')]
+  const registry = new FakeRegistry(packages)
+  registry.add(artifactFor('foldkit', '1.2.2'))
+  registry.add(artifactFor('foldkit', '1.2.3'))
+  registry.packuments.get('foldkit')['dist-tags'].latest = '1.2.2'
+  const readPackument = registry.packument.bind(registry)
+  let isPromoted = false
+  let postPromotionReads = 0
+  let tagChanges = 0
+
+  registry.packument = async name => {
+    if (isPromoted) {
+      postPromotionReads += 1
+
+      if (postPromotionReads === 1) {
+        throw new Error('temporary registry read failure')
+      }
+    }
+
+    return readPackument(name)
+  }
+
+  await promoteSnapshot({
+    packages,
+    tag: 'latest',
+    registry,
+    addTag: async (pkg, tag) => {
+      tagChanges += 1
+      registry.packuments.get(pkg.packageJson.name)['dist-tags'][tag] =
+        pkg.packageJson.version
+      isPromoted = true
+    },
+    attempts: 2,
+    delayMilliseconds: 0,
+  })
+
+  assert.equal(tagChanges, 1)
+  assert.equal(postPromotionReads, 3)
+})
+
+test('npm registry requests abort when a read never settles', async () => {
+  const testTimeoutMilliseconds = 50
+  let isAborted = false
+  let testTimeout
+  const registry = new NpmRegistry('https://registry.example', {
+    requestTimeoutMilliseconds: 1,
+    fetchRegistry: (_url, { signal }) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            isAborted = true
+            reject(signal.reason)
+          },
+          { once: true },
+        )
+      }),
+  })
+
+  const testGuard = new Promise((_resolve, reject) => {
+    testTimeout = setTimeout(
+      () => reject(new Error('test timed out before the registry request')),
+      testTimeoutMilliseconds,
+    )
+  })
+
+  try {
+    await assert.rejects(
+      Promise.race([registry.packument('foldkit'), testGuard]),
+      /registry request timed out for foldkit/,
+    )
+  } finally {
+    clearTimeout(testTimeout)
+  }
+
+  assert.equal(isAborted, true)
+})
+
+test('npm tag changes share one OTP without exposing it in arguments', async () => {
+  const calls = []
+  let prompts = 0
+  const tagPackage = createNpmTagger({
+    env: { PATH: '/usr/bin' },
+    promptForOtp: async () => {
+      prompts += 1
+
+      return '123456'
+    },
+    run: (command, args, options) => {
+      calls.push({ command, args, options })
+    },
+  })
+
+  await tagPackage(packageFor('foldkit', '1.2.3'), 'latest')
+  await tagPackage(packageFor('@foldkit/ui', '1.2.3'), 'latest')
+
+  assert.equal(prompts, 1)
+  assert.deepEqual(
+    calls.map(({ command, args }) => [command, ...args]),
+    [
+      ['npm', 'dist-tag', 'add', 'foldkit@1.2.3', 'latest'],
+      ['npm', 'dist-tag', 'add', '@foldkit/ui@1.2.3', 'latest'],
+    ],
+  )
+
+  for (const call of calls) {
+    assert.equal(call.options.inherit, true)
+    assert.equal(call.options.env.NPM_CONFIG_OTP, '123456')
+    assert.doesNotMatch(call.args.join(' '), /123456/)
+  }
+})
+
+test('npm tag changes honor a supplied OTP without prompting', async () => {
+  let prompts = 0
+  let receivedEnvironment
+  const tagPackage = createNpmTagger({
+    env: {
+      NPM_CONFIG_OTP: '654321',
+      npm_config_otp: 'lowercase-secret',
+      PATH: '/usr/bin',
+    },
+    promptForOtp: async () => {
+      prompts += 1
+
+      return 'unexpected'
+    },
+    run: (_command, _args, options) => {
+      receivedEnvironment = options.env
+    },
+  })
+
+  await tagPackage(packageFor('foldkit', '1.2.3'), 'latest')
+
+  assert.equal(prompts, 0)
+  assert.deepEqual(receivedEnvironment, {
+    NPM_CONFIG_OTP: '654321',
+    PATH: '/usr/bin',
+  })
+})
+
+test('interactive npm OTP input is not echoed', async () => {
+  const input = new PassThrough()
+  const output = new PassThrough()
+  let outputText = ''
+
+  input.isTTY = true
+  input.isRaw = false
+  input.setRawMode = isRaw => {
+    input.isRaw = isRaw
+
+    return input
+  }
+  output.on('data', chunk => {
+    outputText += chunk.toString()
+  })
+
+  const otpPromise = promptForNpmOtp({ input, output })
+  input.write('123456\n')
+
+  assert.equal(await otpPromise, '123456')
+  assert.equal(outputText, 'npm OTP: \n')
+  assert.doesNotMatch(outputText, /123456/)
+
+  input.end()
+  output.end()
+})
+
+test('release promotion resolves an exact commit from a clean checkout', () => {
+  const commit = '0123456789abcdef0123456789abcdef01234567'
+  const calls = []
+  const environment = {
+    NPM_CONFIG_OTP: 'uppercase-secret',
+    npm_config_otp: 'lowercase-secret',
+    PATH: '/usr/bin',
+  }
+  const run = (command, args, options) => {
+    calls.push({ command, args, options })
+
+    if (args.includes('status')) {
+      return { stdout: '' }
+    }
+
+    return { stdout: `${commit}\n` }
+  }
+
+  assert.equal(resolveReleaseCommit('/repo', run, environment), commit)
+  assert.deepEqual(calls, [
+    {
+      command: 'git',
+      args: ['status', '--short'],
+      options: { cwd: '/repo', env: { PATH: '/usr/bin' } },
+    },
+    {
+      command: 'git',
+      args: ['rev-parse', 'HEAD'],
+      options: { cwd: '/repo', env: { PATH: '/usr/bin' } },
+    },
+  ])
+
+  assert.throws(
+    () =>
+      resolveReleaseCommit('/repo', () => ({
+        stdout: '?? packages/untracked/package.json\n',
+      })),
+    /requires a clean checkout/,
+  )
+})
+
+test('stable promotion validates the release commit on current main', () => {
+  const commit = '0123456789abcdef0123456789abcdef01234567'
+  const environment = {
+    NPM_CONFIG_OTP: 'uppercase-secret',
+    PATH: '/usr/bin',
+  }
+  const workspacePackages = [packageFor('foldkit', '1.2.3')]
+  const repository = {}
+  const calls = []
+  const derived = []
+  const run = (command, args, options) => {
+    calls.push({ command, args, options })
+
+    return {
+      stdout: args.includes('branch') ? 'origin/main\n' : '',
+    }
+  }
+
+  verifyStableReleaseCommit({
+    root: '/repo',
+    commit,
+    env: environment,
+    run,
+    workspacePackages,
+    git: repository,
+    deriveReleasePackages: options => {
+      derived.push(options)
+
+      return { commit, packages: [{ name: 'foldkit', version: '1.2.3' }] }
+    },
+  })
+
+  assert.deepEqual(calls, [
+    {
+      command: 'git',
+      args: ['fetch', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+      options: { cwd: '/repo', env: { PATH: '/usr/bin' } },
+    },
+    {
+      command: 'git',
+      args: [
+        'branch',
+        '--remotes',
+        '--contains',
+        commit,
+        '--format=%(refname:short)',
+      ],
+      options: { cwd: '/repo', env: { PATH: '/usr/bin' } },
+    },
+  ])
+  assert.deepEqual(derived, [
+    {
+      root: '/repo',
+      publishedCommit: commit,
+      git: repository,
+      workspacePackages,
+    },
+  ])
+
+  assert.throws(
+    () =>
+      verifyStableReleaseCommit({
+        root: '/repo',
+        commit,
+        env: environment,
+        run: (_command, args) => ({
+          stdout: args.includes('branch') ? 'origin/feature\n' : '',
+        }),
+        workspacePackages,
+        git: repository,
+        deriveReleasePackages: assert.fail,
+      }),
+    /is not an ancestor of origin\/main/,
+  )
+})
+
+test('release finalization targets the exact published commit', () => {
+  const commit = '0123456789abcdef0123456789abcdef01234567'
+  const calls = []
+  const environment = {
+    NPM_CONFIG_OTP: 'uppercase-secret',
+    npm_config_otp: 'lowercase-secret',
+    PATH: '/usr/bin',
+  }
+
+  dispatchReleaseFinalization(
+    '/repo',
+    commit,
+    (command, args, options) => {
+      calls.push({ command, args, options })
+    },
+    environment,
+  )
+
+  assert.deepEqual(calls, [
+    {
+      command: 'gh',
+      args: [
+        'workflow',
+        'run',
+        'release.yml',
+        '-f',
+        `published_commit=${commit}`,
+      ],
+      options: {
+        cwd: '/repo',
+        inherit: true,
+        env: { PATH: '/usr/bin' },
+      },
+    },
+  ])
+  assert.throws(
+    () => dispatchReleaseFinalization('/repo', 'HEAD', assert.fail),
+    /requires a full lowercase Git commit/,
+  )
+})
+
+test('stable finalization starts only after verified promotion', async () => {
+  const commit = '0123456789abcdef0123456789abcdef01234567'
+  const events = []
+  const result = await promoteAndFinalizeCurrentWorkspace({
+    root: '/repo',
+    resolveCommit: () => {
+      events.push('resolved commit')
+
+      return commit
+    },
+    verifyCommit: publishedCommit => {
+      events.push(`verified ${publishedCommit}`)
+    },
+    promote: async () => {
+      events.push('verified promotion')
+
+      return { promoted: ['foldkit'], alreadyPromoted: [] }
+    },
+    dispatch: async publishedCommit => {
+      events.push(`dispatched ${publishedCommit}`)
+    },
+  })
+
+  assert.deepEqual(events, [
+    'resolved commit',
+    `verified ${commit}`,
+    'verified promotion',
+    `dispatched ${commit}`,
+  ])
+  assert.equal(result.publishedCommit, commit)
+
+  events.length = 0
+
+  await assert.rejects(
+    promoteAndFinalizeCurrentWorkspace({
+      root: '/repo',
+      resolveCommit: () => commit,
+      verifyCommit: () => {},
+      promote: async () => {
+        events.push('failed promotion')
+
+        throw new Error('registry verification failed')
+      },
+      dispatch: async () => {
+        events.push('unexpected dispatch')
+      },
+    }),
+    /registry verification failed/,
+  )
+  assert.deepEqual(events, ['failed promotion'])
+
+  events.length = 0
+
+  await assert.rejects(
+    promoteAndFinalizeCurrentWorkspace({
+      root: '/repo',
+      resolveCommit: () => commit,
+      verifyCommit: () => {
+        events.push('rejected release commit')
+
+        throw new Error('commit did not version public packages')
+      },
+      promote: async () => {
+        events.push('unexpected promotion')
+      },
+      dispatch: async () => {
+        events.push('unexpected dispatch')
+      },
+    }),
+    /commit did not version public packages/,
+  )
+  assert.deepEqual(events, ['rejected release commit'])
+})
+
+test('stable finalization can retry after a dispatch failure', async () => {
+  const commit = '0123456789abcdef0123456789abcdef01234567'
+  let promotions = 0
+  let dispatches = 0
+  const options = {
+    root: '/repo',
+    resolveCommit: () => commit,
+    verifyCommit: () => {},
+    promote: async () => {
+      promotions += 1
+
+      return { promoted: [], alreadyPromoted: ['foldkit'] }
+    },
+    dispatch: async () => {
+      dispatches += 1
+
+      if (dispatches === 1) {
+        throw new Error('GitHub dispatch failed')
+      }
+    },
+  }
+
+  await assert.rejects(
+    promoteAndFinalizeCurrentWorkspace(options),
+    /GitHub dispatch failed/,
+  )
+  await promoteAndFinalizeCurrentWorkspace(options)
+
+  assert.equal(promotions, 2)
+  assert.equal(dispatches, 2)
 })

--- a/scripts/lib/github-release.mjs
+++ b/scripts/lib/github-release.mjs
@@ -59,14 +59,16 @@ export const extractReleaseNotes = (changelog, version) => {
 }
 
 export class GitRepository {
-  constructor(root) {
+  constructor(root, env = process.env) {
     this.root = root
+    this.env = env
   }
 
   run(args) {
     return spawnSync('git', args, {
       cwd: this.root,
       encoding: 'utf8',
+      env: this.env,
     })
   }
 

--- a/scripts/lib/workspace-packages.mjs
+++ b/scripts/lib/workspace-packages.mjs
@@ -54,12 +54,21 @@ export const workspacePackagesFromEntries = (root, entries) => {
   return packages
 }
 
-export const readWorkspacePackages = root => {
-  const pnpm = process.env['FOLDKIT_PNPM_EXECUTABLE'] ?? 'pnpm'
+export const readWorkspacePackages = (
+  root,
+  { env = process.env, run = spawnSync } = {},
+) => {
+  const childEnvironment = { ...env }
 
-  const result = spawnSync(pnpm, ['ls', '-r', '--depth', '-1', '--json'], {
+  delete childEnvironment['NPM_CONFIG_OTP']
+  delete childEnvironment['npm_config_otp']
+
+  const pnpm = childEnvironment['FOLDKIT_PNPM_EXECUTABLE'] ?? 'pnpm'
+
+  const result = run(pnpm, ['ls', '-r', '--depth', '-1', '--json'], {
     cwd: root,
     encoding: 'utf8',
+    env: childEnvironment,
   })
 
   if (result.status !== 0) {

--- a/scripts/lib/workspace-packages.test.mjs
+++ b/scripts/lib/workspace-packages.test.mjs
@@ -7,6 +7,7 @@ import { test } from 'node:test'
 import {
   assertCompleteReleaseSet,
   publicWorkspacePackages,
+  readWorkspacePackages,
   workspacePackagesFromEntries,
 } from './workspace-packages.mjs'
 
@@ -55,4 +56,56 @@ test('rejects a coherent set that omits a public workspace package', () => {
     () => assertCompleteReleaseSet(packages, packages.slice(0, 1)),
     /missing public packages: @foldkit\/ui/,
   )
+})
+
+test('workspace discovery does not expose npm OTP values to pnpm', () => {
+  const root = mkdtempSync(join(tmpdir(), 'foldkit-workspaces-'))
+
+  try {
+    const entries = [
+      writePackage(root, 'packages/alpha', {
+        name: '@foldkit/alpha',
+        version: '1.0.0',
+      }),
+    ]
+    const calls = []
+    const packages = readWorkspacePackages(root, {
+      env: {
+        FOLDKIT_PNPM_EXECUTABLE: '/usr/bin/pnpm',
+        NPM_CONFIG_OTP: 'uppercase-secret',
+        npm_config_otp: 'lowercase-secret',
+        PATH: '/usr/bin',
+      },
+      run: (command, args, options) => {
+        calls.push({ command, args, options })
+
+        return {
+          status: 0,
+          stdout: JSON.stringify(entries),
+          stderr: '',
+        }
+      },
+    })
+
+    assert.deepEqual(
+      packages.map(pkg => pkg.packageJson.name),
+      ['@foldkit/alpha'],
+    )
+    assert.deepEqual(calls, [
+      {
+        command: '/usr/bin/pnpm',
+        args: ['ls', '-r', '--depth', '-1', '--json'],
+        options: {
+          cwd: root,
+          encoding: 'utf8',
+          env: {
+            FOLDKIT_PNPM_EXECUTABLE: '/usr/bin/pnpm',
+            PATH: '/usr/bin',
+          },
+        },
+      },
+    ])
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 })

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -5,6 +5,7 @@ import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const gitignore = readFileSync(resolve(REPO_ROOT, '.gitignore'), 'utf8')
 const workflow = readFileSync(
   resolve(REPO_ROOT, '.github/workflows/release.yml'),
   'utf8',
@@ -18,6 +19,10 @@ const rootPackage = JSON.parse(
 )
 const coherentPublisher = readFileSync(
   resolve(REPO_ROOT, 'scripts/lib/coherent-release.mjs'),
+  'utf8',
+)
+const coherentReleaseCli = readFileSync(
+  resolve(REPO_ROOT, 'scripts/coherent-release.mjs'),
   'utf8',
 )
 
@@ -164,4 +169,21 @@ test('website deployment waits for a separately verified latest promotion', () =
   assert.match(workflow, /finalize:[\s\S]+permissions:\n\s+contents: write/)
   assert.match(workflow, /needs: finalize/)
   assert.doesNotMatch(workflow, /needs: release\n\s+if: needs\.release/)
+})
+
+test('interactive promotion dispatches finalization after registry verification', () => {
+  assert.equal(
+    rootPackage.scripts['release:promote'],
+    'node scripts/coherent-release.mjs promote',
+  )
+  assert.match(
+    coherentReleaseCli,
+    /const result = await promoteAndFinalizeCurrentWorkspace\(\{ root: REPO_ROOT \}\)/,
+  )
+  assert.match(
+    coherentReleaseCli,
+    /Dispatched stable finalization for \$\{result\.publishedCommit\}/,
+  )
+  assert.doesNotMatch(coherentReleaseCli, /Finalize the release with:/)
+  assert.match(gitignore, /^\.pnpm-store\/$/m)
 })


### PR DESCRIPTION
## Summary

- wait for each dependency-ordered `dist-tag` change before starting the next
  one, then retry complete `latest` verification
- collect one hidden npm OTP and reuse it only for the promotion child
  processes
- dispatch stable GitHub finalization for the exact release commit after the
  complete npm snapshot verifies

## Failure model

The 0.150.0 promotion moved every `latest` tag successfully, but an immediate
registry read still returned `@foldkit/devtools@0.149.0`. The promoter reported
failure even though npm exposed the complete 0.150.0 snapshot seconds later.
Promotion also required a separate OTP interaction for each package and left a
second manual GitHub workflow dispatch after npm had completed.

The promoter now waits for each planned tag change to become visible before
starting the next one, so npm propagation cannot reorder the dependency-safe
path. It then polls the complete public package set until every intended
`latest` tag is visible. Registry requests have their own timeout, so a stalled
read cannot hang the retry loop. The promoter still verifies every uploaded
version and internal dependency before changing a tag, and the finalizer
repeats those checks before creating Git tags, GitHub Releases, or deploying
the website.

## Authentication constraints

Trusted publishing remains the only package-upload credential. Stable uploads
still use OIDC provenance under the commit-addressed holding tag. npm's current
trusted-publisher permissions cover `npm publish` and `npm stage publish`, not
`npm dist-tag`, so this PR does not add an npm token or weaken package
authentication.

Stable promotion remains one local command with one interactive npm OTP. The
OTP is not echoed or placed in command arguments. A bypass-2FA granular access
token is deliberately not used because it would be a long-lived write secret,
and npm has announced the retirement of direct publishing with those tokens
around January 2027. Supplied uppercase or lowercase npm OTP environment values
are stripped from the pnpm, Git, and GitHub subprocesses.

- https://docs.npmjs.com/trusted-publishers/
- https://docs.npmjs.com/cli/commands/npm-dist-tag/
- https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/

## Retry behavior

`pnpm release:promote` requires a clean checkout, including untracked files,
and resolves its exact commit before promotion. The generated local pnpm store
is ignored so package-manager setup does not trip that gate. Before npm changes,
the promoter refreshes `origin/main`, confirms that the commit is on current
main, and derives at least one versioned public package and changelog section
from that exact commit. Promotion then skips tags that already name the intended
versions, rejects backward or concurrently changed tags, waits after each
ordered mutation, polls complete registry propagation with bounded requests and
retries, and dispatches `release.yml` only after the complete snapshot verifies.

If GitHub dispatch fails after npm succeeds, rerunning the same command moves
no npm tags and needs no new OTP. It verifies npm again and retries the
idempotent finalizer for the same commit. Existing matching Git tags and
Releases remain no-ops, while conflicting metadata still fails closed.

## Consumer coherence

Stable consumers see the same dependency-compatible promotion order and no
GitHub release metadata or website deployment until the full `latest` snapshot
verifies. Canary upload and consumption are unchanged: canaries remain exact,
commit-addressed snapshots under their non-consumer holding tags and never
create stable GitHub Releases.

## Verification

- `pnpm test:scripts` (132 tests)
- `pnpm typecheck:scripts`
- `pnpm lint:ci`
- `pnpm check:dead-code`
- `pnpm format:check`
- mutation: bypassing tag propagation polling failed both propagation tests
- mutation: prompting for every tag change failed the OTP reuse tests
- mutation: removing finalizer dispatch failed the ordering and retry tests
- mutation: advancing before an earlier tag propagated failed the two-package
  compatibility test
- mutation: ignoring untracked files failed the clean-checkout test
- mutation: leaking OTP variables failed the npm, git, and GitHub process tests
- mutation: removing the registry abort signal failed the stalled-read test
- mutation: leaking OTP variables to pnpm failed the workspace-discovery test
- mutation: skipping exact release-commit validation failed before promotion
- mutation: dropping transient read recovery failed without repeating a tag
- mutation: removing the local pnpm store ignore failed the workflow test

No changeset is included because this changes repository release tooling and
documentation, not a published package artifact.
