### PR TITLE
docs: add AGENTS.md upgrade guidance

### DIFF
--- a/.changeset/fresh-files-guide.md
+++ b/.changeset/fresh-files-guide.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Tell agents that the scaffolded `AGENTS.md` is a snapshot and prompt them to offer an update from the current template when it drifts, while preserving `subtree_prompted` and project-specific notes.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Skills for building Foldkit apps \u2014 app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/packages/create-foldkit-app/templates/base/AGENTS.md
+++ b/packages/create-foldkit-app/templates/base/AGENTS.md
@@ -20,6 +20,16 @@ subtree_prompted: false
 
 If `foldkit-skills` is installed as a Claude Code plugin, the `generate-program` and `audit-program` skills carry snapshot architecture and conventions guides synced from the live code.
 
+### Keeping this file current
+
+This file was copied from Foldkit's scaffolder when the project was created. Foldkit updates this template often as its APIs and conventions change.
+
+If `./repos/foldkit` exists, compare this file with `repos/foldkit/packages/create-foldkit-app/templates/base/AGENTS.md`. Ignore the `subtree_prompted` line and any project-specific additions when comparing. The template keeps `subtree_prompted` set to `false`, while a project that has answered the subtree offer uses `true`.
+
+If the remaining content differs, offer to replace this file with the current template. Act only if the user accepts. Preserve this file's existing `subtree_prompted` value and any project-specific additions instead of overwriting them.
+
+If `./repos/foldkit` does not exist, use the [current template on GitHub](https://github.com/foldkit/foldkit/blob/main/packages/create-foldkit-app/templates/base/AGENTS.md) for the comparison and the same replacement offer.
+
 ## Project Conventions
 
 - Foldkit is tightly coupled to the Effect ecosystem. Do not suggest solutions outside of Effect-TS.

--- a/packages/website/src/page/aiOverview.md
+++ b/packages/website/src/page/aiOverview.md
@@ -28,6 +28,8 @@ Refresh the subtree when you want the latest source and examples:
 git subtree pull --prefix=repos/foldkit https://github.com/foldkit/foldkit.git main --squash
 ```
 
+`create-foldkit-app` writes `AGENTS.md` only when it creates the project, but the conventions in that file change with the framework. When you upgrade Foldkit, replace `AGENTS.md` from the [current scaffolder template](https://github.com/foldkit/foldkit/blob/main/packages/create-foldkit-app/templates/base/AGENTS.md) too. If you vendor the repository, copy it from `repos/foldkit/packages/create-foldkit-app/templates/base/AGENTS.md`. Keep the existing `subtree_prompted` value and any project-specific notes. A stale copy can steer an agent toward APIs that the installed packages no longer export.
+
 ## Foldkit Skills
 
 Foldkit ships [agent skills](/ai/skills) for Claude Code, Codex, the ChatGPT desktop app, and OpenCode. The skills encode repeatable workflows for building and auditing Foldkit applications. They also direct the agent to the vendored repository when the live source is more authoritative than a written guide.

--- a/packages/website/src/page/gettingStarted.md
+++ b/packages/website/src/page/gettingStarted.md
@@ -43,7 +43,7 @@ The exact files depend on the rendering mode and starter example. A small browse
 - `tsconfig.json`: TypeScript configuration
 - `.oxlintrc.json`: Oxlint configuration
 - `.prettierrc`: Prettier configuration
-- `AGENTS.md`: conventions for AI coding assistants working on the project
+- `AGENTS.md`: conventions for AI coding assistants working on the project; this file is a scaffolder snapshot, so [replace it from the current template when you upgrade Foldkit](/ai/overview)
 
 In a small starter, `src/main.ts` holds the Model, Messages, update, init, and view. Larger examples move those definitions into focused modules as the application grows.
 

--- a/skills/foldkit/SKILL.md
+++ b/skills/foldkit/SKILL.md
@@ -22,6 +22,8 @@ Foldkit is not incremental. There is no React interop, no escape hatch, no "just
 
 The foldkit repo is vendored as a git subtree at `repos/foldkit/` from the project root. It is the source of truth for everything: conventions, framework source, examples, the quality bar. Browse it directly.
 
+A consumer project's `AGENTS.md` is a scaffolder snapshot and can lag behind the installed packages. The current copy is `repos/foldkit/packages/create-foldkit-app/templates/base/AGENTS.md`, or `packages/create-foldkit-app/templates/base/AGENTS.md` when working in the Foldkit repository itself. Compare the consumer project's file with that template while ignoring `subtree_prompted` and any project-specific additions. If the remaining content differs, offer to replace it while preserving both. The Foldkit repository's root `AGENTS.md` is not a scaffold copy; never compare or replace it.
+
 Stable top-level entry points:
 
 - `repos/foldkit/examples/`: runnable example apps spanning every complexity tier. Usually your first stop when looking for a precedent.


### PR DESCRIPTION
Scaffolded agent instructions do not change when applications update their
Foldkit packages. Point agents and users to the current template so stale
guidance does not keep retired APIs in use.