### PR TITLE
fix: align SSG container ids and gate repeatable prerenders

### DIFF
--- a/.changeset/prerender-container-id-drives-injection.md
+++ b/.changeset/prerender-container-id-drives-injection.md
@@ -1,0 +1,5 @@
+---
+'create-foldkit-app': patch
+---
+
+Give the SSG scaffold's `injectIntoTemplate` call the container id the rest of its prerender script already uses. `scripts/prerender.ts` names the container in one `CONTAINER_ID` constant and tests the built `index.html` for that placeholder, but the injection call fell back to its own `root` default. Renaming the container left the guard looking for the new placeholder while injection still demanded `<div id="root"></div>`, so the first prerender failed with an error naming a container id the project no longer used. The constant now drives both.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,15 @@ jobs:
       - name: Build reusable packages
         run: pnpm build:packages && pnpm --filter @typing-game/shared build
 
+      # The prerender step writes the generated `/` over the same `index.html`
+      # the client build left its template in, so running it twice against one
+      # client build is the case that regressed. Nothing else here builds once
+      # and prerenders twice, so a repeat of that regression would reach a
+      # release unseen.
+      - name: Check the prerender step is repeatable
+        if: steps.scope.outputs.prerender_repeatable == 'true'
+        run: pnpm check:prerender-repeatable
+
       - name: Check packed peer dependency floors
         if: steps.scope.outputs.peer_floors == 'true'
         run: pnpm check:peer-floors

--- a/examples/ssg/scripts/prerender.ts
+++ b/examples/ssg/scripts/prerender.ts
@@ -107,7 +107,9 @@ const program = Effect.gen(function* () {
         ),
       )
     }
-    const html = Server.injectIntoTemplate(template, result.application)
+    const html = Server.injectIntoTemplate(template, result.application, {
+      containerId: CONTAINER_ID,
+    })
     const outputFile = outputFileFor(path)
 
     yield* fs.makeDirectory(dirname(outputFile), { recursive: true })

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check:host-parity": "tsx scripts/check-host-parity.ts",
     "check:host-parity:ci": "tsx scripts/check-host-parity.ts --skip-build",
     "check:playground-ssg-build": "tsx scripts/check-playground-ssg-build.ts",
+    "check:prerender-repeatable": "tsx scripts/check-prerender-repeatable.ts",
     "pre-push": "pnpm check:no-claude-comments && pnpm check:commit-message-line-length && pnpm check:changeset-unwrapped && pnpm format:check && pnpm check:skill-version && pnpm check:no-major-changesets && pnpm check:changeset-ignore && pnpm changeset status --since=origin/main && pnpm lint && pnpm check:dead-code && pnpm typecheck:scripts && pnpm test:scripts && pnpm check:effect-prebundle && pnpm check:circular-deps && pnpm build && pnpm -r typecheck && pnpm test && bash scripts/run-website-e2e.sh",
     "test": "pnpm -r --filter './examples/*' --filter './packages/*' run --if-present test",
     "typecheck:scripts": "tsc -p scripts/tsconfig.json --noEmit",

--- a/packages/create-foldkit-app/templates/rendering/ssg/scripts/prerender.ts
+++ b/packages/create-foldkit-app/templates/rendering/ssg/scripts/prerender.ts
@@ -106,7 +106,9 @@ const program = Effect.gen(function* () {
         ),
       )
     }
-    const html = Server.injectIntoTemplate(template, result.application)
+    const html = Server.injectIntoTemplate(template, result.application, {
+      containerId: CONTAINER_ID,
+    })
     const outputFile = outputFileFor(path)
 
     yield* fs.makeDirectory(dirname(outputFile), { recursive: true })

