### PR TITLE
feat(foldkit): accept ChildAttribute in custom element attribute arrays

### DIFF
--- a/.changeset/custom-element-child-attributes.md
+++ b/.changeset/custom-element-child-attributes.md
@@ -1,0 +1,9 @@
+---
+'foldkit': minor
+---
+
+Accept `ChildAttribute` in a custom element's attribute array.
+
+An `ElementBuilder` minted by `CustomElement.define` typed its attributes as `ReadonlyArray<Attribute<Message>>`, while every html element builder accepts `ReadonlyArray<Attribute<Message> | ChildAttribute>`. Spreading a Submodel's published `childAttributes` group into `h.div` typechecked, but spreading the same group into a defined custom element was rejected, even though the runtime routes a `ChildAttribute` through its originating Submodel's boundary regardless of the element's tag. Wrappers that forward caller attributes into a custom element inherited the narrowing, so their own attribute parameters could not accept published groups either.
+
+The builder's call signature now accepts the union, matching the html element builders. Nothing changes at runtime.

--- a/packages/foldkit/src/customElement/customElement.test.ts
+++ b/packages/foldkit/src/customElement/customElement.test.ts
@@ -3,11 +3,15 @@ import { expect } from 'vitest'
 
 import { describe, it } from '@effect/vitest'
 
+import { beginRender, createBoundaryRegistry } from '../html/boundary.js'
+import { type ChildAttribute, childAttributes } from '../html/childAttribute.js'
 import {
+  type Html,
   __htmlBuilder,
   __clearRuntime as clearHtmlRuntime,
   __setRuntime as setHtmlRuntime,
 } from '../html/index.js'
+import { defineView, submodel as submodelImpl } from '../html/submodel.js'
 import { defineMessageUnion } from '../message/index.js'
 import { MountTracker } from '../mount/index.js'
 import { propsModule } from '../propsModule.js'
@@ -196,6 +200,83 @@ describe('CustomElement.define', () => {
       'change-rating',
       'clear-rating',
     ])
+  })
+})
+
+describe('ElementBuilder ChildAttribute support', () => {
+  type ChildClicked = Readonly<{ _tag: 'ChildClicked' }>
+  type GotChild = Readonly<{ _tag: 'GotChild'; message: ChildClicked }>
+
+  const GotChild = (args: { message: ChildClicked }): GotChild => ({
+    _tag: 'GotChild',
+    ...args,
+  })
+
+  it('routes a published ChildAttribute OnClick through the Submodel boundary when spread into a custom element', () => {
+    // Mirrors the childAttributes scenario: a Submodel publishes an
+    // attribute group and the consumer spreads it into an element built
+    // in the parent's boundary. Here the consumer's element is a defined
+    // custom element rather than an html builder element, so this locks
+    // in both halves: the ElementBuilder signature accepts the union,
+    // and the runtime routes the handler through the Submodel's wrap.
+    const registry = createBoundaryRegistry()
+    const { dispatch, dispatched } = createCapturingDispatch()
+    const testContext = Context.make(Dispatch, dispatch).pipe(
+      Context.add(MountTracker, {
+        started: () => {},
+        ended: () => {},
+      }),
+    )
+
+    setHtmlRuntime(dispatch.dispatchSync, testContext, registry)
+    beginRender(registry)
+    try {
+      type ControlViewInputs = Readonly<{
+        toView: (attributes: { control: ReadonlyArray<ChildAttribute> }) => Html
+      }>
+
+      const fakeControlView = defineView<
+        object,
+        ChildClicked,
+        ControlViewInputs
+      >((_model, viewInputs) => {
+        const h = __htmlBuilder<ChildClicked>()
+        return viewInputs.toView({
+          control: childAttributes([h.OnClick({ _tag: 'ChildClicked' })]),
+        })
+      })
+
+      const result = submodelImpl(
+        {
+          slotId: 'fake-control',
+          model: {},
+          view: fakeControlView,
+          viewInputs: {
+            toView: attributes => {
+              const rating = emojiRating.withMessage(__htmlBuilder<Message>())
+              return rating([...attributes.control, rating.Value(3)])
+            },
+          },
+          toParentMessage: message => GotChild({ message }),
+        },
+        __htmlBuilder(),
+      )
+      if (result === null) {
+        throw new Error('submodel returned null Html')
+      }
+
+      const element = patchInto(result)
+      expect(element.tagName).toBe('FK-EMOJI-RATING')
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+      expect((element as unknown as { value: number }).value).toBe(3)
+
+      element.dispatchEvent(new Event('click'))
+      expect(dispatched).toStrictEqual([
+        { _tag: 'GotChild', message: { _tag: 'ChildClicked' } },
+      ])
+    } finally {
+      clearHtmlRuntime()
+    }
   })
 })
 

--- a/packages/foldkit/src/customElement/index.ts
+++ b/packages/foldkit/src/customElement/index.ts
@@ -1,6 +1,12 @@
 import { Array, type Schema, String, pipe } from 'effect'
 
-import type { Attribute, Child, Html, HtmlBuilder } from '../html/index.js'
+import type {
+  Attribute,
+  Child,
+  ChildAttribute,
+  Html,
+  HtmlBuilder,
+} from '../html/index.js'
 import {
   OnCustomEvent,
   Prop,
@@ -41,13 +47,16 @@ type EventFactories<Message, Events extends Record<string, Schema.Top>> = {
 
 /** Typed call site for a defined custom element. The element constructor
  *  itself is callable; each declared property gets a PascalCase factory
- *  method, and each declared event gets an `On{PascalCase}` factory method. */
+ *  method, and each declared event gets an `On{PascalCase}` factory method.
+ *  The attribute array accepts {@link ChildAttribute} alongside
+ *  `Attribute<Message>`, like every html element builder, so a Submodel's
+ *  published attribute groups can be spread into a custom element. */
 export type ElementBuilder<
   Message,
   Properties extends Record<string, Schema.Top>,
   Events extends Record<string, Schema.Top>,
 > = ((
-  attributes?: ReadonlyArray<Attribute<Message>>,
+  attributes?: ReadonlyArray<Attribute<Message> | ChildAttribute>,
   children?: ReadonlyArray<Child>,
 ) => Html) &
   PropertyFactories<Message, Properties> &
@@ -195,7 +204,7 @@ export const define = <
     const createVNode = customElementVNode<unknown>()(config.tag)
 
     const elementFn = (
-      attributes: ReadonlyArray<Attribute<unknown>> = [],
+      attributes: ReadonlyArray<Attribute<unknown> | ChildAttribute> = [],
       children: ReadonlyArray<Child> = [],
     ): Html => createVNode(attributes, children)
 


### PR DESCRIPTION
An `ElementBuilder` minted by `CustomElement.define` typed its attributes as `ReadonlyArray<Attribute<Message>>`, while every html element builder accepts `ReadonlyArray<Attribute<Message> | ChildAttribute>`. A Submodel's published `childAttributes` group could be spread into `h.div` but not into a defined custom element, and wrappers forwarding caller attributes into a custom element inherited the narrowing.

The vnode factory the builder delegates to already accepts the union, and `buildVNodeData` routes each `ChildAttribute` through its originating Submodel's boundary without looking at the tag. Widen the `ElementBuilder` call signature and the internal `elementFn` parameter to match. Nothing changes at runtime.