### PR TITLE
chore: link package metadata to Foldkit docs

### DIFF
--- a/.changeset/published-packages-link-docs.md
+++ b/.changeset/published-packages-link-docs.md
@@ -1,0 +1,6 @@
+---
+'create-foldkit-app': patch
+'@foldkit/devtools-mcp': patch
+---
+
+Point each package's npm metadata at its Foldkit documentation page so developers and automated tools can identify the official setup guide.

--- a/packages/create-foldkit-app/package.json
+++ b/packages/create-foldkit-app/package.json
@@ -45,6 +45,7 @@
     "url": "https://github.com/foldkit/foldkit.git",
     "directory": "packages/create-foldkit-app"
   },
+  "homepage": "https://foldkit.dev/get-started/getting-started",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/devtools-mcp/package.json
+++ b/packages/devtools-mcp/package.json
@@ -56,6 +56,7 @@
     "url": "https://github.com/foldkit/foldkit.git",
     "directory": "packages/devtools-mcp"
   },
+  "homepage": "https://foldkit.dev/ai/mcp",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Point the scaffolder and DevTools MCP packages at their focused setup guides instead of npm-inferred repository README homepages.