### PR TITLE
fix(foldkit): complete ManagedResource cleanup after release defects

### DIFF
--- a/.changeset/managed-resource-release-cleanup.md
+++ b/.changeset/managed-resource-release-cleanup.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Clear a ManagedResource reference and dispatch its release Message when the user-provided release effect fails.

--- a/packages/foldkit/src/managedResource/managedResource.ts
+++ b/packages/foldkit/src/managedResource/managedResource.ts
@@ -252,11 +252,13 @@ export type EntryBuilder<Model, Message> = <
  *   `Layer`-built resource therefore needs only `release: () => Effect.void`:
  *   the `Layer` finalizers run automatically when the scope closes.
  * - `release` — Tears down the resource. Errors thrown here are silently
- *   swallowed: release must not block cleanup. Resources that register their
- *   teardown as scope finalizers in `acquire` leave this as `() => Effect.void`.
+ *   swallowed, but the runtime still clears the resource reference and
+ *   dispatches `onReleased()` so bookkeeping completes. Resources that
+ *   register their teardown as scope finalizers in `acquire` leave this as
+ *   `() => Effect.void`.
  * - `onAcquired` — Message dispatched when `acquire` succeeds.
  * - `onAcquireError` — Message dispatched when `acquire` fails.
- * - `onReleased` — Message dispatched after `release` completes.
+ * - `onReleased` — Message dispatched after `release` is attempted.
  *
  * @example
  * ```ts

--- a/packages/foldkit/src/runtime/managedResourceLifecycle.test.ts
+++ b/packages/foldkit/src/runtime/managedResourceLifecycle.test.ts
@@ -16,13 +16,15 @@ class EngineService extends Context.Service<EngineService, EngineShape>()(
   'EngineService',
 ) {}
 
-const FAIL_ID = 'fail'
+const ACQUIRE_FAILURE_ID = 'acquire-failure'
+const RELEASE_DEFECT_ID = 'release-defect'
 const LAYER_BUILD_ERROR = 'engine layer failed to build'
+const RELEASE_ERROR = 'engine release failed'
 
 let log: Array<string> = []
 
 const acquireEngine = (id: string): Effect.Effect<EngineShape, Error> => {
-  if (id === FAIL_ID) {
+  if (id === ACQUIRE_FAILURE_ID) {
     return Effect.fail(new Error(LAYER_BUILD_ERROR))
   } else {
     return Effect.sync(() => {
@@ -41,6 +43,19 @@ const makeEngineLayer = (id: string): Layer.Layer<EngineService, Error> =>
       }),
     ),
   )
+
+const releaseEngine = ({ id }: EngineShape) =>
+  Effect.gen(function* () {
+    yield* Effect.sync(() => {
+      log.push('release')
+    })
+
+    if (id === RELEASE_DEFECT_ID) {
+      yield* Effect.sync(() => {
+        throw new Error(RELEASE_ERROR)
+      })
+    }
+  })
 
 const Engine = ManagedResource.tag<EngineShape>()('Engine')
 type EngineServiceId = ManagedResource.ServiceOf<typeof Engine>
@@ -105,10 +120,7 @@ const managedResources = make<Model, Message>()(entry => ({
       Layer.build(makeEngineLayer(id)).pipe(
         Effect.map(context => Context.get(context, EngineService)),
       ),
-    release: () =>
-      Effect.sync(() => {
-        log.push('release')
-      }),
+    release: releaseEngine,
     onAcquired: () => Message.AcquiredEngine(),
     onReleased: () => Message.ReleasedEngine(),
     onAcquireError: error => Message.FailedEngine({ error: String(error) }),
@@ -241,7 +253,7 @@ describe('managed resource lifecycle with a Layer-built resource', () => {
   })
 
   it('dispatches onAcquireError and leaves the ref empty when acquire fails', async () => {
-    const element = startEngineApp(FAIL_ID)
+    const element = startEngineApp(ACQUIRE_FAILURE_ID)
     const fiber = Effect.runFork(element.start())
 
     try {
@@ -268,6 +280,25 @@ describe('managed resource lifecycle with a Layer-built resource', () => {
       await awaitLogEntry('finalize:a')
 
       expect(log).toStrictEqual(['build:a', 'release', 'finalize:a'])
+    } finally {
+      await Effect.runPromise(Fiber.interrupt(fiber))
+    }
+  })
+
+  it('clears the ref and dispatches onReleased after a release defect', async () => {
+    const element = startEngineApp(RELEASE_DEFECT_ID)
+    const fiber = Effect.runFork(element.start())
+
+    try {
+      await awaitBodyText('status:acquired')
+
+      clickButton('stop')
+      await awaitBodyText('status:released')
+
+      expect(document.body.textContent).not.toContain('Crash view')
+
+      clickButton('read')
+      await awaitBodyText('value:unavailable')
     } finally {
       await Effect.runPromise(Fiber.interrupt(fiber))
     }

--- a/packages/foldkit/src/runtime/runtime.ts
+++ b/packages/foldkit/src/runtime/runtime.ts
@@ -3445,10 +3445,12 @@ const makeRuntime = <
 
             const release = (value: unknown) =>
               Effect.gen(function* () {
-                yield* config.release(value)
+                yield* config
+                  .release(value)
+                  .pipe(Effect.catchCause(() => Effect.void))
                 yield* Ref.set(resourceRef, Option.none())
                 yield* enqueueMessageEffect(config.onReleased())
-              }).pipe(Effect.catchCause(() => Effect.void))
+              })
 
             return pipe(
               Stream.scoped(


### PR DESCRIPTION
A defect in a ManagedResource release skipped clearing its reference and dispatching onReleased, leaving the Model and Command service with a dead handle.

Catch defects only around the user-provided release effect so runtime bookkeeping always runs.

Fixes #1180