--- a/packages/website/scripts/prerender.ts
+++ b/packages/website/scripts/prerender.ts
@@ -613,6 +613,7 @@ const prerenderRoute =
       const injectedHtml = Server.injectIntoTemplate(
         baseHtml,
         captured.application,
+        { containerId: CONTAINER_ID },
       )
       const outputHtml = injectMetaTags(
         injectedHtml,
@@ -677,7 +678,11 @@ const prerenderPlaygroundShells = (
 ) =>
   Effect.gen(function* () {
     const captured = yield* renderRoutePage(serverEntry, PLAYGROUND_SHELL_ROUTE)
-    const shellHtml = Server.injectIntoTemplate(baseHtml, captured.application)
+    const shellHtml = Server.injectIntoTemplate(
+      baseHtml,
+      captured.application,
+      { containerId: CONTAINER_ID },
+    )
 
     const fs = yield* FileSystem.FileSystem
     const writeShell = (route: AppRoute, outputPath: string) => {
@@ -727,6 +732,7 @@ const prerenderNotFoundPage = (
     const injectedHtml = Server.injectIntoTemplate(
       baseHtml,
       captured.application,
+      { containerId: CONTAINER_ID },
     )
     const outputHtml = injectMetaTags(
       injectedHtml,

--- a/scripts/check-prerender-repeatable.ts
+++ b/scripts/check-prerender-repeatable.ts
@@ -1,0 +1,200 @@
+import { spawnSync } from 'node:child_process'
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+const REPO_DIR = resolve(import.meta.dirname, '..')
+const EXAMPLE_DIR = resolve(REPO_DIR, 'examples/ssg')
+const CLIENT_DIR = resolve(EXAMPLE_DIR, 'dist/client')
+const DIST_DIR = resolve(EXAMPLE_DIR, 'dist')
+const CACHE_DIR = resolve(EXAMPLE_DIR, 'node_modules/.cache')
+const INDEX_PATH = resolve(CLIENT_DIR, 'index.html')
+const BUILD_ID = 'prerender-repeatable-gate'
+const HYDRATION_STAMP_PATTERN = /\sdata-foldkit-[a-z-]+="[^"]*"/g
+const HYDRATION_STAMP_PREFIX = 'data-foldkit-'
+
+class PrerenderRepeatableError extends Error {}
+
+const log = (message: string): void => {
+  console.log(`[prerender-repeatable] ${message}`)
+}
+
+const fail = (message: string): never => {
+  throw new PrerenderRepeatableError(message)
+}
+
+const runRequired = (
+  label: string,
+  command: string,
+  args: ReadonlyArray<string>,
+): void => {
+  log(label)
+  const result = spawnSync(command, args, {
+    cwd: EXAMPLE_DIR,
+    stdio: 'inherit',
+    env: { ...process.env, FOLDKIT_BUILD_ID: BUILD_ID },
+  })
+
+  if (result.error !== undefined) {
+    return fail(`${command} ${args.join(' ')} failed: ${result.error.message}`)
+  }
+  if (result.status !== 0) {
+    return fail(`${command} ${args.join(' ')} exited ${String(result.status)}`)
+  }
+}
+
+const prerender = (label: string): void => {
+  runRequired(label, 'pnpm', ['exec', 'tsx', 'scripts/prerender.ts'])
+}
+
+// NOTE: the cached template copy is the mechanism under test, and the build is
+// byte-identical between runs because the build id is pinned, so a copy left by
+// an earlier invocation is indistinguishable from the one the first run is
+// supposed to write. The whole cache directory goes rather than the one path
+// the prerender script names today, which the example is free to rename.
+const clearPriorState = (): void => {
+  rmSync(DIST_DIR, { recursive: true, force: true })
+  rmSync(CACHE_DIR, { recursive: true, force: true })
+}
+
+const readClientFiles = (): Readonly<Record<string, Buffer>> => {
+  const entries = readdirSync(CLIENT_DIR, {
+    recursive: true,
+    withFileTypes: true,
+  })
+  const files: Record<string, Buffer> = {}
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue
+    }
+
+    const filePath = join(entry.parentPath, entry.name)
+    files[relative(CLIENT_DIR, filePath)] = readFileSync(filePath)
+  }
+
+  return files
+}
+
+// The prerender writes the generated `/` over the `index.html` the client build
+// left its template in, so that file changing is proof the step ran. Comparing
+// against the built template rather than testing for a placeholder literal
+// keeps this working when the example renames its container. Without it a
+// prerender that generates nothing compares untouched build output with itself
+// and agrees.
+const assertPrerenderRan = (builtTemplate: Buffer): void => {
+  if (readFileSync(INDEX_PATH).equals(builtTemplate)) {
+    return fail(
+      `"${INDEX_PATH}" is unchanged from the client build, so the prerender generated no page over it`,
+    )
+  }
+}
+
+const assertCachedTemplate = (): void => {
+  const cached = readdirSync(CACHE_DIR, {
+    recursive: true,
+    withFileTypes: true,
+  })
+
+  if (!cached.some(entry => entry.isFile())) {
+    return fail(
+      `"${CACHE_DIR}" holds no cached template after the first prerender, so a re-run has nothing to read back`,
+    )
+  }
+}
+
+const assertSameFiles = (
+  label: string,
+  before: Readonly<Record<string, Buffer>>,
+  after: Readonly<Record<string, Buffer>>,
+): void => {
+  const paths = [...new Set([...Object.keys(before), ...Object.keys(after)])]
+
+  for (const path of paths.sort()) {
+    const first = before[path]
+    const second = after[path]
+
+    if (first === undefined) {
+      return fail(`${label}: "${path}" appeared only after the re-run`)
+    }
+    if (second === undefined) {
+      return fail(`${label}: "${path}" stopped being written by the re-run`)
+    }
+    if (!first.equals(second)) {
+      return fail(`${label}: "${path}" differs between runs`)
+    }
+  }
+
+  log(`${label}: ${String(paths.length)} build files match`)
+}
+
+// A static render carries none of the hydration stamps, so a guard reading any
+// of them mistakes a generated page for a template. Stripping every
+// `data-foldkit-` attribute rather than a named list models that render without
+// a second build and keeps covering a stamp the renderer adds later.
+const stripHydrationStamps = (): void => {
+  const generated = readFileSync(INDEX_PATH, 'utf8')
+  const stripped = generated.replaceAll(HYDRATION_STAMP_PATTERN, '')
+
+  if (stripped === generated) {
+    return fail(
+      `"${INDEX_PATH}" carries no ${HYDRATION_STAMP_PREFIX} attribute to strip, so this step no longer models a static render`,
+    )
+  }
+
+  if (stripped.includes(HYDRATION_STAMP_PREFIX)) {
+    return fail(
+      `a ${HYDRATION_STAMP_PREFIX} attribute survived stripping in "${INDEX_PATH}", so this step no longer models a static render`,
+    )
+  }
+
+  writeFileSync(INDEX_PATH, stripped, 'utf8')
+}
+
+const main = (): void => {
+  clearPriorState()
+
+  runRequired('Building the client', 'pnpm', [
+    'exec',
+    'vite',
+    'build',
+    '--outDir',
+    'dist/client',
+  ])
+  runRequired('Building the server entry', 'pnpm', [
+    'exec',
+    'vite',
+    'build',
+    '--ssr',
+    'src/entry.server.ts',
+    '--outDir',
+    'dist/server',
+  ])
+
+  const builtTemplate = readFileSync(INDEX_PATH)
+
+  prerender('Prerendering against a fresh client build')
+  assertPrerenderRan(builtTemplate)
+  assertCachedTemplate()
+  const firstRun = readClientFiles()
+
+  prerender('Prerendering again against the same client build')
+  assertSameFiles(
+    're-run against one client build',
+    firstRun,
+    readClientFiles(),
+  )
+
+  stripHydrationStamps()
+  prerender('Prerendering again with the hydration stamps stripped')
+  assertSameFiles('re-run against static output', firstRun, readClientFiles())
+
+  log('PASS')
+}
+
+try {
+  main()
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`[prerender-repeatable] FAIL ${message}`)
+  process.exitCode = 1
+}

--- a/scripts/plan-ci.mjs
+++ b/scripts/plan-ci.mjs
@@ -93,6 +93,17 @@ const domStateParity =
     ],
     prefixes: ['packages/foldkit/'],
   })
