### PR TITLE
fix(website): improve popover arrow rendering

### DIFF
--- a/packages/website/src/page/ui/popover.ts
+++ b/packages/website/src/page/ui/popover.ts
@@ -38,7 +38,7 @@ const POPOVER_ANCHOR: AnchorConfig = {
 
 const POPOVER_ARROW_ANCHOR: AnchorConfig = {
   placement: 'bottom-start',
-  gap: 8,
+  gap: 10,
   padding: 8,
 }
 
@@ -102,9 +102,18 @@ const popoverDemo = (
                               [
                                 ...arrow,
                                 h.Class('popover-arrow'),
-                                h.ViewBox('0 0 12 12'),
+                                h.ViewBox('0 0 16 16'),
                               ],
-                              [h.path([h.D('M 0.5 5.5 L 6 0.5 L 11.5 5.5')])],
+                              [
+                                h.path([
+                                  h.Class('popover-arrow-fill'),
+                                  h.D('M 0.5 8 L 8 0.5 L 15.5 8 V 10 H 0.5 Z'),
+                                ]),
+                                h.path([
+                                  h.Class('popover-arrow-outline'),
+                                  h.D('M 0.5 8 L 8 0.5 L 15.5 8'),
+                                ]),
+                              ],
                             ),
                           ]
                         : []),

--- a/packages/website/src/page/ui/popoverPage.md
+++ b/packages/website/src/page/ui/popoverPage.md
@@ -65,7 +65,7 @@ When `isAnimated` is true, enter/leave animations flow through the [Animation](/
 
 Write a rule for every side the panel can use because a `bottom` placement can flip to `top`, and a `left` placement can flip to `right`. The direct-child selector keeps a nested popover tied to its own panel. Pass `arrowPadding` to keep the arrow clear of rounded corners.
 
-The square SVG keeps its measurements stable when the placement flips, while the path draws only the outward-facing half. At `top: -6px`, the path ends at the panel edge instead of extending beneath its border. Its tip reaches 6px past the panel, so the demo uses `gap: 8` to keep it clear of the trigger.
+The square SVG keeps its measurements stable when the placement flips. Its fill extends 2px into the panel to mask the border beneath it, while a separate path outlines only the two outward-facing edges. The 16px arrow reaches 8px past the panel, so the demo uses `gap: 10` to keep it clear of the trigger. Anchor centers the arrow on the trigger along the panel's edge.
 
 ### Scrollable Panels with an Arrow
 

--- a/packages/website/src/snippet/uiPopoverArrow.ts
+++ b/packages/website/src/snippet/uiPopoverArrow.ts
@@ -10,8 +10,8 @@ const view = (h: HtmlBuilder<Message>) =>
     model: model.popover,
     view: Popover.view,
     viewInputs: {
-      // Leave room for the arrow tip, which reaches 6px past the panel:
-      anchor: { placement: 'bottom-start', gap: 8, padding: 8 },
+      // Leave room for the arrow tip, which reaches 8px past the panel:
+      anchor: { placement: 'bottom-start', gap: 10, padding: 8 },
       // Keep the arrow clear of the panel's rounded corners:
       arrowPadding: 12,
       // Take the arrow bundle from the render payload:
@@ -40,15 +40,24 @@ const view = (h: HtmlBuilder<Message>) =>
                     ],
                     [
                       // Spread the bundle onto your own element, inside the
-                      // panel. The path draws only the outward-facing half of
-                      // its square view box:
+                      // panel. The fill masks the panel border, while the
+                      // outline draws only the two outward-facing edges:
                       h.svg(
                         [
                           ...arrow,
                           h.Class('popover-arrow'),
-                          h.ViewBox('0 0 12 12'),
+                          h.ViewBox('0 0 16 16'),
                         ],
-                        [h.path([h.D('M 0.5 5.5 L 6 0.5 L 11.5 5.5')])],
+                        [
+                          h.path([
+                            h.Class('popover-arrow-fill'),
+                            h.D('M 0.5 8 L 8 0.5 L 15.5 8 V 10 H 0.5 Z'),
+                          ]),
+                          h.path([
+                            h.Class('popover-arrow-outline'),
+                            h.D('M 0.5 8 L 8 0.5 L 15.5 8'),
+                          ]),
+                        ],
                       ),
                       h.h3([h.Class('font-medium')], ['Analytics']),
                       h.p(

--- a/packages/website/src/snippet/uiPopoverArrowStyles.css
+++ b/packages/website/src/snippet/uiPopoverArrowStyles.css
@@ -7,31 +7,39 @@
 
 .popover-arrow {
   position: absolute;
-  width: 12px;
-  height: 12px;
-  fill: var(--popover-background);
-  stroke: var(--popover-border);
-  stroke-linejoin: round;
-  stroke-width: 1px;
+  width: 16px;
+  height: 16px;
   left: var(--arrow-x);
   top: var(--arrow-y);
 }
 
+.popover-arrow-fill {
+  fill: var(--popover-background);
+  stroke: none;
+}
+
+.popover-arrow-outline {
+  fill: none;
+  stroke: var(--popover-border);
+  stroke-linejoin: round;
+  stroke-width: 1px;
+}
+
 .popover-panel[data-placement='top'] > .popover-arrow {
-  bottom: -6px;
+  bottom: -8px;
   transform: rotate(180deg);
 }
 
 .popover-panel[data-placement='bottom'] > .popover-arrow {
-  top: -6px;
+  top: -8px;
 }
 
 .popover-panel[data-placement='left'] > .popover-arrow {
-  right: -6px;
+  right: -8px;
   transform: rotate(90deg);
 }
 
 .popover-panel[data-placement='right'] > .popover-arrow {
-  left: -6px;
+  left: -8px;
   transform: rotate(-90deg);
 }

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -440,29 +440,38 @@
   }
 
   .popover-arrow {
-    @apply absolute w-3 h-3 fill-cream stroke-gray-200 dark:fill-gray-800 dark:stroke-gray-700;
-    stroke-linejoin: round;
-    stroke-width: 1px;
+    @apply absolute w-4 h-4;
     left: var(--arrow-x);
     top: var(--arrow-y);
   }
 
+  .popover-arrow-fill {
+    @apply fill-cream dark:fill-gray-800;
+    stroke: none;
+  }
+
+  .popover-arrow-outline {
+    @apply fill-none stroke-gray-200 dark:stroke-gray-700;
+    stroke-linejoin: round;
+    stroke-width: 1px;
+  }
+
   .popover-panel[data-placement='top'] > .popover-arrow {
-    bottom: -6px;
+    bottom: -8px;
     transform: rotate(180deg);
   }
 
   .popover-panel[data-placement='bottom'] > .popover-arrow {
-    top: -6px;
+    top: -8px;
   }
 
   .popover-panel[data-placement='left'] > .popover-arrow {
-    right: -6px;
+    right: -8px;
     transform: rotate(90deg);
   }
 
   .popover-panel[data-placement='right'] > .popover-arrow {
-    left: -6px;
+    left: -8px;
     transform: rotate(-90deg);
   }
 


### PR DESCRIPTION
Enlarge the documented popover arrow and use separate fill and outline paths. Clip the outline at the panel edge so it meets the border without drawing into the panel.

Keep the SVG square and let Anchor position the 16px element, preserving trigger-centered placement across flips.