### PR TITLE
feat(release): notify when stable packages are ready to promote

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -26,9 +26,17 @@ A markdown file will be created in `.changeset/` - commit this with your PR.
 
 ## For Maintainers
 
-When changesets are merged to main, a "Version Packages" PR is automatically created. Merging that PR will:
+When changesets are merged to main, a "Version Packages" pull request is automatically created. Merging that pull request:
 
-1. Update package versions
-2. Update CHANGELOG.md files
-3. Publish to npm
-4. Create GitHub releases
+1. Updates package versions
+2. Updates CHANGELOG.md files
+3. Uploads and verifies the stable package set without moving `latest`
+4. Comments on the merged Version Packages pull request when that exact commit is ready to promote
+
+After the notification arrives, confirm that `npm whoami` and `gh auth status` both succeed. Check out the commit named in the notification with a clean working tree, install its dependencies, and run:
+
+```bash
+pnpm release:promote
+```
+
+Enter the npm OTP when prompted. Promotion moves the complete package set to `latest` and dispatches the finalization workflow. That workflow verifies the promoted versions, creates the matching Git tags and GitHub Releases, and deploys the production website from the published commit.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout Repo
@@ -123,6 +124,76 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
           SKIP_SIMPLE_GIT_HOOKS: '1'
+
+      - name: Notify the maintainer that promotion is ready
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const { data: pullRequests } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: context.sha,
+              })
+            const versionPullRequest = pullRequests.find(
+              pullRequest =>
+                pullRequest.head.ref === 'changeset-release/main' &&
+                typeof pullRequest.merged_at === 'string',
+            )
+
+            if (versionPullRequest === undefined) {
+              core.info(
+                'No merged Version Packages pull request is associated with this commit. Skipping the promotion notification.',
+              )
+              return
+            }
+
+            const marker =
+              `<!-- foldkit-release-promotion-ready:${context.sha} -->`
+            const body = [
+              marker,
+              `@devinjameson The stable packages for \`${context.sha}\` are uploaded and verified. They are ready to promote.`,
+              '',
+              'Confirm that `npm whoami` and `gh auth status` both succeed. Then, from a clean local checkout, run:',
+              '',
+              '```bash',
+              'git fetch origin main',
+              `git switch --detach ${context.sha}`,
+              'pnpm install --frozen-lockfile',
+              'pnpm release:promote',
+              '```',
+              '',
+              '`pnpm release:promote` prompts for your npm OTP, moves the complete package set to `latest`, and dispatches GitHub Release creation and the production website deployment.',
+            ].join('\n')
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number: versionPullRequest.number,
+                per_page: 100,
+              },
+            )
+            const existingComment = comments.find(comment =>
+              comment.body?.includes(marker),
+            )
+
+            if (existingComment === undefined) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: versionPullRequest.number,
+                body,
+              })
+            } else {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              })
+            }
 
   canary:
     name: Upload and verify commit-addressed package canary

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,22 +11,28 @@ set exists. It also keeps a long-lived npm token out of GitHub Actions.
 
 1. Merge the Version Packages pull request.
 
-2. Wait for the Release workflow's stable job. The coherent uploader discovers
-   every public package from the pnpm workspace manifests. It builds and packs
-   every untagged release version, then uploads them one at a time under the
-   commit-specific non-consumer tag such as
-   `foldkit-stable-upload-0123456789ab`. A rerun skips a matching version that
-   npm already has and rejects one whose registry integrity differs.
+2. The Release workflow's stable job discovers every public package from the
+   pnpm workspace manifests. It builds and packs every untagged release
+   version, then uploads them one at a time under the commit-specific
+   non-consumer tag such as `foldkit-stable-upload-0123456789ab`. A rerun skips
+   a matching version that npm already has and rejects one whose registry
+   integrity differs.
 
-3. Check that the stable job passed. The last upload is not enough. The job
+3. Wait for GitHub Actions to mention `@devinjameson` on the merged Version
+   Packages pull request. The stable job posts that comment only after it
    fetches the complete public package set from npm and checks each internal
-   dependency and peer range against the versions in this release. Changesets
-   only creates the Version Packages pull request. The coherent uploader runs
-   in a separate workflow step, so its output cannot be mistaken for
-   Changesets' tag-push protocol.
+   dependency and peer range against the versions in this release. The comment
+   names the exact release commit and gives the local promotion commands. A
+   rerun updates the existing comment instead of posting another notification.
 
