### PR TITLE
chore(website): upgrade Monaco Editor

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -33,7 +33,7 @@
     "clsx": "^2.1.1",
     "effect": "4.0.0-rc.112",
     "foldkit": "workspace:*",
-    "monaco-editor": "^0.55.1",
+    "monaco-editor": "^0.56.0",
     "shiki": "^4.4.3",
     "tailwind-merge": "^3.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2172,8 +2172,8 @@ importers:
         specifier: workspace:*
         version: link:../foldkit
       monaco-editor:
-        specifier: ^0.55.1
-        version: 0.55.1
+        specifier: ^0.56.0
+        version: 0.56.0
       shiki:
         specifier: ^4.4.3
         version: 4.4.3
@@ -5649,8 +5649,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  monaco-editor@0.55.1:
-    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
+  monaco-editor@0.56.0:
+    resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -9969,7 +9969,7 @@ snapshots:
       requirejs: 2.3.8
       requirejs-config-file: 4.0.0
 
-  monaco-editor@0.55.1:
+  monaco-editor@0.56.0:
     dependencies:
       dompurify: 3.4.14
       marked: 14.0.0


### PR DESCRIPTION
Upgrade Monaco Editor to 0.56. The website's playground API usage and bundled worker entry files remain compatible with this release.