### PR TITLE
refactor(foldkit)!: return an update record from Machine.transition

### DIFF
--- a/.changeset/machine-transition-record.md
+++ b/.changeset/machine-transition-record.md
@@ -1,0 +1,22 @@
+---
+'foldkit': minor
+---
+
+`Machine.transition` now returns `Update.Return<State, Message, R>` instead of a two-element tuple containing the next state and Commands. The Machine state is the return's `model`, and an ignored Message omits `commands`.
+
+Before:
+
+```typescript
+const [nextState, commands] = machine.transition(state, message)
+```
+
+After:
+
+```typescript
+const stateTransition = machine.transition(state, message)
+
+stateTransition.model
+stateTransition.commands
+```
+
+The record can also serve directly as the child update in `Update.foldChild`. Use `Machine.step` instead when code needs to distinguish a `Transitioned` result from an `Ignored` result or inspect Edge metadata.

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -7,14 +7,14 @@ import {
   Schema as S,
   Stream,
 } from 'effect'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
 import * as Command from '../../command/public.js'
 import * as ManagedResource from '../../managedResource/public.js'
 import { defineMessageUnion, ts } from '../../schema/index.js'
 import { evo } from '../../struct/index.js'
 import * as Subscription from '../../subscription/public.js'
-import type * as Update from '../../update/index.js'
+import * as Update from '../../update/index.js'
 import { define, otherwise, to, when } from './machine.js'
 
 // REMOTE DATA
@@ -221,34 +221,26 @@ type AppModel = typeof AppModel.Type
 
 type AppUpdateReturn = Update.Return<AppModel, ConnectionMessage>
 
-const updateConnection = (
-  model: AppModel,
-  connectionMessage: ConnectionMessage,
-): AppUpdateReturn => {
-  const [nextConnection, commands] = connectionMachine.transition(
-    model.connection,
-    connectionMessage,
-  )
-  return {
-    model: evo(model, { connection: () => nextConnection }),
-    commands,
-  }
-}
+const foldConnection = Update.foldChild({
+  update: connectionMachine.transition,
+  read: (model: AppModel) => Option.some(model.connection),
+  write: (model, nextConnection) =>
+    evo(model, { connection: () => nextConnection }),
+  toParentMessage: (message: ConnectionMessage) => message,
+})
 
 const update = (model: AppModel, message: ConnectionMessage) =>
   ConnectionMessage.match<AppUpdateReturn>(message, {
     ClickedConnect: connectionMessage =>
-      updateConnection(model, connectionMessage),
+      foldConnection(model, connectionMessage),
     ClickedDisconnect: connectionMessage =>
-      updateConnection(model, connectionMessage),
-    SocketOpened: connectionMessage =>
-      updateConnection(model, connectionMessage),
+      foldConnection(model, connectionMessage),
+    SocketOpened: connectionMessage => foldConnection(model, connectionMessage),
     SocketErrored: connectionMessage =>
-      updateConnection(model, connectionMessage),
-    SocketClosed: connectionMessage =>
-      updateConnection(model, connectionMessage),
+      foldConnection(model, connectionMessage),
+    SocketClosed: connectionMessage => foldConnection(model, connectionMessage),
     TimedOutBackoff: connectionMessage =>
-      updateConnection(model, connectionMessage),
+      foldConnection(model, connectionMessage),
     ReleasedSocket: () => ({ model }),
     CompletedLogTransition: () => ({ model }),
   })
