### PR TITLE
docs: avoid double-wrapping pull request descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ If a Mount factory doesn't read or write its element, you've misidentified the c
 - Do not co-author or mention AI assistants in commit messages or release notes.
 - Use the repo's commit helper when asked to create a commit: `/commit` in Claude Code, `.agents/skills/commit-changes` in Codex.
 - Treat every pull request title and description as the final squash commit message. The title is the Conventional Commit subject, and the description is the commit body. Keep review-only boilerplate, checklists, generated commit lists, and verification details out of the description. Put verification details in a pull request comment instead.
+- Do not hard-wrap pull request description prose. Write each paragraph as one source line and let GitHub wrap it when creating the squash commit. GitHub wraps each source line independently and does not reflow across existing line breaks, so manual wrapping can leave words stranded on their own lines. Preserve intentional line breaks in code blocks, command output, lists, and tables, and never alter literal content to satisfy a prose line length.
 - After creating or amending a commit, have a separate agent review the exact committed diff before pushing it or opening a PR. Treat the review as a gate: address every finding, amend the commit, and have the amended commit reviewed again. Only push or open the PR after the latest commit passes review.
 - Squash-merge only. `gh pr merge --squash`.
 


### PR DESCRIPTION
GitHub wraps each pull request description source line independently when it creates a squash commit. Manually wrapped prose is therefore wrapped a second time, which can leave words stranded on their own lines.

Tell agents to keep each prose paragraph on one source line while preserving intentional line breaks and literal content in code blocks, command output, lists, and tables.
