### PR TITLE
feat(foldkit): add composable click controls

### DIFF
--- a/.changeset/curly-plums-click.md
+++ b/.changeset/curly-plums-click.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Add composable `OnClick` controls for preventing the browser default, stopping DOM propagation, and synchronously focusing an existing element before dispatch. The existing one-argument call keeps its allow-and-bubble behavior, while `OnClickFocus` remains source compatible and is deprecated in favor of the new focus control. Scene now follows the full click propagation path, honors the default-action and propagation controls, and runs submit-button default actions.

--- a/packages/foldkit/src/experimental/server/serialize.test.ts
+++ b/packages/foldkit/src/experimental/server/serialize.test.ts
@@ -583,7 +583,13 @@ describe('serializeHtml', () => {
     // hydrate carries none of it either.
     const view = h.keyed('button')(
       'submit',
-      [h.OnClick(Message.ClickedButton()), h.Id('submit')],
+      [
+        h.OnClick(Message.ClickedButton(), {
+          defaultAction: 'Prevent',
+          propagation: 'Stop',
+        }),
+        h.Id('submit'),
+      ],
       ['Send'],
     )
     expect(serializeHtml(view)).toBe('<button id="submit">Send</button>')

--- a/packages/foldkit/src/html/click.test.ts
+++ b/packages/foldkit/src/html/click.test.ts
@@ -1,0 +1,147 @@
+import { Context, Effect } from 'effect'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { defineMessageUnion } from '../message/index.js'
+import { MountTracker } from '../mount/index.js'
+import { Dispatch } from '../runtime/index.js'
+import { type HtmlBuilder, __htmlBuilder } from './index.js'
+import {
+  type DispatchSync,
+  clearRuntime,
+  setRuntime,
+} from './runtimeSingleton.js'
+
+const Message = defineMessageUnion({
+  ClickedFirst: {},
+  ClickedSecond: {},
+})
+type Message = typeof Message.Type
+
+const setUpRuntime = (
+  dispatched: Array<unknown>,
+  activeElementsAtDispatch: Array<Element | null>,
+): void => {
+  const dispatchSync: DispatchSync = message => {
+    activeElementsAtDispatch.push(document.activeElement)
+    dispatched.push(message)
+  }
+  const dispatchService = Dispatch.of({
+    dispatchAsync: () => Effect.void,
+    dispatchSync,
+  })
+  const context = Context.make(Dispatch, dispatchService).pipe(
+    Context.add(MountTracker, {
+      started: () => {},
+      ended: () => {},
+    }),
+  )
+  setRuntime(dispatchSync, context)
+}
+
+const fakeClick = () => {
+  let isDefaultPrevented = false
+  let isPropagationStopped = false
+
+  return {
+    event: {
+      preventDefault: () => {
+        isDefaultPrevented = true
+      },
+      stopPropagation: () => {
+        isPropagationStopped = true
+      },
+    },
+    isDefaultPrevented: () => isDefaultPrevented,
+    isPropagationStopped: () => isPropagationStopped,
+  }
+}
+
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+const clickHandlerOf = (
+  vnode: ReturnType<HtmlBuilder<Message>['button']>,
+): ((event: unknown) => void) =>
+  vnode?.data?.on?.['click'] as unknown as (event: unknown) => void
+/* eslint-enable @typescript-eslint/consistent-type-assertions */
+
+describe('OnClick', () => {
+  let dispatched: Array<unknown>
+  let activeElementsAtDispatch: Array<Element | null>
+  let focusTarget: HTMLInputElement
+
+  beforeEach(() => {
+    dispatched = []
+    activeElementsAtDispatch = []
+    focusTarget = document.createElement('input')
+    focusTarget.id = 'click-focus-target'
+    document.body.appendChild(focusTarget)
+    setUpRuntime(dispatched, activeElementsAtDispatch)
+  })
+
+  afterEach(() => {
+    focusTarget.remove()
+    clearRuntime()
+  })
+
+  it('allows the default and bubbling when controls are omitted', () => {
+    const h = __htmlBuilder<Message>()
+    const vnode = h.button([h.OnClick(Message.ClickedFirst())])
+    const click = fakeClick()
+
+    clickHandlerOf(vnode)(click.event)
+
+    expect(click.isDefaultPrevented()).toBe(false)
+    expect(click.isPropagationStopped()).toBe(false)
+    expect(dispatched).toEqual([Message.ClickedFirst()])
+  })
+
+  it('combines default prevention, stopped propagation, and focus', () => {
+    const h = __htmlBuilder<Message>()
+    const vnode = h.button([
+      h.OnClick(Message.ClickedFirst(), {
+        defaultAction: 'Prevent',
+        propagation: 'Stop',
+        focusSelector: '#click-focus-target',
+      }),
+    ])
+    const click = fakeClick()
+
+    clickHandlerOf(vnode)(click.event)
+
+    expect(click.isDefaultPrevented()).toBe(true)
+    expect(click.isPropagationStopped()).toBe(true)
+    expect(document.activeElement).toBe(focusTarget)
+    expect(activeElementsAtDispatch).toEqual([focusTarget])
+    expect(dispatched).toEqual([Message.ClickedFirst()])
+  })
+
+  it('runs every handler on the current element after propagation stops', () => {
+    const h = __htmlBuilder<Message>()
+    const vnode = h.button([
+      h.OnClick(Message.ClickedFirst(), { propagation: 'Stop' }),
+      h.OnClick(Message.ClickedSecond()),
+    ])
+    const click = fakeClick()
+
+    clickHandlerOf(vnode)(click.event)
+
+    expect(click.isPropagationStopped()).toBe(true)
+    expect(dispatched).toEqual([
+      Message.ClickedFirst(),
+      Message.ClickedSecond(),
+    ])
+  })
+
+  it('keeps OnClickFocus focus-before-dispatch behavior', () => {
+    const h = __htmlBuilder<Message>()
+    const vnode = h.button([
+      h.OnClickFocus('#click-focus-target', Message.ClickedFirst()),
+    ])
+    const click = fakeClick()
+
+    clickHandlerOf(vnode)(click.event)
+
+    expect(document.activeElement).toBe(focusTarget)
+    expect(activeElementsAtDispatch).toEqual([focusTarget])
+    expect(dispatched).toEqual([Message.ClickedFirst()])
+  })
+})

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -162,6 +162,33 @@ const isFocusInsideCurrentTarget = (event: FocusEvent): boolean =>
 export type Html = VNode | null
 export type Child = Html | string
 
+/** Whether an event handler leaves the browser's default action in place or
+ *  prevents it synchronously. */
+export const DefaultAction = S.Literals(['Allow', 'Prevent'])
+/** Whether an event handler leaves the browser's default action in place or
+ *  prevents it synchronously. */
+export type DefaultAction = typeof DefaultAction.Type
+
+/** Whether an event continues through its DOM propagation path or stops after
+ *  the handlers on its current element have run. */
+export const EventPropagation = S.Literals(['Bubble', 'Stop'])
+/** Whether an event continues through its DOM propagation path or stops after
+ *  the handlers on its current element have run. */
+export type EventPropagation = typeof EventPropagation.Type
+
+/** Declarative controls for an `OnClick` handler. Omitted
+ *  fields keep the browser default, allow the click to bubble, and leave focus
+ *  unchanged. */
+export const ClickOptions = S.Struct({
+  defaultAction: S.optional(DefaultAction),
+  propagation: S.optional(EventPropagation),
+  focusSelector: S.optional(S.String),
+})
+/** Declarative controls for an `OnClick` handler. Omitted
+ *  fields keep the browser default, allow the click to bubble, and leave focus
+ *  unchanged. */
+export type ClickOptions = typeof ClickOptions.Type
+
 /** Text direction for the document root, applied to `dir` on the `<html>`
  *  element. `Auto` defers to the browser's first-strong-character heuristic. */
 export const TextDirection = S.Literals(['Ltr', 'Rtl', 'Auto'])
@@ -504,7 +531,7 @@ export type Attribute<Message> = Data.TaggedEnum<{
   Popover: { readonly value: string }
   Popovertarget: { readonly value: string }
   Popovertargetaction: { readonly value: string }
-  OnClick: { readonly message: Message }
+  OnClick: { readonly message: Message; readonly options?: ClickOptions }
   OnClickFocus: { readonly focusSelector: string; readonly message: Message }
   OnDoubleClick: { readonly message: Message }
   OnMouseDown: { readonly message: Message }
@@ -1533,17 +1560,30 @@ const attributeHandlers: AttributeHandlers = {
     setDataAttr(ctx, 'popovertarget', value),
   Popovertargetaction: ({ value }, ctx: BuildContext) =>
     setDataAttr(ctx, 'popovertargetaction', value),
-  OnClick: ({ message }, ctx: BuildContext) =>
-    addDataOn(ctx, 'click', () => ctx.dispatch(message)),
-  OnClickFocus: ({ focusSelector, message }, ctx: BuildContext) =>
-    updateDataOn(ctx, {
-      click: () => {
+  OnClick: ({ message, options }, ctx: BuildContext) =>
+    addDataOn(ctx, 'click', (event: MouseEvent) => {
+      if (options?.defaultAction === 'Prevent') {
+        event.preventDefault()
+      }
+      if (options?.propagation === 'Stop') {
+        event.stopPropagation()
+      }
+      const focusSelector = options?.focusSelector
+      if (focusSelector !== undefined) {
         const focusTarget = document.querySelector(focusSelector)
         if (focusTarget instanceof HTMLElement) {
           focusTarget.focus()
         }
-        ctx.dispatch(message)
-      },
+      }
+      ctx.dispatch(message)
+    }),
+  OnClickFocus: ({ focusSelector, message }, ctx: BuildContext) =>
+    addDataOn(ctx, 'click', () => {
+      const focusTarget = document.querySelector(focusSelector)
+      if (focusTarget instanceof HTMLElement) {
+        focusTarget.focus()
+      }
+      ctx.dispatch(message)
     }),
   OnDoubleClick: ({ message }, ctx: BuildContext) =>
     addDataOn(ctx, 'dblclick', () => ctx.dispatch(message)),
@@ -3493,10 +3533,41 @@ type HtmlAttributes<Message> = {
     readonly _tag: 'Popovertargetaction'
     readonly value: string
   }
-  OnClick: (message: Message) => {
+  /** Dispatches `message` when the element is clicked. The optional controls
+   *  can synchronously prevent the browser default, stop DOM propagation, and
+   *  focus an existing element before dispatch. Omitted controls preserve the
+   *  existing allow-and-bubble behavior.
+   *
+   *  `propagation: 'Stop'` still lets every click handler registered on the
+   *  current element run, matching `Event.stopPropagation()`. It only prevents
+   *  ancestor handlers from receiving the click.
+   *
+   *  `focusSelector` is for browser APIs that require focus during the
+   *  originating user gesture, such as opening the iOS on-screen keyboard. The
+   *  target must already exist. If the real input mounts after the Message
+   *  changes the view, focus an always-present warmup input here, then return a
+   *  `Dom.focus` Command from update to transfer focus after the real input
+   *  mounts.
+   *
+   *  @example
+   *  ```typescript
+   *  h.OnClick(Message.ClickedExpand(), {
+   *    defaultAction: 'Prevent',
+   *    propagation: 'Stop',
+   *  })
+   *  ``` */
+  OnClick: (
+    message: Message,
+    options?: ClickOptions,
+  ) => {
     readonly _tag: 'OnClick'
     readonly message: Message
+    readonly options?: ClickOptions
   }
+  /** Synchronously focuses the element matching `focusSelector`, then
+   *  dispatches `message`.
+   *
+   *  @deprecated Use {@link HtmlBuilder.OnClick} with `focusSelector`. */
   OnClickFocus: (
     focusSelector: string,
     message: Message,
@@ -4602,37 +4673,10 @@ const htmlAttributes = <Message>(): HtmlAttributes<Message> => ({
   Popover: (value: string) => Popover({ value }),
   Popovertarget: (value: string) => Popovertarget({ value }),
   Popovertargetaction: (value: string) => Popovertargetaction({ value }),
-  OnClick: (message: Message) => OnClick({ message }),
-  /**
-   * Click handler that synchronously focuses the element matching
-   * `focusSelector`, then dispatches `message`. Both run inside the originating
-   * click event handler, preserving the user-gesture context.
-   *
-   * Use this when tapping the element must open the on-screen keyboard on
-   * iOS Safari. Safari only opens the keyboard if `.focus()` runs synchronously
-   * inside the originating user-gesture handler, which a Command's `Dom.focus`
-   * cannot satisfy (Commands fork through `Effect.forkDetach` +
-   * `requestAnimationFrame` and resolve after the gesture has expired).
-   *
-   * When the real input only mounts later (a search field inside a dialog,
-   * say), focus it in two steps. First, keep a focusable text input that is
-   * always in the DOM (a visually hidden "keyboard warmup") and point
-   * `focusSelector` at it, so the tap focuses the input (which opens the
-   * keyboard) and dispatches a Message. Second, update's branch for that
-   * Message opens the dialog and returns a `Dom.focus` Command pointed at the
-   * real input; by the time it runs the input has mounted, so focus moves to
-   * it. iOS keeps the keyboard up when focus moves between two text inputs,
-   * so it stays open and now targets the real input.
-   *
-   * Like `OnKeyDownPreventDefault`, the side effect (focusing another
-   * element) lives inside the framework's event handler so user code stays
-   * declarative.
-   *
-   * @example
-   * ```typescript
-   * h.OnClickFocus('#search-keyboard-warmup', ClickedSearch())
-   * ```
-   */
+  OnClick: (message: Message, options?: ClickOptions) =>
+    options === undefined
+      ? OnClick({ message })
+      : OnClick({ message, options }),
   OnClickFocus: (focusSelector: string, message: Message) =>
     OnClickFocus({ focusSelector, message }),
   OnDoubleClick: (message: Message) => OnDoubleClick({ message }),

--- a/packages/foldkit/src/html/public.ts
+++ b/packages/foldkit/src/html/public.ts
@@ -1,7 +1,10 @@
 export {
   childAttributes,
+  ClickOptions,
   createKeyedLazy,
   createLazy,
+  DefaultAction,
+  EventPropagation,
   inertHtml,
   TextDirection,
 } from './index.js'

--- a/packages/foldkit/src/hydrate.test.ts
+++ b/packages/foldkit/src/hydrate.test.ts
@@ -139,19 +139,45 @@ describe('__hydrateVNode', () => {
 
   it('attaches event listeners to adopted elements', () => {
     const view = buildView(() =>
-      h.button([h.Id('go'), h.OnClick(Message.ClickedButton())], ['Go']),
+      h.button(
+        [
+          h.Id('go'),
+          h.OnClick(Message.ClickedButton(), {
+            defaultAction: 'Prevent',
+            propagation: 'Stop',
+          }),
+        ],
+        ['Go'],
+      ),
     )
     const root = mountServerHtml(serializeHydratable(view))
 
     buildView(() =>
       hydrateVNode(
         root,
-        h.button([h.Id('go'), h.OnClick(Message.ClickedButton())], ['Go']),
+        h.button(
+          [
+            h.Id('go'),
+            h.OnClick(Message.ClickedButton(), {
+              defaultAction: 'Prevent',
+              propagation: 'Stop',
+            }),
+          ],
+          ['Go'],
+        ),
       ),
     )
 
-    root.dispatchEvent(new MouseEvent('click'))
+    let isBubbleObserved = false
+    host.addEventListener('click', () => {
+      isBubbleObserved = true
+    })
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+    root.dispatchEvent(click)
+
     expect(dispatched).toEqual([Message.ClickedButton()])
+    expect(click.defaultPrevented).toBe(true)
+    expect(isBubbleObserved).toBe(false)
   })
 
   it('attaches focus boundary listeners without replaying existing focus', () => {

--- a/packages/foldkit/src/test/apps/bubbling.ts
+++ b/packages/foldkit/src/test/apps/bubbling.ts
@@ -9,15 +9,19 @@ import type * as Update from '../../update/index.js'
 
 export const Model = S.Struct({
   clicks: S.Number,
+  childClicks: S.Number,
   doubleClicks: S.Number,
+  submissions: S.Number,
 })
 export type Model = typeof Model.Type
 
 // MESSAGE
 
 const Message = defineMessageUnion({
+  ClickedChild: {},
   ClickedContainer: {},
   DoubleClickedContainer: {},
+  SubmittedForm: {},
 })
 type Message = typeof Message.Type
 
@@ -25,18 +29,26 @@ type Message = typeof Message.Type
 
 export const initialModel: Model = {
   clicks: 0,
+  childClicks: 0,
   doubleClicks: 0,
+  submissions: 0,
 }
 
 // UPDATE
 
 export const update = (model: Model, message: Message) =>
   Message.match<Update.Return<Model, Message>>(message, {
+    ClickedChild: () => ({
+      model: evo(model, { childClicks: Number.increment }),
+    }),
     ClickedContainer: () => ({
       model: evo(model, { clicks: Number.increment }),
     }),
     DoubleClickedContainer: () => ({
       model: evo(model, { doubleClicks: Number.increment }),
+    }),
+    SubmittedForm: () => ({
+      model: evo(model, { submissions: Number.increment }),
     }),
   })
 
@@ -48,11 +60,71 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
     [
       h.div(
         [h.Role('option'), h.OnClick(Message.ClickedContainer())],
-        [h.span([], [`clicks=${model.clicks}`])],
+        [
+          h.span([], [`clicks=${model.clicks}`]),
+          h.button(
+            [
+              h.Type('button'),
+              h.OnClick(Message.ClickedChild()),
+              h.AriaLabel('Bubbling child'),
+            ],
+            [`child clicks=${model.childClicks}`],
+          ),
+          h.button(
+            [
+              h.Type('button'),
+              h.OnClick(Message.ClickedChild(), {
+                defaultAction: 'Prevent',
+                propagation: 'Stop',
+              }),
+              h.AriaLabel('Stopped child'),
+            ],
+            [`stopped child clicks=${model.childClicks}`],
+          ),
+        ],
       ),
       h.div(
         [h.Role('listitem'), h.OnDoubleClick(Message.DoubleClickedContainer())],
         [h.span([], [`dbl=${model.doubleClicks}`])],
+      ),
+      h.form(
+        [h.Id('submission-form'), h.OnSubmit(Message.SubmittedForm())],
+        [
+          h.button(
+            [
+              h.OnClick(Message.ClickedChild()),
+              h.AriaLabel('Submit with default'),
+            ],
+            [h.span([], ['Submit with default'])],
+          ),
+          h.button(
+            [
+              h.OnClick(Message.ClickedChild(), {
+                defaultAction: 'Prevent',
+              }),
+              h.AriaLabel('Submit without default'),
+            ],
+            ['Submit without default'],
+          ),
+          h.button(
+            [
+              h.Type('not-a-button-type'),
+              h.OnClick(Message.ClickedChild()),
+              h.AriaLabel('Submit with invalid type'),
+            ],
+            ['Submit with invalid type'],
+          ),
+          h.span([], [`submissions=${model.submissions}`]),
+        ],
+      ),
+      h.button(
+        [
+          h.Type('SUBMIT'),
+          h.Attribute('form', 'submission-form'),
+          h.OnClick(Message.ClickedChild()),
+          h.AriaLabel('Submit through form owner'),
+        ],
+        ['Submit through form owner'],
       ),
     ],
   )

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -2960,6 +2960,24 @@ const mixedArityUpdate = (model: LogoutModel, message: LogoutMessage) =>
     CompletedAction: () => ({ model }),
   })
 
+const outMessageBubblingView = (
+  model: LogoutModel,
+  h: HtmlBuilder<LogoutMessage>,
+) =>
+  h.div(
+    [h.OnClick(LogoutButtonMessage.CompletedAction())],
+    [h.button([h.OnClick(LogoutButtonMessage.ClickedLogout())], [model.label])],
+  )
+
+const multipleOutMessagesView = (
+  model: LogoutModel,
+  h: HtmlBuilder<LogoutMessage>,
+) =>
+  h.div(
+    [h.OnClick(LogoutButtonMessage.ClickedLogout())],
+    [h.button([h.OnClick(LogoutButtonMessage.ClickedLogout())], [model.label])],
+  )
+
 describe('Scene.expectOutMessage and Scene.expectNoOutMessage', () => {
   test('assert the OutMessage across steps', () => {
     Scene.scene(
@@ -3016,6 +3034,25 @@ describe('Scene.expectOutMessage and Scene.expectNoOutMessage', () => {
       Scene.Subscription.emit(LogoutButtonMessage.CompletedAction()),
       Scene.expectNoOutMessage(),
     )
+  })
+
+  test('preserves an OutMessage followed by a Message without one', () => {
+    Scene.scene(
+      { update: mixedArityUpdate, view: outMessageBubblingView },
+      Scene.given(logoutInitialModel),
+      Scene.click(Scene.role('button', { name: 'Log out' })),
+      Scene.expectOutMessage(OutMessage.RequestedLogout()),
+    )
+  })
+
+  test('fails explicitly when one interaction emits multiple OutMessages', () => {
+    expect(() =>
+      Scene.scene(
+        { update: mixedArityUpdate, view: multipleOutMessagesView },
+        Scene.given(logoutInitialModel),
+        Scene.click(Scene.role('button', { name: 'Log out' })),
+      ),
+    ).toThrow('One interaction emitted multiple OutMessages')
   })
 })
 
@@ -3394,6 +3431,66 @@ describe('scene with click bubbling', () => {
       Scene.given(bubblingInitialModel),
       Scene.click(Scene.text('clicks=0')),
       Scene.expect(Scene.text('clicks=1')).toExist(),
+    )
+  })
+
+  test('click invokes handlers on the target and its ancestor', () => {
+    Scene.scene(
+      { update: bubblingUpdate, view: bubblingView },
+      Scene.given(bubblingInitialModel),
+      Scene.click(Scene.role('button', { name: 'Bubbling child' })),
+      Scene.expect(Scene.text('child clicks=1')).toExist(),
+      Scene.expect(Scene.text('clicks=1')).toExist(),
+    )
+  })
+
+  test('click stops before an ancestor when propagation is stopped', () => {
+    Scene.scene(
+      { update: bubblingUpdate, view: bubblingView },
+      Scene.given(bubblingInitialModel),
+      Scene.click(Scene.role('button', { name: 'Stopped child' })),
+      Scene.expect(Scene.text('stopped child clicks=1')).toExist(),
+      Scene.expect(Scene.text('clicks=0')).toExist(),
+    )
+  })
+
+  test('click submits a form when its default action is allowed', () => {
+    Scene.scene(
+      { update: bubblingUpdate, view: bubblingView },
+      Scene.given(bubblingInitialModel),
+      Scene.click(Scene.text('Submit with default')),
+      Scene.expect(Scene.text('child clicks=1')).toExist(),
+      Scene.expect(Scene.text('submissions=1')).toExist(),
+    )
+  })
+
+  test('click uses a submit button explicit form owner', () => {
+    Scene.scene(
+      { update: bubblingUpdate, view: bubblingView },
+      Scene.given(bubblingInitialModel),
+      Scene.click(Scene.role('button', { name: 'Submit through form owner' })),
+      Scene.expect(Scene.text('child clicks=1')).toExist(),
+      Scene.expect(Scene.text('submissions=1')).toExist(),
+    )
+  })
+
+  test('an invalid button type defaults to submit', () => {
+    Scene.scene(
+      { update: bubblingUpdate, view: bubblingView },
+      Scene.given(bubblingInitialModel),
+      Scene.click(Scene.role('button', { name: 'Submit with invalid type' })),
+      Scene.expect(Scene.text('child clicks=1')).toExist(),
+      Scene.expect(Scene.text('submissions=1')).toExist(),
+    )
+  })
+
+  test('click does not submit a form when its default action is prevented', () => {
+    Scene.scene(
+      { update: bubblingUpdate, view: bubblingView },
+      Scene.given(bubblingInitialModel),
+      Scene.click(Scene.role('button', { name: 'Submit without default' })),
+      Scene.expect(Scene.text('child clicks=1')).toExist(),
+      Scene.expect(Scene.text('submissions=0')).toExist(),
     )
   })
 

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -196,7 +196,7 @@ type DispatchService = Readonly<{
 
 type CapturingDispatch = Readonly<{
   dispatch: DispatchService
-  getCapturedMessage: () => unknown | undefined
+  getCapturedMessages: () => ReadonlyArray<unknown>
   reset: () => void
 }>
 
@@ -402,18 +402,18 @@ const applyScopeToLocatorAll = (
 // CAPTURING DISPATCH
 
 const createCapturingDispatch = (): CapturingDispatch => {
-  let capturedMessage: unknown | undefined
+  let capturedMessages: Array<unknown> = []
 
   return {
     dispatch: Dispatch.of({
       dispatchAsync: () => Effect.void,
       dispatchSync: (dispatchedMessage: unknown) => {
-        capturedMessage = dispatchedMessage
+        capturedMessages.push(dispatchedMessage)
       },
     }),
-    getCapturedMessage: () => capturedMessage,
+    getCapturedMessages: () => capturedMessages,
     reset: () => {
-      capturedMessage = undefined
+      capturedMessages = []
     },
   }
 }
@@ -497,16 +497,122 @@ const maybeCaptureFromElement = <Model, Message, OutMessage>(
   internal.capturingDispatch.reset()
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   invokeHandler(maybeHandler.value as Function)
+  const capturedMessages = internal.capturingDispatch.getCapturedMessages()
 
-  return Option.map(
-    Option.fromNullishOr(internal.capturingDispatch.getCapturedMessage()),
-    captured =>
-      applyExternalMessage(
-        simulation,
-        captured,
-        'when an interaction dispatched a new Message',
+  return Array.match(capturedMessages, {
+    onEmpty: () => Option.none(),
+    onNonEmpty: messages =>
+      Option.some(
+        applyExternalMessages(
+          simulation,
+          messages,
+          'when an interaction dispatched a new Message',
+        ),
       ),
+  })
+}
+
+const finishCapturedInteraction = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  description: string,
+  eventName: string,
+): SceneSimulation<Model, Message, OutMessage> => {
+  const capturedMessages =
+    toInternal(simulation).capturingDispatch.getCapturedMessages()
+
+  return Array.match(capturedMessages, {
+    onEmpty: () =>
+      advanceInteraction(
+        simulation,
+        Ignored,
+        Option.some({ eventName, description }),
+      ),
+    onNonEmpty: messages =>
+      advanceInteraction(
+        applyExternalMessages(
+          simulation,
+          messages,
+          'when an interaction dispatched a new Message',
+        ),
+        Handled,
+        Option.none(),
+      ),
+  })
+}
+
+const applyMessageWithoutBoundaryChecks = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  message: unknown,
+): SceneSimulation<Model, Message, OutMessage> => {
+  const internal = toInternal(simulation)
+
+  /* eslint-disable @typescript-eslint/consistent-type-assertions */
+  const messageAsParent = message as unknown as Message
+  const messageUpdate = internal.updateFn(internal.model, messageAsParent)
+  return {
+    ...internal,
+    model: messageUpdate.model,
+    message: messageAsParent,
+    commands: Array.appendAll(internal.commands, messageUpdate.commands ?? []),
+    outMessage: messageUpdate.outMessage,
+  } as unknown as SceneSimulation<Model, Message, OutMessage>
+  /* eslint-enable @typescript-eslint/consistent-type-assertions */
+}
+
+const applyExternalMessages = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  messages: ReadonlyArray<unknown>,
+  context: string,
+): SceneSimulation<Model, Message, OutMessage> => {
+  const internal = toInternal(simulation)
+
+  assertNoUnresolvedCommands(internal.commands, context)
+  assertNoUnresolvedMounts(internal.mounts, context)
+  assertNoUnacknowledgedUnmounts(
+    unacknowledgedEndedMountsOf(internal.mountSlots),
+    context,
   )
+
+  const appliedMessages = Array.reduce(
+    messages,
+    {
+      simulation,
+      outMessages: Array.empty<OutMessage>(),
+    },
+    (current, message) => {
+      const nextSimulation = applyMessageWithoutBoundaryChecks(
+        current.simulation,
+        message,
+      )
+      const nextOutMessage = toInternal(nextSimulation).outMessage
+
+      return {
+        simulation: nextSimulation,
+        outMessages: Predicate.isUndefined(nextOutMessage)
+          ? current.outMessages
+          : Array.append(current.outMessages, nextOutMessage),
+      }
+    },
+  )
+
+  if (
+    Array.isReadonlyArrayNonEmpty(Array.drop(appliedMessages.outMessages, 1))
+  ) {
+    throw new Error(
+      'One interaction emitted multiple OutMessages, but Scene can expose only one OutMessage per step.\n\n' +
+        'Split the DOM handlers into separate interactions, or test this composition at the parent boundary where each OutMessage is folded.',
+    )
+  }
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  return {
+    ...toInternal(appliedMessages.simulation),
+    outMessage: pipe(
+      appliedMessages.outMessages,
+      Array.head,
+      Option.getOrUndefined,
+    ),
+  } as unknown as SceneSimulation<Model, Message, OutMessage>
 }
 
 /** Clears the pending fall-through, marking it acknowledged. Paired with
@@ -616,25 +722,80 @@ const invokeAndCapture = <Model, Message, OutMessage>(
   )
 }
 
-const lookupTypeAttribute = (vnode: VNode): string | undefined => {
-  const fromAttrs = vnode.data?.attrs?.['type']
-  const fromProps = vnode.data?.props?.['type']
-  return typeof fromAttrs === 'string'
-    ? fromAttrs
-    : typeof fromProps === 'string'
-      ? fromProps
-      : undefined
+const lookupStringAttribute = (
+  vnode: VNode,
+  name: string,
+): string | undefined => {
+  const fromAttrs = vnode.data?.attrs?.[name]
+  const fromProps = vnode.data?.props?.[name]
+  if (Predicate.isString(fromAttrs)) {
+    return fromAttrs
+  }
+
+  if (Predicate.isString(fromProps)) {
+    return fromProps
+  }
+
+  return undefined
 }
 
 const isSubmitButton = (element: VNode): boolean => {
-  const type = lookupTypeAttribute(element)
+  const maybeType = pipe(
+    lookupStringAttribute(element, 'type'),
+    Option.fromNullishOr,
+    Option.map(String_.toLowerCase),
+  )
+
   if (element.sel === 'button') {
-    return type === undefined || type === 'submit'
+    return Option.match(maybeType, {
+      onNone: () => true,
+      onSome: value => value !== 'button' && value !== 'reset',
+    })
   }
+
   if (element.sel === 'input') {
-    return type === 'submit' || type === 'image'
+    return Option.exists(
+      maybeType,
+      value => value === 'submit' || value === 'image',
+    )
   }
+
   return false
+}
+
+const findElementById = (root: VNode, id: string): Option.Option<VNode> => {
+  if (lookupStringAttribute(root, 'id') === id) {
+    return Option.some(root)
+  }
+
+  for (const child of root.children ?? []) {
+    if (Predicate.isString(child)) {
+      continue
+    }
+
+    const maybeMatch = findElementById(child, id)
+    if (Option.isSome(maybeMatch)) {
+      return maybeMatch
+    }
+  }
+
+  return Option.none()
+}
+
+const formOwnerOf = (root: VNode, submitter: VNode): Option.Option<VNode> => {
+  const formId = lookupStringAttribute(submitter, 'form')
+  if (formId !== undefined) {
+    return pipe(
+      findElementById(root, formId),
+      Option.filter(element => element.sel === 'form'),
+    )
+  }
+
+  return pipe(
+    root,
+    ancestorsOf(submitter),
+    Array.findLast(element => element.sel === 'form'),
+  )
 }
 
 const isElementDisabled = (element: VNode): boolean => {
@@ -996,26 +1157,7 @@ const applyExternalMessage = <Model, Message, OutMessage>(
   message: unknown,
   context: string,
 ): SceneSimulation<Model, Message, OutMessage> => {
-  const internal = toInternal(simulation)
-
-  assertNoUnresolvedCommands(internal.commands, context)
-  assertNoUnresolvedMounts(internal.mounts, context)
-  assertNoUnacknowledgedUnmounts(
-    unacknowledgedEndedMountsOf(internal.mountSlots),
-    context,
-  )
-
-  /* eslint-disable @typescript-eslint/consistent-type-assertions */
-  const messageAsParent = message as unknown as Message
-  const messageUpdate = internal.updateFn(internal.model, messageAsParent)
-  return {
-    ...internal,
-    model: messageUpdate.model,
-    message: messageAsParent,
-    commands: Array.appendAll(internal.commands, messageUpdate.commands ?? []),
-    outMessage: messageUpdate.outMessage,
-  } as unknown as SceneSimulation<Model, Message, OutMessage>
-  /* eslint-enable @typescript-eslint/consistent-type-assertions */
+  return applyExternalMessages(simulation, [message], context)
 }
 
 /** Feeds a Message through update as if a Subscription had emitted it,
@@ -1534,15 +1676,42 @@ const findAncestorWithHandler = (
     Array.findFirst(vnode => vnode.data?.on?.[eventName] !== undefined),
   )
 
+type SimulatedClick = Readonly<{
+  event: Readonly<{
+    preventDefault: () => void
+    stopPropagation: () => void
+  }>
+  isDefaultPrevented: () => boolean
+  isPropagationStopped: () => boolean
+}>
+
+const createSimulatedClick = (): SimulatedClick => {
+  let isDefaultPrevented = false
+  let isPropagationStopped = false
+
+  return {
+    event: {
+      preventDefault: () => {
+        isDefaultPrevented = true
+      },
+      stopPropagation: () => {
+        isPropagationStopped = true
+      },
+    },
+    isDefaultPrevented: () => isDefaultPrevented,
+    isPropagationStopped: () => isPropagationStopped,
+  }
+}
+
 // INTERACTION STEPS
 
 /** Simulates a click on the element matching the target.
- *  When the element has no click handler, the event bubbles up to the
- *  nearest ancestor with one, mirroring browser event propagation.
- *  When the element is a submit button (`<button>` with no type or
- *  `type="submit"`, `<input type="submit">`, `<input type="image">`) with no
- *  click handler in its ancestor chain, the click falls through to the
- *  `submit` handler of the nearest ancestor `<form>`. */
+ *  Runs click handlers from the target through its ancestors until one stops
+ *  propagation, mirroring browser event propagation.
+ *  When the target activates a submit button and no click handler prevents
+ *  the default, the click falls through to the `submit` handler of its form
+ *  owner. Scene honors an explicit `form` attribute before looking for the
+ *  nearest ancestor `<form>`. */
 export const click =
   (target: string | Locator) =>
   <Model, Message, OutMessage = undefined>(
@@ -1563,8 +1732,17 @@ export const click =
     }
 
     const { value: element } = maybeElement
+    const propagationPath = [
+      element,
+      ...pipe(internal.html, ancestorsOf(element), Array.reverse),
+    ]
+    const activationElement = pipe(
+      propagationPath,
+      Array.findFirst(currentElement => currentElement.sel === 'button'),
+      Option.getOrElse(() => element),
+    )
 
-    if (isElementDisabled(element)) {
+    if (isElementDisabled(activationElement)) {
       throw new Error(
         `I found an element matching ${description} but it is disabled.\n\n` +
           'Disabled elements do not receive click events in the browser. ' +
@@ -1574,62 +1752,59 @@ export const click =
       )
     }
 
-    const hasClickHandler = element.data?.on?.['click'] !== undefined
+    const simulatedClick = createSimulatedClick()
+    let isClickHandled = false
+    let isSubmitHandled = false
 
-    if (hasClickHandler) {
-      return captureFromElement(
-        simulation,
-        element,
-        description,
-        'click',
-        handler => {
-          handler()
-        },
+    internal.capturingDispatch.reset()
+
+    for (const currentElement of propagationPath) {
+      const maybeClickHandler = Option.fromNullishOr(
+        currentElement.data?.on?.['click'],
       )
-    }
+      if (Option.isNone(maybeClickHandler)) {
+        continue
+      }
 
-    const maybeAncestor = findAncestorWithHandler(
-      internal.html,
-      element,
-      'click',
-    )
+      isClickHandled = true
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const clickHandler = maybeClickHandler.value as Function
+      clickHandler(simulatedClick.event)
 
-    if (Option.isSome(maybeAncestor)) {
-      return captureFromElement(
-        simulation,
-        maybeAncestor.value,
-        `ancestor of ${description}`,
-        'click',
-        handler => {
-          handler()
-        },
-      )
-    }
-
-    if (isSubmitButton(element)) {
-      const maybeForm = pipe(
-        internal.html,
-        ancestorsOf(element),
-        Array.findLast(vnode => vnode.sel === 'form'),
-      )
-      if (Option.isSome(maybeForm)) {
-        return captureFromElement(
-          simulation,
-          maybeForm.value,
-          `form containing ${description}`,
-          'submit',
-          handler => {
-            handler({ preventDefault: Function.constVoid })
-          },
-        )
+      if (simulatedClick.isPropagationStopped()) {
+        break
       }
     }
 
-    const attributeName = EVENT_NAMES['click'] ?? 'click'
-    throw new Error(
-      `I found an element matching ${description} but neither it nor any ancestor has a click handler.\n\n` +
-        `Make sure the element or a parent has an ${attributeName} attribute.`,
-    )
+    if (!simulatedClick.isDefaultPrevented()) {
+      const maybeSubmitter = Array.findFirst(propagationPath, isSubmitButton)
+      const maybeForm = pipe(
+        maybeSubmitter,
+        Option.flatMap(submitter => formOwnerOf(internal.html, submitter)),
+      )
+
+      if (Option.isSome(maybeForm)) {
+        const maybeSubmitHandler = Option.fromNullishOr(
+          maybeForm.value.data?.on?.['submit'],
+        )
+        if (Option.isSome(maybeSubmitHandler)) {
+          isSubmitHandled = true
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          const submitHandler = maybeSubmitHandler.value as Function
+          submitHandler({ preventDefault: Function.constVoid })
+        }
+      }
+    }
+
+    if (!isClickHandled && !isSubmitHandled) {
+      const attributeName = EVENT_NAMES['click'] ?? 'click'
+      throw new Error(
+        `I found an element matching ${description} but neither it nor any ancestor has a click handler.\n\n` +
+          `Make sure the element or a parent has an ${attributeName} attribute.`,
+      )
+    }
+
+    return finishCapturedInteraction(simulation, description, 'click')
   }
 
 /** Simulates a double-click on the element matching the target.

--- a/packages/website/src/page/core/view.md
+++ b/packages/website/src/page/core/view.md
@@ -90,6 +90,8 @@ Event attributes return Messages instead of mutating state. Pass a Message direc
 
 `h.OnClick` takes a Message. `h.OnInput` takes a function because the input value becomes part of the Message. Both remain declarative: view reports what happened, and update decides what follows.
 
+Clicks allow the browser default and bubble to ancestors unless you say otherwise. Pass a second argument when the view owns either part of that browser contract. For example, an expand button inside a clickable tree row can use `{ defaultAction: 'Prevent', propagation: 'Stop' }`. The button dispatches its expansion Message without also dispatching the row's selection Message. The controls are independent, so use either one or both.
+
 ## Complex Handlers
 
 A handler can do more than return a one-line Message. The constraint is purity, not size. It may branch on event data, read Model-derived state from view scope, and return `Option<Message>` when only some events should dispatch:
@@ -118,12 +120,12 @@ Most side effects can run after the browser event returns, through a Command, Su
 
 Two constraints account for most uses. `event.preventDefault()` must run before the browser commits its default action. On iOS Safari, `.focus()` must run during the gesture to open the on-screen keyboard.
 
-`OnKeyDownPreventDefault` lets a translator decide whether to claim a key event. `OnPastePreventDefault` passes the clipboard's `text/plain` payload to its translator; `Some` suppresses the default insertion and dispatches the Message, while `None` leaves the paste alone. `OnCopyText` and `OnCutText` write Model-derived text to the clipboard and suppress the browser's default payload; the cut variant also dispatches a Message. `OnClickFocus` synchronously focuses the element matching a selector, then dispatches its Message.
+`OnClick` accepts `defaultAction`, `propagation`, and `focusSelector` controls. Foldkit applies them synchronously before dispatching the Message. `OnKeyDownPreventDefault` lets a translator decide whether to claim a key event. `OnPastePreventDefault` passes the clipboard's `text/plain` payload to its translator; `Some` suppresses the default insertion and dispatches the Message, while `None` leaves the paste alone. `OnCopyText` and `OnCutText` write Model-derived text to the clipboard and suppress the browser's default payload; the cut variant also dispatches a Message.
 
 ::Snippet{name="eventHandlerSideEffects" label="event handler side effects example"}
 
-The iOS keyboard case has one extra constraint: the target must already exist when the user taps. An input inside a closed dialog does not. Keep an always-present, visually hidden text input as a keyboard warmup and point `OnClickFocus` at it. The same attribute dispatches the Message that opens the dialog. Update can then return a `Dom.focus` Command to move focus to the real input after it mounts, while iOS keeps the keyboard open.
+The iOS keyboard case has one extra constraint: the target must already exist when the user taps. An input inside a closed dialog does not. Keep an always-present, visually hidden text input as a keyboard warmup and pass its selector as `focusSelector` to `OnClick`. The same attribute dispatches the Message that opens the dialog. Update can then return a `Dom.focus` Command to move focus to the real input after it mounts, while iOS keeps the keyboard open.
 
-These attributes are narrow browser-integration primitives, not a general escape hatch. Use them only when the browser requires synchronous work inside a gesture. Anything that can wait belongs in the normal lifecycle, usually a Command.
+These controls and attributes are narrow browser-integration primitives, not a general escape hatch. Use them only when the browser requires synchronous work inside a gesture. Anything that can wait belongs in the normal lifecycle, usually a Command.
 
 The basic loop is now complete: a Message reaches update, update returns a Model, and view renders it. The next step is side effects. [Commands](/core/commands) describe one-shot work for the runtime to execute.

--- a/packages/website/src/page/testingScene.md
+++ b/packages/website/src/page/testingScene.md
@@ -69,7 +69,7 @@ An interaction invokes the matched element's event handler. If the handler produ
 
 | Step                               | Invokes                                                                                          |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `click(target)`                    | `OnClick` (bubbles to ancestors)                                                                 |
+| `click(target)`                    | `OnClick` (runs target and ancestor handlers until propagation stops)                            |
 | `doubleClick(target)`              | `OnDoubleClick` (bubbles to ancestors)                                                           |
 | `contextMenu(target)`              | `OnContextMenu` (bubbles to ancestors)                                                           |
 | `pointerDown(target, options?)`    | `OnPointerDown` with optional `{ pointerType, button, screenX, screenY }` (bubbles to ancestors) |
@@ -85,6 +85,8 @@ An interaction invokes the matched element's event handler. If the handler produ
 | `submit(target)`                   | `OnSubmit`                                                                                       |
 
 `tap(fn)` runs a function for side effects (like ad-hoc assertions on raw VNodes or accumulated Commands) without breaking the step chain.
+
+`click` keeps default action and propagation separate, like the browser. A target `OnClick` with `propagation: 'Stop'` skips ancestor click handlers but still submits a surrounding form when the clicked element is a submit button. Add `defaultAction: 'Prevent'` to suppress that submission. When neither control is present, Scene dispatches every click Message from the target through its ancestor chain, then dispatches the form's submit Message when applicable.
 
 ## Assertions
 

--- a/packages/website/src/search/view.ts
+++ b/packages/website/src/search/view.ts
@@ -228,11 +228,11 @@ const resultCountAnnouncement = (model: Model): Html => {
 // synchronously inside the originating user-gesture event handler. The real
 // search input doesn't exist in the DOM until the dialog renders, so it
 // can't be focused inside the gesture. This always-rendered hidden input
-// gives `h.OnClickFocus` (used on the search trigger buttons in
-// `view/docs.ts`) something to focus inside the click handler, which opens
-// the keyboard; the `FocusSearchInput` Command then transfers focus to the
-// real input once the dialog renders, and iOS keeps the keyboard up across
-// a programmatic focus transfer between two text inputs.
+// gives the search trigger's `h.OnClick` focus control something to focus
+// inside the click handler, which opens the keyboard; the `FocusSearchInput`
+// Command then transfers focus to the real input once the dialog renders, and
+// iOS keeps the keyboard up across a programmatic focus transfer between two
+// text inputs.
 const keyboardWarmupInput: Html = ih.input([
   ih.Id(KEYBOARD_WARMUP_INPUT_ID),
   ih.Type('text'),

--- a/packages/website/src/snippet/eventHandlerSideEffects.ts
+++ b/packages/website/src/snippet/eventHandlerSideEffects.ts
@@ -7,7 +7,7 @@ h.input([
   h.Value(model.draft),
   h.OnKeyDownPreventDefault(key =>
     key === 'Enter' && model.draft !== ''
-      ? Option.some(SubmittedDraft())
+      ? Option.some(Message.SubmittedDraft())
       : Option.none(),
   ),
 ])
@@ -23,21 +23,40 @@ h.input([
 // update can delete the selection.
 h.div([
   h.Contenteditable('true'),
-  h.OnPastePreventDefault(text => Option.some(PastedText({ text }))),
+  h.OnPastePreventDefault(text => Option.some(Message.PastedText({ text }))),
   h.OnCopyText(serializeSelectionToMarkdown(model)),
-  h.OnCutText(serializeSelectionToMarkdown(model), CutSelection()),
+  h.OnCutText(serializeSelectionToMarkdown(model), Message.CutSelection()),
 ])
 
-// OnClickFocus: synchronously focuses the element matching
-// the selector, then dispatches the Message. The focus runs
-// inside the click event, so iOS Safari opens the on-screen
-// keyboard. The target here is an always-present warmup input;
-// a Dom.focus Command hands focus to the real search input
-// once the dialog mounts.
+// OnClick controls can be combined. This nested expand button prevents
+// its browser default and stops the row's OnClick from also
+// selecting the row.
+h.div(
+  [h.Role('treeitem'), h.OnClick(Message.ClickedSelectRow())],
+  [
+    h.button(
+      [
+        h.OnClick(Message.ClickedExpandRow(), {
+          defaultAction: 'Prevent',
+          propagation: 'Stop',
+        }),
+      ],
+      ['Expand'],
+    ),
+  ],
+)
+
+// focusSelector synchronously focuses the matching element,
+// then dispatches the Message. The focus runs inside the click
+// event, so iOS Safari opens the on-screen keyboard. The target
+// here is an always-present warmup input; a Dom.focus Command
+// hands focus to the real search input once the dialog mounts.
 h.button(
   [
     h.AriaLabel('Search documentation'),
-    h.OnClickFocus('#search-keyboard-warmup', ClickedSearch()),
+    h.OnClick(Message.ClickedSearch(), {
+      focusSelector: '#search-keyboard-warmup',
+    }),
   ],
   [Icon.magnifyingGlass()],
 )

--- a/packages/website/src/view/docs.ts
+++ b/packages/website/src/view/docs.ts
@@ -97,7 +97,9 @@ export const docsHeaderView = (model: Model, h: HtmlBuilder<Message>) =>
                 'hidden md:flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/50 dark:bg-gray-800/50 text-gray-500 dark:text-gray-400 text-sm hover:border-gray-400 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-300 transition cursor-pointer',
               ),
               h.AriaLabel('Search documentation'),
-              h.OnClickFocus(searchKeyboardWarmupSelector, openSearchDialog),
+              h.OnClick(openSearchDialog, {
+                focusSelector: searchKeyboardWarmupSelector,
+              }),
             ],
             [
               Icon.magnifyingGlass('w-4 h-4'),
@@ -141,7 +143,9 @@ export const docsHeaderView = (model: Model, h: HtmlBuilder<Message>) =>
                 'md:hidden p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-700 dark:text-gray-300 cursor-pointer',
               ),
               h.AriaLabel('Search documentation'),
-              h.OnClickFocus(searchKeyboardWarmupSelector, openSearchDialog),
+              h.OnClick(openSearchDialog, {
+                focusSelector: searchKeyboardWarmupSelector,
+              }),
             ],
             [Icon.magnifyingGlass('w-5 h-5')],
           ),


### PR DESCRIPTION
Add Schema-backed `OnClick` controls for browser default behavior, DOM propagation, and synchronous focus while keeping the existing one-argument call source compatible. `OnClickFocus` remains available as a deprecated compatibility method.

Make Scene run target and ancestor click handlers in browser order, honor stopped propagation, preserve the interaction's observable OutMessage, and model submit-button default actions including descendant activation and explicit form ownership. Cover client behavior, SSR serialization, hydration, and Scene parity, and migrate Foldkit's own focus usage to the composable API.