### PR TITLE
refactor(website): constrain router helpers to payload-free routes

### DIFF
--- a/packages/website/src/route.ts
+++ b/packages/website/src/route.ts
@@ -10,6 +10,7 @@ import {
   slash,
   string,
 } from 'foldkit/route'
+import type { CallableTaggedStruct } from 'foldkit/schema'
 
 // ROUTE SCHEMAS
 
@@ -247,12 +248,14 @@ export const isDocsSectionRoute = (route: AppRoute): boolean =>
 
 // ROUTERS
 
-const page = <T>(slug: string, route: { make: (input: {}) => T }) =>
+type PayloadFreeRoute<Tag extends string> = CallableTaggedStruct<Tag, {}>
+
+const page = <Tag extends string>(slug: string, route: PayloadFreeRoute<Tag>) =>
   pipe(literal(slug), mapTo(route))
 
 const section =
   (sectionSlug: string) =>
-  <T>(pageSlug: string, route: { make: (input: {}) => T }) =>
+  <Tag extends string>(pageSlug: string, route: PayloadFreeRoute<Tag>) =>
     pipe(literal(sectionSlug), slash(literal(pageSlug)), mapTo(route))
 
 const getStarted = section('get-started')


### PR DESCRIPTION
The `page` and `section` helpers took `route: { make: (input: {}) => T }`, which constrains "has a make" rather than "carries no payload". An object that is not a route at all typechecks at the call site and collapses to `never` downstream, where the mistake is hard to trace back. A route whose fields are all optional also passes, producing a router whose payload the URL can never carry.

`CallableTaggedStruct<Tag, {}>` is what `r(tag)` returns when called with no fields, so it rejects a value that is not a callable tagged struct and a callable tagged struct that has fields. Both now fail where they are written. Routers infer the same `Router<{ readonly _tag: Tag }>` as before, and the import is type-only, so there is no runtime change. `PayloadFreeRoute` names what the helpers accept.

The `{}` means something different in the two signatures. In `make: (input: {})` it was TypeScript's "any non-nullish value", and the payload-free check fell out of contravariance. In `CallableTaggedStruct<Tag, {}>` it is the empty field record, and `keyof {} extends never` is what selects the no-argument callable branch.

Two things this leaves alone. `mapTo` and `parseUrlWithFallback` in `foldkit/route` carry the same `{ make: ... }` shape, so `mapTo({ make: (_input: {}) => ({ value: 1 }) })` still typechecks and still yields `never`. That is a library API decision rather than a website fix, and it has more than one answer: constraining the parameter to `CallableTaggedStruct` would reject a plain `S.TaggedStruct` that works today, while constraining the result to `T extends { readonly _tag: string }` would close the hole without breaking anyone.

`typingTerminalRouter` is a hand-inlined `section('example-apps')` call, so it escapes the new constraint. Converting it would add a section binding used exactly once, beside `exampleDetailRouter`, which carries a payload and can never use the helpers, so that block reads in two styles either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEQSJzwRgLee8RtGCHjJiS)_