+const prerenderRepeatable =
+  fullWorkspaceChecks ||
+  hasChanged({
+    files: ['scripts/check-prerender-repeatable.ts'],
+    prefixes: [
+      'examples/ssg/',
+      'packages/create-foldkit-app/templates/rendering/ssg/',
+      'packages/foldkit/',
+      'packages/vite-plugin-foldkit/',
+    ],
+  })
 const peerFloors =
   fullWorkspaceChecks ||
   hasChanged({
@@ -159,6 +170,7 @@ process.stdout.write(`packed_ssr_consumer=${packedSsrConsumer}\n`)
 process.stdout.write(`scaffold_server_rendering=${scaffoldServerRendering}\n`)
 process.stdout.write(`host_parity=${hostParity}\n`)
 process.stdout.write(`dom_state_parity=${domStateParity}\n`)
+process.stdout.write(`prerender_repeatable=${prerenderRepeatable}\n`)
 process.stdout.write(`peer_floors=${peerFloors}\n`)
 process.stdout.write(`typing_game=${typingGame}\n`)
 process.stdout.write(`website=${website}\n`)

--- a/scripts/plan-ci.test.mjs
+++ b/scripts/plan-ci.test.mjs
@@ -15,6 +15,7 @@ const SCOPES = [
   'scaffold_server_rendering',
   'host_parity',
   'dom_state_parity',
+  'prerender_repeatable',
   'peer_floors',
   'typing_game',
   'website',


### PR DESCRIPTION
Nothing built once and prerendered twice, so a repeat of the #1148 regression would reach a release unseen. The new gate builds the SSG example once, prerenders three times, and requires every file in the client build to be byte-identical each time.

The third run strips the hydration stamps from the generated `index.html` first. The first attempt in #1148 tested the built file for `data-foldkit-app`, which a static render never writes, so a static site kept failing with the error the change set out to remove. Stripping every `data-foldkit-` attribute rather than a named list models that render without a second build and keeps covering a stamp the renderer adds later.

The gate owns the state it depends on. It clears `dist` and the example's cache directory before building, then asserts a template was cached and that the prerender changed `index.html` from what the client build left there. The cached template copy is the mechanism under test, and the build is byte-identical between runs because the build id is pinned, so a copy left by an earlier invocation would stand in for the one the first run is supposed to write. Deriving those checks from the build rather than from a placeholder literal keeps them working when the example renames its container.

Pass `CONTAINER_ID` to `injectIntoTemplate` in the three prerender scripts while here. Each names its container in one constant and tests the built `index.html` for that placeholder, but injection fell back to its own `root` default, so renaming the container failed on the first prerender with an error naming an id the project no longer used.