### PR TITLE
chore(vite-plugin): upgrade MagicString

### DIFF
--- a/.changeset/magic-string-one.md
+++ b/.changeset/magic-string-one.md
@@ -1,0 +1,5 @@
+---
+'@foldkit/vite-plugin': patch
+---
+
+Upgrade the Vite plugin's `magic-string` dependency to 1.2.3 while preserving Vite 7 source-map compatibility.

--- a/packages/vite-plugin-foldkit/package.json
+++ b/packages/vite-plugin-foldkit/package.json
@@ -28,7 +28,7 @@
     "vite": "^7.0.0 || ^8.0.0"
   },
   "dependencies": {
-    "magic-string": "^0.30.21",
+    "magic-string": "^1.2.3",
     "ws": "^8.21.3"
   },
   "devDependencies": {

--- a/packages/vite-plugin-foldkit/src/viewIdentity.ts
+++ b/packages/vite-plugin-foldkit/src/viewIdentity.ts
@@ -431,10 +431,40 @@ const uniqueBrandAlias = (code: string): string => {
 
 // TRANSFORM
 
+// NOTE: MagicString 0.x declared `file` as a string even though generated maps
+// leave it undefined when no file is supplied. Keep that published type while
+// narrowing `sourcesContent` for Vite 7. `file` remains untouched at runtime.
+type ViteCompatibleSourceMap = SourceMap & {
+  file: string
+  sourcesContent: Array<string> | undefined
+}
+
+const isViteCompatibleSourceMap = (
+  sourceMap: SourceMap,
+): sourceMap is SourceMap & ViteCompatibleSourceMap =>
+  sourceMap.sourcesContent === undefined ||
+  sourceMap.sourcesContent.every(content => content !== null)
+
+const toViteCompatibleSourceMap = (
+  sourceMap: SourceMap,
+): ViteCompatibleSourceMap => {
+  if (sourceMap.sourcesContent !== undefined) {
+    sourceMap.sourcesContent = sourceMap.sourcesContent.map(
+      content => content ?? '',
+    )
+  }
+
+  if (isViteCompatibleSourceMap(sourceMap)) {
+    return sourceMap
+  }
+
+  throw new Error('Failed to normalize the generated source map')
+}
+
 /** Result of {@link transformViewIdentity}: rewritten code plus a source map. */
 export type ViewIdentityTransformResult = Readonly<{
   code: string
-  map: SourceMap
+  map: ViteCompatibleSourceMap
 }>
 
 /**
@@ -522,7 +552,9 @@ export const transformViewIdentity = (
   }
   return {
     code: sourceText.toString(),
-    map: sourceText.generateMap({ hires: 'boundary' }),
+    map: toViteCompatibleSourceMap(
+      sourceText.generateMap({ hires: 'boundary' }),
+    ),
   }
 }
 

--- a/packages/vite-plugin-foldkit/test/viewIdentity.test.ts
+++ b/packages/vite-plugin-foldkit/test/viewIdentity.test.ts
@@ -1,5 +1,7 @@
+import type { SourceMap } from 'magic-string'
 import { parseAst } from 'vite'
-import { describe, expect, it } from 'vitest'
+import type { Plugin as Vite7Plugin } from 'vite7'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
 import { transformViewIdentity } from '../src/viewIdentity.ts'
 
@@ -374,6 +376,18 @@ const view = () => 1
 })
 
 describe('output stability', () => {
+  it('returns a Vite 7 compatible source map', () => {
+    const result = requireTransform('const view = () => 1\n')
+    const plugin: Vite7Plugin = {
+      name: 'vite7-source-map-compatibility',
+      transform: (code, id) => transformViewIdentity(code, id, ROOT),
+    }
+
+    expectTypeOf(result.map.file).toEqualTypeOf<string>()
+    expectTypeOf(result.map).toMatchTypeOf<SourceMap>()
+    expect(plugin.name).toBe('vite7-source-map-compatibility')
+  })
+
   it('produces identical output across runs', () => {
     const source = `const view = () => 1
 const panel = () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2102,8 +2102,8 @@ importers:
   packages/vite-plugin-foldkit:
     dependencies:
       magic-string:
-        specifier: ^0.30.21
-        version: 0.30.21
+        specifier: ^1.2.3
+        version: 1.2.3
       ws:
         specifier: ^8.21.3
         version: 8.21.3
@@ -5418,6 +5418,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magic-string@1.2.3:
+    resolution: {integrity: sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==}
 
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
@@ -9515,6 +9518,10 @@ snapshots:
       - supports-color
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.2.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 


### PR DESCRIPTION
Upgrade MagicString to 1.2.3 for the Vite plugin's source transforms.

Normalize generated source maps at the public boundary so they remain compatible with Vite 7 while preserving the existing MagicString SourceMap contract.