### PR TITLE
fix(website): let share images render on other origins

### DIFF
--- a/scripts/deploy-website-workflow.test.mjs
+++ b/scripts/deploy-website-workflow.test.mjs
@@ -53,6 +53,8 @@ const DEPLOYED_FILES = new Set([
   '404.json',
   'core/model/index.html',
   'core/model.md',
+  'og/core-model.png',
+  'blog/dispatch-1/cover.webp',
   'newsletter/index.html',
   'playground/index.html',
   'playground/counter/index.html',
@@ -192,6 +194,32 @@ test('the deployed playground and Monaco workers share an embedder policy', () =
     workerEmbedderRoutes.every(route => route.continue === true),
     true,
   )
+})
+
+test('share images stay embeddable from other origins', () => {
+  const ogCard = resolveRequest(productionConfig, '/og/core-model.png')
+  assert.equal(ogCard.servedFile, 'og/core-model.png')
+  assert.deepEqual(ogCard.headers, {
+    'Content-Type': 'image/png',
+    'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    'Cross-Origin-Resource-Policy': 'cross-origin',
+  })
+
+  const canaryOgCard = resolveRequest(canaryConfig, '/og/core-model.png')
+  assert.equal(
+    canaryOgCard.headers['Cross-Origin-Resource-Policy'],
+    'cross-origin',
+  )
+
+  const cover = resolveRequest(productionConfig, '/blog/dispatch-1/cover.webp')
+  assert.equal(cover.servedFile, 'blog/dispatch-1/cover.webp')
+  assert.equal(cover.headers['Cross-Origin-Resource-Policy'], 'cross-origin')
+
+  const page = resolveRequest(productionConfig, '/core/model', 'text/html')
+  assert.equal(page.headers['Cross-Origin-Resource-Policy'], 'same-origin')
+
+  const feed = resolveRequest(productionConfig, '/blog/rss.xml')
+  assert.equal(feed.headers['Cross-Origin-Resource-Policy'], 'same-origin')
 })
 
 test('unknown paths return a real 404 in the format the client asked for', () => {

--- a/scripts/website-vercel-config.mjs
+++ b/scripts/website-vercel-config.mjs
@@ -34,6 +34,15 @@ const acceptsMediaType = mediaType => [
 const MARKDOWN_PAGE_PATTERN =
   '^/(?!playground(?:/|$)|newsletter(?:/|$)|404(?:/|$))([^.]+?)/?$'
 
+// NOTE: OG cards and blog post images render on other origins by design:
+// share-preview testers hotlink the card, and feed readers hotlink the RSS
+// enclosure and article images. The blanket same-origin resource policy makes
+// browsers refuse those loads, so these paths override it. Later `continue`
+// routes win when both match, so the override must sit after the blanket
+// route.
+const EMBEDDABLE_IMAGE_PATTERN =
+  '^/(?:og/.*\\.png|blog/.*\\.(?:avif|gif|jpe?g|png|svg|webp))$'
+
 export const websiteVercelConfig = channel => {
   if (channel !== 'production' && channel !== 'canary') {
     throw new Error(`Unknown website deployment channel: ${channel}`)
@@ -90,6 +99,13 @@ export const websiteVercelConfig = channel => {
       {
         src: '.*',
         headers: sharedResponseHeaders(channel),
+        continue: true,
+      },
+      {
+        src: EMBEDDABLE_IMAGE_PATTERN,
+        headers: {
+          'Cross-Origin-Resource-Policy': 'cross-origin',
+        },
         continue: true,
       },
       {


### PR DESCRIPTION
Every response, including the `/og/*.png` share cards and the blog post images the RSS feed advertises, carried `Cross-Origin-Resource-Policy: same-origin` from the blanket header route. Browsers therefore refused to render those images anywhere but foldkit.dev itself: an OG preview tester shows an empty card, and a web-based feed reader shows a blocked enclosure image. Platforms that rehost images server-side kept working, which hid the breakage. The header has shipped with the playground's isolation config since May, but the playground does not need it on these paths: COEP `credentialless` requires no CORP anywhere, and CORP on our own resources only controls whether other origins may embed them, which for share images is the point.

The fix adds a `continue` route overriding the policy to `cross-origin` for OG cards and blog images. It sits after the blanket route because later `continue` routes win when both match; a new test pins both the headers and that ordering. Pages, the feed itself, the playground, and the Monaco workers keep `same-origin`. The alternative of excluding these paths from the blanket route's regex was rejected: a negative lookahead there would complicate the one route that every response flows through, while a later override keeps each concern in its own route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUHBeopqsFw1WjRSQHZPHL)_