-4. Check out the exact release commit in a clean worktree and sign in to npm
-   with 2FA. Run:
+   The last upload is not enough. Changesets only creates the Version Packages
+   pull request. The coherent uploader runs in a separate workflow step, so its
+   output cannot be mistaken for Changesets' tag-push protocol.
+
+4. Follow the commands in the notification from a clean local checkout. Confirm
+   that `npm whoami` and `gh auth status` both succeed, then sign in to npm with
+   2FA. The notification fetches `main`, checks out the exact release commit,
+   and installs its locked dependencies before running:
 
    ```sh
    pnpm release:promote

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -6,6 +6,11 @@ import { fileURLToPath } from 'node:url'
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const gitignore = readFileSync(resolve(REPO_ROOT, '.gitignore'), 'utf8')
+const changesetReadme = readFileSync(
+  resolve(REPO_ROOT, '.changeset/README.md'),
+  'utf8',
+)
+const releasingGuide = readFileSync(resolve(REPO_ROOT, 'RELEASING.md'), 'utf8')
 const workflow = readFileSync(
   resolve(REPO_ROOT, '.github/workflows/release.yml'),
   'utf8',
@@ -73,12 +78,60 @@ test('Changesets only versions packages and cannot parse publisher output', () =
     /if: github\.event_name == 'push' && needs\.version\.outputs\.has_changesets == 'false'/,
   )
   assert.match(stableJob, /\n    needs: version\n/)
-  assert.match(stableJob, /permissions:\n\s+contents: read\n\s+id-token: write/)
-  assert.doesNotMatch(stableJob, /contents: write|pull-requests: write/)
+  assert.match(
+    stableJob,
+    /permissions:\n\s+contents: read\n\s+pull-requests: write\n\s+id-token: write/,
+  )
+  assert.doesNotMatch(stableJob, /contents: write/)
   assert.doesNotMatch(stableJob, /changesets\/action/)
   assert.match(stableJob, /run: pnpm release/)
   assert.doesNotMatch(coherentPublisher, /New tag:/)
   assert.match(stableJob, /NPM_CONFIG_PROVENANCE: true/)
+})
+
+test('stable uploads notify the merged Version Packages pull request', () => {
+  const stableJob = job('stable', 'canary')
+  const upload = stableJob.indexOf('run: pnpm release')
+  const notification = stableJob.indexOf(
+    '- name: Notify the maintainer that promotion is ready',
+  )
+
+  assert.ok(upload > 0)
+  assert.ok(notification > upload)
+  assert.match(stableJob, /uses: actions\/github-script@v9/)
+  assert.match(stableJob, /listPullRequestsAssociatedWithCommit/)
+  assert.match(
+    stableJob,
+    /pullRequest\.head\.ref === 'changeset-release\/main'/,
+  )
+  assert.match(stableJob, /No merged Version Packages pull request/)
+  assert.match(stableJob, /@devinjameson The stable packages/)
+  assert.match(stableJob, /git switch --detach \$\{context\.sha\}/)
+  assert.match(stableJob, /pnpm install --frozen-lockfile/)
+  assert.match(stableJob, /pnpm release:promote/)
+  assert.match(stableJob, /npm OTP/)
+  assert.match(stableJob, /github\.paginate/)
+  assert.match(stableJob, /github\.rest\.issues\.updateComment/)
+  assert.match(stableJob, /github\.rest\.issues\.createComment/)
+
+  assert.match(
+    changesetReadme,
+    /Uploads and verifies the stable package set without moving `latest`/,
+  )
+  assert.match(
+    changesetReadme,
+    /Comments on the merged Version Packages pull request/,
+  )
+  assert.match(changesetReadme, /pnpm release:promote/)
+  assert.match(
+    releasingGuide,
+    /Wait for GitHub Actions to mention `@devinjameson`/,
+  )
+  assert.match(
+    releasingGuide,
+    /A\s+rerun updates the existing comment instead of posting another notification/,
+  )
+  assert.match(releasingGuide, /`npm whoami` and `gh auth status`/)
 })
 
 test('canaries publish from the trusted release workflow and use exact snapshots', () => {


### PR DESCRIPTION
Comment on the merged Version Packages pull request after the stable
upload passes its complete registry verification. Mention the maintainer and
include the exact commit, authentication checks, clean-checkout commands, and
the promotion command so the manual handoff no longer depends on watching
Actions.

Limit the notification to commits associated with
`changeset-release/main`, and update the existing comment on reruns. Document
the upload, promotion, and finalization split in both maintainer guides.