### PR TITLE
perf(foldkit): reduce renderer hot-path overhead

### DIFF
--- a/.changeset/renderer-hot-path.md
+++ b/.changeset/renderer-hot-path.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Reduce render overhead by caching unchanged document metadata, writing ordinary properties directly, and skipping masked module scans for VNodes with no module data. External metadata changes and URL updates are still reconciled on the next render.

--- a/packages/foldkit/src/html/index.ts
+++ b/packages/foldkit/src/html/index.ts
@@ -1250,12 +1250,16 @@ const writeDataProp = (
 ): Record<string, unknown> => {
   /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
   const props = (ctx.data.props ??= {}) as Record<string, unknown>
-  Object.defineProperty(props, key, {
-    configurable: true,
-    enumerable: true,
-    value,
-    writable: true,
-  })
+  if (key === '__proto__') {
+    Object.defineProperty(props, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    })
+  } else {
+    props[key] = value
+  }
   addVNodeDataMask(ctx, VNodeDataMask.Props)
   return props
 }

--- a/packages/foldkit/src/propsModule.ts
+++ b/packages/foldkit/src/propsModule.ts
@@ -25,9 +25,9 @@ const writeProperty = (element: object, name: string, value: unknown): void => {
       writable: true,
     })
   } else {
-    if (!Reflect.set(element, name, value)) {
-      throw new TypeError(`[foldkit] Cannot assign DOM property ${name}.`)
-    }
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const properties = element as Record<string, unknown>
+    properties[name] = value
   }
 }
 

--- a/packages/foldkit/src/propsModule.ts
+++ b/packages/foldkit/src/propsModule.ts
@@ -26,8 +26,8 @@ const writeProperty = (element: object, name: string, value: unknown): void => {
     })
   } else {
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-    const properties = element as Record<string, unknown>
-    properties[name] = value
+    const elementProperties = element as Record<string, unknown>
+    elementProperties[name] = value
   }
 }
 