@@ -677,29 +669,32 @@ describe('remote data machine', () => {
   })
 
   it('transitions along the obvious edges', () => {
-    const [loading] = remoteDataMachine.transition(
+    const fetchClick = remoteDataMachine.transition(
       Idle(),
       RemoteDataMessage.ClickedFetch(),
     )
-    expect(loading).toStrictEqual(Loading())
+    expectTypeOf(fetchClick).toEqualTypeOf<
+      Update.Return<RemoteData, RemoteDataMessage>
+    >()
+    expect(fetchClick.model).toStrictEqual(Loading())
 
-    const [ok] = remoteDataMachine.transition(
+    const fetchSuccess = remoteDataMachine.transition(
       Loading(),
       RemoteDataMessage.SucceededFetch({ data: 'payload' }),
     )
-    expect(ok).toStrictEqual(Ok({ data: 'payload' }))
+    expect(fetchSuccess.model).toStrictEqual(Ok({ data: 'payload' }))
 
-    const [errored] = remoteDataMachine.transition(
+    const fetchFailure = remoteDataMachine.transition(
       Loading(),
       RemoteDataMessage.FailedFetch({ error: 'boom' }),
     )
-    expect(errored).toStrictEqual(Error({ error: 'boom' }))
+    expect(fetchFailure.model).toStrictEqual(Error({ error: 'boom' }))
 
-    const [retrying] = remoteDataMachine.transition(
+    const fetchRetry = remoteDataMachine.transition(
       Error({ error: 'boom' }),
       RemoteDataMessage.ClickedRetry(),
     )
-    expect(retrying).toStrictEqual(Loading())
+    expect(fetchRetry.model).toStrictEqual(Loading())
   })
 
   it('reports unmatched messages as Ignored without changing state', () => {
@@ -716,12 +711,12 @@ describe('remote data machine', () => {
       state: Idle(),
     })
 
-    const [unchanged, commands] = remoteDataMachine.transition(
+    const ignoredRetry = remoteDataMachine.transition(
       idle,
       RemoteDataMessage.ClickedRetry(),
     )
-    expect(unchanged).toBe(idle)
-    expect(commands).toEqual([])
+    expect(ignoredRetry).toEqual({ model: idle })
+    expect(Object.hasOwn(ignoredRetry, 'commands')).toBe(false)
   })
 
   it('exposes the edge set as data', () => {
@@ -787,11 +782,11 @@ describe('remote data machine', () => {
 
 describe('connection machine', () => {
   it('walks the happy path and emits the edge command', () => {
-    const [connecting] = connectionMachine.transition(
+    const connectClick = connectionMachine.transition(
       Disconnected(),
       ConnectionMessage.ClickedConnect(),
     )
-    expect(connecting).toStrictEqual(Connecting({ attemptCount: 1 }))
+    expect(connectClick.model).toStrictEqual(Connecting({ attemptCount: 1 }))
 
     const result = connectionMachine.step(
       Connecting({ attemptCount: 1 }),
@@ -817,27 +812,29 @@ describe('connection machine', () => {
   })
 
   it('reconnects with exponential backoff below the attempt limit', () => {
-    const [reconnecting] = connectionMachine.transition(
+    const socketError = connectionMachine.transition(
       Connecting({ attemptCount: 4 }),
       ConnectionMessage.SocketErrored({ reason: 'boom' }),
     )
-    expect(reconnecting).toStrictEqual(
+    expect(socketError.model).toStrictEqual(
       Reconnecting({ attemptCount: 4, delayMillis: 2000 }),
     )
 
-    const [connectingAgain] = connectionMachine.transition(
+    const backoffTimeout = connectionMachine.transition(
       Reconnecting({ attemptCount: 4, delayMillis: 2000 }),
       ConnectionMessage.TimedOutBackoff(),
     )
-    expect(connectingAgain).toStrictEqual(Connecting({ attemptCount: 5 }))
+    expect(backoffTimeout.model).toStrictEqual(Connecting({ attemptCount: 5 }))
   })
 
   it('fails at the attempt limit via the otherwise guard', () => {
-    const [failed] = connectionMachine.transition(
+    const attemptLimitFailure = connectionMachine.transition(
       Connecting({ attemptCount: 5 }),
       ConnectionMessage.SocketErrored({ reason: 'boom' }),
     )
-    expect(failed).toStrictEqual(Failed({ attemptCount: 5, reason: 'boom' }))
+    expect(attemptLimitFailure.model).toStrictEqual(
+      Failed({ attemptCount: 5, reason: 'boom' }),
+    )
   })
 
   it('ignores messages with no edge from the current state', () => {
@@ -908,19 +905,19 @@ describe('connection machine', () => {
 
 describe('guard lists', () => {
   it('fires a boolean guard on true and falls through to otherwise on false', () => {
-    const [reconnecting] = booleanGuardMachine.transition(
+    const belowLimitSocketError = booleanGuardMachine.transition(
       Connecting({ attemptCount: 2 }),
       ConnectionMessage.SocketErrored({ reason: 'boom' }),
     )
-    expect(reconnecting).toStrictEqual(
+    expect(belowLimitSocketError.model).toStrictEqual(
       Reconnecting({ attemptCount: 2, delayMillis: 500 }),
     )
 
-    const [failed] = booleanGuardMachine.transition(
+    const atLimitSocketError = booleanGuardMachine.transition(
       Connecting({ attemptCount: MAX_CONNECT_ATTEMPTS }),
       ConnectionMessage.SocketErrored({ reason: 'boom' }),
     )
-    expect(failed).toStrictEqual(
+    expect(atLimitSocketError.model).toStrictEqual(
       Failed({ attemptCount: MAX_CONNECT_ATTEMPTS, reason: 'boom' }),
     )
   })
@@ -939,12 +936,11 @@ describe('guard lists', () => {
       state: atLimit,
     })
 
-    const [unchanged, commands] = guardValueMachine.transition(
+    const declinedSocketError = guardValueMachine.transition(
       atLimit,
       ConnectionMessage.SocketErrored({ reason: 'boom' }),
     )
-    expect(unchanged).toBe(atLimit)
-    expect(commands).toEqual([])
+    expect(declinedSocketError).toEqual({ model: atLimit })
   })
 })
 
@@ -952,32 +948,32 @@ describe('state tag extraction', () => {
   it('reads tags from members whose _tag is a plain Literal', () => {
     expect(plainTagMachine.stateTags).toEqual(['PlainIdle', 'PlainActive'])
 
-    const [active] = plainTagMachine.transition(
+    const fetchClick = plainTagMachine.transition(
       { _tag: 'PlainIdle' },
       RemoteDataMessage.ClickedFetch(),
     )
-    expect(active).toStrictEqual({ _tag: 'PlainActive' })
+    expect(fetchClick.model).toStrictEqual({ _tag: 'PlainActive' })
   })
 })
 
 describe('type-level guarantees', () => {
   it('narrows state and message to the table position without annotations', () => {
-    const [failed] = narrowingMachine.transition(
+    const socketError = narrowingMachine.transition(
       Connecting({ attemptCount: 0 }),
       ConnectionMessage.SocketErrored({ reason: 'boom' }),
     )
-    expect(failed).toStrictEqual(
+    expect(socketError.model).toStrictEqual(
       Failed({ attemptCount: 0, reason: 'Connecting SocketErrored boom' }),
     )
   })
 
   it('passes the guard value into the matching edge', () => {
-    const [reconnecting] = guardValueMachine.transition(
+    const socketError = guardValueMachine.transition(
       Connecting({ attemptCount: 2 }),
       ConnectionMessage.SocketErrored({ reason: 'offline' }),
     )
 
-    expect(reconnecting).toStrictEqual(
+    expect(socketError.model).toStrictEqual(
       Reconnecting({ attemptCount: 3, delayMillis: 500 }),
     )
   })
@@ -1005,7 +1001,7 @@ describe('type-level guarantees', () => {
 })
 
 describe('integration', () => {
-  it('splices the machine into update via evo', () => {
+  it('folds the machine directly into update', () => {
     const model: AppModel = {
       connection: Disconnected(),
       isDebugPanelOpen: false,
@@ -1031,19 +1027,20 @@ describe('integration', () => {
 
 describe('edge command requirements', () => {
   it('threads a requirement inferred from a single edge command into R', () => {
-    const [nextState, commands] = inferredRequirementsMachine.transition(
+    const submitClick = inferredRequirementsMachine.transition(
       SubmitIdle(),
       SubmitMessage.ClickedSubmit(),
     )
-    expect(nextState).toStrictEqual(Presigning())
+    expect(submitClick.model).toStrictEqual(Presigning())
 
-    const requiresUploads: ReadonlyArray<
-      Command.Command<SubmitMessage, never, UploadsClient>
-    > = commands
-    expect(requiresUploads).toHaveLength(1)
+    expectTypeOf(submitClick.commands).toEqualTypeOf<
+      | ReadonlyArray<Command.Command<SubmitMessage, never, UploadsClient>>
+      | undefined
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
 
     const uploads: UploadsShape = { presign: Effect.succeed(PRESIGNED_URL) }
-    const messages = commands.map(command =>
+    const messages = (submitClick.commands ?? []).map(command =>
       Effect.runSync(
         Effect.provideService(command.effect, UploadsClient, uploads),
       ),
@@ -1054,19 +1051,20 @@ describe('edge command requirements', () => {
   })
 
   it('threads a requirement inferred from a guard-list edge command', () => {
-    const [nextState, commands] = inferredGuardRequirementsMachine.transition(
+    const submitClick = inferredGuardRequirementsMachine.transition(
       SubmitIdle(),
       SubmitMessage.ClickedSubmit(),
     )
-    expect(nextState).toStrictEqual(Presigning())
+    expect(submitClick.model).toStrictEqual(Presigning())
 
-    const requiresUploads: ReadonlyArray<
-      Command.Command<SubmitMessage, never, UploadsClient>
-    > = commands
-    expect(requiresUploads).toHaveLength(1)
+    expectTypeOf(submitClick.commands).toEqualTypeOf<
+      | ReadonlyArray<Command.Command<SubmitMessage, never, UploadsClient>>
+      | undefined
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
 
     const uploads: UploadsShape = { presign: Effect.succeed(PRESIGNED_URL) }
-    const messages = commands.map(command =>
+    const messages = (submitClick.commands ?? []).map(command =>
       Effect.runSync(
         Effect.provideService(command.effect, UploadsClient, uploads),
       ),
@@ -1077,20 +1075,20 @@ describe('edge command requirements', () => {
   })
 
   it('threads a requirement inferred from an otherwise fallback command', () => {
-    const [nextState, commands] =
-      inferredOtherwiseRequirementsMachine.transition(
-        SubmitIdle(),
-        SubmitMessage.ClickedSubmit(),
-      )
-    expect(nextState).toStrictEqual(Presigning())
+    const submitClick = inferredOtherwiseRequirementsMachine.transition(
+      SubmitIdle(),
+      SubmitMessage.ClickedSubmit(),
+    )
+    expect(submitClick.model).toStrictEqual(Presigning())
 
-    const requiresUploads: ReadonlyArray<
-      Command.Command<SubmitMessage, never, UploadsClient>
-    > = commands
-    expect(requiresUploads).toHaveLength(1)
+    expectTypeOf(submitClick.commands).toEqualTypeOf<
+      | ReadonlyArray<Command.Command<SubmitMessage, never, UploadsClient>>
+      | undefined
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
 
     const uploads: UploadsShape = { presign: Effect.succeed(PRESIGNED_URL) }
-    const messages = commands.map(command =>
+    const messages = (submitClick.commands ?? []).map(command =>
       Effect.runSync(
         Effect.provideService(command.effect, UploadsClient, uploads),
       ),
@@ -1101,19 +1099,20 @@ describe('edge command requirements', () => {
   })
 
   it('leaves R as never when no edge command needs a service', () => {
-    const [, commands] = remoteDataMachine.transition(
+    const fetchClick = remoteDataMachine.transition(
       Idle(),
       RemoteDataMessage.ClickedFetch(),
     )
 
-    const requiresNever: ReadonlyArray<
-      Command.Command<RemoteDataMessage, never, never>
-    > = commands
-    expect(requiresNever).toEqual([])
+    expectTypeOf(fetchClick.commands).toEqualTypeOf<
+      | ReadonlyArray<Command.Command<RemoteDataMessage, never, never>>
+      | undefined
+    >()
+    expect(fetchClick.commands ?? []).toEqual([])
   })
 
   it('does not collapse an edge command requirement to never', () => {
-    const [, commands] = inferredRequirementsMachine.transition(
+    const submitClick = inferredRequirementsMachine.transition(
       SubmitIdle(),
       SubmitMessage.ClickedSubmit(),
     )
@@ -1121,7 +1120,7 @@ describe('edge command requirements', () => {
     // @ts-expect-error the edge command requires UploadsClient, so R is not never
     const requiresNever: ReadonlyArray<
       Command.Command<SubmitMessage, never, never>
-    > = commands
+    > = submitClick.commands ?? []
     expect(requiresNever).toHaveLength(1)
   })
 
@@ -1129,19 +1128,21 @@ describe('edge command requirements', () => {
     const uploads: UploadsShape = { presign: Effect.succeed(PRESIGNED_URL) }
     const save: SaveShape = { save: Effect.succeed(PERSISTED_ID) }
 
-    const [presigning, presignCommands] =
-      explicitRequirementsMachine.transition(
-        SubmitIdle(),
-        SubmitMessage.ClickedSubmit(),
-      )
-    expect(presigning).toStrictEqual(Presigning())
+    const submitClick = explicitRequirementsMachine.transition(
+      SubmitIdle(),
+      SubmitMessage.ClickedSubmit(),
+    )
+    expect(submitClick.model).toStrictEqual(Presigning())
 
-    const requiresBoth: ReadonlyArray<
-      Command.Command<SubmitMessage, never, UploadsClient | SaveClient>
-    > = presignCommands
-    expect(requiresBoth).toHaveLength(1)
+    expectTypeOf(submitClick.commands).toEqualTypeOf<
+      | ReadonlyArray<
+          Command.Command<SubmitMessage, never, UploadsClient | SaveClient>
+        >
+      | undefined
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
 
-    const presignMessages = presignCommands.map(command =>
+    const presignMessages = (submitClick.commands ?? []).map(command =>
       Effect.runSync(
         command.effect.pipe(
           Effect.provideService(UploadsClient, uploads),
@@ -1153,14 +1154,13 @@ describe('edge command requirements', () => {
       SubmitMessage.SucceededPresign({ url: PRESIGNED_URL }),
     ])
 
-    const [persisting, persistCommands] =
-      explicitRequirementsMachine.transition(
-        Presigning(),
-        SubmitMessage.SucceededPresign({ url: PRESIGNED_URL }),
-      )
-    expect(persisting).toStrictEqual(Persisting())
+    const presignSuccess = explicitRequirementsMachine.transition(
+      Presigning(),
+      SubmitMessage.SucceededPresign({ url: PRESIGNED_URL }),
+    )
+    expect(presignSuccess.model).toStrictEqual(Persisting())
 
-    const persistMessages = persistCommands.map(command =>
+    const persistMessages = (presignSuccess.commands ?? []).map(command =>
       Effect.runSync(
         command.effect.pipe(
           Effect.provideService(UploadsClient, uploads),

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -9,6 +9,7 @@ import {
 } from 'effect'
 
 import type { Command } from '../../command/index.js'
+import type * as Update from '../../update/index.js'
 
 // STATE
 
@@ -383,10 +384,16 @@ export type Machine<
   initial: State
   stateTags: ReadonlyArray<TagOf<State>>
   edges: ReadonlyArray<EdgeSummary<State, Message>>
+  /** Runs one Message through the Machine as a Foldkit update. The returned
+   * `Update.Return<State, Message, R>` stores the next Machine state in
+   * `model` and any transition-time Commands in `commands`, so `transition`
+   * can be passed directly to `Update.foldChild`. Use `step` when code needs
+   * to distinguish a `Transitioned` result from an `Ignored` result or
+   * inspect Edge metadata. */
   transition: (
     state: State,
     message: Message,
-  ) => [State, ReadonlyArray<Command<Message, never, R>>]
+  ) => Update.Return<State, Message, R>
   step: (state: State, message: Message) => TransitionResult<State, Message, R>
   reachableFrom: (tag: TagOf<State>) => ReadonlySet<TagOf<State>>
   unreachableStates: () => ReadonlyArray<TagOf<State>>
@@ -523,7 +530,7 @@ const extractMemberTag = (member: unknown): Option.Option<string> =>
  *     },
  *   },
  * })
- * // machine.transition(...) returns Commands typed with UploadsClient in R.
+ * // Commands on the return from machine.transition(...) require UploadsClient.
  * ```
  *
  * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
@@ -697,13 +704,13 @@ export const define =
     const transition = (
       state: State,
       message: Message,
-    ): [State, ReadonlyArray<Command<Message, never, R>>] => {
+    ): Update.Return<State, Message, R> => {
       const result = step(state, message)
 
       if (result._tag === 'Transitioned') {
-        return [result.state, result.commands]
+        return { model: result.state, commands: result.commands }
       } else {
-        return [result.state, []]
+        return { model: result.state }
       }
     }
 


### PR DESCRIPTION
Replace the remaining State-and-Commands tuple API with
`Update.Return<State, Message, R>`. This makes `Machine.transition` usable
directly with `Update.foldChild` and gives it the plain return’s
`outMessage?: never` guard.

Omit `commands` for ignored Messages, preserve computed transition Commands,
and migrate the Machine integration to the child-fold boundary.