### PR TITLE
fix(release): ignore test-only website deploy changes

### DIFF
--- a/scripts/plan-website-deploy.mjs
+++ b/scripts/plan-website-deploy.mjs
@@ -2,8 +2,9 @@ import { spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-// NOTE: A direct website deployment is safe only when every package whose source the
-// website bundles still matches the tag for the exact version in its manifest.
+// NOTE: A direct website deployment is safe only when every package build input
+// the website uses still matches the tag for the exact version in its manifest.
+// Test-only files are excluded because they cannot change the website bundle.
 // Looking only at the current push is insufficient: a website-only follow-up
 // could otherwise deploy package work left unpublished by an earlier push.
 const PACKAGES = [
@@ -22,6 +23,16 @@ const SHARED_PACKAGE_INPUTS = [
   'pnpm-lock.yaml',
   'pnpm-workspace.yaml',
   'tsconfig.base.json',
+]
+
+const packageBuildInputs = directory => [
+  directory,
+  `:(exclude,glob)${directory}/**/*.test.*`,
+  `:(exclude,glob)${directory}/**/*.spec.*`,
+  `:(exclude,glob)${directory}/test/**`,
+  `:(exclude,glob)${directory}/**/__snapshots__/**`,
+  `:(exclude,glob)${directory}/vitest.config.*`,
+  `:(exclude,glob)${directory}/tsconfig.test.*`,
 ]
 
 const TARGET = process.argv.at(2) ?? 'HEAD'
@@ -100,7 +111,7 @@ for (const packageEntry of PACKAGES) {
     tagCommit,
     TARGET,
     '--',
-    packageEntry.directory,
+    ...packageBuildInputs(packageEntry.directory),
   ])
   if (changed.status === 1) {
     blockers.push(

--- a/scripts/plan-website-deploy.test.mjs
+++ b/scripts/plan-website-deploy.test.mjs
@@ -118,6 +118,29 @@ test('allows a website-only commit after the package set was released', () => {
   }
 })
 
+test('allows test-only package changes after the package set was released', () => {
+  const repo = makeReleasedRepo()
+  try {
+    for (const path of [
+      'packages/vite-plugin-foldkit/test/viewIdentity.runtime.test.ts',
+      'packages/foldkit/source.test.ts',
+      'packages/devtools/source.spec.ts',
+      'packages/markdown/src/__snapshots__/view.snap',
+      'packages/ui/vitest.config.ts',
+      'packages/ui/tsconfig.test.json',
+    ]) {
+      write(repo, path, 'test input\n')
+    }
+    commit(repo, 'update package tests')
+
+    const result = plan(repo)
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout.trim(), 'deploy=true')
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+})
+
 test('defers a website deploy while package source is unpublished', () => {
   const repo = makeReleasedRepo()
   try {


### PR DESCRIPTION
The stable website gate compared entire package directories. A migrated
Vite plugin test therefore blocked deployment even though published code was
unchanged.

Exclude test files, fixtures, snapshots, and test configuration from package
build input comparisons. Runtime source and shared build inputs remain
protected.