### PR TITLE
docs(website): show Commands in update returns

### DIFF
--- a/packages/website/src/page/core/update.md
+++ b/packages/website/src/page/core/update.md
@@ -20,6 +20,12 @@ Update returns a record containing the next Model and, when needed, an array of 
 
 ## Returning Commands
 
+Return Commands beside the next Model from the Message branch that requests the work:
+
+::Snippet{name="updateReturningCommands" label="returning a Command from update"}
+
+`ClickedIncrement` changes the count and asks the runtime to persist it. `CompletedPersistCount` records that the Command finished, but it has no more work to request, so that branch omits `commands`.
+
 An update, init, boot, or component helper that statically creates no Commands omits `commands`. When it computes a Commands collection, it returns that collection directly without checking whether it is empty. The [`foldkit/no-empty-commands-array`](/tooling/oxlint-plugin#no-empty-commands-array) lint rule rejects only a literal `commands: []` property.
 
 ## Composing Results
@@ -97,5 +103,3 @@ The object-spread alternative is easy to get wrong:
 `Update.withOutMessage` preserves `dialogClose.model` and `dialogClose.commands`. A defined value becomes `outMessage`; `undefined` leaves the property out. The update result must be a plain return, so the helper cannot overwrite an OutMessage another operation emitted.
 
 When constructing the plain result in the same expression and the value has the type `OutMessage | undefined`, pass the result first: `Update.withOutMessage({ model, commands }, outMessage)`.
-
-First, the [view function](/core/view) completes the basic loop by turning the Model into what the user sees.

--- a/packages/website/src/snippet/updateReturningCommands.ts
+++ b/packages/website/src/snippet/updateReturningCommands.ts
@@ -1,0 +1,15 @@
+import { type Update } from 'foldkit'
+import { evo } from 'foldkit/struct'
+
+const update = (model: Model, message: Message) =>
+  Message.match<Update.Return<Model, Message>>(message, {
+    ClickedIncrement: () => {
+      const nextCount = model.count + 1
+
+      return {
+        model: evo(model, { count: () => nextCount }),
+        commands: [PersistCount({ count: nextCount })],
+      }
+    },
+    CompletedPersistCount: () => ({ model }),
+  })


### PR DESCRIPTION
Show a complete update branch that returns its next Model and Command
together. Pair it with a completion branch that omits commands when no work
remains. Remove the stale handoff to the View page so the Update page ends
with its final guidance.