### PR TITLE
feat(foldkit)!: preserve multiple Scene OutMessages

### DIFF
--- a/.changeset/scene-multiple-outmessages.md
+++ b/.changeset/scene-multiple-outmessages.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+Let Scene preserve multiple OutMessages emitted by one update-producing step in runtime order and assert the complete sequence with `expectOutMessages`.
+
+This changes OutMessage assertions after `Command.resolveAll`, `Command.resolveAllExact`, and `Mount.resolveAll`. `expectOutMessage` now requires exactly one OutMessage from the whole step, and `expectNoOutMessage` requires none. Use `expectOutMessages` when several resolvers emit OutMessages. When a step emits several, the singular `SceneSimulation.outMessage` field is `undefined` because no single value can represent the result.

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -6,6 +6,7 @@ import {
   __htmlBuilder as attributeHtml,
   inertHtml,
 } from '../html/index.js'
+import { defineMessageUnion } from '../message/index.js'
 import { h } from '../snabbdom/index.js'
 import type { VNode } from '../snabbdom/index.js'
 import { defineView } from '../submodel/public.js'
@@ -97,6 +98,7 @@ import {
   FocusButton,
   MeasurePanel,
   Message as MountPanelMessage,
+  type Model as MountPanelModel,
   ScrollList,
   initialModel as mountInitialModel,
   scrollListView as mountScrollListView,
@@ -2969,16 +2971,111 @@ const outMessageBubblingView = (
     [h.button([h.OnClick(LogoutButtonMessage.ClickedLogout())], [model.label])],
   )
 
+const InteractionMessage = defineMessageUnion({
+  ClickedExpand: {},
+  ClickedRow: {},
+  SubmittedForm: {},
+  CompletedAction: {},
+})
+
+type InteractionMessage = typeof InteractionMessage.Type
+
+const InteractionOutMessage = defineMessageUnion({
+  RequestedExpand: {},
+  RequestedFocus: {},
+  RequestedMeasurement: {},
+  RequestedSelection: {},
+  RequestedSubmission: {},
+})
+
+type InteractionOutMessage = typeof InteractionOutMessage.Type
+
+const multipleOutMessagesUpdate = (
+  model: LogoutModel,
+  message: InteractionMessage,
+) =>
+  InteractionMessage.match<
+    Update.ReturnWithOutMessage<
+      LogoutModel,
+      InteractionMessage,
+      InteractionOutMessage
+    >
+  >(message, {
+    ClickedExpand: () => ({
+      model,
+      outMessage: InteractionOutMessage.RequestedExpand(),
+    }),
+    ClickedRow: () => ({
+      model,
+      outMessage: InteractionOutMessage.RequestedSelection(),
+    }),
+    SubmittedForm: () => ({
+      model,
+      outMessage: InteractionOutMessage.RequestedSubmission(),
+    }),
+    CompletedAction: () => ({ model }),
+  })
+
 const multipleOutMessagesView = (
   model: LogoutModel,
-  h: HtmlBuilder<LogoutMessage>,
+  h: HtmlBuilder<InteractionMessage>,
 ) =>
   h.div(
-    [h.OnClick(LogoutButtonMessage.ClickedLogout())],
-    [h.button([h.OnClick(LogoutButtonMessage.ClickedLogout())], [model.label])],
+    [h.OnClick(InteractionMessage.ClickedRow())],
+    [
+      h.button(
+        [h.OnClick(InteractionMessage.ClickedExpand()), h.Type('button')],
+        [model.label],
+      ),
+    ],
   )
 
-describe('Scene.expectOutMessage and Scene.expectNoOutMessage', () => {
+const clickAndSubmitOutMessagesView = (
+  model: LogoutModel,
+  h: HtmlBuilder<InteractionMessage>,
+) =>
+  h.form(
+    [h.OnSubmit(InteractionMessage.SubmittedForm())],
+    [
+      h.button(
+        [h.OnClick(InteractionMessage.ClickedExpand()), h.Type('submit')],
+        [model.label],
+      ),
+    ],
+  )
+
+const interactionInitialModel = LogoutModel.make({ label: 'Expand' })
+const submitInteractionInitialModel = LogoutModel.make({ label: 'Submit' })
+
+const multipleMountOutMessagesUpdate = (
+  model: MountPanelModel,
+  message: MountPanelMessage,
+) => {
+  const mountPanelUpdate = mountUpdate(model, message)
+
+  return MountPanelMessage.match<
+    Update.ReturnWithOutMessage<
+      MountPanelModel,
+      MountPanelMessage,
+      InteractionOutMessage
+    >
+  >(message, {
+    ClickedToggle: () => mountPanelUpdate,
+    MeasuredPanel: () => ({
+      ...mountPanelUpdate,
+      outMessage: InteractionOutMessage.RequestedMeasurement(),
+    }),
+    CompletedFocusButton: () => ({
+      ...mountPanelUpdate,
+      outMessage: InteractionOutMessage.RequestedFocus(),
+    }),
+    FailedMountSidebar: () => mountPanelUpdate,
+    ClickedIncrement: () => mountPanelUpdate,
+    ScrolledTo: () => mountPanelUpdate,
+  })
+}
+
+describe('Scene OutMessage assertions', () => {
   test('assert the OutMessage across steps', () => {
     Scene.scene(
       { update: logoutUpdate, view: logoutView },
@@ -3045,14 +3142,111 @@ describe('Scene.expectOutMessage and Scene.expectNoOutMessage', () => {
     )
   })
 
-  test('fails explicitly when one interaction emits multiple OutMessages', () => {
+  test('asserts target and ancestor OutMessages in runtime order', () => {
+    Scene.scene(
+      { update: multipleOutMessagesUpdate, view: multipleOutMessagesView },
+      Scene.given(interactionInitialModel),
+      Scene.click(Scene.role('button', { name: 'Expand' })),
+      Scene.expectOutMessages(
+        InteractionOutMessage.RequestedExpand(),
+        InteractionOutMessage.RequestedSelection(),
+      ),
+      Scene.tap(({ outMessage }) => {
+        expect(outMessage).toBeUndefined()
+      }),
+    )
+  })
+
+  test('preserves click and submit OutMessages in runtime order', () => {
+    Scene.scene(
+      {
+        update: multipleOutMessagesUpdate,
+        view: clickAndSubmitOutMessagesView,
+      },
+      Scene.given(submitInteractionInitialModel),
+      Scene.click(Scene.role('button', { name: 'Submit' })),
+      Scene.expectOutMessages(
+        InteractionOutMessage.RequestedExpand(),
+        InteractionOutMessage.RequestedSubmission(),
+      ),
+    )
+  })
+
+  test('preserves every OutMessage from Mount.resolveAll', () => {
+    Scene.scene(
+      { update: multipleMountOutMessagesUpdate, view: mountView },
+      Scene.given({ ...mountInitialModel, isOpen: true }),
+      Scene.Mount.resolveAll(
+        [FocusButton, MountPanelMessage.CompletedFocusButton()],
+        [MeasurePanel, MountPanelMessage.MeasuredPanel({ width: 100 })],
+      ),
+      Scene.expectOutMessages(
+        InteractionOutMessage.RequestedFocus(),
+        InteractionOutMessage.RequestedMeasurement(),
+      ),
+      Scene.tap(({ outMessage }) => {
+        expect(outMessage).toBeUndefined()
+      }),
+    )
+  })
+
+  test('a later update replaces every OutMessage from the previous step', () => {
+    Scene.scene(
+      { update: multipleOutMessagesUpdate, view: multipleOutMessagesView },
+      Scene.given(interactionInitialModel),
+      Scene.click(Scene.role('button', { name: 'Expand' })),
+      Scene.expectOutMessages(
+        InteractionOutMessage.RequestedExpand(),
+        InteractionOutMessage.RequestedSelection(),
+      ),
+      Scene.Subscription.emit(InteractionMessage.CompletedAction()),
+      Scene.expectNoOutMessage(),
+    )
+  })
+
+  test('inside preserves the sequence from its latest child step', () => {
+    Scene.scene(
+      { update: multipleOutMessagesUpdate, view: multipleOutMessagesView },
+      Scene.given(interactionInitialModel),
+      Scene.inside(
+        Scene.selector('div'),
+        Scene.Subscription.emit(InteractionMessage.ClickedExpand()),
+        Scene.Subscription.emit(InteractionMessage.ClickedRow()),
+      ),
+      Scene.expectOutMessage(InteractionOutMessage.RequestedSelection()),
+    )
+  })
+
+  test('expectOutMessage fails when multiple OutMessages were emitted', () => {
     expect(() =>
       Scene.scene(
-        { update: mixedArityUpdate, view: multipleOutMessagesView },
-        Scene.given(logoutInitialModel),
-        Scene.click(Scene.role('button', { name: 'Log out' })),
+        { update: multipleOutMessagesUpdate, view: multipleOutMessagesView },
+        Scene.given(interactionInitialModel),
+        Scene.click(Scene.role('button', { name: 'Expand' })),
+        Scene.expectOutMessage(InteractionOutMessage.RequestedExpand()),
       ),
-    ).toThrow('One interaction emitted multiple OutMessages')
+    ).toThrow('Expected exactly one OutMessage but got multiple')
+  })
+
+  test('expectOutMessages fails when the runtime order is wrong', () => {
+    expect(() =>
+      Scene.scene(
+        { update: multipleOutMessagesUpdate, view: multipleOutMessagesView },
+        Scene.given(interactionInitialModel),
+        Scene.click(Scene.role('button', { name: 'Expand' })),
+        Scene.expectOutMessages(
+          InteractionOutMessage.RequestedSelection(),
+          InteractionOutMessage.RequestedExpand(),
+        ),
+      ),
+    ).toThrow('Expected OutMessages:')
+  })
+
+  test('expectOutMessages requires at least two expected values', () => {
+    // @ts-expect-error use expectNoOutMessage to assert an empty sequence
+    Scene.expectOutMessages()
+    // @ts-expect-error use expectOutMessage to assert one value
+    Scene.expectOutMessages(InteractionOutMessage.RequestedExpand())
   })
 })
 

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -170,6 +170,8 @@ export type SceneSimulation<Model, Message, OutMessage = undefined> = Readonly<{
   _phantom: [Model, Message]
   commands: ReadonlyArray<AnyCommand>
   mounts: ReadonlyArray<PendingMount>
+  /** The sole OutMessage from the latest update-producing Scene step.
+   *  Undefined when that step emitted none or more than one. */
   outMessage: OutMessage | undefined
   html: VNode
 }>
@@ -251,6 +253,8 @@ type InternalSceneSimulation<
     capturingDispatch: CapturingDispatch
     scope: Option.Option<Locator>
     mountSlots: ReadonlyArray<MountSlotState>
+    outMessages: ReadonlyArray<OutMessage>
+    outMessageRevision: number
     lastInteractionOutcome: InteractionOutcome
     maybeUnacknowledgedIgnored: Option.Option<IgnoredInteraction>
   }>
@@ -358,6 +362,60 @@ const toInternal = <Model, Message, OutMessage>(
 ): InternalSceneSimulation<Model, Message, OutMessage> =>
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   simulation as InternalSceneSimulation<Model, Message, OutMessage>
+
+type OutMessageCapture<Model, Message, OutMessage> = Readonly<{
+  updateFn: (
+    model: Model,
+    message: Message,
+  ) => SimulationUpdateReturn<Model, OutMessage>
+  getOutMessages: () => ReadonlyArray<OutMessage>
+  isUpdateApplied: () => boolean
+}>
+
+const createOutMessageCapture = <Model, Message, OutMessage>(
+  updateFn: (
+    model: Model,
+    message: Message,
+  ) => SimulationUpdateReturn<Model, OutMessage>,
+): OutMessageCapture<Model, Message, OutMessage> => {
+  const outMessages: Array<OutMessage> = []
+  let isUpdateApplied = false
+
+  return {
+    updateFn: (model, message) => {
+      isUpdateApplied = true
+      const messageUpdate = updateFn(model, message)
+
+      if (!Predicate.isUndefined(messageUpdate.outMessage)) {
+        outMessages.push(messageUpdate.outMessage)
+      }
+
+      return messageUpdate
+    },
+    getOutMessages: () => outMessages,
+    isUpdateApplied: () => isUpdateApplied,
+  }
+}
+
+const withOutMessages = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  outMessages: ReadonlyArray<OutMessage>,
+): SceneSimulation<Model, Message, OutMessage> => {
+  const internal = toInternal(simulation)
+  const outMessage = Array.matchLeft(outMessages, {
+    onEmpty: () => undefined,
+    onNonEmpty: (head, tail) =>
+      Array.isReadonlyArrayEmpty(tail) ? head : undefined,
+  })
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  return {
+    ...internal,
+    outMessage,
+    outMessages,
+    outMessageRevision: internal.outMessageRevision + 1,
+  } as unknown as SceneSimulation<Model, Message, OutMessage>
+}
 
 const applyScopeToTarget = (
   scope: Option.Option<Locator>,
@@ -572,46 +630,7 @@ const applyExternalMessages = <Model, Message, OutMessage>(
     context,
   )
 
-  const appliedMessages = Array.reduce(
-    messages,
-    {
-      simulation,
-      outMessages: Array.empty<OutMessage>(),
-    },
-    (current, message) => {
-      const nextSimulation = applyMessageWithoutBoundaryChecks(
-        current.simulation,
-        message,
-      )
-      const nextOutMessage = toInternal(nextSimulation).outMessage
-
-      return {
-        simulation: nextSimulation,
-        outMessages: Predicate.isUndefined(nextOutMessage)
-          ? current.outMessages
-          : Array.append(current.outMessages, nextOutMessage),
-      }
-    },
-  )
-
-  if (
-    Array.isReadonlyArrayNonEmpty(Array.drop(appliedMessages.outMessages, 1))
-  ) {
-    throw new Error(
-      'One interaction emitted multiple OutMessages, but Scene can expose only one OutMessage per step.\n\n' +
-        'Split the DOM handlers into separate interactions, or test this composition at the parent boundary where each OutMessage is folded.',
-    )
-  }
-
-  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-  return {
-    ...toInternal(appliedMessages.simulation),
-    outMessage: pipe(
-      appliedMessages.outMessages,
-      Array.head,
-      Option.getOrUndefined,
-    ),
-  } as unknown as SceneSimulation<Model, Message, OutMessage>
+  return Array.reduce(messages, simulation, applyMessageWithoutBoundaryChecks)
 }
 
 /** Clears the pending fall-through, marking it acknowledged. Paired with
@@ -1458,37 +1477,73 @@ export const CustomElement = {
   emit: emitCustomElementEvent,
 } as const
 
-/** Asserts by structural equality that update emitted the expected OutMessage,
- *  so callers can pass a freshly constructed expected value. */
+/** Asserts by structural equality that the latest update-producing Scene step
+ *  emitted exactly the expected OutMessage. */
 export const expectOutMessage =
   <Expected>(expected: Expected) =>
   <Model, Message, OutMessage>(
     simulation: SceneSimulation<Model, Message, OutMessage>,
   ): SceneSimulation<Model, Message, OutMessage> => {
     const internal = toInternal(simulation)
-    const outMessage = internal.outMessage
+    const maybeOutMessage = Array.head(internal.outMessages)
 
-    if (outMessage === undefined || !Equal.equals(outMessage, expected)) {
+    if (Option.isNone(maybeOutMessage)) {
       throw new Error(
-        `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(outMessage)}`,
+        `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    undefined`,
+      )
+    }
+
+    if (Array.isReadonlyArrayNonEmpty(Array.drop(internal.outMessages, 1))) {
+      throw new Error(
+        `Expected exactly one OutMessage but got multiple:\n\n    ${JSON.stringify(internal.outMessages)}`,
+      )
+    }
+
+    if (!Equal.equals(maybeOutMessage.value, expected)) {
+      throw new Error(
+        `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(maybeOutMessage.value)}`,
       )
     }
 
     return simulation
   }
 
-/** Asserts that update emitted no OutMessage. */
+/** Asserts by structural equality that the latest update-producing Scene
+ *  step emitted two or more expected OutMessages in runtime order. */
+export const expectOutMessages =
+  <Expected extends readonly [unknown, unknown, ...ReadonlyArray<unknown>]>(
+    ...expected: Expected
+  ) =>
+  <Model, Message, OutMessage>(
+    simulation: SceneSimulation<Model, Message, OutMessage>,
+  ): SceneSimulation<Model, Message, OutMessage> => {
+    const actual = toInternal(simulation).outMessages
+
+    if (!Equal.equals(actual, expected)) {
+      throw new Error(
+        `Expected OutMessages:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(actual)}`,
+      )
+    }
+
+    return simulation
+  }
+
+/** Asserts that the latest update-producing Scene step emitted no OutMessages. */
 export const expectNoOutMessage =
   () =>
   <Model, Message, OutMessage>(
     simulation: SceneSimulation<Model, Message, OutMessage>,
   ): SceneSimulation<Model, Message, OutMessage> => {
     const internal = toInternal(simulation)
-    const outMessage = internal.outMessage
 
-    if (!Predicate.isUndefined(outMessage)) {
+    if (Array.isReadonlyArrayNonEmpty(internal.outMessages)) {
+      const actual = Array.isReadonlyArrayEmpty(
+        Array.drop(internal.outMessages, 1),
+      )
+        ? Array.headNonEmpty(internal.outMessages)
+        : internal.outMessages
       throw new Error(
-        `Expected no OutMessage but got:\n\n    ${JSON.stringify(outMessage)}`,
+        `Expected no OutMessage but got:\n\n    ${JSON.stringify(actual)}`,
       )
     }
 
@@ -1603,11 +1658,31 @@ const runSteps = <Model, Message, OutMessage>(
 ): SceneSimulation<Model, Message, OutMessage> =>
   /* eslint-disable @typescript-eslint/consistent-type-assertions */
   Array.reduce(steps, seed, (current, step) => {
-    const next = (
+    const currentInternal = toInternal(current)
+    const outMessageCapture = createOutMessageCapture(currentInternal.updateFn)
+    const capturingSimulation = {
+      ...currentInternal,
+      updateFn: outMessageCapture.updateFn,
+    } as unknown as SceneSimulation<Model, Message, OutMessage>
+    const stepResult = (
       step as (
         simulation: SceneSimulation<Model, Message, OutMessage>,
       ) => SceneSimulation<Model, Message, OutMessage>
-    )(current)
+    )(capturingSimulation)
+    const restoredSimulation = {
+      ...toInternal(stepResult),
+      updateFn: currentInternal.updateFn,
+    } as unknown as SceneSimulation<Model, Message, OutMessage>
+    const isSequenceUpdatedByNestedSteps =
+      toInternal(restoredSimulation).outMessageRevision !==
+      currentInternal.outMessageRevision
+    const next =
+      outMessageCapture.isUpdateApplied() && !isSequenceUpdatedByNestedSteps
+        ? withOutMessages(
+            restoredSimulation,
+            outMessageCapture.getOutMessages(),
+          )
+        : restoredSimulation
 
     const internal = toInternal(next)
 
@@ -2802,6 +2877,8 @@ export const scene: {
     mounts: [],
     mountSlots: [],
     outMessage: undefined,
+    outMessages: [],
+    outMessageRevision: 0,
     updateFn: config.update,
     resolvers: [],
     html: undefined as unknown,

--- a/packages/website/src/page/testingScene.md
+++ b/packages/website/src/page/testingScene.md
@@ -223,11 +223,13 @@ The target must be in the rendered tree with that event handler attached. A miss
 
 ## OutMessages
 
-When the update under test can return an OutMessage, Scene tracks the optional `outMessage` field. `expectOutMessage(expected)` asserts the emitted value. `expectNoOutMessage()` asserts that the field was absent.
+When the update under test can return an OutMessage, Scene tracks every OutMessage produced by the latest update-producing step. `expectOutMessage(expected)` asserts that the step emitted exactly one. `expectOutMessages(first, second, ...rest)` asserts several in runtime order. `expectNoOutMessage()` asserts that it emitted none.
 
 ::Snippet{name="sceneOutMessageAssertions" label="OutMessage assertions example"}
 
-Scene replaces the tracked OutMessage after every update. A branch with no `outMessage` clears the previous value, so `expectNoOutMessage()` describes the current transition instead of inheriting an earlier result.
+A single interaction can drive several updates. A click may invoke a target handler, ancestor handlers, and then a form's submit handler. Scene collects their OutMessages in that same order.
+
+Scene replaces the tracked sequence after every step that drives update. A step whose updates omit `outMessage` clears the previous sequence, so `expectNoOutMessage()` describes the current transition instead of inheriting an earlier result. Assertions and other steps that do not drive update leave the sequence in place.
 
 ## Submodels with ViewInputs
 

--- a/packages/website/src/snippet/sceneOutMessageAssertions.ts
+++ b/packages/website/src/snippet/sceneOutMessageAssertions.ts
@@ -3,18 +3,27 @@ import {
   click,
   expectNoOutMessage,
   expectOutMessage,
+  expectOutMessages,
   given,
   role,
   scene,
 } from 'foldkit/scene'
 
-// A Submodel's update can return an optional OutMessage. Scene tracks that
-// field, so a page-level test asserts what the child announced to its parent.
 scene(
   { update, view },
   given(initialModel),
   click(role('button', { name: 'Log out' })),
-  expectOutMessage(RequestedLogout()),
-  Subscription.emit(CompletedAction()),
+  expectOutMessage(OutMessage.RequestedLogout()),
+  Subscription.emit(Message.CompletedAction()),
   expectNoOutMessage(),
+)
+
+scene(
+  { update, view: treeRowView },
+  given(initialModel),
+  click(role('button', { name: 'Expand' })),
+  expectOutMessages(
+    OutMessage.RequestedExpand(),
+    OutMessage.RequestedSelection(),
+  ),
 )


### PR DESCRIPTION
A single Scene step can drive several updates through interactions or batch resolvers. Each update may emit an OutMessage, but Scene previously either failed or retained only the final result.

Collect OutMessages at the Scene-step boundary, preserve runtime order, and add `expectOutMessages` for explicit multi-result assertions. Make the singular and empty assertions describe the whole step.

BREAKING CHANGE: After `Command.resolveAll`, `Command.resolveAllExact`, or `Mount.resolveAll`, `expectOutMessage` now requires exactly one OutMessage from the whole step and `expectNoOutMessage` requires none. Use `expectOutMessages` when several resolvers emit values.

Closes #1200.
