### PR TITLE
feat(foldkit)!: remove OnClickFocus

### DIFF
--- a/.changeset/remove-onclick-focus.md
+++ b/.changeset/remove-onclick-focus.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Remove the deprecated `h.OnClickFocus`. Replace `h.OnClickFocus(focusSelector, message)` with `h.OnClick(message, { focusSelector })`.

--- a/packages/foldkit/src/html/click.test.ts
+++ b/packages/foldkit/src/html/click.test.ts
@@ -130,18 +130,4 @@ describe('OnClick', () => {
       Message.ClickedSecond(),
     ])
   })
-
-  it('keeps OnClickFocus focus-before-dispatch behavior', () => {
-    const h = __htmlBuilder<Message>()
-    const vnode = h.button([
-      h.OnClickFocus('#click-focus-target', Message.ClickedFirst()),
-    ])
-    const click = fakeClick()
-
-    clickHandlerOf(vnode)(click.event)
-
-    expect(document.activeElement).toBe(focusTarget)
-    expect(activeElementsAtDispatch).toEqual([focusTarget])
-    expect(dispatched).toEqual([Message.ClickedFirst()])
-  })
 })

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -532,7 +532,6 @@ export type Attribute<Message> = Data.TaggedEnum<{
   Popovertarget: { readonly value: string }
   Popovertargetaction: { readonly value: string }
   OnClick: { readonly message: Message; readonly options?: ClickOptions }
-  OnClickFocus: { readonly focusSelector: string; readonly message: Message }
   OnDoubleClick: { readonly message: Message }
   OnMouseDown: { readonly message: Message }
   OnMouseUp: { readonly message: Message }
@@ -909,7 +908,6 @@ const {
   Popovertarget,
   Popovertargetaction,
   OnClick,
-  OnClickFocus,
   OnDoubleClick,
   OnMouseDown,
   OnMouseUp,
@@ -1574,14 +1572,6 @@ const attributeHandlers: AttributeHandlers = {
         if (focusTarget instanceof HTMLElement) {
           focusTarget.focus()
         }
-      }
-      ctx.dispatch(message)
-    }),
-  OnClickFocus: ({ focusSelector, message }, ctx: BuildContext) =>
-    addDataOn(ctx, 'click', () => {
-      const focusTarget = document.querySelector(focusSelector)
-      if (focusTarget instanceof HTMLElement) {
-        focusTarget.focus()
       }
       ctx.dispatch(message)
     }),
@@ -3564,18 +3554,6 @@ type HtmlAttributes<Message> = {
     readonly message: Message
     readonly options?: ClickOptions
   }
-  /** Synchronously focuses the element matching `focusSelector`, then
-   *  dispatches `message`.
-   *
-   *  @deprecated Use {@link HtmlBuilder.OnClick} with `focusSelector`. */
-  OnClickFocus: (
-    focusSelector: string,
-    message: Message,
-  ) => {
-    readonly _tag: 'OnClickFocus'
-    readonly focusSelector: string
-    readonly message: Message
-  }
   OnDoubleClick: (message: Message) => {
     readonly _tag: 'OnDoubleClick'
     readonly message: Message
@@ -4677,8 +4655,6 @@ const htmlAttributes = <Message>(): HtmlAttributes<Message> => ({
     options === undefined
       ? OnClick({ message })
       : OnClick({ message, options }),
-  OnClickFocus: (focusSelector: string, message: Message) =>
-    OnClickFocus({ focusSelector, message }),
   OnDoubleClick: (message: Message) => OnDoubleClick({ message }),
   OnMouseDown: (message: Message) => OnMouseDown({ message }),
   OnMouseUp: (message: Message) => OnMouseUp({ message }),


### PR DESCRIPTION
OnClick now provides the same synchronous focus behavior through its composable options object, and OnClickFocus has completed its deprecation window.

Remove the duplicate attribute and direct consumers to `OnClick(message, { focusSelector })`.