### PR TITLE
fix(foldkit): infer folded command environments

### DIFF
--- a/.changeset/fuzzy-menus-fold.md
+++ b/.changeset/fuzzy-menus-fold.md
@@ -2,4 +2,4 @@
 'foldkit': patch
 ---
 
-Infer child update Command and parent `foldOutMessage` Step service requirements independently in `Update.foldChild` and `Update.foldChildStep`.
+Prevent `foldOutMessage` from narrowing the parent Model while combining child-wrapper and OutMessage Step Message and Command service types in `Update.foldChild` and `Update.foldChildStep`.

--- a/.changeset/fuzzy-menus-fold.md
+++ b/.changeset/fuzzy-menus-fold.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Infer child update Command and parent `foldOutMessage` Step service requirements independently in `Update.foldChild` and `Update.foldChildStep`.

--- a/packages/foldkit/src/update/update.test.ts
+++ b/packages/foldkit/src/update/update.test.ts
@@ -1,4 +1,5 @@
 import { Array, Effect, HashMap, Match as M, Number, Option } from 'effect'
+import * as KeyValueStore from 'effect/unstable/persistence/KeyValueStore'
 import { expect, expectTypeOf } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
@@ -951,9 +952,50 @@ describe('foldChildStep', () => {
 
 describe('types', () => {
   type TestServices = Readonly<{ baseUrl: string }>
+  type PersistenceServices = KeyValueStore.KeyValueStore
   type TestOutMessage = Readonly<{ _tag: 'ClosedEditor' }>
 
   const baseModel: TestModel = { count: 0 }
+  const testOutMessage: TestOutMessage = { _tag: 'ClosedEditor' }
+  const saveWithServices: Command<CounterMessage, never, TestServices> = {
+    name: 'SaveWithServices',
+    effect: Effect.context<TestServices>().pipe(
+      Effect.as(Message.CompletedSaveCount()),
+    ),
+  }
+  const updateCounterWithServices = (
+    model: CounterModel,
+    _message: CounterMessage,
+  ): ReturnWithOutMessage<
+    CounterModel,
+    CounterMessage,
+    ChangedValue,
+    TestServices
+  > => [model, [saveWithServices], Option.some(ChangedValue())]
+  const resetCounterWithServices = (
+    model: CounterModel,
+  ): ReturnWithOutMessage<
+    CounterModel,
+    CounterMessage,
+    ChangedValue,
+    TestServices
+  > => [model, [saveWithServices], Option.some(ChangedValue())]
+  const notifyWithPersistence: Command<
+    TestMessage,
+    never,
+    PersistenceServices
+  > = {
+    name: 'NotifyWithPersistence',
+    effect: Effect.context<PersistenceServices>().pipe(
+      Effect.as(Message.CompletedLoad()),
+    ),
+  }
+  const foldChangedValueWithPersistence = M.type<ChangedValue>().pipe(
+    M.withReturnType<Step<DashboardModel, TestMessage, PersistenceServices>>(),
+    M.tagsExhaustive({
+      ChangedValue: () => model => [model, [notifyWithPersistence]],
+    }),
+  )
 
   it('Return carries the Model and optional Commands', () => {
     expectTypeOf<Return<TestModel, TestMessage>>().toEqualTypeOf<
@@ -1081,6 +1123,60 @@ describe('types', () => {
     >()
     expectTypeOf(handleGotReportingCounterMessage).returns.toEqualTypeOf<
       Return<DashboardModel, DashboardMessage>
+    >()
+  })
+
+  it('foldChild combines child and OutMessage Step service requirements', () => {
+    const foldWithServices = foldChild({
+      update: updateCounterWithServices,
+      read: (model: DashboardModel) => Option.some(model.counter),
+      write: (model, nextCounter) => ({ ...model, counter: nextCounter }),
+      toParentMessage: () => Message.IncrementedCount(),
+      foldOutMessage: foldChangedValueWithPersistence,
+    })
+
+    expectTypeOf(foldWithServices).toEqualTypeOf<
+      Fold<
+        DashboardModel,
+        TestMessage,
+        CounterMessage,
+        TestServices | PersistenceServices
+      >
+    >()
+  })
+
+  it('foldChild combines service requirements when lifting the OutMessage', () => {
+    const foldWithServices = foldChild({
+      update: updateCounterWithServices,
+      read: (model: DashboardModel) => Option.some(model.counter),
+      write: (model, nextCounter) => ({ ...model, counter: nextCounter }),
+      toParentMessage: () => Message.IncrementedCount(),
+      toParentOutMessage: () => Option.some(testOutMessage),
+      foldOutMessage: foldChangedValueWithPersistence,
+    })
+
+    expectTypeOf(foldWithServices).toEqualTypeOf<
+      FoldWithOutMessage<
+        DashboardModel,
+        TestMessage,
+        CounterMessage,
+        TestOutMessage,
+        TestServices | PersistenceServices
+      >
+    >()
+  })
+
+  it('foldChildStep combines child and OutMessage Step service requirements', () => {
+    const foldStepWithServices = foldChildStep({
+      update: resetCounterWithServices,
+      read: (model: DashboardModel) => Option.some(model.counter),
+      write: (model, nextCounter) => ({ ...model, counter: nextCounter }),
+      toParentMessage: () => Message.IncrementedCount(),
+      foldOutMessage: foldChangedValueWithPersistence,
+    })
+
+    expectTypeOf(foldStepWithServices).toEqualTypeOf<
+      Step<DashboardModel, TestMessage, TestServices | PersistenceServices>
     >()
   })
 

--- a/packages/foldkit/src/update/update.test.ts
+++ b/packages/foldkit/src/update/update.test.ts
@@ -954,6 +954,10 @@ describe('types', () => {
   type TestServices = Readonly<{ baseUrl: string }>
   type PersistenceServices = KeyValueStore.KeyValueStore
   type TestOutMessage = Readonly<{ _tag: 'ClosedEditor' }>
+  type FoldInferenceModel = Readonly<{
+    counter: CounterModel
+    status: 'Idle' | 'Saved'
+  }>
 
   const baseModel: TestModel = { count: 0 }
   const testOutMessage: TestOutMessage = { _tag: 'ClosedEditor' }
@@ -971,7 +975,7 @@ describe('types', () => {
     CounterMessage,
     ChangedValue,
     TestServices
-  > => [model, [saveWithServices], Option.some(ChangedValue())]
+  > => ({ model, commands: [saveWithServices], outMessage: ChangedValue() })
   const resetCounterWithServices = (
     model: CounterModel,
   ): ReturnWithOutMessage<
@@ -979,7 +983,7 @@ describe('types', () => {
     CounterMessage,
     ChangedValue,
     TestServices
-  > => [model, [saveWithServices], Option.some(ChangedValue())]
+  > => ({ model, commands: [saveWithServices], outMessage: ChangedValue() })
   const notifyWithPersistence: Command<
     TestMessage,
     never,
@@ -991,9 +995,14 @@ describe('types', () => {
     ),
   }
   const foldChangedValueWithPersistence = M.type<ChangedValue>().pipe(
-    M.withReturnType<Step<DashboardModel, TestMessage, PersistenceServices>>(),
+    M.withReturnType<
+      Step<FoldInferenceModel, TestMessage, PersistenceServices>
+    >(),
     M.tagsExhaustive({
-      ChangedValue: () => model => [model, [notifyWithPersistence]],
+      ChangedValue: () => model => ({
+        model: evo(model, { status: () => 'Saved' }),
+        commands: [notifyWithPersistence],
+      }),
     }),
   )
 
@@ -1129,16 +1138,16 @@ describe('types', () => {
   it('foldChild combines child and OutMessage Step service requirements', () => {
     const foldWithServices = foldChild({
       update: updateCounterWithServices,
-      read: (model: DashboardModel) => Option.some(model.counter),
+      read: (model: FoldInferenceModel) => Option.some(model.counter),
       write: (model, nextCounter) => ({ ...model, counter: nextCounter }),
-      toParentMessage: () => Message.IncrementedCount(),
+      toParentMessage: GotCounterMessage,
       foldOutMessage: foldChangedValueWithPersistence,
     })
 
     expectTypeOf(foldWithServices).toEqualTypeOf<
       Fold<
-        DashboardModel,
-        TestMessage,
+        FoldInferenceModel,
+        GotCounterMessage | TestMessage,
         CounterMessage,
         TestServices | PersistenceServices
       >
@@ -1148,17 +1157,17 @@ describe('types', () => {
   it('foldChild combines service requirements when lifting the OutMessage', () => {
     const foldWithServices = foldChild({
       update: updateCounterWithServices,
-      read: (model: DashboardModel) => Option.some(model.counter),
+      read: (model: FoldInferenceModel) => Option.some(model.counter),
       write: (model, nextCounter) => ({ ...model, counter: nextCounter }),
-      toParentMessage: () => Message.IncrementedCount(),
-      toParentOutMessage: () => Option.some(testOutMessage),
+      toParentMessage: GotCounterMessage,
+      toParentOutMessage: () => testOutMessage,
       foldOutMessage: foldChangedValueWithPersistence,
     })
 
     expectTypeOf(foldWithServices).toEqualTypeOf<
       FoldWithOutMessage<
-        DashboardModel,
-        TestMessage,
+        FoldInferenceModel,
+        GotCounterMessage | TestMessage,
         CounterMessage,
         TestOutMessage,
         TestServices | PersistenceServices
@@ -1169,14 +1178,38 @@ describe('types', () => {
   it('foldChildStep combines child and OutMessage Step service requirements', () => {
     const foldStepWithServices = foldChildStep({
       update: resetCounterWithServices,
-      read: (model: DashboardModel) => Option.some(model.counter),
+      read: (model: FoldInferenceModel) => Option.some(model.counter),
       write: (model, nextCounter) => ({ ...model, counter: nextCounter }),
-      toParentMessage: () => Message.IncrementedCount(),
+      toParentMessage: GotCounterMessage,
       foldOutMessage: foldChangedValueWithPersistence,
     })
 
     expectTypeOf(foldStepWithServices).toEqualTypeOf<
-      Step<DashboardModel, TestMessage, TestServices | PersistenceServices>
+      Step<
+        FoldInferenceModel,
+        GotCounterMessage | TestMessage,
+        TestServices | PersistenceServices
+      >
+    >()
+  })
+
+  it('foldChildStep combines requirements when lifting the OutMessage', () => {
+    const foldStepWithServices = foldChildStep({
+      update: resetCounterWithServices,
+      read: (model: FoldInferenceModel) => Option.some(model.counter),
+      write: (model, nextCounter) => ({ ...model, counter: nextCounter }),
+      toParentMessage: GotCounterMessage,
+      toParentOutMessage: () => testOutMessage,
+      foldOutMessage: foldChangedValueWithPersistence,
+    })
+
+    expectTypeOf(foldStepWithServices).toEqualTypeOf<
+      StepWithOutMessage<
+        FoldInferenceModel,
+        GotCounterMessage | TestMessage,
+        TestOutMessage,
+        TestServices | PersistenceServices
+      >
     >()
   })
 

--- a/packages/foldkit/src/update/update.ts
+++ b/packages/foldkit/src/update/update.ts
@@ -292,9 +292,10 @@ export type FoldContext<ChildMessage, ParentMessage> = Readonly<{
  *    (`M.tagsExhaustive`), and build a multi-step fold with
  *    {@link combine}. Takes an optional second parameter, a
  *    {@link FoldContext} of lifters bound to `toParentMessage`, for a
- *    Command the Step returns whose result is the child's Message. The child
- *    update and OutMessage Step infer their service requirements independently;
- *    the resulting Fold requires their union. */
+ *    Command the Step returns whose result is the child's Message. Parent Model
+ *    inference comes from `read` and `write`; the child wrapper and OutMessage
+ *    Step infer their Message and service requirements independently, and the
+ *    resulting Fold requires their unions. */
 export type ChildFoldWithOutMessage<
   ParentModel,
   ParentMessage,
@@ -304,6 +305,7 @@ export type ChildFoldWithOutMessage<
   ChildOutMessage,
   ChildR = never,
   ParentR = ChildR,
+  OutMessageParentMessage = ParentMessage,
 > = Readonly<{
   update: (
     childModel: ChildModel,
@@ -315,7 +317,7 @@ export type ChildFoldWithOutMessage<
   foldOutMessage: (
     outMessage: ChildOutMessage,
     context: FoldContext<ChildMessage, ParentMessage>,
-  ) => Step<ParentModel, ParentMessage, ParentR>
+  ) => Step<NoInfer<ParentModel>, OutMessageParentMessage, ParentR>
 }>
 
 /** {@link ChildFoldWithOutMessage} for a parent that is itself a
@@ -345,6 +347,7 @@ export type ChildFoldWithParentOutMessage<
   ParentOutMessage,
   ChildR = never,
   ParentR = ChildR,
+  OutMessageParentMessage = ParentMessage,
 > = Readonly<{
   update: (
     childModel: ChildModel,
@@ -359,7 +362,7 @@ export type ChildFoldWithParentOutMessage<
   foldOutMessage?: (
     outMessage: ChildOutMessage,
     context: FoldContext<ChildMessage, ParentMessage>,
-  ) => Step<ParentModel, ParentMessage, ParentR>
+  ) => Step<NoInfer<ParentModel>, OutMessageParentMessage, ParentR>
 }>
 
 /** @internal Implementation-facing view of every {@link ChildFold}
@@ -492,6 +495,7 @@ export const foldChild: {
     ParentOutMessage,
     ChildR = never,
     ParentR = ChildR,
+    OutMessageParentMessage = ParentMessage,
   >(
     childFold: ChildFoldWithParentOutMessage<
       ParentModel,
@@ -502,11 +506,12 @@ export const foldChild: {
       ChildOutMessage,
       ParentOutMessage,
       ChildR,
-      ParentR
+      ParentR,
+      OutMessageParentMessage
     >,
   ): FoldWithOutMessage<
     ParentModel,
-    ParentMessage,
+    ParentMessage | OutMessageParentMessage,
     Input,
     ParentOutMessage,
     ChildR | ParentR
@@ -520,6 +525,7 @@ export const foldChild: {
     ChildOutMessage,
     ChildR = never,
     ParentR = ChildR,
+    OutMessageParentMessage = ParentMessage,
   >(
     childFold: ChildFoldWithOutMessage<
       ParentModel,
@@ -529,9 +535,15 @@ export const foldChild: {
       ChildMessage,
       ChildOutMessage,
       ChildR,
-      ParentR
+      ParentR,
+      OutMessageParentMessage
     >,
-  ): Fold<ParentModel, ParentMessage, Input, ChildR | ParentR>
+  ): Fold<
+    ParentModel,
+    ParentMessage | OutMessageParentMessage,
+    Input,
+    ChildR | ParentR
+  >
   <ParentModel, ParentMessage, ChildModel, Input, ChildMessage, R = never>(
     childFold: ChildFold<
       ParentModel,
@@ -626,7 +638,7 @@ export type ChildStepFold<
  *  OutMessage channel, adding `foldOutMessage`. It behaves exactly as it does
  *  in {@link ChildFoldWithOutMessage}, down to the optional second parameter,
  *  a {@link FoldContext} of lifters bound to `toParentMessage`, and combines
- *  the child update and OutMessage Step service requirements. */
+ *  the child update and OutMessage Step Message and service requirements. */
 export type ChildStepFoldWithOutMessage<
   ParentModel,
   ParentMessage,
@@ -635,6 +647,7 @@ export type ChildStepFoldWithOutMessage<
   ChildOutMessage,
   ChildR = never,
   ParentR = ChildR,
+  OutMessageParentMessage = ParentMessage,
 > = Readonly<{
   update: (
     childModel: ChildModel,
@@ -645,7 +658,7 @@ export type ChildStepFoldWithOutMessage<
   foldOutMessage: (
     outMessage: ChildOutMessage,
     context: FoldContext<ChildMessage, ParentMessage>,
-  ) => Step<ParentModel, ParentMessage, ParentR>
+  ) => Step<NoInfer<ParentModel>, OutMessageParentMessage, ParentR>
 }>
 
 /** {@link ChildStepFoldWithOutMessage} for a parent that is itself a
@@ -668,6 +681,7 @@ export type ChildStepFoldWithParentOutMessage<
   ParentOutMessage,
   ChildR = never,
   ParentR = ChildR,
+  OutMessageParentMessage = ParentMessage,
 > = Readonly<{
   update: (
     childModel: ChildModel,
@@ -681,7 +695,7 @@ export type ChildStepFoldWithParentOutMessage<
   foldOutMessage?: (
     outMessage: ChildOutMessage,
     context: FoldContext<ChildMessage, ParentMessage>,
-  ) => Step<ParentModel, ParentMessage, ParentR>
+  ) => Step<NoInfer<ParentModel>, OutMessageParentMessage, ParentR>
 }>
 
 /** @internal Implementation-facing view of both {@link ChildStepFold}
@@ -748,6 +762,7 @@ export const foldChildStep: {
     ParentOutMessage,
     ChildR = never,
     ParentR = ChildR,
+    OutMessageParentMessage = ParentMessage,
   >(
     childFold: ChildStepFoldWithParentOutMessage<
       ParentModel,
@@ -757,11 +772,12 @@ export const foldChildStep: {
       ChildOutMessage,
       ParentOutMessage,
       ChildR,
-      ParentR
+      ParentR,
+      OutMessageParentMessage
     >,
   ): StepWithOutMessage<
     ParentModel,
-    ParentMessage,
+    ParentMessage | OutMessageParentMessage,
     ParentOutMessage,
     ChildR | ParentR
   >
@@ -773,6 +789,7 @@ export const foldChildStep: {
     ChildOutMessage,
     ChildR = never,
     ParentR = ChildR,
+    OutMessageParentMessage = ParentMessage,
   >(
     childFold: ChildStepFoldWithOutMessage<
       ParentModel,
@@ -781,9 +798,14 @@ export const foldChildStep: {
       ChildMessage,
       ChildOutMessage,
       ChildR,
-      ParentR
+      ParentR,
+      OutMessageParentMessage
     >,
-  ): Step<ParentModel, ParentMessage, ChildR | ParentR>
+  ): Step<
+    ParentModel,
+    ParentMessage | OutMessageParentMessage,
+    ChildR | ParentR
+  >
   <ParentModel, ParentMessage, ChildModel, ChildMessage, R = never>(
     childFold: ChildStepFold<
       ParentModel,

--- a/packages/foldkit/src/update/update.ts
+++ b/packages/foldkit/src/update/update.ts
@@ -292,7 +292,9 @@ export type FoldContext<ChildMessage, ParentMessage> = Readonly<{
  *    (`M.tagsExhaustive`), and build a multi-step fold with
  *    {@link combine}. Takes an optional second parameter, a
  *    {@link FoldContext} of lifters bound to `toParentMessage`, for a
- *    Command the Step returns whose result is the child's Message. */
+ *    Command the Step returns whose result is the child's Message. The child
+ *    update and OutMessage Step infer their service requirements independently;
+ *    the resulting Fold requires their union. */
 export type ChildFoldWithOutMessage<
   ParentModel,
   ParentMessage,
@@ -300,19 +302,20 @@ export type ChildFoldWithOutMessage<
   Input,
   ChildMessage,
   ChildOutMessage,
-  R = never,
+  ChildR = never,
+  ParentR = ChildR,
 > = Readonly<{
   update: (
     childModel: ChildModel,
     input: Input,
-  ) => ReturnWithOutMessage<ChildModel, ChildMessage, ChildOutMessage, R>
+  ) => ReturnWithOutMessage<ChildModel, ChildMessage, ChildOutMessage, ChildR>
   read: (model: ParentModel) => Option.Option<ChildModel>
   write: (model: ParentModel, nextChildModel: ChildModel) => ParentModel
   toParentMessage: (message: ChildMessage) => ParentMessage
   foldOutMessage: (
     outMessage: ChildOutMessage,
     context: FoldContext<ChildMessage, ParentMessage>,
-  ) => Step<ParentModel, ParentMessage, R>
+  ) => Step<ParentModel, ParentMessage, ParentR>
 }>
 
 /** {@link ChildFoldWithOutMessage} for a parent that is itself a
@@ -340,12 +343,13 @@ export type ChildFoldWithParentOutMessage<
   ChildMessage,
   ChildOutMessage,
   ParentOutMessage,
-  R = never,
+  ChildR = never,
+  ParentR = ChildR,
 > = Readonly<{
   update: (
     childModel: ChildModel,
     input: Input,
-  ) => ReturnWithOutMessage<ChildModel, ChildMessage, ChildOutMessage, R>
+  ) => ReturnWithOutMessage<ChildModel, ChildMessage, ChildOutMessage, ChildR>
   read: (model: ParentModel) => Option.Option<ChildModel>
   write: (model: ParentModel, nextChildModel: ChildModel) => ParentModel
   toParentMessage: (message: ChildMessage) => ParentMessage
@@ -355,7 +359,7 @@ export type ChildFoldWithParentOutMessage<
   foldOutMessage?: (
     outMessage: ChildOutMessage,
     context: FoldContext<ChildMessage, ParentMessage>,
-  ) => Step<ParentModel, ParentMessage, R>
+  ) => Step<ParentModel, ParentMessage, ParentR>
 }>
 
 /** @internal Implementation-facing view of every {@link ChildFold}
@@ -486,7 +490,8 @@ export const foldChild: {
     ChildMessage,
     ChildOutMessage,
     ParentOutMessage,
-    R = never,
+    ChildR = never,
+    ParentR = ChildR,
   >(
     childFold: ChildFoldWithParentOutMessage<
       ParentModel,
@@ -496,9 +501,16 @@ export const foldChild: {
       ChildMessage,
       ChildOutMessage,
       ParentOutMessage,
-      R
+      ChildR,
+      ParentR
     >,
-  ): FoldWithOutMessage<ParentModel, ParentMessage, Input, ParentOutMessage, R>
+  ): FoldWithOutMessage<
+    ParentModel,
+    ParentMessage,
+    Input,
+    ParentOutMessage,
+    ChildR | ParentR
+  >
   <
     ParentModel,
     ParentMessage,
@@ -506,7 +518,8 @@ export const foldChild: {
     Input,
     ChildMessage,
     ChildOutMessage,
-    R = never,
+    ChildR = never,
+    ParentR = ChildR,
   >(
     childFold: ChildFoldWithOutMessage<
       ParentModel,
@@ -515,9 +528,10 @@ export const foldChild: {
       Input,
       ChildMessage,
       ChildOutMessage,
-      R
+      ChildR,
+      ParentR
     >,
-  ): Fold<ParentModel, ParentMessage, Input, R>
+  ): Fold<ParentModel, ParentMessage, Input, ChildR | ParentR>
   <ParentModel, ParentMessage, ChildModel, Input, ChildMessage, R = never>(
     childFold: ChildFold<
       ParentModel,
@@ -608,29 +622,30 @@ export type ChildStepFold<
   toParentMessage: (message: ChildMessage) => ParentMessage
 }>
 
-/** {@link ChildStepFold} for an entry point that can emit the child's
- *  OutMessage, adding `foldOutMessage`. The function has the same contract as
- *  `foldOutMessage` in {@link ChildFoldWithOutMessage}, including the optional
- *  second parameter: a {@link FoldContext} of lifters bound to
- *  `toParentMessage`. */
+/** {@link ChildStepFold} for an entry point whose return carries the child's
+ *  OutMessage channel, adding `foldOutMessage`. It behaves exactly as it does
+ *  in {@link ChildFoldWithOutMessage}, down to the optional second parameter,
+ *  a {@link FoldContext} of lifters bound to `toParentMessage`, and combines
+ *  the child update and OutMessage Step service requirements. */
 export type ChildStepFoldWithOutMessage<
   ParentModel,
   ParentMessage,
   ChildModel,
   ChildMessage,
   ChildOutMessage,
-  R = never,
+  ChildR = never,
+  ParentR = ChildR,
 > = Readonly<{
   update: (
     childModel: ChildModel,
-  ) => ReturnWithOutMessage<ChildModel, ChildMessage, ChildOutMessage, R>
+  ) => ReturnWithOutMessage<ChildModel, ChildMessage, ChildOutMessage, ChildR>
   read: (model: ParentModel) => Option.Option<ChildModel>
   write: (model: ParentModel, nextChildModel: ChildModel) => ParentModel
   toParentMessage: (message: ChildMessage) => ParentMessage
   foldOutMessage: (
     outMessage: ChildOutMessage,
     context: FoldContext<ChildMessage, ParentMessage>,
-  ) => Step<ParentModel, ParentMessage, R>
+  ) => Step<ParentModel, ParentMessage, ParentR>
 }>
 
 /** {@link ChildStepFoldWithOutMessage} for a parent that is itself a
@@ -651,11 +666,12 @@ export type ChildStepFoldWithParentOutMessage<
   ChildMessage,
   ChildOutMessage,
   ParentOutMessage,
-  R = never,
+  ChildR = never,
+  ParentR = ChildR,
 > = Readonly<{
   update: (
     childModel: ChildModel,
-  ) => ReturnWithOutMessage<ChildModel, ChildMessage, ChildOutMessage, R>
+  ) => ReturnWithOutMessage<ChildModel, ChildMessage, ChildOutMessage, ChildR>
   read: (model: ParentModel) => Option.Option<ChildModel>
   write: (model: ParentModel, nextChildModel: ChildModel) => ParentModel
   toParentMessage: (message: ChildMessage) => ParentMessage
@@ -665,7 +681,7 @@ export type ChildStepFoldWithParentOutMessage<
   foldOutMessage?: (
     outMessage: ChildOutMessage,
     context: FoldContext<ChildMessage, ParentMessage>,
-  ) => Step<ParentModel, ParentMessage, R>
+  ) => Step<ParentModel, ParentMessage, ParentR>
 }>
 
 /** @internal Implementation-facing view of both {@link ChildStepFold}
@@ -730,7 +746,8 @@ export const foldChildStep: {
     ChildMessage,
     ChildOutMessage,
     ParentOutMessage,
-    R = never,
+    ChildR = never,
+    ParentR = ChildR,
   >(
     childFold: ChildStepFoldWithParentOutMessage<
       ParentModel,
@@ -739,16 +756,23 @@ export const foldChildStep: {
       ChildMessage,
       ChildOutMessage,
       ParentOutMessage,
-      R
+      ChildR,
+      ParentR
     >,
-  ): StepWithOutMessage<ParentModel, ParentMessage, ParentOutMessage, R>
+  ): StepWithOutMessage<
+    ParentModel,
+    ParentMessage,
+    ParentOutMessage,
+    ChildR | ParentR
+  >
   <
     ParentModel,
     ParentMessage,
     ChildModel,
     ChildMessage,
     ChildOutMessage,
-    R = never,
+    ChildR = never,
+    ParentR = ChildR,
   >(
     childFold: ChildStepFoldWithOutMessage<
       ParentModel,
@@ -756,9 +780,10 @@ export const foldChildStep: {
       ChildModel,
       ChildMessage,
       ChildOutMessage,
-      R
+      ChildR,
+      ParentR
     >,
-  ): Step<ParentModel, ParentMessage, R>
+  ): Step<ParentModel, ParentMessage, ChildR | ParentR>
   <ParentModel, ParentMessage, ChildModel, ChildMessage, R = never>(
     childFold: ChildStepFold<
       ParentModel,


### PR DESCRIPTION
Infer child update, wrapper, and OutMessage Step types independently in
`Update.foldChild` and `Update.foldChildStep`. The returned Fold now
preserves the parent Model and combines the Message and Command service
requirements produced by each part.

This lets dependency-free child updates compose with parent Commands
that require services without explicit fold configuration annotations,
while narrow OutMessage Match branches can no longer replace the parent
Model or Message type.