### PR TITLE
fix(oxlint-plugin): ship type declarations

### DIFF
--- a/.changeset/oxlint-plugin-ships-types.md
+++ b/.changeset/oxlint-plugin-ships-types.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/oxlint-plugin': patch
+---
+
+Ship type declarations for `@foldkit/oxlint-plugin`. The package built with esbuild alone, which bundles the runtime but emits no `.d.ts`, so importing it from an `oxlint.config.ts` failed with "Could not find a declaration file for module '@foldkit/oxlint-plugin'". The build now also runs `tsc` to emit declarations into `dist`, and `package.json` points at them through `types` and a `types` condition in its exports.

--- a/packages/oxlint-plugin-foldkit/package.json
+++ b/packages/oxlint-plugin-foldkit/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./recommended.json": "./recommended.json",
@@ -14,7 +16,7 @@
   },
   "scripts": {
     "clean": "rimraf dist recommended.json all.json *.tsbuildinfo",
-    "build": "pnpm run clean && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js && node scripts/generate-presets.mjs",
+    "build": "pnpm run clean && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js && tsc -b tsconfig.build.json && node scripts/generate-presets.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/oxlint-plugin-foldkit/tsconfig.build.json
+++ b/packages/oxlint-plugin-foldkit/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
The package built with esbuild alone, which bundles the runtime but emits no declarations, so importing it from an `oxlint.config.ts` failed with "Could not find a declaration file for module '@foldkit/oxlint-plugin'". The build now runs `tsc` after esbuild to emit declarations into `dist`, and `package.json` points at them through a `types` field and a `types` condition in its exports.

Declaration emit uses a dedicated `tsconfig.build.json` with `emitDeclarationOnly`, because esbuild owns the JS bundle and the source imports its rule modules with `.ts` extensions under Bundler resolution.

Fixes #1128.