### PR TITLE
chore(kanban): upgrade fractional-indexing

### DIFF
--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -14,7 +14,7 @@
     "clsx": "^2.1.1",
     "effect": "4.0.0-rc.112",
     "foldkit": "workspace:*",
-    "fractional-indexing": "^3.4.0"
+    "fractional-indexing": "^4.0.0"
   },
   "devDependencies": {
     "@foldkit/devtools": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,8 +701,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/foldkit
       fractional-indexing:
-        specifier: ^3.4.0
-        version: 3.4.0
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@foldkit/devtools':
         specifier: workspace:*
@@ -4883,8 +4883,8 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  fractional-indexing@3.4.0:
-    resolution: {integrity: sha512-8J3glhz2rrpKG6KmI7wmJo3zH1VjeOpN+vTJSw1fOyO+Viqq3zX6/5NGh6oaZB2qIAYdOYuu5Dz9xp4faOO0Pg==}
+  fractional-indexing@4.0.0:
+    resolution: {integrity: sha512-Nr2P1Yyaj2sy1Qdt/wI3GcByxrUdbSKg5+cGvw8f18hT2SkQt6V72iOjBpk7IO3UkzBsdlGRs2a4z6dLrJprgw==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
   fresh@2.0.0:
@@ -9025,7 +9025,7 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  fractional-indexing@3.4.0: {}
+  fractional-indexing@4.0.0: {}
 
   fresh@2.0.0: {}
 


### PR DESCRIPTION
Upgrade the Kanban example ordering dependency to fractional-indexing 4. The default alphabet behavior used by the example remains byte-compatible; version 4's breaking change applies only to custom alphabets.