--- a/packages/foldkit/src/runtime/makeElement.test.ts
+++ b/packages/foldkit/src/runtime/makeElement.test.ts
@@ -344,9 +344,9 @@ describe('makeApplication', () => {
   })
 
   it('invalidates the default canonical cache when the location changes', async () => {
-    const originalUrl = window.location.href
-    const nextUrl = new URL('/next?mode=fast#ignored', originalUrl)
-    const nextCanonical = `${nextUrl.origin}${nextUrl.pathname}${nextUrl.search}`
+    const originalHref = window.location.href
+    const nextUrl = new URL('/next?mode=fast#ignored', originalHref)
+    const nextCanonicalUrl = `${nextUrl.origin}${nextUrl.pathname}${nextUrl.search}`
     const application = makeApplication({
       Model,
       init: () => ({ model: { label: 'hello' } }),
@@ -362,9 +362,11 @@ describe('makeApplication', () => {
 
     try {
       await awaitBodyText('hello')
-      const canonical = document.head.querySelector('link[rel="canonical"]')
+      const canonicalElement = document.head.querySelector(
+        'link[rel="canonical"]',
+      )
       const button = document.body.querySelector('button')
-      if (!(canonical instanceof HTMLLinkElement) || button === null) {
+      if (!(canonicalElement instanceof HTMLLinkElement) || button === null) {
         throw new Error('expected application canonical metadata and button')
       }
 
@@ -372,10 +374,10 @@ describe('makeApplication', () => {
       button.click()
 
       await vi.waitFor(() => {
-        expect(canonical.getAttribute('href')).toBe(nextCanonical)
+        expect(canonicalElement.getAttribute('href')).toBe(nextCanonicalUrl)
       })
     } finally {
-      history.replaceState(null, '', originalUrl)
+      history.replaceState(null, '', originalHref)
       await Effect.runPromise(Fiber.interrupt(fiber))
     }
   })

--- a/packages/foldkit/src/runtime/makeElement.test.ts
+++ b/packages/foldkit/src/runtime/makeElement.test.ts
@@ -267,7 +267,7 @@ describe('makeApplication', () => {
       init: () => ({ model: { label: 'hello' } }),
       update,
       view: model => ({
-        title: model.label,
+        title: 'Metadata test',
         canonical: canonicalUrl,
         ogUrl: canonicalUrl,
         body: h.div(
@@ -297,6 +297,8 @@ describe('makeApplication', () => {
       }
 
       const querySelectorSpy = vi.spyOn(document.head, 'querySelector')
+      const canonicalGetAttributeSpy = vi.spyOn(canonical, 'getAttribute')
+      const ogUrlGetAttributeSpy = vi.spyOn(ogUrl, 'getAttribute')
       const canonicalSetAttributeSpy = vi.spyOn(canonical, 'setAttribute')
       const ogUrlSetAttributeSpy = vi.spyOn(ogUrl, 'setAttribute')
       try {
@@ -304,6 +306,8 @@ describe('makeApplication', () => {
         await awaitBodyText('world')
 
         expect(querySelectorSpy).not.toHaveBeenCalled()
+        expect(canonicalGetAttributeSpy).not.toHaveBeenCalled()
+        expect(ogUrlGetAttributeSpy).not.toHaveBeenCalled()
         expect(canonicalSetAttributeSpy).not.toHaveBeenCalled()
         expect(ogUrlSetAttributeSpy).not.toHaveBeenCalled()
 
@@ -329,10 +333,97 @@ describe('makeApplication', () => {
         )
       } finally {
         querySelectorSpy.mockRestore()
+        canonicalGetAttributeSpy.mockRestore()
+        ogUrlGetAttributeSpy.mockRestore()
         canonicalSetAttributeSpy.mockRestore()
         ogUrlSetAttributeSpy.mockRestore()
       }
     } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('invalidates the default canonical cache when the location changes', async () => {
+    const originalUrl = window.location.href
+    const nextUrl = new URL('/next?mode=fast#ignored', originalUrl)
+    const nextCanonical = `${nextUrl.origin}${nextUrl.pathname}${nextUrl.search}`
+    const application = makeApplication({
+      Model,
+      init: () => ({ model: { label: 'hello' } }),
+      update,
+      view: model => ({
+        title: model.label,
+        body: h.button([h.OnClick(Message.ClickedBump())], [model.label]),
+      }),
+      container,
+    })
+
+    const fiber = Effect.runFork(application.start())
+
+    try {
+      await awaitBodyText('hello')
+      const canonical = document.head.querySelector('link[rel="canonical"]')
+      const button = document.body.querySelector('button')
+      if (!(canonical instanceof HTMLLinkElement) || button === null) {
+        throw new Error('expected application canonical metadata and button')
+      }
+
+      history.pushState(null, '', nextUrl)
+      button.click()
+
+      await vi.waitFor(() => {
+        expect(canonical.getAttribute('href')).toBe(nextCanonical)
+      })
+    } finally {
+      history.replaceState(null, '', originalUrl)
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('rebuilds document metadata after the head is replaced', async () => {
+    const canonicalUrl = 'https://example.com/replaced-head'
+    const application = makeApplication({
+      Model,
+      init: () => ({ model: { label: 'hello' } }),
+      update,
+      view: model => ({
+        title: 'Metadata test',
+        canonical: canonicalUrl,
+        ogUrl: canonicalUrl,
+        body: h.button([h.OnClick(Message.ClickedBump())], [model.label]),
+      }),
+      container,
+    })
+    const fiber = Effect.runFork(application.start())
+    const originalHead = document.head
+
+    try {
+      await awaitBodyText('hello')
+      const button = document.body.querySelector('button')
+      if (button === null) {
+        throw new Error('expected application button')
+      }
+
+      originalHead.replaceWith(document.createElement('head'))
+      button.click()
+
+      await vi.waitFor(() => {
+        expect(document.title).toBe('Metadata test')
+        expect(
+          document.head
+            .querySelector('link[rel="canonical"]')
+            ?.getAttribute('href'),
+        ).toBe(canonicalUrl)
+        expect(
+          document.head
+            .querySelector('meta[property="og:url"]')
+            ?.getAttribute('content'),
+        ).toBe(canonicalUrl)
+      })
+    } finally {
+      if (document.head !== originalHead) {
+        document.head.replaceWith(originalHead)
+      }
       await Effect.runPromise(Fiber.interrupt(fiber))
     }
   })

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -3601,24 +3601,24 @@ type DocumentMetadataElements = {
   ogUrl?: HTMLMetaElement
 }
 
-type AppliedDocumentMetadata = Readonly<{
+type ResolvedDocumentMetadata = Readonly<{
   title: string
   lang: string | undefined
-  dir: string | undefined
-  canonical: string
+  dirAttribute: string | undefined
+  canonicalUrl: string
   ogUrl: string
 }>
 
-type DocumentMetadataMutationState = { isDirty: boolean }
+type DocumentMetadataInvalidation = { isInvalidated: boolean }
 
 type DocumentMetadataState = {
   readonly elements: DocumentMetadataElements
   readonly observer: MutationObserver
-  readonly mutationState: DocumentMetadataMutationState
+  readonly invalidation: DocumentMetadataInvalidation
   observedHead: HTMLHeadElement
-  applied?: AppliedDocumentMetadata
-  locationHref?: string
-  locationCanonical?: string
+  lastApplied?: ResolvedDocumentMetadata
+  cachedLocationHref?: string
+  cachedLocationCanonical?: string
 }
 
 const documentMetadataStates = new WeakMap<
@@ -3626,7 +3626,7 @@ const documentMetadataStates = new WeakMap<
   DocumentMetadataState
 >()
 
-const observeDocumentMetadata = (
+const observeDocumentMetadataMutations = (
   observer: MutationObserver,
 ): HTMLHeadElement => {
   const observedHead = document.head
@@ -3644,33 +3644,33 @@ const observeDocumentMetadata = (
   return observedHead
 }
 
-const metadataStateForDocument = (): DocumentMetadataState => {
-  const existing = documentMetadataStates.get(document)
-  if (existing !== undefined) {
-    return existing
+const getOrCreateDocumentMetadataState = (): DocumentMetadataState => {
+  const existingState = documentMetadataStates.get(document)
+  if (existingState !== undefined) {
+    return existingState
   }
 
-  const mutationState: DocumentMetadataMutationState = { isDirty: true }
+  const invalidation: DocumentMetadataInvalidation = { isInvalidated: true }
   const observer = new MutationObserver(() => {
-    mutationState.isDirty = true
+    invalidation.isInvalidated = true
   })
-  const state: DocumentMetadataState = {
+  const metadataState: DocumentMetadataState = {
     elements: {},
     observer,
-    mutationState,
-    observedHead: observeDocumentMetadata(observer),
+    invalidation,
+    observedHead: observeDocumentMetadataMutations(observer),
   }
-  documentMetadataStates.set(document, state)
-  return state
+  documentMetadataStates.set(document, metadataState)
+  return metadataState
 }
 
-const metadataElementsForDocument = (
-  state: DocumentMetadataState,
+const findOrCreateDocumentMetadataElements = (
+  metadataState: DocumentMetadataState,
 ): Readonly<{
   canonical: HTMLLinkElement
   ogUrl: HTMLMetaElement
 }> => {
-  const { elements } = state
+  const { elements } = metadataState
 
   let canonical = elements.canonical
   if (canonical === undefined || canonical.parentNode !== document.head) {
@@ -3691,16 +3691,84 @@ const metadataElementsForDocument = (
   return { canonical, ogUrl }
 }
 
-const currentLocationUrlForState = (state: DocumentMetadataState): string => {
-  const href = window.location.href
-  if (state.locationHref === href && state.locationCanonical !== undefined) {
-    return state.locationCanonical
+const readOrCacheCurrentLocationUrl = (
+  metadataState: DocumentMetadataState,
+): string => {
+  const currentLocationHref = window.location.href
+  if (
+    metadataState.cachedLocationHref === currentLocationHref &&
+    metadataState.cachedLocationCanonical !== undefined
+  ) {
+    return metadataState.cachedLocationCanonical
   }
 
-  const canonical = currentLocationUrl()
-  state.locationHref = href
-  state.locationCanonical = canonical
-  return canonical
+  const canonicalUrl = currentLocationUrl()
+  metadataState.cachedLocationHref = currentLocationHref
+  metadataState.cachedLocationCanonical = canonicalUrl
+  return canonicalUrl
+}
+
+const rebindDocumentMetadataObserverToCurrentHead = (
+  metadataState: DocumentMetadataState,
+): void => {
+  // NOTE: a MutationObserver remains attached to a detached head after
+  // document.head is replaced. Rebind it and invalidate the metadata snapshot
+  // before the next unchanged guard.
+  metadataState.observer.disconnect()
+  metadataState.observedHead = observeDocumentMetadataMutations(
+    metadataState.observer,
+  )
+  metadataState.invalidation.isInvalidated = true
+}
+
+const reconcileDocumentMetadata = (
+  metadataState: DocumentMetadataState,
+  nextMetadata: ResolvedDocumentMetadata,
+): void => {
+  if (document.title !== nextMetadata.title) {
+    document.title = nextMetadata.title
+  }
+
+  const { documentElement } = document
+
+  if (
+    nextMetadata.lang !== undefined &&
+    documentElement.lang !== nextMetadata.lang
+  ) {
+    documentElement.lang = nextMetadata.lang
+  }
+
+  if (
+    nextMetadata.dirAttribute !== undefined &&
+    documentElement.dir !== nextMetadata.dirAttribute
+  ) {
+    documentElement.dir = nextMetadata.dirAttribute
+  }
+
+  const metadataElements = findOrCreateDocumentMetadataElements(metadataState)
+
+  if (metadataElements.canonical.getAttribute('rel') !== 'canonical') {
+    metadataElements.canonical.setAttribute('rel', 'canonical')
+  }
+  if (
+    metadataElements.canonical.getAttribute('href') !==
+    nextMetadata.canonicalUrl
+  ) {
+    metadataElements.canonical.setAttribute('href', nextMetadata.canonicalUrl)
+  }
+  if (metadataElements.ogUrl.getAttribute('property') !== 'og:url') {
+    metadataElements.ogUrl.setAttribute('property', 'og:url')
+  }
+  if (metadataElements.ogUrl.getAttribute('content') !== nextMetadata.ogUrl) {
+    metadataElements.ogUrl.setAttribute('content', nextMetadata.ogUrl)
+  }
+
+  metadataState.lastApplied = nextMetadata
+  metadataState.invalidation.isInvalidated = false
+  // NOTE: clear the records produced by Foldkit's own writes before the
+  // observer callback runs. Otherwise the next unchanged render would be
+  // marked dirty and repeat every DOM read this cache is meant to avoid.
+  metadataState.observer.takeRecords()
 }
 
 const applyDocumentMetadata = (
@@ -3711,77 +3779,47 @@ const applyDocumentMetadata = (
     return
   }
 
-  const state = metadataStateForDocument()
-  if (state.observedHead !== document.head) {
-    state.observer.disconnect()
-    state.observedHead = observeDocumentMetadata(state.observer)
-    state.mutationState.isDirty = true
+  const metadataState = getOrCreateDocumentMetadataState()
+
+  if (metadataState.observedHead !== document.head) {
+    rebindDocumentMetadataObserverToCurrentHead(metadataState)
   }
-  const canonical = nextDocument.canonical ?? currentLocationUrlForState(state)
-  const ogUrl = nextDocument.ogUrl ?? canonical
-  const dir =
+
+  const canonicalUrl =
+    nextDocument.canonical ?? readOrCacheCurrentLocationUrl(metadataState)
+  const ogUrl = nextDocument.ogUrl ?? canonicalUrl
+  const dirAttribute =
     nextDocument.dir === undefined
       ? undefined
       : textDirectionToAttribute(nextDocument.dir)
-  if (Array.isArrayNonEmpty(state.observer.takeRecords())) {
-    state.mutationState.isDirty = true
+
+  // NOTE: MutationObserver callbacks are asynchronous. Consume queued records
+  // synchronously before trusting the unchanged fast path.
+  if (Array.isArrayNonEmpty(metadataState.observer.takeRecords())) {
+    metadataState.invalidation.isInvalidated = true
   }
-  const applied = state.applied
-  if (
-    !state.mutationState.isDirty &&
-    applied !== undefined &&
-    applied.title === nextDocument.title &&
-    applied.lang === nextDocument.lang &&
-    applied.dir === dir &&
-    applied.canonical === canonical &&
-    applied.ogUrl === ogUrl
-  ) {
+
+  const lastApplied = metadataState.lastApplied
+  const isAppliedMetadataCurrent =
+    !metadataState.invalidation.isInvalidated &&
+    lastApplied !== undefined &&
+    lastApplied.title === nextDocument.title &&
+    lastApplied.lang === nextDocument.lang &&
+    lastApplied.dirAttribute === dirAttribute &&
+    lastApplied.canonicalUrl === canonicalUrl &&
+    lastApplied.ogUrl === ogUrl
+
+  if (isAppliedMetadataCurrent) {
     return
   }
 
-  if (document.title !== nextDocument.title) {
-    document.title = nextDocument.title
-  }
-
-  const { documentElement } = document
-
-  if (
-    nextDocument.lang !== undefined &&
-    documentElement.lang !== nextDocument.lang
-  ) {
-    documentElement.lang = nextDocument.lang
-  }
-
-  if (dir !== undefined && documentElement.dir !== dir) {
-    documentElement.dir = dir
-  }
-
-  const metadataElements = metadataElementsForDocument(state)
-
-  if (metadataElements.canonical.getAttribute('rel') !== 'canonical') {
-    metadataElements.canonical.setAttribute('rel', 'canonical')
-  }
-  if (metadataElements.canonical.getAttribute('href') !== canonical) {
-    metadataElements.canonical.setAttribute('href', canonical)
-  }
-  if (metadataElements.ogUrl.getAttribute('property') !== 'og:url') {
-    metadataElements.ogUrl.setAttribute('property', 'og:url')
-  }
-  if (metadataElements.ogUrl.getAttribute('content') !== ogUrl) {
-    metadataElements.ogUrl.setAttribute('content', ogUrl)
-  }
-  state.applied = {
+  reconcileDocumentMetadata(metadataState, {
     title: nextDocument.title,
     lang: nextDocument.lang,
-    dir,
-    canonical,
+    dirAttribute,
+    canonicalUrl,
     ogUrl,
-  }
-  state.mutationState.isDirty = false
-  // NOTE: clear the records produced by Foldkit's own writes before the
-  // observer callback runs. Otherwise the next unchanged render would be
-  // marked dirty and repeat every DOM read this cache is meant to avoid.
-  state.observer.takeRecords()
+  })
 }
 
 const renderCrashView = <Model, Message>(

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -3601,20 +3601,76 @@ type DocumentMetadataElements = {
   ogUrl?: HTMLMetaElement
 }
 
-const documentMetadataElements = new WeakMap<
+type AppliedDocumentMetadata = Readonly<{
+  title: string
+  lang: string | undefined
+  dir: string | undefined
+  canonical: string
+  ogUrl: string
+}>
+
+type DocumentMetadataMutationState = { isDirty: boolean }
+
+type DocumentMetadataState = {
+  readonly elements: DocumentMetadataElements
+  readonly observer: MutationObserver
+  readonly mutationState: DocumentMetadataMutationState
+  observedHead: HTMLHeadElement
+  applied?: AppliedDocumentMetadata
+  locationHref?: string
+  locationCanonical?: string
+}
+
+const documentMetadataStates = new WeakMap<
   globalThis.Document,
-  DocumentMetadataElements
+  DocumentMetadataState
 >()
 
-const metadataElementsForDocument = (): Readonly<{
+const observeDocumentMetadata = (
+  observer: MutationObserver,
+): HTMLHeadElement => {
+  const observedHead = document.head
+  observer.observe(observedHead, {
+    attributes: true,
+    attributeFilter: ['rel', 'href', 'property', 'content'],
+    childList: true,
+    characterData: true,
+    subtree: true,
+  })
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['lang', 'dir'],
+  })
+  return observedHead
+}
+
+const metadataStateForDocument = (): DocumentMetadataState => {
+  const existing = documentMetadataStates.get(document)
+  if (existing !== undefined) {
+    return existing
+  }
+
+  const mutationState: DocumentMetadataMutationState = { isDirty: true }
+  const observer = new MutationObserver(() => {
+    mutationState.isDirty = true
+  })
+  const state: DocumentMetadataState = {
+    elements: {},
+    observer,
+    mutationState,
+    observedHead: observeDocumentMetadata(observer),
+  }
+  documentMetadataStates.set(document, state)
+  return state
+}
+
+const metadataElementsForDocument = (
+  state: DocumentMetadataState,
+): Readonly<{
   canonical: HTMLLinkElement
   ogUrl: HTMLMetaElement
 }> => {
-  let elements = documentMetadataElements.get(document)
-  if (elements === undefined) {
-    elements = {}
-    documentMetadataElements.set(document, elements)
-  }
+  const { elements } = state
 
   let canonical = elements.canonical
   if (canonical === undefined || canonical.parentNode !== document.head) {
@@ -3635,11 +3691,51 @@ const metadataElementsForDocument = (): Readonly<{
   return { canonical, ogUrl }
 }
 
+const currentLocationUrlForState = (state: DocumentMetadataState): string => {
+  const href = window.location.href
+  if (state.locationHref === href && state.locationCanonical !== undefined) {
+    return state.locationCanonical
+  }
+
+  const canonical = currentLocationUrl()
+  state.locationHref = href
+  state.locationCanonical = canonical
+  return canonical
+}
+
 const applyDocumentMetadata = (
   nextDocument: Document,
   mountedRoot: Node | undefined,
 ): void => {
   if (!mountedRoot || !document.body.contains(mountedRoot)) {
+    return
+  }
+
+  const state = metadataStateForDocument()
+  if (state.observedHead !== document.head) {
+    state.observer.disconnect()
+    state.observedHead = observeDocumentMetadata(state.observer)
+    state.mutationState.isDirty = true
+  }
+  const canonical = nextDocument.canonical ?? currentLocationUrlForState(state)
+  const ogUrl = nextDocument.ogUrl ?? canonical
+  const dir =
+    nextDocument.dir === undefined
+      ? undefined
+      : textDirectionToAttribute(nextDocument.dir)
+  if (Array.isArrayNonEmpty(state.observer.takeRecords())) {
+    state.mutationState.isDirty = true
+  }
+  const applied = state.applied
+  if (
+    !state.mutationState.isDirty &&
+    applied !== undefined &&
+    applied.title === nextDocument.title &&
+    applied.lang === nextDocument.lang &&
+    applied.dir === dir &&
+    applied.canonical === canonical &&
+    applied.ogUrl === ogUrl
+  ) {
     return
   }
 
@@ -3656,16 +3752,11 @@ const applyDocumentMetadata = (
     documentElement.lang = nextDocument.lang
   }
 
-  if (nextDocument.dir !== undefined) {
-    const dir = textDirectionToAttribute(nextDocument.dir)
-    if (documentElement.dir !== dir) {
-      documentElement.dir = dir
-    }
+  if (dir !== undefined && documentElement.dir !== dir) {
+    documentElement.dir = dir
   }
 
-  const canonical = nextDocument.canonical ?? currentLocationUrl()
-  const ogUrl = nextDocument.ogUrl ?? canonical
-  const metadataElements = metadataElementsForDocument()
+  const metadataElements = metadataElementsForDocument(state)
 
   if (metadataElements.canonical.getAttribute('rel') !== 'canonical') {
     metadataElements.canonical.setAttribute('rel', 'canonical')
@@ -3679,6 +3770,18 @@ const applyDocumentMetadata = (
   if (metadataElements.ogUrl.getAttribute('content') !== ogUrl) {
     metadataElements.ogUrl.setAttribute('content', ogUrl)
   }
+  state.applied = {
+    title: nextDocument.title,
+    lang: nextDocument.lang,
+    dir,
+    canonical,
+    ogUrl,
+  }
+  state.mutationState.isDirty = false
+  // NOTE: clear the records produced by Foldkit's own writes before the
+  // observer callback runs. Otherwise the next unchanged render would be
+  // marked dirty and repeat every DOM read this cache is meant to avoid.
+  state.observer.takeRecords()
 }
 
 const renderCrashView = <Model, Message>(

--- a/packages/foldkit/src/snabbdom/init.ts
+++ b/packages/foldkit/src/snabbdom/init.ts
@@ -144,6 +144,16 @@ export function init(
     }
   }
 
+  const areCreateModulesMasked = moduleDataMasks.create.every(
+    dataMask => dataMask !== undefined,
+  )
+  const areUpdateModulesMasked = moduleDataMasks.update.every(
+    dataMask => dataMask !== undefined,
+  )
+  const areDestroyModulesMasked = moduleDataMasks.destroy.every(
+    dataMask => dataMask !== undefined,
+  )
+
   function emptyNodeAt(element: Element) {
     const id = element.id ? '#' + element.id : ''
 
@@ -214,18 +224,20 @@ export function init(
         )
       }
       const dataMask = data?.[vnodeDataMaskKey]
-      for (
-        let moduleIndex = 0;
-        moduleIndex < moduleHooks.create.length;
-        ++moduleIndex
-      ) {
-        const moduleDataMask = moduleDataMasks.create[moduleIndex]
-        if (
-          moduleDataMask === undefined ||
-          dataMask === undefined ||
-          (dataMask & moduleDataMask) !== 0
+      if (!areCreateModulesMasked || dataMask === undefined || dataMask !== 0) {
+        for (
+          let moduleIndex = 0;
+          moduleIndex < moduleHooks.create.length;
+          ++moduleIndex
         ) {
-          moduleHooks.create[moduleIndex]!(emptyNode, vnode)
+          const moduleDataMask = moduleDataMasks.create[moduleIndex]
+          if (
+            moduleDataMask === undefined ||
+            dataMask === undefined ||
+            (dataMask & moduleDataMask) !== 0
+          ) {
+            moduleHooks.create[moduleIndex]!(emptyNode, vnode)
+          }
         }
       }
       if (
@@ -257,18 +269,20 @@ export function init(
         api.createDocumentFragment ?? documentFragmentIsNotSupported
       )()
       const dataMask = data?.[vnodeDataMaskKey]
-      for (
-        let moduleIndex = 0;
-        moduleIndex < moduleHooks.create.length;
-        ++moduleIndex
-      ) {
-        const moduleDataMask = moduleDataMasks.create[moduleIndex]
-        if (
-          moduleDataMask === undefined ||
-          dataMask === undefined ||
-          (dataMask & moduleDataMask) !== 0
+      if (!areCreateModulesMasked || dataMask === undefined || dataMask !== 0) {
+        for (
+          let moduleIndex = 0;
+          moduleIndex < moduleHooks.create.length;
+          ++moduleIndex
         ) {
-          moduleHooks.create[moduleIndex]!(emptyNode, vnode)
+          const moduleDataMask = moduleDataMasks.create[moduleIndex]
+          if (
+            moduleDataMask === undefined ||
+            dataMask === undefined ||
+            (dataMask & moduleDataMask) !== 0
+          ) {
+            moduleHooks.create[moduleIndex]!(emptyNode, vnode)
+          }
         }
       }
       for (
@@ -315,18 +329,24 @@ export function init(
     if (data !== undefined) {
       data?.hook?.destroy?.(vnode)
       const dataMask = data[vnodeDataMaskKey]
-      for (
-        let moduleIndex = 0;
-        moduleIndex < moduleHooks.destroy.length;
-        ++moduleIndex
+      if (
+        !areDestroyModulesMasked ||
+        dataMask === undefined ||
+        dataMask !== 0
       ) {
-        const moduleDataMask = moduleDataMasks.destroy[moduleIndex]
-        if (
-          moduleDataMask === undefined ||
-          dataMask === undefined ||
-          (dataMask & moduleDataMask) !== 0
+        for (
+          let moduleIndex = 0;
+          moduleIndex < moduleHooks.destroy.length;
+          ++moduleIndex
         ) {
-          moduleHooks.destroy[moduleIndex]!(vnode)
+          const moduleDataMask = moduleDataMasks.destroy[moduleIndex]
+          if (
+            moduleDataMask === undefined ||
+            dataMask === undefined ||
+            (dataMask & moduleDataMask) !== 0
+          ) {
+            moduleHooks.destroy[moduleIndex]!(vnode)
+          }
         }
       }
       if (vnode.children !== undefined) {
@@ -605,19 +625,26 @@ export function init(
       oldVnode.data ??= {}
       const oldDataMask = oldVnode.data[vnodeDataMaskKey]
       const dataMask = vnode.data[vnodeDataMaskKey]
-      for (
-        let moduleIndex = 0;
-        moduleIndex < moduleHooks.update.length;
-        ++moduleIndex
+      if (
+        !areUpdateModulesMasked ||
+        oldDataMask === undefined ||
+        dataMask === undefined ||
+        (oldDataMask | dataMask) !== 0
       ) {
-        const moduleDataMask = moduleDataMasks.update[moduleIndex]
-        if (
-          moduleDataMask === undefined ||
-          oldDataMask === undefined ||
-          dataMask === undefined ||
-          ((oldDataMask | dataMask) & moduleDataMask) !== 0
+        for (
+          let moduleIndex = 0;
+          moduleIndex < moduleHooks.update.length;
+          ++moduleIndex
         ) {
-          moduleHooks.update[moduleIndex]!(oldVnode, vnode)
+          const moduleDataMask = moduleDataMasks.update[moduleIndex]
+          if (
+            moduleDataMask === undefined ||
+            oldDataMask === undefined ||
+            dataMask === undefined ||
+            ((oldDataMask | dataMask) & moduleDataMask) !== 0
+          ) {
+            moduleHooks.update[moduleIndex]!(oldVnode, vnode)
+          }
         }
       }
       vnode.data?.hook?.update?.(oldVnode, vnode)

--- a/packages/foldkit/src/snabbdom/init.ts
+++ b/packages/foldkit/src/snabbdom/init.ts
@@ -144,13 +144,13 @@ export function init(
     }
   }
 
-  const areCreateModulesMasked = moduleDataMasks.create.every(
+  const isCreateModuleDataMaskCoverageComplete = moduleDataMasks.create.every(
     dataMask => dataMask !== undefined,
   )
-  const areUpdateModulesMasked = moduleDataMasks.update.every(
+  const isUpdateModuleDataMaskCoverageComplete = moduleDataMasks.update.every(
     dataMask => dataMask !== undefined,
   )
-  const areDestroyModulesMasked = moduleDataMasks.destroy.every(
+  const isDestroyModuleDataMaskCoverageComplete = moduleDataMasks.destroy.every(
     dataMask => dataMask !== undefined,
   )
 
@@ -224,7 +224,11 @@ export function init(
         )
       }
       const dataMask = data?.[vnodeDataMaskKey]
-      if (!areCreateModulesMasked || dataMask === undefined || dataMask !== 0) {
+      if (
+        !isCreateModuleDataMaskCoverageComplete ||
+        dataMask === undefined ||
+        dataMask !== 0
+      ) {
         for (
           let moduleIndex = 0;
           moduleIndex < moduleHooks.create.length;
@@ -269,7 +273,11 @@ export function init(
         api.createDocumentFragment ?? documentFragmentIsNotSupported
       )()
       const dataMask = data?.[vnodeDataMaskKey]
-      if (!areCreateModulesMasked || dataMask === undefined || dataMask !== 0) {
+      if (
+        !isCreateModuleDataMaskCoverageComplete ||
+        dataMask === undefined ||
+        dataMask !== 0
+      ) {
         for (
           let moduleIndex = 0;
           moduleIndex < moduleHooks.create.length;
@@ -330,7 +338,7 @@ export function init(
       data?.hook?.destroy?.(vnode)
       const dataMask = data[vnodeDataMaskKey]
       if (
-        !areDestroyModulesMasked ||
+        !isDestroyModuleDataMaskCoverageComplete ||
         dataMask === undefined ||
         dataMask !== 0
       ) {
@@ -626,7 +634,7 @@ export function init(
       const oldDataMask = oldVnode.data[vnodeDataMaskKey]
       const dataMask = vnode.data[vnodeDataMaskKey]
       if (
-        !areUpdateModulesMasked ||
+        !isUpdateModuleDataMaskCoverageComplete ||
         oldDataMask === undefined ||
         dataMask === undefined ||
         (oldDataMask | dataMask) !== 0

--- a/packages/foldkit/src/vdom.ts
+++ b/packages/foldkit/src/vdom.ts
@@ -1,4 +1,4 @@
-import { Option, Predicate } from 'effect'
+import { Option } from 'effect'
 
 import { propsModule } from './propsModule.js'
 import {
@@ -146,12 +146,12 @@ export const __patchVNode = (
   container: HTMLElement,
   seen?: Set<object>,
 ): VNode => {
-  const dedupedVNode = Predicate.isNotNull(nextVNode)
-    ? dedupeSharedVNodes(nextVNode, seen)
-    : h('!')
+  const dedupedVNode =
+    nextVNode !== null ? dedupeSharedVNodes(nextVNode, seen) : h('!')
 
-  return Option.match(maybeCurrentVNode, {
-    onNone: () => patchFreshInto(container, dedupedVNode),
-    onSome: currentVNode => patch(currentVNode, dedupedVNode),
-  })
+  if (Option.isNone(maybeCurrentVNode)) {
+    return patchFreshInto(container, dedupedVNode)
+  }
+
+  return patch(maybeCurrentVNode.value, dedupedVNode)
 }


### PR DESCRIPTION
Cache document metadata with mutation invalidation so unchanged renders skip redundant DOM reads.

Skip masked module dispatch for zero-data VNodes and use direct property writes along the renderer hot path.