### PR TITLE
fix(website): clip popover arrow outline

### DIFF
--- a/packages/website/src/page/ui/popover.ts
+++ b/packages/website/src/page/ui/popover.ts
@@ -109,10 +109,20 @@ const popoverDemo = (
                                   h.Class('popover-arrow-fill'),
                                   h.D('M 0.5 8 L 8 0.5 L 15.5 8 V 10 H 0.5 Z'),
                                 ]),
-                                h.path([
-                                  h.Class('popover-arrow-outline'),
-                                  h.D('M 0.5 8 L 8 0.5 L 15.5 8'),
-                                ]),
+                                h.svg(
+                                  [
+                                    h.Class('popover-arrow-outline-clip'),
+                                    h.Width('16'),
+                                    h.Height('8'),
+                                    h.ViewBox('0 0 16 8'),
+                                  ],
+                                  [
+                                    h.path([
+                                      h.Class('popover-arrow-outline'),
+                                      h.D('M 0.5 8 L 8 0.5 L 15.5 8'),
+                                    ]),
+                                  ],
+                                ),
                               ],
                             ),
                           ]

--- a/packages/website/src/snippet/uiPopoverArrow.ts
+++ b/packages/website/src/snippet/uiPopoverArrow.ts
@@ -41,7 +41,7 @@ const view = (h: HtmlBuilder<Message>) =>
                     [
                       // Spread the bundle onto your own element, inside the
                       // panel. The fill masks the panel border, while the
-                      // outline draws only the two outward-facing edges:
+                      // nested SVG clips the outline at the panel edge:
                       h.svg(
                         [
                           ...arrow,
@@ -53,10 +53,20 @@ const view = (h: HtmlBuilder<Message>) =>
                             h.Class('popover-arrow-fill'),
                             h.D('M 0.5 8 L 8 0.5 L 15.5 8 V 10 H 0.5 Z'),
                           ]),
-                          h.path([
-                            h.Class('popover-arrow-outline'),
-                            h.D('M 0.5 8 L 8 0.5 L 15.5 8'),
-                          ]),
+                          h.svg(
+                            [
+                              h.Class('popover-arrow-outline-clip'),
+                              h.Width('16'),
+                              h.Height('8'),
+                              h.ViewBox('0 0 16 8'),
+                            ],
+                            [
+                              h.path([
+                                h.Class('popover-arrow-outline'),
+                                h.D('M 0.5 8 L 8 0.5 L 15.5 8'),
+                              ]),
+                            ],
+                          ),
                         ],
                       ),
                       h.h3([h.Class('font-medium')], ['Analytics']),

--- a/packages/website/src/snippet/uiPopoverArrowStyles.css
+++ b/packages/website/src/snippet/uiPopoverArrowStyles.css
@@ -18,6 +18,10 @@
   stroke: none;
 }
 
+.popover-arrow-outline-clip {
+  overflow: hidden;
+}
+
 .popover-arrow-outline {
   fill: none;
   stroke: var(--popover-border);

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -450,6 +450,10 @@
     stroke: none;
   }
 
+  .popover-arrow-outline-clip {
+    overflow: hidden;
+  }
+
   .popover-arrow-outline {
     @apply fill-none stroke-gray-200 dark:stroke-gray-700;
     stroke-linejoin: round;


### PR DESCRIPTION
Clip the arrow outline at the panel edge so antialiasing does not draw through the panel border.

Keep the fill outside the clip so it can still mask the panel border across every rotated placement.