### PR TITLE
docs(website): refresh performance benchmark results

### DIFF
--- a/packages/website/src/page/performance.md
+++ b/packages/website/src/page/performance.md
@@ -29,31 +29,31 @@ Keep `Message.match` anyway. Its signature requires a handler for every tag in t
 
 Foldkit ships a TodoMVC implementation for the [lustre-labs/benchmark](https://github.com/lustre-labs/benchmark) harness, which drives each implementation through the same TodoMVC workload and required selectors (add 100 todos, toggle each one, destroy the first one 100 times). Same-batch timings are comparable because every implementation uses the same driver, runbook, and browser batch. Foldkit registers two slots: an unoptimized view that rebuilds the entire tree on every Message with no memoization, and an optimized view that adds `createLazy` slots for the header, the footer, the filters list, and the toggle-all controls, and `createKeyedLazy` per todo item. The Model and update logic are identical in both. The implementation lives [in the Foldkit repo](https://github.com/foldkit/foldkit/tree/main/internal/lustre-benchmark), so you can run the comparison yourself.
 
-These cover every current-version framework variant in the harness plus Foldkit’s two current development slots; the legacy Lustre 4 and older Foldkit slots are excluded. The medians come from fifteen interleaved runs in one position-balanced batch, so every implementation occupied every ordinal run position once. The batch used harness commit 03fff17 and Chromium 149.0.7827.55. The relative column divides each displayed median by the fastest median from that same batch. A parenthesized label appears only where the harness registers both a baseline and a memoized slot. Solid and Alpine drive the DOM without a diff to skip, so each registers one implementation and its row carries a bare name. Absolute times depend on hardware and browser conditions; the same-run relationships are the result to compare.
+These cover every current-version framework variant in the harness plus Foldkit’s two current development slots; the legacy Lustre 4 and older Foldkit slots are excluded. The medians come from fifteen interleaved runs in one position-balanced batch, so every implementation occupied every ordinal run position once. The batch used harness commit 03fff17 and Chromium 152.0.7977.65. The relative column divides each displayed median by the fastest median from that same batch. A parenthesized label appears only where the harness registers both a baseline and a memoized slot. Solid and Alpine drive the DOM without a diff to skip, so each registers one implementation and its row carries a bare name. Absolute times depend on hardware and browser conditions; the same-run relationships are the result to compare.
 
 | Implementation         | Median time | Relative to fastest |
 | ---------------------- | ----------- | ------------------- |
-| Svelte (optimized)     | 59.2ms      | 1.00×               |
-| Gren (optimized)       | 70.6ms      | 1.19×               |
-| Elm (optimized)        | 72.7ms      | 1.23×               |
-| Svelte (unoptimized)   | 79.1ms      | 1.34×               |
-| Solid                  | 86.7ms      | 1.46×               |
-| Lustre 5 (optimized)   | 97.1ms      | 1.64×               |
-| Foldkit (optimized)    | 119.3ms     | 2.02×               |
-| Vue (unoptimized)      | 134.2ms     | 2.27×               |
-| React 19 (optimized)   | 136.1ms     | 2.30×               |
-| Gren (unoptimized)     | 159.3ms     | 2.69×               |
-| Elm (unoptimized)      | 161.4ms     | 2.73×               |
-| Lustre 5 (unoptimized) | 169.0ms     | 2.85×               |
-| React 19 (unoptimized) | 198.9ms     | 3.36×               |
-| Alpine                 | 258.1ms     | 4.36×               |
-| Foldkit (unoptimized)  | 352.9ms     | 5.96×               |
+| Svelte (optimized)     | 104.5ms     | 1.00×               |
+| Gren (optimized)       | 114.3ms     | 1.09×               |
+| Elm (optimized)        | 116.3ms     | 1.11×               |
+| Svelte (unoptimized)   | 156.2ms     | 1.49×               |
+| Lustre 5 (optimized)   | 192.8ms     | 1.84×               |
+| Solid                  | 192.9ms     | 1.85×               |
+| Foldkit (optimized)    | 210.0ms     | 2.01×               |
+| Vue (unoptimized)      | 270.6ms     | 2.59×               |
+| React 19 (optimized)   | 279.1ms     | 2.67×               |
+| Gren (unoptimized)     | 306.4ms     | 2.93×               |
+| Elm (unoptimized)      | 309.1ms     | 2.96×               |
+| Lustre 5 (unoptimized) | 405.2ms     | 3.88×               |
+| React 19 (unoptimized) | 503.8ms     | 4.82×               |
+| Alpine                 | 540.3ms     | 5.17×               |
+| Foldkit (unoptimized)  | 614.0ms     | 5.88×               |
 
 ### Reading the numbers
 
-Foldkit optimized ranks seventh of fifteen in this batch. It takes 2.02 times the fastest row, about 1.23 times optimized Lustre’s time, and 1.38 times Solid’s. Vue takes about 1.12 times Foldkit’s time, while optimized React takes about 1.14 times Foldkit’s. Per-bucket attribution puts the remaining distance in view and patch work inside animation frames rather than Message dispatch.
+Foldkit optimized ranks seventh of fifteen in this batch. It takes 2.01 times the fastest row, about 1.09 times optimized Lustre’s time, and 1.09 times Solid’s. Vue takes about 1.29 times Foldkit’s time, while optimized React takes about 1.33 times Foldkit’s. Per-bucket attribution puts the remaining distance in view and patch work inside animation frames rather than Message dispatch.
 
-Elm is the proof of what this architecture can do. Elm renders a pure view into a virtual DOM with lazy memoization, exactly Foldkit’s design, and sits near the batch leaders at 1.23 times the fastest row. Foldkit takes 1.64 times Elm’s time. That distance is runtime implementation, not architecture, which is why optimization work targets the runtime and owned differ rather than replacing the rendering model.
+Elm is the proof of what this architecture can do. Elm renders a pure view into a virtual DOM with lazy memoization, exactly Foldkit’s design, and sits near the batch leaders at 1.11 times the fastest row. Foldkit takes 1.81 times Elm’s time. That distance is runtime implementation, not architecture, which is why optimization work targets runtime hot paths rather than replacing the rendering model.
 
 ## Development mode is not production
 


### PR DESCRIPTION
Refresh the TodoMVC comparison with a position-balanced 15-run batch on Chromium 152 and recalculate the accompanying ratios.