### PR TITLE
chore: isolate TypeDoc generation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,6 +12,7 @@
   },
   "ignore": [
     "website",
+    "@foldkit/api-reference-generator",
     "@typing-game/client",
     "@typing-game/server",
     "@typing-game/shared",

--- a/.changeset/isolate-typedoc-generator.md
+++ b/.changeset/isolate-typedoc-generator.md
@@ -1,0 +1,6 @@
+---
+'foldkit': patch
+'@foldkit/ui': patch
+---
+
+Move TypeDoc generation into a private workspace so package TypeScript upgrades are independent from TypeDoc's compiler support.

--- a/internal/api-reference-generator/generate.mjs
+++ b/internal/api-reference-generator/generate.mjs
@@ -1,0 +1,52 @@
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const generatorDirectory = dirname(fileURLToPath(import.meta.url))
+const workspaceDirectory = resolve(generatorDirectory, '../..')
+const require = createRequire(import.meta.url)
+const typedocDirectory = dirname(require.resolve('typedoc/package.json'))
+const typedocExecutable = join(typedocDirectory, 'bin/typedoc')
+const projects = new Map([
+  ['foldkit', 'packages/foldkit'],
+  ['ui', 'packages/ui'],
+])
+
+const requestedProjects = process.argv.slice(2)
+const selectedProjects = requestedProjects.length
+  ? requestedProjects.map(projectName => {
+      const projectDirectory = projects.get(projectName)
+
+      if (projectDirectory === undefined) {
+        throw new Error(`Unknown API reference project: ${projectName}`)
+      }
+
+      return projectDirectory
+    })
+  : [...projects.values()]
+
+for (const projectDirectory of selectedProjects) {
+  const result = spawnSync(process.execPath, [typedocExecutable], {
+    cwd: join(workspaceDirectory, projectDirectory),
+    stdio: 'inherit',
+  })
+
+  if (result.error !== undefined) {
+    throw result.error
+  }
+
+  if (result.status === 0) {
+    continue
+  }
+
+  if (result.signal !== null) {
+    throw new Error(
+      `TypeDoc generation for ${projectDirectory} stopped with signal ${result.signal}`,
+    )
+  }
+
+  throw new Error(
+    `TypeDoc generation for ${projectDirectory} exited with status ${result.status}`,
+  )
+}

--- a/internal/api-reference-generator/package.json
+++ b/internal/api-reference-generator/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@foldkit/api-reference-generator",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "generate": "node generate.mjs",
+    "generate:foldkit": "node generate.mjs foldkit",
+    "generate:ui": "node generate.mjs ui",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@foldkit/ui": "workspace:*",
+    "@types/node": "^25.9.5",
+    "foldkit": "workspace:*",
+    "typedoc": "^0.28.20",
+    "typescript": "6.0.3"
+  }
+}

--- a/internal/api-reference-generator/tsconfig.json
+++ b/internal/api-reference-generator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["generate.mjs"]
+}

--- a/knip.json
+++ b/knip.json
@@ -62,7 +62,10 @@
         "e2e/livePlaygrounds.ts"
       ],
       "ignore": ["src/snippet/**", "public/**"],
-      "ignoreDependencies": ["@foldkit/devtools"]
+      "ignoreDependencies": [
+        "@foldkit/api-reference-generator",
+        "@foldkit/devtools"
+      ]
     },
     "packages/typing-game/client": {
       "ignoreDependencies": ["@foldkit/devtools"]
@@ -122,6 +125,9 @@
     },
     "internal/lustre-benchmark": {
       "entry": ["src/main.ts", "src/entry.optimised.ts", "bench/*.mjs"]
+    },
+    "internal/api-reference-generator": {
+      "ignoreDependencies": ["@foldkit/ui", "foldkit"]
     },
     "internal/performance-harness": {
       "entry": ["src/main.ts"],

--- a/packages/foldkit/package.json
+++ b/packages/foldkit/package.json
@@ -162,8 +162,7 @@
     "build": "pnpm run clean && tsc -b tsconfig.build.json",
     "watch": "tsc -b tsconfig.build.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run --coverage",
-    "docs": "typedoc"
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "parse5": "^8.0.1"
@@ -177,7 +176,6 @@
     "effect": "4.0.0-rc.112",
     "happy-dom": "^20.11.7",
     "rimraf": "^6.1.3",
-    "typedoc": "^0.28.20",
     "typescript": "^6.0.3",
     "vitest": "^4.1.11"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -119,7 +119,6 @@
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
     "build": "pnpm run clean && tsc -b tsconfig.build.json && node scripts/brand-dist.mjs",
-    "docs": "typedoc",
     "watch": "tsc -b tsconfig.build.json --watch",
     "lint": "pnpm --filter @foldkit/oxlint-plugin build && oxlint src",
     "typecheck": "tsc -p tsconfig.json --noEmit",
@@ -139,7 +138,6 @@
     "foldkit": "workspace:*",
     "happy-dom": "^20.11.7",
     "rimraf": "^6.1.3",
-    "typedoc": "^0.28.20",
     "typescript": "^6.0.3",
     "vitest": "^4.1.11"
   },

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -4,12 +4,12 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "predev": "pnpm --filter foldkit --filter @foldkit/ui run docs",
+    "predev": "node ../../internal/api-reference-generator/generate.mjs",
     "dev": "vite",
-    "prebuild": "pnpm --filter foldkit --filter @foldkit/ui run docs",
+    "prebuild": "node ../../internal/api-reference-generator/generate.mjs",
     "build": "export FOLDKIT_BUILD_ID=\"${FOLDKIT_BUILD_ID:-$(git rev-parse HEAD 2>/dev/null)}\"; vite build",
     "preview": "vite preview",
-    "pretypecheck": "pnpm --filter foldkit --filter @foldkit/ui run docs",
+    "pretypecheck": "node ../../internal/api-reference-generator/generate.mjs",
     "typecheck": "tsc --noEmit",
     "format": "prettier -w .",
     "test": "vitest run",
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@effect/platform-node": "4.0.0-rc.112",
+    "@foldkit/api-reference-generator": "workspace:*",
     "@foldkit/vite-plugin": "workspace:*",
     "@playwright/test": "^1.62.1",
     "@resvg/resvg-js": "^2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1679,6 +1679,24 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@25.9.5)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.7)(jsdom@29.1.1)(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  internal/api-reference-generator:
+    devDependencies:
+      '@foldkit/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@types/node':
+        specifier: 25.9.5
+        version: 25.9.5
+      foldkit:
+        specifier: workspace:*
+        version: link:../../packages/foldkit
+      typedoc:
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@6.0.3)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
   internal/lustre-benchmark:
     dependencies:
       effect:
@@ -1879,9 +1897,6 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
-      typedoc:
-        specifier: ^0.28.20
-        version: 0.28.20(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2068,9 +2083,6 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
-      typedoc:
-        specifier: ^0.28.20
-        version: 0.28.20(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2163,6 +2175,9 @@ importers:
       '@effect/platform-node':
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+      '@foldkit/api-reference-generator':
+        specifier: workspace:*
+        version: link:../../internal/api-reference-generator
       '@foldkit/vite-plugin':
         specifier: workspace:*
         version: link:../vite-plugin-foldkit


### PR DESCRIPTION
Move TypeDoc and its TypeScript version into a private workspace so package compiler upgrades are not coupled to TypeDoc support.

Route website API generation through the private workspace and model its build-time dependency for filtered installs.