### PR TITLE
feat(oxlint-plugin)!: flag decision-time nondeterminism

### DIFF
--- a/.changeset/pure-command-arguments.md
+++ b/.changeset/pure-command-arguments.md
@@ -1,0 +1,8 @@
+---
+'@foldkit/oxlint-plugin': minor
+'create-foldkit-app': patch
+---
+
+Add `foldkit/no-impure-call-at-decision-time`, which flags direct time and randomness calls unless they appear inside a recognized deferred Effect or lifecycle execution callback. The rule reports a call whether it appears directly in Command args or is assigned to a local variable first. It respects shadowed globals, stays off in tests, runtime entry files, and host server files, and is enabled by the recommended preset used in newly scaffolded apps.
+
+This can introduce lint failures in existing applications that use the recommended or all preset. Move reported calls into an Effect or lifecycle execution callback, then return generated values through Messages. Consumers can temporarily disable the rule while migrating.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -65,6 +65,7 @@
         "foldkit/no-duplicate-onmount-per-element": "error",
         "foldkit/no-hand-rolled-command-struct": "error",
         "foldkit/no-hardcoded-route-strings": "error",
+        "foldkit/no-impure-call-at-decision-time": "error",
         "foldkit/no-raw-dom-event-attributes": "error",
         "foldkit/no-spread-in-evo": "error",
         "foldkit/require-rel-for-external-link": "error",
@@ -74,11 +75,30 @@
     },
     {
       "files": [
+        "**/entry.ts",
+        "**/entry.tsx",
+        "**/entry.client.ts",
+        "**/entry.client.tsx",
+        "**/entry.server.ts",
+        "**/entry.server.tsx",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "examples/slow-warnings/src/main.ts"
+      ],
+      "rules": {
+        "foldkit/no-impure-call-at-decision-time": "off"
+      }
+    },
+    {
+      "files": [
         "**/entry.server.ts",
         "**/entry.server.tsx",
         "**/server/**/*.ts",
         "**/server/**/*.tsx",
-        "**/prerender.ts"
+        "**/prerender.ts",
+        "**/prerender.tsx"
       ],
       "excludeFiles": [
         "**/*.test.ts",
@@ -87,7 +107,8 @@
         "**/*.spec.tsx"
       ],
       "rules": {
-        "foldkit/no-nonportable-server-globals": "error"
+        "foldkit/no-nonportable-server-globals": "error",
+        "foldkit/no-impure-call-at-decision-time": "off"
       }
     }
   ],

--- a/packages/create-foldkit-app/templates/base/FOLDKIT.md
+++ b/packages/create-foldkit-app/templates/base/FOLDKIT.md
@@ -84,9 +84,11 @@ Omit the children argument when an element has none: `h.div([h.Class('divider')]
 
 Define a Command with `Command.define(name, { args, messages, execute })`; omit `args` when the Command takes none. Assign definitions to PascalCase constants. Never inline in pipe chains. Name the effect `execute` performs, not the later Model transition caused when update handles its result: a timer that only waits before update starts a dismissal is `WaitBeforeDismissal`, not `DismissAfter`. Commands catch all errors via `Effect.catch(() => Effect.succeed(Message.FailedX(...)))` so side effects never crash the app. Definitions live colocated with the update function that returns them.
 
+Command args contain values already present in the Model or Message. Calling `Date.now()`, `crypto.randomUUID()`, or another source of time or randomness while preparing a Command happens before the Command executes, whether the call appears directly in the args object or its result is assigned to a local variable first. Obtain those values in `execute` and return them in the result Message.
+
 For the with-args shape, see `repos/foldkit/examples/weather/src/main.ts` or `repos/foldkit/examples/kanban/src/command.ts`. For an argless DOM-side-effect Command, the argless form in `kanban/src/command.ts` (`FocusAddCardInput`) is the canonical reference.
 
-For DOM operations (focus, scroll, modals, scroll lock), Foldkit ships a `Dom` module. For time, randomness, UUIDs, and delays, use Effect's built-ins directly (`Clock`, `Random`, `Effect.uuid`, `Effect.sleep`). Don't reach for raw `document.querySelector`, `setTimeout`, `Date.now()`, or `Math.random()`.
+For DOM operations (focus, scroll, modals, scroll lock), Foldkit ships a `Dom` module. For time, randomness, UUIDs, and delays, use Effect's APIs directly (`Clock`, `Random`, `Crypto.Crypto`, `Effect.sleep`). Provide the platform Crypto layer when using `Crypto.Crypto`. Don't reach for raw `document.querySelector`, `setTimeout`, `Date.now()`, or `Math.random()`.
 
 ### File Organization
 

--- a/packages/oxlint-plugin-foldkit/src/guards.ts
+++ b/packages/oxlint-plugin-foldkit/src/guards.ts
@@ -1,5 +1,5 @@
 import { Array, Option } from 'effect'
-import { type ESTree } from 'effect-oxlint'
+import { type ESTree, type OxlintScope, type Reference } from 'effect-oxlint'
 
 export const isIdentifier = (
   node: unknown,
@@ -12,6 +12,10 @@ export const isIdentifier = (
   'name' in node &&
   typeof node.name === 'string' &&
   (name === undefined || node.name === name)
+
+export const isIdentifierReference = (
+  node: unknown,
+): node is ESTree.IdentifierReference => isIdentifier(node)
 
 export const isStringLiteral = (node: unknown): node is ESTree.StringLiteral =>
   typeof node === 'object' &&
@@ -39,12 +43,7 @@ export const isCallExpression = (
 
 export const isMemberExpression = (
   node: unknown,
-): node is Readonly<{
-  type: 'MemberExpression'
-  object: unknown
-  property: unknown
-  computed?: boolean
-}> =>
+): node is ESTree.MemberExpression =>
   typeof node === 'object' &&
   node !== null &&
   'type' in node &&
@@ -57,6 +56,14 @@ export const isObjectExpression = (
   node !== null &&
   'type' in node &&
   node.type === 'ObjectExpression'
+
+export const isObjectProperty = (
+  node: unknown,
+): node is ESTree.ObjectProperty =>
+  typeof node === 'object' &&
+  node !== null &&
+  'type' in node &&
+  node.type === 'Property'
 
 export const isArrayExpression = (
   node: unknown,
@@ -105,6 +112,55 @@ export const staticStringValue = (node: unknown): Option.Option<string> => {
     )
   }
   return Option.none()
+}
+
+export const staticMemberName = (
+  node: ESTree.MemberExpression,
+): Option.Option<string> => {
+  if (!node.computed && isIdentifier(node.property)) {
+    return Option.some(node.property.name)
+  }
+  return staticStringValue(node.property)
+}
+
+export const staticPropertyName = (
+  property: Readonly<{
+    computed?: boolean
+    key: ESTree.PropertyKey
+  }>,
+): Option.Option<string> => {
+  if (!property.computed && isIdentifier(property.key)) {
+    return Option.some(property.key.name)
+  }
+  return staticStringValue(property.key)
+}
+
+export const indexReferences = (
+  scopes: ReadonlyArray<OxlintScope>,
+): WeakMap<ESTree.Node, Reference> => {
+  const references = new WeakMap<ESTree.Node, Reference>()
+
+  for (const scope of scopes) {
+    for (const reference of scope.references) {
+      references.set(reference.identifier, reference)
+    }
+  }
+  return references
+}
+
+export const isUnshadowedReference = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  node: ESTree.Node,
+): boolean => {
+  if (references === undefined) {
+    return true
+  }
+
+  const reference = references.get(node)
+  return (
+    reference !== undefined &&
+    (reference.resolved === null || Array.isArrayEmpty(reference.resolved.defs))
+  )
 }
 
 export const isVariableDeclarator = (

--- a/packages/oxlint-plugin-foldkit/src/index.ts
+++ b/packages/oxlint-plugin-foldkit/src/index.ts
@@ -18,6 +18,7 @@ import { noEmptyObjectTaggedCall } from './rules/no-empty-object-tagged-call.ts'
 import { noEmptyToParentOutMessage } from './rules/no-empty-to-parent-out-message.ts'
 import { noHandRolledCommandStruct } from './rules/no-hand-rolled-command-struct.ts'
 import { noHardcodedRouteStrings } from './rules/no-hardcoded-route-strings.ts'
+import { noImpureCallAtDecisionTime } from './rules/no-impure-call-at-decision-time.ts'
 import { noModuleLevelMutableState } from './rules/no-module-level-mutable-state.ts'
 import { noNonportableServerGlobals } from './rules/no-nonportable-server-globals.ts'
 import { noNoopMessage } from './rules/no-noop-message.ts'
@@ -50,6 +51,7 @@ const basePlugin = Plugin.define({
     'no-empty-object-tagged-call': noEmptyObjectTaggedCall,
     'no-hand-rolled-command-struct': noHandRolledCommandStruct,
     'no-hardcoded-route-strings': noHardcodedRouteStrings,
+    'no-impure-call-at-decision-time': noImpureCallAtDecisionTime,
     'no-module-level-mutable-state': noModuleLevelMutableState,
     'no-nonportable-server-globals': noNonportableServerGlobals,
     'no-noop-message': noNoopMessage,
@@ -86,13 +88,34 @@ const serverFilePatterns = [
   '**/server/**/*.ts',
   '**/server/**/*.tsx',
   '**/prerender.ts',
+  '**/prerender.tsx',
 ]
+
+const entryFilePatterns = [
+  '**/entry.ts',
+  '**/entry.tsx',
+  '**/entry.client.ts',
+  '**/entry.client.tsx',
+  '**/entry.server.ts',
+  '**/entry.server.tsx',
+]
+
+const decisionTimeRuleId = 'foldkit/no-impure-call-at-decision-time'
 
 const serverOverride: Override = {
   files: serverFilePatterns,
   excludeFiles: testFilePatterns,
   rules: {
     'foldkit/no-nonportable-server-globals': 'error',
+    [decisionTimeRuleId]: 'off',
+  },
+}
+
+const entryOverride: Override = {
+  files: entryFilePatterns,
+  excludeFiles: testFilePatterns,
+  rules: {
+    [decisionTimeRuleId]: 'off',
   },
 }
 
@@ -117,7 +140,7 @@ const withOverrides = (config: Plugin.OxlintConfig): OverriddenConfig => ({
     ...config.rules,
     'foldkit/no-nonportable-server-globals': 'off',
   },
-  overrides: [serverOverride, testOverride(config)],
+  overrides: [serverOverride, entryOverride, testOverride(config)],
 })
 
 export default {

--- a/packages/oxlint-plugin-foldkit/src/message.ts
+++ b/packages/oxlint-plugin-foldkit/src/message.ts
@@ -1,7 +1,12 @@
 import { Option } from 'effect'
 import { type ESTree } from 'effect-oxlint'
 
-import { isIdentifier, isObjectExpression, isStringLiteral } from './guards.ts'
+import {
+  isIdentifier,
+  isObjectExpression,
+  isStringLiteral,
+  staticPropertyName,
+} from './guards.ts'
 
 const foldkitMessageModule = 'foldkit/message'
 
@@ -10,24 +15,6 @@ export type MessageCase = Readonly<{
   nameNode: ESTree.Node
   fields: ESTree.ObjectExpression
 }>
-
-const staticPropertyName = (
-  property: ESTree.ObjectPropertyKind,
-): Option.Option<Readonly<{ name: string; node: ESTree.Node }>> => {
-  if (property.type !== 'Property') {
-    return Option.none()
-  }
-
-  if (!property.computed && isIdentifier(property.key)) {
-    return Option.some({ name: property.key.name, node: property.key })
-  }
-
-  if (isStringLiteral(property.key)) {
-    return Option.some({ name: property.key.value, node: property.key })
-  }
-
-  return Option.none()
-}
 
 export const recordFoldkitMessageUnionBindings = (
   bindings: Set<string>,
@@ -74,19 +61,19 @@ export const messageCases = (
   }
 
   return casesByTag.properties.flatMap(property => {
+    if (property.type !== 'Property') {
+      return []
+    }
+
     const maybeName = staticPropertyName(property)
-    if (
-      property.type !== 'Property' ||
-      Option.isNone(maybeName) ||
-      !isObjectExpression(property.value)
-    ) {
+    if (Option.isNone(maybeName) || !isObjectExpression(property.value)) {
       return []
     }
 
     return [
       {
-        name: maybeName.value.name,
-        nameNode: maybeName.value.node,
+        name: maybeName.value,
+        nameNode: property.key,
         fields: property.value,
       },
     ]

--- a/packages/oxlint-plugin-foldkit/src/rules/no-empty-commands-array.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-empty-commands-array.ts
@@ -3,27 +3,12 @@ import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
 
 import {
   isArrayExpression,
-  isIdentifier,
   isObjectExpression,
-  staticStringValue,
+  isObjectProperty,
+  staticPropertyName,
 } from '../guards.ts'
 
 const COMMANDS_PROPERTY = 'commands'
-
-const isObjectProperty = (node: unknown): node is ESTree.ObjectProperty =>
-  typeof node === 'object' &&
-  node !== null &&
-  'type' in node &&
-  node.type === 'Property'
-
-const staticPropertyName = (
-  property: ESTree.ObjectProperty,
-): Option.Option<string> => {
-  if (!property.computed && isIdentifier(property.key)) {
-    return Option.some(property.key.name)
-  }
-  return staticStringValue(property.key)
-}
 
 const isEmptyCommandsProperty = (property: ESTree.ObjectProperty): boolean =>
   Option.contains(staticPropertyName(property), COMMANDS_PROPERTY) &&

--- a/packages/oxlint-plugin-foldkit/src/rules/no-empty-to-parent-out-message.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-empty-to-parent-out-message.ts
@@ -2,34 +2,21 @@ import { Array, Effect, Option } from 'effect'
 import {
   Diagnostic,
   type ESTree,
-  type OxlintScope,
   type Reference,
   Rule,
   RuleContext,
 } from 'effect-oxlint'
 
 import {
-  isIdentifier,
+  indexReferences,
+  isIdentifierReference,
   isObjectExpression,
-  staticStringValue,
+  isObjectProperty,
+  isUnshadowedReference,
+  staticPropertyName,
 } from '../guards.ts'
 
 const TO_PARENT_OUT_MESSAGE_PROPERTY = 'toParentOutMessage'
-
-const isObjectProperty = (node: unknown): node is ESTree.ObjectProperty =>
-  typeof node === 'object' &&
-  node !== null &&
-  'type' in node &&
-  node.type === 'Property'
-
-const staticPropertyName = (
-  property: ESTree.ObjectProperty,
-): Option.Option<string> => {
-  if (!property.computed && isIdentifier(property.key)) {
-    return Option.some(property.key.name)
-  }
-  return staticStringValue(property.key)
-}
 
 const isArrowFunctionExpression = (
   node: unknown,
@@ -51,23 +38,6 @@ const isMapperFunction = (
   (isArrowFunctionExpression(node) && !node.async) ||
   (isFunctionExpression(node) && !node.async && !node.generator)
 
-const isIdentifierReference = (
-  node: unknown,
-): node is ESTree.IdentifierReference => isIdentifier(node)
-
-const indexReferences = (
-  scopes: ReadonlyArray<OxlintScope>,
-): WeakMap<ESTree.Node, Reference> => {
-  const references = new WeakMap<ESTree.Node, Reference>()
-
-  for (const scope of scopes) {
-    for (const reference of scope.references) {
-      references.set(reference.identifier, reference)
-    }
-  }
-  return references
-}
-
 const isUnshadowedUndefined = (
   references: WeakMap<ESTree.Node, Reference> | undefined,
   node: unknown,
@@ -75,15 +45,7 @@ const isUnshadowedUndefined = (
   if (!isIdentifierReference(node) || node.name !== 'undefined') {
     return false
   }
-  if (references === undefined) {
-    return true
-  }
-
-  const reference = references.get(node)
-  return (
-    reference !== undefined &&
-    (reference.resolved === null || Array.isArrayEmpty(reference.resolved.defs))
-  )
+  return isUnshadowedReference(references, node)
 }
 
 const directlyReturnsUndefined = (

--- a/packages/oxlint-plugin-foldkit/src/rules/no-impure-call-at-decision-time.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-impure-call-at-decision-time.ts
@@ -1,0 +1,893 @@
+import { Array, Effect, Option } from 'effect'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
+
+import {
+  indexReferences,
+  isIdentifierReference,
+  isMemberExpression,
+  isObjectExpression,
+  isObjectProperty,
+  isUnshadowedReference,
+  staticMemberName,
+  staticPropertyName,
+} from '../guards.ts'
+
+type StaticPath = Readonly<{
+  root: ESTree.IdentifierReference
+  members: ReadonlyArray<string>
+}>
+
+type ImportedPath = Readonly<{
+  source: string
+  members: ReadonlyArray<string>
+}>
+
+type ImpureOperation = Readonly<{
+  display: string
+  guidance: string
+}>
+
+const globalContainers = new Set(['globalThis', 'self', 'window'])
+
+const impureCallByPath = new Map<string, ImpureOperation>([
+  [
+    'Date',
+    {
+      display: 'Date()',
+      guidance:
+        'Use Clock.currentTimeMillis and construct the Date from that value.',
+    },
+  ],
+  [
+    'Date.now',
+    {
+      display: 'Date.now()',
+      guidance: 'Use Clock.currentTimeMillis.',
+    },
+  ],
+  [
+    'Math.random',
+    {
+      display: 'Math.random()',
+      guidance: 'Use Random.',
+    },
+  ],
+  [
+    'performance.now',
+    {
+      display: 'performance.now()',
+      guidance: 'Use Clock.',
+    },
+  ],
+  [
+    'crypto.randomUUID',
+    {
+      display: 'crypto.randomUUID()',
+      guidance:
+        "Use Crypto.Crypto's randomUUIDv4 Effect with a platform Crypto layer.",
+    },
+  ],
+  [
+    'crypto.getRandomValues',
+    {
+      display: 'crypto.getRandomValues()',
+      guidance: 'Use Random or Crypto.Crypto with a platform Crypto layer.',
+    },
+  ],
+])
+
+const newDateOperation: ImpureOperation = {
+  display: 'new Date()',
+  guidance:
+    'Use Clock.currentTimeMillis and construct the Date from that value.',
+}
+
+const isFunction = (
+  node: unknown,
+): node is ESTree.ArrowFunctionExpression | ESTree.Function =>
+  typeof node === 'object' &&
+  node !== null &&
+  'type' in node &&
+  (node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'FunctionDeclaration')
+
+type TransparentExpression =
+  | ESTree.ChainExpression
+  | ESTree.ParenthesizedExpression
+  | ESTree.TSAsExpression
+  | ESTree.TSInstantiationExpression
+  | ESTree.TSNonNullExpression
+  | ESTree.TSSatisfiesExpression
+  | ESTree.TSTypeAssertion
+
+const isTransparentExpression = (
+  node: unknown,
+): node is TransparentExpression => {
+  if (typeof node !== 'object' || node === null || !('type' in node)) {
+    return false
+  }
+
+  return (
+    node.type === 'ChainExpression' ||
+    node.type === 'ParenthesizedExpression' ||
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSInstantiationExpression' ||
+    node.type === 'TSNonNullExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSTypeAssertion'
+  )
+}
+
+const innermostExpression = (node: unknown): unknown =>
+  isTransparentExpression(node) ? innermostExpression(node.expression) : node
+
+const outermostExpression = (node: ESTree.Node): ESTree.Node => {
+  const parent = node.parent
+  return isTransparentExpression(parent) && parent.expression === node
+    ? outermostExpression(parent)
+    : node
+}
+
+const staticPath = (node: unknown): Option.Option<StaticPath> => {
+  const expression = innermostExpression(node)
+  if (isIdentifierReference(expression)) {
+    return Option.some({ root: expression, members: [] })
+  }
+  if (!isMemberExpression(expression)) {
+    return Option.none()
+  }
+
+  return Option.flatMap(staticPath(expression.object), path =>
+    Option.map(staticMemberName(expression), member => ({
+      root: path.root,
+      members: [...path.members, member],
+    })),
+  )
+}
+
+const globalPathKey = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  node: unknown,
+): Option.Option<string> =>
+  Option.flatMap(staticPath(node), path => {
+    if (!isUnshadowedReference(references, path.root)) {
+      return Option.none()
+    }
+
+    const members = globalContainers.has(path.root.name)
+      ? path.members
+      : [path.root.name, ...path.members]
+    return Option.some(members.join('.'))
+  })
+
+const importedName = (node: ESTree.ImportSpecifier): Option.Option<string> =>
+  node.imported.type === 'Identifier'
+    ? Option.some(node.imported.name)
+    : Option.some(node.imported.value)
+
+const importedPath = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  node: unknown,
+): Option.Option<ImportedPath> =>
+  Option.flatMap(staticPath(node), path => {
+    if (references === undefined) {
+      return Option.some({
+        source: '',
+        members: [path.root.name, ...path.members],
+      })
+    }
+
+    const reference = references.get(path.root)
+    const maybeDefinition = Option.flatMap(
+      Option.fromNullishOr(reference?.resolved),
+      variable =>
+        Array.findFirst(
+          variable.defs,
+          definition => definition.type === 'ImportBinding',
+        ),
+    )
+
+    return Option.flatMap(maybeDefinition, definition => {
+      if (definition.parent?.type !== 'ImportDeclaration') {
+        return Option.none()
+      }
+
+      const source = definition.parent.source.value
+      if (definition.node.type === 'ImportNamespaceSpecifier') {
+        return Option.some({ source, members: path.members })
+      }
+      if (definition.node.type !== 'ImportSpecifier') {
+        return Option.none()
+      }
+
+      return Option.map(importedName(definition.node), name => ({
+        source,
+        members: [name, ...path.members],
+      }))
+    })
+  })
+
+const normalizedApiPath = (
+  path: ImportedPath,
+): Option.Option<ReadonlyArray<string>> => {
+  if (
+    path.source === '' ||
+    path.source === 'effect' ||
+    path.source === 'foldkit'
+  ) {
+    return Option.some(path.members)
+  }
+  if (path.source === 'effect/Effect') {
+    return Option.some(['Effect', ...path.members])
+  }
+  if (path.source === 'effect/Stream') {
+    return Option.some(['Stream', ...path.members])
+  }
+  if (path.source === 'foldkit/command') {
+    return Option.some(['Command', ...path.members])
+  }
+  if (path.source === 'foldkit/managedResource') {
+    return Option.some(['ManagedResource', ...path.members])
+  }
+  if (path.source === 'foldkit/mount') {
+    return Option.some(['Mount', ...path.members])
+  }
+  if (path.source === 'foldkit/subscription') {
+    return Option.some(['Subscription', ...path.members])
+  }
+  return Option.none()
+}
+
+const headCall = (node: ESTree.CallExpression): ESTree.CallExpression =>
+  node.callee.type === 'CallExpression' ? headCall(node.callee) : node
+
+const apiCallKey = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  node: ESTree.CallExpression,
+): Option.Option<string> =>
+  Option.flatMap(importedPath(references, headCall(node).callee), path =>
+    Option.map(normalizedApiPath(path), members => members.join('.')),
+  )
+
+type EnclosingCallArgument = Readonly<{
+  call: ESTree.CallExpression
+  argument: ESTree.Node
+}>
+
+const enclosingCallArgument = (
+  node: ESTree.Node,
+): Option.Option<EnclosingCallArgument> => {
+  const argument = outermostExpression(node)
+  const parent = argument.parent
+  return parent?.type === 'CallExpression' &&
+    parent.arguments.some(candidate => candidate === argument)
+    ? Option.some({ call: parent, argument })
+    : Option.none()
+}
+
+const enclosingPropertyValue = (
+  node: ESTree.Node,
+): Option.Option<ESTree.ObjectProperty> => {
+  const value = outermostExpression(node)
+  const parent = value.parent
+  return isObjectProperty(parent) && parent.value === value
+    ? Option.some(parent)
+    : Option.none()
+}
+
+const effectFunctionFactories = new Set(['Effect.fn', 'Effect.fnUntraced'])
+
+type ArgumentPositions = Readonly<[number, ...Array<number>]>
+
+type PropertyPositions = Readonly<[number, number, ...Array<string>]>
+
+type DeferredPropertyNames = true | ReadonlySet<string>
+
+type DeferredCallbackMetadata = Readonly<{
+  direct?: ReadonlyMap<number, ReadonlySet<number>>
+  properties?: ReadonlyMap<number, ReadonlyMap<number, DeferredPropertyNames>>
+}>
+
+const directByArity = (
+  ...entries: ReadonlyArray<ArgumentPositions>
+): ReadonlyMap<number, ReadonlySet<number>> =>
+  new Map(
+    entries.map(([arity, ...argumentIndices]) => [
+      arity,
+      new Set(argumentIndices),
+    ]),
+  )
+
+const propertiesByArity = (
+  ...entries: ReadonlyArray<PropertyPositions>
+): ReadonlyMap<number, ReadonlyMap<number, DeferredPropertyNames>> => {
+  const properties = new Map<number, Map<number, DeferredPropertyNames>>()
+
+  for (const [arity, argumentIndex, ...propertyNames] of entries) {
+    const byArgument = properties.get(arity) ?? new Map()
+    byArgument.set(
+      argumentIndex,
+      Array.isArrayEmpty(propertyNames) ? true : new Set(propertyNames),
+    )
+    properties.set(arity, byArgument)
+  }
+
+  return properties
+}
+
+const direct = (
+  ...entries: ReadonlyArray<ArgumentPositions>
+): DeferredCallbackMetadata => ({ direct: directByArity(...entries) })
+
+const properties = (
+  ...entries: ReadonlyArray<PropertyPositions>
+): DeferredCallbackMetadata => ({
+  properties: propertiesByArity(...entries),
+})
+
+const unaryCallback = direct([1, 0])
+const unaryDualCallback = direct([1, 0], [2, 1])
+const unaryDualCallbackWithOptions = direct([1, 0], [2, 0, 1], [3, 1])
+const binaryDualCallback = direct([2, 1], [3, 2])
+const binaryDualCallbackWithOptions = direct([2, 1], [3, 1, 2], [4, 2])
+
+const successAndFailureProperties = properties(
+  [1, 0, 'onFailure', 'onSuccess'],
+  [2, 1, 'onFailure', 'onSuccess'],
+)
+
+const taggedCallback = direct([2, 1], [3, 1, 2], [4, 2, 3])
+
+const taggedCallbackMap: DeferredCallbackMetadata = {
+  direct: directByArity([2, 1], [3, 2]),
+  properties: propertiesByArity([1, 0], [2, 0], [2, 1], [3, 1]),
+}
+
+const reasonCallback = direct([3, 2], [4, 2, 3], [5, 3, 4])
+
+const reasonCallbackMap: DeferredCallbackMetadata = {
+  direct: directByArity([3, 2], [4, 3]),
+  properties: propertiesByArity([2, 1], [3, 1], [3, 2], [4, 2]),
+}
+
+const predicateAndCallback = direct([2, 0, 1], [3, 0, 1, 2], [4, 1, 2, 3])
+
+const deferredCallbackByApi = new Map<string, DeferredCallbackMetadata>([
+  ['Effect.acquireRelease', direct([2, 1], [3, 1])],
+  ['Effect.acquireUseRelease', direct([3, 1, 2])],
+  ['Effect.addFinalizer', unaryCallback],
+  ['Effect.andThen', unaryDualCallback],
+  ['Effect.bind', binaryDualCallback],
+  ['Effect.callback', unaryCallback],
+  ['Effect.catch', unaryDualCallback],
+  ['Effect.catchCause', unaryDualCallback],
+  ['Effect.catchCauseFilter', predicateAndCallback],
+  ['Effect.catchCauseIf', predicateAndCallback],
+  ['Effect.catchDefect', unaryDualCallback],
+  ['Effect.catchFilter', predicateAndCallback],
+  ['Effect.catchIf', predicateAndCallback],
+  ['Effect.catchReason', reasonCallback],
+  ['Effect.catchReasons', reasonCallbackMap],
+  ['Effect.catchTag', taggedCallback],
+  ['Effect.catchTags', taggedCallbackMap],
+  ['Effect.clockWith', unaryCallback],
+  ['Effect.contextWith', unaryCallback],
+  ['Effect.effectify', direct([1, 0], [2, 0, 1], [3, 0, 1, 2])],
+  ['Effect.failCauseSync', unaryCallback],
+  ['Effect.failSync', unaryCallback],
+  ['Effect.filter', unaryDualCallbackWithOptions],
+  ['Effect.filterMap', unaryDualCallback],
+  ['Effect.filterMapEffect', unaryDualCallbackWithOptions],
+  ['Effect.filterMapOrElse', direct([2, 0, 1], [3, 1, 2])],
+  ['Effect.filterMapOrFail', direct([1, 0], [2, 0, 1], [3, 1, 2])],
+  ['Effect.filterOrElse', direct([2, 0, 1], [3, 1, 2])],
+  ['Effect.filterOrFail', direct([1, 0], [2, 0, 1], [3, 1, 2])],
+  ['Effect.findFirst', unaryDualCallback],
+  ['Effect.findFirstFilter', unaryDualCallback],
+  ['Effect.flatMap', unaryDualCallback],
+  ['Effect.forEach', unaryDualCallbackWithOptions],
+  ['Effect.gen', direct([1, 0], [2, 1])],
+  ['Effect.interruptibleMask', unaryCallback],
+  ['Effect.let', binaryDualCallback],
+  ['Effect.map', unaryDualCallback],
+  ['Effect.mapBoth', successAndFailureProperties],
+  ['Effect.mapError', unaryDualCallback],
+  ['Effect.match', successAndFailureProperties],
+  ['Effect.matchCause', successAndFailureProperties],
+  ['Effect.matchCauseEffect', successAndFailureProperties],
+  ['Effect.matchEffect', successAndFailureProperties],
+  ['Effect.onError', unaryDualCallback],
+  ['Effect.onErrorFilter', predicateAndCallback],
+  ['Effect.onErrorIf', predicateAndCallback],
+  ['Effect.onExit', unaryDualCallback],
+  ['Effect.onExitFilter', predicateAndCallback],
+  ['Effect.onExitIf', predicateAndCallback],
+  ['Effect.onExitPrimitive', direct([2, 1], [3, 1])],
+  ['Effect.onInterrupt', unaryDualCallback],
+  ['Effect.orElseSucceed', unaryDualCallback],
+  ['Effect.partition', unaryDualCallbackWithOptions],
+  ['Effect.promise', unaryCallback],
+  ['Effect.reduce', direct([2, 0, 1], [3, 1, 2])],
+  [
+    'Effect.repeat',
+    properties([1, 0, 'while', 'until'], [2, 1, 'while', 'until']),
+  ],
+  ['Effect.repeatOrElse', binaryDualCallback],
+  [
+    'Effect.retry',
+    properties([1, 0, 'while', 'until'], [2, 1, 'while', 'until']),
+  ],
+  ['Effect.retryOrElse', binaryDualCallback],
+  ['Effect.scopedWith', unaryCallback],
+  ['Effect.suspend', unaryCallback],
+  ['Effect.sync', unaryCallback],
+  ['Effect.tap', unaryDualCallback],
+  ['Effect.tapCause', unaryDualCallback],
+  ['Effect.tapCauseFilter', predicateAndCallback],
+  ['Effect.tapCauseIf', predicateAndCallback],
+  ['Effect.tapDefect', unaryDualCallback],
+  ['Effect.tapError', unaryDualCallback],
+  ['Effect.tapErrorTag', taggedCallback],
+  ['Effect.timeoutOrElse', properties([1, 0, 'orElse'], [2, 1, 'orElse'])],
+  ['Effect.track', direct([2, 1], [3, 2])],
+  ['Effect.trackDefects', direct([2, 1], [3, 2])],
+  ['Effect.trackDuration', direct([2, 1], [3, 2])],
+  ['Effect.trackErrors', direct([2, 1], [3, 2])],
+  ['Effect.trackSuccesses', direct([2, 1], [3, 2])],
+  [
+    'Effect.try',
+    {
+      direct: directByArity([1, 0]),
+      properties: propertiesByArity([1, 0, 'try', 'catch']),
+    },
+  ],
+  [
+    'Effect.tryPromise',
+    {
+      direct: directByArity([1, 0]),
+      properties: propertiesByArity([1, 0, 'try', 'catch']),
+    },
+  ],
+  ['Effect.uninterruptibleMask', unaryCallback],
+  ['Effect.updateContext', unaryDualCallback],
+  ['Effect.updateService', binaryDualCallback],
+  [
+    'Effect.updateServiceScoped',
+    {
+      direct: directByArity([2, 1], [3, 1]),
+      properties: propertiesByArity([3, 2, 'reset']),
+    },
+  ],
+  ['Effect.useSpan', direct([2, 1], [3, 2])],
+  ['Effect.validate', unaryDualCallbackWithOptions],
+  ['Effect.whileLoop', properties([1, 0, 'while', 'body', 'step'])],
+  [
+    'Effect.withExecutionPlan',
+    properties([2, 1, 'onEvent'], [3, 2, 'onEvent']),
+  ],
+  ['Effect.withFiber', unaryCallback],
+  ['Effect.zipWith', binaryDualCallbackWithOptions],
+  ['Effect.race', properties([2, 1, 'onWinner'], [3, 2, 'onWinner'])],
+  ['Effect.raceFirst', properties([2, 1, 'onWinner'], [3, 2, 'onWinner'])],
+  ['Effect.raceAll', properties([2, 1, 'onWinner'])],
+  ['Effect.raceAllFirst', properties([2, 1, 'onWinner'])],
+  ['Stream.bind', binaryDualCallbackWithOptions],
+  ['Stream.bindEffect', binaryDualCallbackWithOptions],
+  ['Stream.callback', unaryCallback],
+  ['Stream.catch', unaryDualCallback],
+  ['Stream.catchCause', unaryDualCallback],
+  ['Stream.catchCauseFilter', predicateAndCallback],
+  ['Stream.catchCauseIf', predicateAndCallback],
+  ['Stream.catchFilter', predicateAndCallback],
+  ['Stream.catchIf', predicateAndCallback],
+  ['Stream.catchReason', reasonCallback],
+  ['Stream.catchReasons', reasonCallbackMap],
+  ['Stream.catchTag', taggedCallback],
+  ['Stream.catchTags', taggedCallbackMap],
+  ['Stream.changesWith', unaryDualCallback],
+  ['Stream.changesWithEffect', unaryDualCallback],
+  ['Stream.combine', direct([3, 1, 2], [4, 2, 3])],
+  ['Stream.combineArray', direct([3, 1, 2], [4, 2, 3])],
+  ['Stream.crossWith', binaryDualCallback],
+  ['Stream.dropUntil', unaryDualCallback],
+  ['Stream.dropUntilEffect', unaryDualCallback],
+  ['Stream.dropWhile', unaryDualCallback],
+  ['Stream.dropWhileEffect', unaryDualCallback],
+  ['Stream.dropWhileFilter', unaryDualCallback],
+  ['Stream.failCauseSync', unaryCallback],
+  ['Stream.failSync', unaryCallback],
+  ['Stream.filter', unaryDualCallback],
+  ['Stream.filterEffect', unaryDualCallback],
+  ['Stream.filterMap', unaryDualCallback],
+  ['Stream.filterMapEffect', unaryDualCallback],
+  ['Stream.flatMap', unaryDualCallbackWithOptions],
+  ['Stream.fromAsyncIterable', direct([2, 1])],
+  ['Stream.fromReadableStream', properties([1, 0, 'evaluate', 'onError'])],
+  ['Stream.groupAdjacentBy', unaryDualCallback],
+  ['Stream.groupBy', unaryDualCallbackWithOptions],
+  ['Stream.groupByKey', unaryDualCallbackWithOptions],
+  ['Stream.iterate', direct([2, 1])],
+  ['Stream.limitBytes', direct([2, 1], [3, 2])],
+  ['Stream.map', unaryDualCallback],
+  [
+    'Stream.mapAccum',
+    {
+      direct: directByArity([2, 0, 1], [3, 0, 1, 2], [4, 1, 2]),
+      properties: propertiesByArity([3, 2, 'onHalt'], [4, 3, 'onHalt']),
+    },
+  ],
+  [
+    'Stream.mapAccumArray',
+    {
+      direct: directByArity([2, 0, 1], [3, 0, 1, 2], [4, 1, 2]),
+      properties: propertiesByArity([3, 2, 'onHalt'], [4, 3, 'onHalt']),
+    },
+  ],
+  [
+    'Stream.mapAccumArrayEffect',
+    {
+      direct: directByArity([2, 0, 1], [3, 0, 1, 2], [4, 1, 2]),
+      properties: propertiesByArity([3, 2, 'onHalt'], [4, 3, 'onHalt']),
+    },
+  ],
+  [
+    'Stream.mapAccumEffect',
+    {
+      direct: directByArity([2, 0, 1], [3, 0, 1, 2], [4, 1, 2]),
+      properties: propertiesByArity([3, 2, 'onHalt'], [4, 3, 'onHalt']),
+    },
+  ],
+  ['Stream.mapArray', unaryDualCallback],
+  ['Stream.mapArrayEffect', unaryDualCallback],
+  ['Stream.mapBoth', successAndFailureProperties],
+  ['Stream.mapEffect', unaryDualCallbackWithOptions],
+  ['Stream.mapError', unaryDualCallback],
+  ['Stream.let', binaryDualCallback],
+  ['Stream.onError', unaryDualCallback],
+  ['Stream.onExit', unaryDualCallback],
+  ['Stream.onFirst', unaryDualCallback],
+  ['Stream.orElseIfEmpty', unaryDualCallback],
+  ['Stream.orElseSucceed', unaryDualCallback],
+  ['Stream.paginate', direct([2, 1])],
+  ['Stream.partition', unaryDualCallbackWithOptions],
+  ['Stream.partitionEffect', unaryDualCallbackWithOptions],
+  ['Stream.partitionQueue', unaryDualCallbackWithOptions],
+  ['Stream.runFold', direct([2, 0, 1], [3, 1, 2])],
+  ['Stream.runFoldEffect', direct([2, 0, 1], [3, 1, 2])],
+  ['Stream.runForEach', unaryDualCallback],
+  ['Stream.runForEachArray', unaryDualCallback],
+  ['Stream.runForEachWhile', unaryDualCallback],
+  ['Stream.scan', direct([2, 1], [3, 2])],
+  ['Stream.scanEffect', direct([2, 1], [3, 2])],
+  ['Stream.split', unaryDualCallback],
+  ['Stream.suspend', unaryCallback],
+  ['Stream.switchMap', unaryDualCallbackWithOptions],
+  ['Stream.sync', unaryCallback],
+  ['Stream.takeUntil', unaryDualCallbackWithOptions],
+  ['Stream.takeUntilEffect', unaryDualCallbackWithOptions],
+  ['Stream.takeWhile', unaryDualCallback],
+  ['Stream.takeWhileEffect', unaryDualCallback],
+  ['Stream.takeWhileFilter', unaryDualCallback],
+  ['Stream.tap', unaryDualCallbackWithOptions],
+  [
+    'Stream.tapBoth',
+    properties([1, 0, 'onElement', 'onError'], [2, 1, 'onElement', 'onError']),
+  ],
+  ['Stream.tapCause', unaryDualCallback],
+  ['Stream.tapError', unaryDualCallback],
+  ['Stream.throttle', properties([1, 0, 'cost'], [2, 1, 'cost'])],
+  ['Stream.throttleEffect', properties([1, 0, 'cost'], [2, 1, 'cost'])],
+  ['Stream.timeoutOrElse', properties([1, 0, 'orElse'], [2, 1, 'orElse'])],
+  ['Stream.transformPull', direct([2, 1])],
+  ['Stream.transformPullBracket', direct([2, 1])],
+  ['Stream.unfold', direct([2, 1])],
+  ['Stream.updateContext', unaryDualCallback],
+  ['Stream.updateService', binaryDualCallback],
+  [
+    'Stream.withExecutionPlan',
+    properties([2, 1, 'onEvent'], [3, 2, 'onEvent']),
+  ],
+  ['Stream.zipLatestWith', binaryDualCallback],
+  ['Stream.zipWith', binaryDualCallback],
+  ['Stream.zipWithArray', binaryDualCallback],
+])
+
+const isEffectFunctionBody = (
+  argument: ESTree.Node,
+  call: ESTree.CallExpression,
+): boolean => {
+  const maybeFirstArgument = Array.head(call.arguments)
+  if (Option.contains(maybeFirstArgument, argument)) {
+    return true
+  }
+
+  return (
+    Option.exists(maybeFirstArgument, argument =>
+      isObjectExpression(innermostExpression(argument)),
+    ) && Option.contains(Array.get(call.arguments, 1), argument)
+  )
+}
+
+const isDeferredDirectEffectApiCallback = (
+  argument: ESTree.Node,
+  call: ESTree.CallExpression,
+  key: string,
+): boolean => {
+  if (effectFunctionFactories.has(key)) {
+    return isEffectFunctionBody(argument, call)
+  }
+
+  const maybeArgumentIndex = Array.findFirstIndex(
+    call.arguments,
+    candidate => candidate === argument,
+  )
+  const maybePositions = Option.fromNullishOr(
+    deferredCallbackByApi.get(key)?.direct?.get(call.arguments.length),
+  )
+
+  return Option.exists(maybeArgumentIndex, argumentIndex =>
+    Option.exists(maybePositions, positions => positions.has(argumentIndex)),
+  )
+}
+
+const isDeferredObjectEffectApiCallback = (
+  property: ESTree.ObjectProperty,
+  argument: ESTree.Node,
+  call: ESTree.CallExpression,
+  key: string,
+): boolean => {
+  const maybeArgumentIndex = Array.findFirstIndex(
+    call.arguments,
+    candidate => candidate === argument,
+  )
+  const maybePropertyName = staticPropertyName(property)
+  const propertiesByArgument = deferredCallbackByApi
+    .get(key)
+    ?.properties?.get(call.arguments.length)
+
+  return Option.exists(maybeArgumentIndex, argumentIndex => {
+    const propertyNames = propertiesByArgument?.get(argumentIndex)
+    return (
+      propertyNames === true ||
+      (propertyNames !== undefined &&
+        Option.exists(maybePropertyName, propertyName =>
+          propertyNames.has(propertyName),
+        ))
+    )
+  })
+}
+
+const isEffectOrStreamCallback = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  fn: ESTree.ArrowFunctionExpression | ESTree.Function,
+): boolean => {
+  const maybeDirectCall = enclosingCallArgument(fn)
+  if (Option.isSome(maybeDirectCall)) {
+    return Option.exists(
+      apiCallKey(references, maybeDirectCall.value.call),
+      key =>
+        isDeferredDirectEffectApiCallback(
+          maybeDirectCall.value.argument,
+          maybeDirectCall.value.call,
+          key,
+        ),
+    )
+  }
+
+  const maybeProperty = enclosingPropertyValue(fn)
+  if (Option.isNone(maybeProperty)) {
+    return false
+  }
+  const property = maybeProperty.value
+
+  const object = property.parent
+  if (object.type !== 'ObjectExpression') {
+    return false
+  }
+
+  const maybeCall = enclosingCallArgument(object)
+  if (Option.isNone(maybeCall)) {
+    return false
+  }
+  const { argument, call } = maybeCall.value
+
+  return Option.exists(apiCallKey(references, call), key =>
+    isDeferredObjectEffectApiCallback(property, argument, call, key),
+  )
+}
+
+const isInlineConfigFunction = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  fn: ESTree.ArrowFunctionExpression | ESTree.Function,
+  propertyNames: ReadonlySet<string>,
+  factoryKeys: ReadonlySet<string>,
+): boolean => {
+  const maybeProperty = enclosingPropertyValue(fn)
+  if (Option.isNone(maybeProperty)) {
+    return false
+  }
+  const property = maybeProperty.value
+  if (
+    property.parent.type !== 'ObjectExpression' ||
+    !Option.exists(staticPropertyName(property), name =>
+      propertyNames.has(name),
+    )
+  ) {
+    return false
+  }
+
+  const maybeCall = enclosingCallArgument(property.parent)
+  if (Option.isNone(maybeCall)) {
+    return false
+  }
+
+  return Option.exists(apiCallKey(references, maybeCall.value.call), key =>
+    factoryKeys.has(key),
+  )
+}
+
+const hasFactoryAncestor = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  node: ESTree.Node,
+  factoryKey: string,
+): boolean => {
+  const parent = node.parent
+  if (parent === null) {
+    return false
+  }
+  if (
+    parent.type === 'CallExpression' &&
+    Option.contains(apiCallKey(references, parent), factoryKey)
+  ) {
+    return true
+  }
+  return hasFactoryAncestor(references, parent, factoryKey)
+}
+
+const isNestedLifecycleFunction = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  fn: ESTree.ArrowFunctionExpression | ESTree.Function,
+): boolean => {
+  const maybeProperty = enclosingPropertyValue(fn)
+  if (Option.isNone(maybeProperty)) {
+    return false
+  }
+  const property = maybeProperty.value
+  if (property.parent.type !== 'ObjectExpression') {
+    return false
+  }
+
+  if (Option.isNone(enclosingCallArgument(property.parent))) {
+    return false
+  }
+
+  const maybePropertyName = staticPropertyName(property)
+  const isSubscriptionEffect = Option.contains(
+    maybePropertyName,
+    'dependenciesToStream',
+  )
+  if (
+    isSubscriptionEffect &&
+    hasFactoryAncestor(references, fn, 'Subscription.make')
+  ) {
+    return true
+  }
+
+  const isManagedResourceEffect = Option.exists(
+    maybePropertyName,
+    name => name === 'acquire' || name === 'release',
+  )
+  return (
+    isManagedResourceEffect &&
+    hasFactoryAncestor(references, fn, 'ManagedResource.make')
+  )
+}
+
+const commandAndMountEffectProperties = new Set(['execute'])
+const commandAndMountFactories = new Set([
+  'Command.define',
+  'Mount.define',
+  'Mount.defineStream',
+])
+
+const isDeferredFunction = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  fn: ESTree.ArrowFunctionExpression | ESTree.Function,
+): boolean =>
+  isEffectOrStreamCallback(references, fn) ||
+  isInlineConfigFunction(
+    references,
+    fn,
+    commandAndMountEffectProperties,
+    commandAndMountFactories,
+  ) ||
+  isNestedLifecycleFunction(references, fn)
+
+const isInsideEffectBoundary = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  node: ESTree.Node,
+): boolean => {
+  const parent = node.parent
+  if (parent === null) {
+    return false
+  }
+  if (isFunction(parent) && isDeferredFunction(references, parent)) {
+    return true
+  }
+  return isInsideEffectBoundary(references, parent)
+}
+
+const callOperation = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  node: ESTree.CallExpression,
+): Option.Option<ImpureOperation> =>
+  Option.flatMap(globalPathKey(references, node.callee), key =>
+    Option.fromNullishOr(impureCallByPath.get(key)),
+  )
+
+const newOperation = (
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  node: ESTree.NewExpression,
+): Option.Option<ImpureOperation> =>
+  Array.isArrayEmpty(node.arguments) &&
+  Option.contains(globalPathKey(references, node.callee), 'Date')
+    ? Option.some(newDateOperation)
+    : Option.none()
+
+const diagnosticMessage = ({ display, guidance }: ImpureOperation): string =>
+  `${display} is outside a recognized callback that Effect or Foldkit defers until execution. ${guidance} Obtain the value in a deferred Effect or lifecycle execution callback and return it in a Message. Assigning it to a local variable or passing it as a Command argument does not defer the call.`
+
+/**
+ * Flags direct calls to known nondeterministic globals unless they appear in a
+ * recognized deferred Effect, Stream, Command, Mount, Subscription, or
+ * ManagedResource callback.
+ */
+export const noImpureCallAtDecisionTime = Rule.define({
+  name: 'no-impure-call-at-decision-time',
+  meta: Rule.meta({
+    type: 'problem',
+    description:
+      'Keep direct time and randomness calls inside deferred Effect and lifecycle execution callbacks.',
+  }),
+  create: function* () {
+    const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
+
+    const report = (
+      node: ESTree.CallExpression | ESTree.NewExpression,
+      maybeOperation: Option.Option<ImpureOperation>,
+    ) =>
+      Option.match(maybeOperation, {
+        onNone: () => Effect.void,
+        onSome: operation =>
+          isInsideEffectBoundary(references, node)
+            ? Effect.void
+            : ctx.report(
+                Diagnostic.make({
+                  node,
+                  message: diagnosticMessage(operation),
+                }),
+              ),
+      })
+
+    return {
+      CallExpression: (node: ESTree.Node) =>
+        node.type === 'CallExpression'
+          ? report(node, callOperation(references, node))
+          : Effect.void,
+      NewExpression: (node: ESTree.Node) =>
+        node.type === 'NewExpression'
+          ? report(node, newOperation(references, node))
+          : Effect.void,
+    }
+  },
+})

--- a/packages/oxlint-plugin-foldkit/src/rules/no-nonportable-server-globals.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-nonportable-server-globals.ts
@@ -1,12 +1,12 @@
-import { Array, Effect } from 'effect'
+import { Effect, Option } from 'effect'
+import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+
 import {
-  Diagnostic,
-  type ESTree,
-  type OxlintScope,
-  type Reference,
-  Rule,
-  RuleContext,
-} from 'effect-oxlint'
+  indexReferences,
+  isUnshadowedReference,
+  staticMemberName,
+  staticPropertyName,
+} from '../guards.ts'
 
 const restrictedGlobalNames: ReadonlySet<string> = new Set([
   'alert',
@@ -47,37 +47,6 @@ const isInsideTypeQuery = (node: ESTree.Node): boolean => {
   return false
 }
 
-const staticMemberName = (
-  node: ESTree.MemberExpression,
-): string | undefined => {
-  if (!node.computed && node.property.type === 'Identifier') {
-    return node.property.name
-  }
-  if (
-    node.computed &&
-    node.property.type === 'Literal' &&
-    typeof node.property.value === 'string'
-  ) {
-    return node.property.value
-  }
-  return undefined
-}
-
-const staticPropertyName = (
-  property: Readonly<{ key: ESTree.PropertyKey }>,
-): string | undefined => {
-  if (property.key.type === 'Identifier') {
-    return property.key.name
-  }
-  if (
-    property.key.type === 'Literal' &&
-    typeof property.key.value === 'string'
-  ) {
-    return property.key.value
-  }
-  return undefined
-}
-
 const destructuringSource = (
   node: ESTree.ObjectPattern | ESTree.ObjectAssignmentTarget,
 ): ESTree.Expression | null | undefined => {
@@ -108,31 +77,6 @@ const restrictedGlobalDiagnostic = (node: ESTree.Node, name: string) =>
     message: `Global \`${name}\` is not portable across Foldkit server targets. Use a server API available everywhere you deploy or pass the value into the entry.`,
   })
 
-const indexReferences = (
-  scopes: ReadonlyArray<OxlintScope>,
-): WeakMap<ESTree.Node, Reference> => {
-  const references = new WeakMap<ESTree.Node, Reference>()
-
-  for (const scope of scopes) {
-    for (const reference of scope.references) {
-      references.set(reference.identifier, reference)
-    }
-  }
-  return references
-}
-
-const isUnshadowedGlobalReference = (
-  references: WeakMap<ESTree.Node, Reference>,
-  node: ESTree.Node,
-): boolean => {
-  const reference = references.get(node)
-
-  return (
-    reference !== undefined &&
-    (reference.resolved === null || Array.isArrayEmpty(reference.resolved.defs))
-  )
-}
-
 /**
  * Flags selected browser-only globals in files that run on a server.
  */
@@ -155,7 +99,7 @@ export const noNonportableServerGlobals = Rule.define({
         ) {
           return Effect.void
         }
-        return isUnshadowedGlobalReference(references, node)
+        return isUnshadowedReference(references, node)
           ? ctx.report(restrictedGlobalDiagnostic(node, node.name))
           : Effect.void
       },
@@ -167,15 +111,15 @@ export const noNonportableServerGlobals = Rule.define({
         ) {
           return Effect.void
         }
-        const memberName = staticMemberName(node)
+        const maybeMemberName = staticMemberName(node)
         if (
-          memberName === undefined ||
-          !restrictedGlobalNames.has(memberName)
+          Option.isNone(maybeMemberName) ||
+          !restrictedGlobalNames.has(maybeMemberName.value)
         ) {
           return Effect.void
         }
-        return isUnshadowedGlobalReference(references, node.object)
-          ? ctx.report(restrictedGlobalDiagnostic(node, memberName))
+        return isUnshadowedReference(references, node.object)
+          ? ctx.report(restrictedGlobalDiagnostic(node, maybeMemberName.value))
           : Effect.void
       },
       ObjectPattern: (node: ESTree.Node) => {
@@ -190,12 +134,13 @@ export const noNonportableServerGlobals = Rule.define({
           if (property.type !== 'Property') {
             return []
           }
-          const name = staticPropertyName(property)
-          return name !== undefined && restrictedGlobalNames.has(name)
-            ? [{ name, property }]
+          const maybeName = staticPropertyName(property)
+          return Option.isSome(maybeName) &&
+            restrictedGlobalNames.has(maybeName.value)
+            ? [{ name: maybeName.value, property }]
             : []
         })
-        return isUnshadowedGlobalReference(references, source)
+        return isUnshadowedReference(references, source)
           ? Effect.forEach(
               restrictedProperties,
               ({ name, property }) =>

--- a/packages/oxlint-plugin-foldkit/test/configs.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/configs.test.ts
@@ -15,9 +15,20 @@ const serverFilePatterns = [
   '**/server/**/*.ts',
   '**/server/**/*.tsx',
   '**/prerender.ts',
+  '**/prerender.tsx',
+]
+
+const entryFilePatterns = [
+  '**/entry.ts',
+  '**/entry.tsx',
+  '**/entry.client.ts',
+  '**/entry.client.tsx',
+  '**/entry.server.ts',
+  '**/entry.server.tsx',
 ]
 
 const serverRuleId = 'foldkit/no-nonportable-server-globals'
+const decisionTimeRuleId = 'foldkit/no-impure-call-at-decision-time'
 
 const presets = [
   { name: 'recommended', config: plugin.configs.recommended },
@@ -37,6 +48,7 @@ describe('configs', () => {
           'error',
         )
         expect(config.rules['foldkit/got-submodel-message-name']).toBe('error')
+        expect(config.rules[decisionTimeRuleId]).toBe('error')
       })
 
       it('scopes the server portability rule to recognized server files', () => {
@@ -45,11 +57,22 @@ describe('configs', () => {
         expect(config.rules[serverRuleId]).toBe('off')
         expect(serverOverride?.files).toEqual(serverFilePatterns)
         expect(serverOverride?.excludeFiles).toEqual(testFilePatterns)
-        expect(serverOverride?.rules).toEqual({ [serverRuleId]: 'error' })
+        expect(serverOverride?.rules).toEqual({
+          [serverRuleId]: 'error',
+          [decisionTimeRuleId]: 'off',
+        })
+      })
+
+      it('allows runtime entry files to obtain outside values', () => {
+        const entryOverride = config.overrides[1]
+
+        expect(entryOverride?.files).toEqual(entryFilePatterns)
+        expect(entryOverride?.excludeFiles).toEqual(testFilePatterns)
+        expect(entryOverride?.rules).toEqual({ [decisionTimeRuleId]: 'off' })
       })
 
       it('turns every foldkit rule off in test files', () => {
-        const testOverride = config.overrides[1]
+        const testOverride = config.overrides[2]
 
         expect(testOverride?.files).toEqual(testFilePatterns)
         for (const ruleId of Object.keys(config.rules)) {

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/invalid/callback-positions.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/invalid/callback-positions.ts
@@ -1,0 +1,31 @@
+import { Effect, Stream } from 'effect'
+
+const effect = Effect.succeed(1)
+
+export const generatedWithFunctionData = Effect.gen(
+  { self: () => Math.random() },
+  function* () {
+    return 1
+  },
+)
+
+export const repeatedWithScheduleBuilder = Effect.repeat(effect, () => {
+  Date.now()
+  return schedule
+})
+
+export const retriedWithScheduleBuilder = Effect.retry(effect, () => {
+  Math.random()
+  return schedule
+})
+
+export const iteratedFromFunctionData = Stream.iterate(
+  () => Math.random(),
+  current => current,
+)
+
+export const scannedFromFunctionData = Stream.scan(
+  Stream.make(1),
+  { read: () => Date.now() },
+  state => state,
+)

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/invalid/update.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/invalid/update.ts
@@ -1,0 +1,78 @@
+import { Effect, Option, Schema as S, Stream } from 'effect'
+import { Command, ManagedResource, Subscription } from 'foldkit'
+
+const Save = Command.define('Save', {
+  args: { id: S.String, createdAt: S.Number },
+  messages: [CompletedSave],
+  execute: () => Effect.succeed(CompletedSave()),
+})
+
+const makeId = () => Math.random().toString()
+const FakeEffect = {
+  sync: <Value>(evaluate: () => Value): Value => evaluate(),
+}
+
+export const update = (model: Model) => ({
+  model,
+  commands: [
+    Save({
+      id: crypto.randomUUID(),
+      createdAt: Date.now(),
+    }),
+  ],
+})
+
+export const initializedAt = new Date()
+export const initializedDateString = Date()
+export const initializedPerformance = globalThis.performance.now()
+export const initializedComputedTime = globalThis['Date']['now']()
+export const initializedBytes = window.crypto.getRandomValues(
+  new Uint8Array(8),
+)
+export const hiddenId = makeId()
+export const fakeEffectValue = FakeEffect.sync(() => Date.now())
+export const eagerMappedEffect = Effect.mapEager(
+  Effect.succeed(1),
+  () => Date.now(),
+)
+export const eagerMatchedEffect = Effect.matchEager(Effect.succeed(1), {
+  onFailure: () => 0,
+  onSuccess: () => Math.random(),
+})
+export const unsafeEffectFunction = Effect.fn(
+  function* () {
+    yield* Effect.void
+  },
+  effect => Effect.as(effect, Date.now()),
+)
+export const cancel = Effect.runCallback(Effect.succeed(1), {
+  onExit: () => Math.random(),
+})
+export const missing = Effect.fromOption(Option.none(), () => Date.now())
+export const functionValue = Effect.succeed(() => Math.random())
+
+export const subscriptions = Subscription.make<Model, Message>()(entry => {
+  const initializedSubscriptionAt = Date.now()
+
+  return {
+    clock: entry(
+      { initializedSubscriptionAt: S.Number },
+      {
+        modelToDependencies: () => ({
+          initializedSubscriptionAt: Date.now(),
+        }),
+        dependenciesToStream: () => Stream.empty,
+      },
+    ),
+  }
+})
+
+export const managedResources = ManagedResource.make<Model, Message>()(
+  entry => ({
+    connection: entry(Resource, S.Struct({}), {
+      modelToMaybeRequirements: () => Option.some({ startedAt: Date.now() }),
+      acquire: () => Effect.succeed(ResourceValue),
+      release: () => Effect.void,
+    }),
+  }),
+)

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/valid/boundaries.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/valid/boundaries.ts
@@ -1,0 +1,110 @@
+import { Effect, Schema as S, Stream } from 'effect'
+import {
+  Command,
+  ManagedResource,
+  Mount,
+  Subscription,
+} from 'foldkit'
+
+export const ReadClock = Command.define('ReadClock', {
+  messages: [CompletedReadClock],
+  execute: () =>
+    Effect.succeed(CompletedReadClock({ timestamp: Date.now() })),
+})
+
+export const ReadClockWithEffect = Command.define('ReadClockWithEffect', {
+  messages: [CompletedReadClockWithEffect],
+  execute: Effect.sync(() => performance.now()),
+})
+
+export const WrappedReadClock = Command.define(
+  'WrappedReadClock',
+  {
+    messages: [CompletedWrappedReadClock],
+    execute: () =>
+      Effect.succeed(CompletedWrappedReadClock({ timestamp: Date.now() })),
+  } satisfies CommandDefinition,
+)
+
+export const MeasureElement = Mount.define('MeasureElement', {
+  messages: [CompletedMeasureElement],
+  execute: () =>
+    Effect.succeed(CompletedMeasureElement({ timestamp: Date.now() })),
+})
+
+export const effect = Effect.gen(function* () {
+  return crypto.randomUUID()
+})
+
+export const wrappedEffect = Effect.sync(
+  (() => Date.now()) satisfies () => number,
+)
+
+export const readClock = Effect.fn('readClock')(function* () {
+  return Date.now()
+})
+
+export const mappedEffect = Effect.succeed(1).pipe(
+  Effect.map(() => Math.random()),
+)
+
+export const matchedEffect = Effect.match(Effect.succeed(1), {
+  onFailure: () => Date.now(),
+  onSuccess: () => Date.now(),
+})
+
+export const matchedWrappedEffect = Effect.match(
+  Effect.succeed(1),
+  {
+    onFailure: () => Date.now(),
+    onSuccess: () => Date.now(),
+  } satisfies MatchHandlers,
+)
+
+export const matchedCause = Effect.matchCause(Effect.succeed(1), {
+  onFailure: () => performance.now(),
+  onSuccess: () => performance.now(),
+})
+
+export const matchedEffectfully = Effect.matchEffect(Effect.succeed(1), {
+  onFailure: () => Effect.succeed(crypto.randomUUID()),
+  onSuccess: () => Effect.succeed(crypto.randomUUID()),
+})
+
+export const mappedBoth = Effect.mapBoth(Effect.succeed(1), {
+  onFailure: () => Math.random(),
+  onSuccess: () => Math.random(),
+})
+
+export const triedEffect = Effect.try({
+  try: () => Date.now(),
+  catch: () => new Date(),
+})
+
+export const stream = Stream.make(1).pipe(Stream.map(() => performance.now()))
+export const mappedStream = Stream.mapBoth(Stream.make(1), {
+  onFailure: () => Date.now(),
+  onSuccess: () => Date.now(),
+})
+
+export const subscriptions = Subscription.make<Model, Message>()(entry => ({
+  clock: entry(
+    {},
+    {
+      modelToDependencies: () => ({}),
+      dependenciesToStream: () => Stream.make(Date.now()),
+    },
+  ),
+}))
+
+export const managedResources = ManagedResource.make<Model, Message>()(
+  entry => ({
+    connection: entry(Resource, S.Struct({}), {
+      modelToMaybeRequirements: () => SomeRequirements,
+      acquire: () => Effect.succeed(crypto.randomUUID()),
+      release: () => Effect.sync(() => crypto.getRandomValues(bytes)),
+    }),
+  }),
+)
+
+export const fromKnownTime = new Date(timestamp)

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/valid/callback-positions.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/valid/callback-positions.ts
@@ -1,0 +1,238 @@
+import { Effect, Stream } from 'effect'
+
+const effect = Effect.succeed(1)
+const numberStream = Stream.make(1)
+const byteStream = Stream.make(new Uint8Array(1))
+
+export const repeated = Effect.repeat(effect, {
+  while: () => Date.now() > 0,
+  until: () => Math.random() > 0.5,
+})
+
+export const retried = Effect.retry(effect, {
+  while: () => Date.now() > 0,
+  until: () => Math.random() > 0.5,
+})
+
+export const filteredOrElse = Effect.filterOrElse(
+  effect,
+  () => Date.now() > 0,
+  () => Effect.succeed(Math.random()),
+)
+
+export const filterMappedOrElse = Effect.filterMapOrElse(
+  effect,
+  value => {
+    Date.now()
+    return value
+  },
+  () => Effect.succeed(Math.random()),
+)
+
+export const filteredOrFailed = Effect.filterOrFail(effect, () => {
+  Date.now()
+  return true
+})
+
+export const filterMappedOrFailed = Effect.filterMapOrFail(effect, value => {
+  Date.now()
+  return value
+})
+
+export const caughtReason = Effect.catchReason(
+  effect,
+  'Error',
+  'Reason',
+  () => Effect.succeed(Date.now()),
+  () => Effect.succeed(Math.random()),
+)
+
+export const caughtReasons = Effect.catchReasons(
+  effect,
+  'Error',
+  { Reason: () => Effect.succeed(Date.now()) },
+  () => Effect.succeed(Math.random()),
+)
+
+export const acquired = Effect.acquireRelease(
+  effect,
+  () => Effect.succeed(Date.now()),
+  { interruptible: true },
+)
+
+export const finalized = Effect.onExitPrimitive(
+  effect,
+  () => Effect.succeed(Date.now()),
+  true,
+)
+
+export const plannedEffect = Effect.withExecutionPlan(effect, plan, {
+  onEvent: () => Effect.succeed(Date.now()),
+})
+
+export const raced = Effect.race(effect, effect, {
+  onWinner: () => Date.now(),
+})
+
+export const racedFirst = Effect.raceFirst(effect, effect, {
+  onWinner: () => Date.now(),
+})
+
+export const racedAll = Effect.raceAll([effect], {
+  onWinner: () => Date.now(),
+})
+
+export const racedAllFirst = Effect.raceAllFirst([effect], {
+  onWinner: () => Date.now(),
+})
+
+export const transformedPull = Stream.transformPull(numberStream, pull => {
+  Date.now()
+  return Effect.succeed(pull)
+})
+
+export const transformedPullBracket = Stream.transformPullBracket(
+  numberStream,
+  pull => {
+    Math.random()
+    return Effect.succeed(pull)
+  },
+)
+
+export const partitionedQueue = Stream.partitionQueue(numberStream, value => {
+  Date.now()
+  return value > 0
+})
+
+export const plannedStream = Stream.withExecutionPlan(numberStream, plan, {
+  onEvent: () => Effect.succeed(Date.now()),
+})
+
+export const limitedBytes = Stream.limitBytes(byteStream, 1, () => {
+  Date.now()
+  return Stream.empty
+})
+
+export const split = Stream.split(numberStream, value => {
+  Math.random()
+  return value > 0
+})
+
+export const zippedArrays = Stream.zipWithArray(
+  numberStream,
+  numberStream,
+  (left, right) => {
+    Date.now()
+    return [left, [], right]
+  },
+)
+
+export const scanned = Stream.scan(numberStream, 0, state => {
+  Date.now()
+  return state + 1
+})
+
+export const caughtStream = Stream.catch(numberStream, () => {
+  Date.now()
+  return Stream.empty
+})
+
+export const extendedStreamRecord = Stream.let(
+  Stream.succeed({ value: 1 }),
+  'timestamp',
+  () => Date.now(),
+)
+
+export const caughtStreamReason = Stream.catchReason(
+  numberStream,
+  'Error',
+  'Reason',
+  () => Stream.succeed(Date.now()),
+  () => Stream.succeed(Math.random()),
+)
+
+export const caughtStreamReasons = Stream.catchReasons(
+  numberStream,
+  'Error',
+  { Reason: () => Stream.succeed(Date.now()) },
+  () => Stream.succeed(Math.random()),
+)
+
+export const combined = Stream.combine(
+  numberStream,
+  numberStream,
+  () => Date.now(),
+  state => Effect.succeed([Math.random(), state]),
+)
+
+export const combinedArrays = Stream.combineArray(
+  numberStream,
+  numberStream,
+  () => Date.now(),
+  state => Effect.succeed([[Math.random()], state]),
+)
+
+export const accumulated = Stream.mapAccum(
+  numberStream,
+  () => Date.now(),
+  state => [state, [Math.random()]],
+  { onHalt: () => [Date.now()] },
+)
+
+export const accumulatedArrays = Stream.mapAccumArray(
+  numberStream,
+  () => Date.now(),
+  state => [state, [Math.random()]],
+  { onHalt: () => [Date.now()] },
+)
+
+export const accumulatedEffectfully = Stream.mapAccumEffect(
+  numberStream,
+  () => Date.now(),
+  state => Effect.succeed([state, [Math.random()]]),
+  { onHalt: () => [Date.now()] },
+)
+
+export const accumulatedArraysEffectfully = Stream.mapAccumArrayEffect(
+  numberStream,
+  () => Date.now(),
+  state => Effect.succeed([state, [Math.random()]]),
+  { onHalt: () => [Date.now()] },
+)
+
+export const grouped = Stream.groupBy(numberStream, () => {
+  Date.now()
+  return Effect.succeed(['key', 1])
+}, {})
+
+export const groupedByKey = Stream.groupByKey(
+  value => {
+    Date.now()
+    return value
+  },
+  {},
+)(numberStream)
+
+export const bound = Stream.bind(
+  Stream.succeed({ value: 1 }),
+  'next',
+  () => Stream.succeed(Date.now()),
+  {},
+)
+
+export const boundEffectfully = Stream.bindEffect(
+  'next',
+  () => Effect.succeed(Date.now()),
+  {},
+)(Stream.succeed({ value: 1 }))
+
+export const takenUntil = Stream.takeUntil(
+  numberStream,
+  () => Date.now() > 0,
+  { excludeLast: true },
+)
+
+export const takenUntilEffectfully = Stream.takeUntilEffect(
+  () => Effect.succeed(Date.now() > 0),
+  { excludeLast: true },
+)(numberStream)

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/valid/import-aliases.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/valid/import-aliases.ts
@@ -1,0 +1,24 @@
+import { Effect as Fx } from 'effect'
+import * as EffectApi from 'effect/Effect'
+import { Command as C } from 'foldkit'
+import * as CommandApi from 'foldkit/command'
+import * as MountApi from 'foldkit/mount'
+
+export const firstEffect = Fx.sync(() => Date.now())
+export const secondEffect = EffectApi.sync(() => Math.random())
+
+export const FirstCommand = C.define('FirstCommand', {
+  messages: [CompletedFirstCommand],
+  execute: () => Fx.succeed(CompletedFirstCommand({ timestamp: Date.now() })),
+})
+
+export const SecondCommand = CommandApi.define('SecondCommand', {
+  messages: [CompletedSecondCommand],
+  execute: () =>
+    Fx.succeed(CompletedSecondCommand({ id: crypto.randomUUID() })),
+})
+
+export const Measure = MountApi.define('Measure', {
+  messages: [CompletedMeasure],
+  execute: () => Fx.succeed(CompletedMeasure({ now: performance.now() })),
+})

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/valid/local-shadows.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-impure-call-at-decision-time/valid/local-shadows.ts
@@ -1,0 +1,23 @@
+const Date = {
+  now: () => 0,
+}
+const Math = {
+  random: () => 0,
+}
+const performance = {
+  now: () => 0,
+}
+const crypto = {
+  randomUUID: () => 'fixed',
+  getRandomValues: (value: Uint8Array) => value,
+}
+const globalThis = { Date, Math, performance, crypto }
+const window = { crypto }
+
+export const localTime = Date.now()
+export const localRandom = Math.random()
+export const localPerformance = performance.now()
+export const localId = crypto.randomUUID()
+export const localBytes = crypto.getRandomValues(new Uint8Array(8))
+export const nestedTime = globalThis.Date.now()
+export const nestedId = window.crypto.randomUUID()

--- a/packages/oxlint-plugin-foldkit/test/integration/real-oxlint.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/real-oxlint.test.ts
@@ -97,6 +97,12 @@ describe('real-oxlint rule fixtures', () => {
     })
   }
 
+  it('reports every direct decision-time operation in its invalid fixture', () => {
+    expect(countDiagnostics('no-impure-call-at-decision-time', 'invalid')).toBe(
+      23,
+    )
+  })
+
   it('fixes only structurally safe empty commands properties', async () => {
     const rule = 'no-empty-commands-array'
     const sourcePath = join(fixturesRoot, rule, 'invalid', 'update.ts')

--- a/packages/oxlint-plugin-foldkit/test/integration/server-globals.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/server-globals.test.ts
@@ -22,12 +22,14 @@ const consumerRuleCode = 'eslint(no-restricted-globals)'
 const patternFixtures: Record<string, string> = {
   'patterns/src/entry.server.ts': `
 export const title = document.title
+export const renderedAt = Date.now()
 `,
   'patterns/src/entry.server.tsx': `
 export const hasWindow = typeof window !== 'undefined'
 `,
   'patterns/server/main.ts': `
 export const title = globalThis.document.title
+export const generatedAt = Date.now()
 `,
   'patterns/server/view.tsx': `
 export const view = <div>{globalThis?.['navigator'].language}</div>
@@ -35,6 +37,9 @@ export const view = <div>{globalThis?.['navigator'].language}</div>
   'patterns/scripts/prerender.ts': `
 const { localStorage: storage } = globalThis
 export const theme = storage.getItem('theme')
+`,
+  'patterns/scripts/prerender.tsx': `
+export const page = <div>{document.title}{Date.now()}</div>
 `,
 }
 
@@ -64,6 +69,7 @@ export const fetchPage = async (request: Request): Promise<Response> => {
 `,
   'valid/src/entry.client.ts': `
 export const title = document.title + globalThis.document.title
+export const startedAt = performance.now()
 `,
 }
 
@@ -78,7 +84,7 @@ export const title = (): string => {
 console.log(document.title)
 `,
   'composition/server/policy.test.ts': `
-console.log(document.title)
+console.log(document.title, Math.random())
 `,
   'composition/server/policy.spec.tsx': `
 console.log(<div>{document.title}</div>)

--- a/packages/oxlint-plugin-foldkit/test/rules/no-impure-call-at-decision-time.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-impure-call-at-decision-time.test.ts
@@ -1,0 +1,573 @@
+import * as Testing from 'effect-oxlint/testing'
+import { describe, expect, it } from 'vitest'
+
+import { noImpureCallAtDecisionTime } from '../../src/rules/no-impure-call-at-decision-time.ts'
+
+const program = { type: 'Program', parent: null }
+
+const atProgram = <Node extends object>(node: Node): Node =>
+  Object.assign(node, { parent: program })
+
+const run = (node: Readonly<{ type: string }>) =>
+  Testing.runRule(noImpureCallAtDecisionTime, node.type, node)
+
+const wrapExpression = (expression: Readonly<{ type: string }>) => {
+  const asExpression = { type: 'TSAsExpression', expression }
+  const satisfiesExpression = {
+    type: 'TSSatisfiesExpression',
+    expression: asExpression,
+  }
+  const parenthesizedExpression = {
+    type: 'ParenthesizedExpression',
+    expression: satisfiesExpression,
+  }
+
+  Object.assign(expression, { parent: asExpression })
+  Object.assign(asExpression, { parent: satisfiesExpression })
+  Object.assign(satisfiesExpression, { parent: parenthesizedExpression })
+
+  return parenthesizedExpression
+}
+
+const inDirectCallback = (
+  operation: Readonly<{ type: string }>,
+  namespace: string,
+  method: string,
+  isWrapped = false,
+) => {
+  const callback = Testing.arrowFn(operation)
+  const argument = isWrapped ? wrapExpression(callback) : callback
+  const boundary = atProgram(
+    Testing.callOfMember(namespace, method, [argument]),
+  )
+
+  Object.assign(operation, { parent: callback })
+  Object.assign(argument, { parent: boundary })
+
+  return operation
+}
+
+const inInlineConfig = (
+  operation: Readonly<{ type: string }>,
+  namespace: string,
+  method: string,
+  propertyName: string,
+  isWrapped = false,
+) => {
+  const callback = Testing.arrowFn(operation)
+  const property = {
+    type: 'Property',
+    kind: 'init',
+    key: Testing.id(propertyName),
+    value: callback,
+    method: false,
+    shorthand: false,
+    computed: false,
+  }
+  const config = {
+    type: 'ObjectExpression',
+    properties: [property],
+  }
+  const argument = isWrapped ? wrapExpression(config) : config
+  const boundary = atProgram(
+    Testing.callOfMember(namespace, method, [
+      Testing.strLiteral('Boundary'),
+      argument,
+    ]),
+  )
+
+  Object.assign(operation, { parent: callback })
+  Object.assign(callback, { parent: property })
+  Object.assign(property, { parent: config })
+  Object.assign(argument, { parent: boundary })
+
+  return operation
+}
+
+const inTrailingCallback = (
+  operation: Readonly<{ type: string }>,
+  namespace: string,
+  method: string,
+) => {
+  const body = Testing.arrowFn(Testing.callOfMember('Effect', 'void'))
+  const callback = Testing.arrowFn(operation)
+  const boundary = atProgram(
+    Testing.callOfMember(namespace, method, [body, callback]),
+  )
+
+  Object.assign(operation, { parent: callback })
+  Object.assign(callback, { parent: boundary })
+  Object.assign(body, { parent: boundary })
+
+  return operation
+}
+
+const inPositionedCallback = (
+  operation: Readonly<{ type: string }>,
+  namespace: string,
+  method: string,
+  before: ReadonlyArray<Readonly<{ type: string }>>,
+  after: ReadonlyArray<Readonly<{ type: string }>>,
+) => {
+  const callback = Testing.arrowFn(operation)
+  const boundary = atProgram(
+    Testing.callOfMember(namespace, method, [...before, callback, ...after]),
+  )
+
+  Object.assign(operation, { parent: callback })
+  Object.assign(callback, { parent: boundary })
+
+  return operation
+}
+
+const inPositionedObjectCallback = (
+  operation: Readonly<{ type: string }>,
+  namespace: string,
+  method: string,
+  propertyName: string,
+  before: ReadonlyArray<Readonly<{ type: string }>>,
+  after: ReadonlyArray<Readonly<{ type: string }>>,
+) => {
+  const callback = Testing.arrowFn(operation)
+  const property = {
+    type: 'Property',
+    kind: 'init',
+    key: Testing.id(propertyName),
+    value: callback,
+    method: false,
+    shorthand: false,
+    computed: false,
+  }
+  const config = { type: 'ObjectExpression', properties: [property] }
+  const boundary = atProgram(
+    Testing.callOfMember(namespace, method, [...before, config, ...after]),
+  )
+
+  Object.assign(operation, { parent: callback })
+  Object.assign(callback, { parent: property })
+  Object.assign(property, { parent: config })
+  Object.assign(config, { parent: boundary })
+
+  return operation
+}
+
+const inNestedLifecycleConfig = (
+  operation: Readonly<{ type: string }>,
+  namespace: string,
+  propertyName: string,
+  isWrapped = false,
+) => {
+  const callback = Testing.arrowFn(operation)
+  const property = {
+    type: 'Property',
+    kind: 'init',
+    key: Testing.id(propertyName),
+    value: callback,
+    method: false,
+    shorthand: false,
+    computed: false,
+  }
+  const config = { type: 'ObjectExpression', properties: [property] }
+  const argument = isWrapped ? wrapExpression(config) : config
+  const entry = Testing.callExpr('entry', [argument])
+  const builder = Testing.arrowFn(entry)
+  const make = Testing.callOfMember(namespace, 'make')
+  const boundary = atProgram({
+    type: 'CallExpression',
+    callee: make,
+    arguments: [builder],
+  })
+
+  Object.assign(operation, { parent: callback })
+  Object.assign(callback, { parent: property })
+  Object.assign(property, { parent: config })
+  Object.assign(argument, { parent: entry })
+  Object.assign(entry, { parent: builder })
+  Object.assign(builder, { parent: boundary })
+  Object.assign(make, { parent: boundary })
+
+  return operation
+}
+
+describe('no-impure-call-at-decision-time', () => {
+  it.each([
+    ['Date.now', Testing.callOfMember('Date', 'now')],
+    ['Date', Testing.callExpr('Date')],
+    ['Math.random', Testing.callOfMember('Math', 'random')],
+    ['performance.now', Testing.callOfMember('performance', 'now')],
+    ['crypto.randomUUID', Testing.callOfMember('crypto', 'randomUUID')],
+    [
+      'crypto.getRandomValues',
+      Testing.callOfMember('crypto', 'getRandomValues'),
+    ],
+  ])('flags %s outside a recognized deferred callback', (_name, operation) => {
+    const result = run(atProgram(operation))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      'Assigning it to a local variable or passing it as a Command argument does not defer the call',
+    )
+  })
+
+  it('flags a zero-argument Date constructor', () => {
+    const result = run(atProgram(Testing.newExpr('Date')))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain('new Date()')
+  })
+
+  it('recommends the Effect v4 Crypto service for UUIDs', () => {
+    const result = run(atProgram(Testing.callOfMember('crypto', 'randomUUID')))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.diagnostic.message).toContain(
+      "Crypto.Crypto's randomUUIDv4 Effect with a platform Crypto layer",
+    )
+  })
+
+  it('flags Date called as a function even when it receives arguments', () => {
+    const result = run(
+      atProgram(Testing.callExpr('Date', [Testing.id('ignored')])),
+    )
+
+    expect(result).toHaveLength(1)
+  })
+
+  it('allows a Date constructed from a known value', () => {
+    const result = run(
+      atProgram(Testing.newExpr('Date', [Testing.id('timestamp')])),
+    )
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('allows direct Effect and Stream callbacks', () => {
+    const effectResult = run(
+      inDirectCallback(Testing.callOfMember('Date', 'now'), 'Effect', 'sync'),
+    )
+    const streamResult = run(
+      inDirectCallback(Testing.callOfMember('Math', 'random'), 'Stream', 'map'),
+    )
+
+    expect(effectResult).toHaveLength(0)
+    expect(streamResult).toHaveLength(0)
+  })
+
+  it('allows callbacks that Effect and Stream defer', () => {
+    const effectResult = run(
+      inInlineConfig(
+        Testing.callOfMember('Date', 'now'),
+        'Effect',
+        'match',
+        'onSuccess',
+      ),
+    )
+    const streamResult = run(
+      inInlineConfig(
+        Testing.callOfMember('Math', 'random'),
+        'Stream',
+        'mapBoth',
+        'onSuccess',
+      ),
+    )
+    const functionBodyResult = run(
+      inDirectCallback(Testing.callOfMember('Date', 'now'), 'Effect', 'fn'),
+    )
+
+    expect(effectResult).toHaveLength(0)
+    expect(streamResult).toHaveLength(0)
+    expect(functionBodyResult).toHaveLength(0)
+  })
+
+  it('allows deferred callbacks behind transparent TypeScript wrappers', () => {
+    const directResult = run(
+      inDirectCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Effect',
+        'sync',
+        true,
+      ),
+    )
+    const objectResult = run(
+      inInlineConfig(
+        Testing.callOfMember('Math', 'random'),
+        'Effect',
+        'match',
+        'onSuccess',
+        true,
+      ),
+    )
+    const lifecycleResult = run(
+      inNestedLifecycleConfig(
+        Testing.callOfMember('crypto', 'randomUUID'),
+        'ManagedResource',
+        'acquire',
+        true,
+      ),
+    )
+
+    expect(directResult).toHaveLength(0)
+    expect(objectResult).toHaveLength(0)
+    expect(lifecycleResult).toHaveLength(0)
+  })
+
+  it('flags synchronous callbacks passed to Effect APIs', () => {
+    const eagerDirectResult = run(
+      inDirectCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Effect',
+        'mapEager',
+      ),
+    )
+    const eagerObjectResult = run(
+      inInlineConfig(
+        Testing.callOfMember('Math', 'random'),
+        'Effect',
+        'matchEager',
+        'onSuccess',
+      ),
+    )
+    const functionTransformResult = run(
+      inTrailingCallback(Testing.callOfMember('Date', 'now'), 'Effect', 'fn'),
+    )
+    const runCallbackResult = run(
+      inInlineConfig(
+        Testing.callOfMember('Math', 'random'),
+        'Effect',
+        'runCallback',
+        'onExit',
+      ),
+    )
+    const fromOptionResult = run(
+      inTrailingCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Effect',
+        'fromOption',
+      ),
+    )
+    const functionValueResult = run(
+      inDirectCallback(
+        Testing.callOfMember('Math', 'random'),
+        'Effect',
+        'succeed',
+      ),
+    )
+
+    expect(eagerDirectResult).toHaveLength(1)
+    expect(eagerObjectResult).toHaveLength(1)
+    expect(functionTransformResult).toHaveLength(1)
+    expect(runCallbackResult).toHaveLength(1)
+    expect(fromOptionResult).toHaveLength(1)
+    expect(functionValueResult).toHaveLength(1)
+  })
+
+  it('matches deferred direct callbacks by arity and argument position', () => {
+    const iterateNextResult = run(
+      inPositionedCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Stream',
+        'iterate',
+        [Testing.id('seed')],
+        [],
+      ),
+    )
+    const iterateSeedResult = run(
+      inPositionedCallback(
+        Testing.callOfMember('Math', 'random'),
+        'Stream',
+        'iterate',
+        [],
+        [Testing.arrowFn(Testing.id('current'))],
+      ),
+    )
+    const scanReducerResult = run(
+      inPositionedCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Stream',
+        'scan',
+        [Testing.id('stream'), Testing.id('initial')],
+        [],
+      ),
+    )
+    const scanInitialResult = run(
+      inPositionedCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Stream',
+        'scan',
+        [Testing.id('stream')],
+        [Testing.arrowFn(Testing.id('state'))],
+      ),
+    )
+
+    expect(iterateNextResult).toHaveLength(0)
+    expect(iterateSeedResult).toHaveLength(1)
+    expect(scanReducerResult).toHaveLength(0)
+    expect(scanInitialResult).toHaveLength(1)
+  })
+
+  it('matches deferred object callbacks by arity, position, and property', () => {
+    const repeatConditionResult = run(
+      inPositionedObjectCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Effect',
+        'repeat',
+        'while',
+        [Testing.id('effect')],
+        [],
+      ),
+    )
+    const repeatScheduleResult = run(
+      inPositionedObjectCallback(
+        Testing.callOfMember('Math', 'random'),
+        'Effect',
+        'repeat',
+        'schedule',
+        [Testing.id('effect')],
+        [],
+      ),
+    )
+    const genSelfResult = run(
+      inPositionedObjectCallback(
+        Testing.callOfMember('Math', 'random'),
+        'Effect',
+        'gen',
+        'self',
+        [],
+        [Testing.arrowFn(Testing.id('body'))],
+      ),
+    )
+    const executionPlanEventResult = run(
+      inPositionedObjectCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Effect',
+        'withExecutionPlan',
+        'onEvent',
+        [Testing.id('effect'), Testing.id('plan')],
+        [],
+      ),
+    )
+
+    expect(repeatConditionResult).toHaveLength(0)
+    expect(repeatScheduleResult).toHaveLength(1)
+    expect(genSelfResult).toHaveLength(1)
+    expect(executionPlanEventResult).toHaveLength(0)
+  })
+
+  it('covers optional and data-first callback overloads', () => {
+    const filterResult = run(
+      inPositionedCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Effect',
+        'filterOrFail',
+        [],
+        [],
+      ),
+    )
+    const releaseResult = run(
+      inPositionedCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Effect',
+        'acquireRelease',
+        [Testing.id('acquire')],
+        [Testing.id('options')],
+      ),
+    )
+    const combineStateResult = run(
+      inPositionedCallback(
+        Testing.callOfMember('Math', 'random'),
+        'Stream',
+        'combine',
+        [Testing.id('left'), Testing.id('right')],
+        [Testing.arrowFn(Testing.id('combined'))],
+      ),
+    )
+    const groupByResult = run(
+      inPositionedCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Stream',
+        'groupBy',
+        [Testing.id('stream')],
+        [Testing.id('options')],
+      ),
+    )
+    const onHaltResult = run(
+      inPositionedObjectCallback(
+        Testing.callOfMember('Date', 'now'),
+        'Stream',
+        'mapAccum',
+        'onHalt',
+        [
+          Testing.id('stream'),
+          Testing.arrowFn(Testing.id('initial')),
+          Testing.arrowFn(Testing.id('reducer')),
+        ],
+        [],
+      ),
+    )
+
+    expect(filterResult).toHaveLength(0)
+    expect(releaseResult).toHaveLength(0)
+    expect(combineStateResult).toHaveLength(0)
+    expect(groupByResult).toHaveLength(0)
+    expect(onHaltResult).toHaveLength(0)
+  })
+
+  it('allows Command and Mount execute callbacks', () => {
+    const commandResult = run(
+      inInlineConfig(
+        Testing.callOfMember('crypto', 'randomUUID'),
+        'Command',
+        'define',
+        'execute',
+      ),
+    )
+    const mountResult = run(
+      inInlineConfig(
+        Testing.callOfMember('performance', 'now'),
+        'Mount',
+        'define',
+        'execute',
+      ),
+    )
+    const mountStreamResult = run(
+      inInlineConfig(
+        Testing.callOfMember('performance', 'now'),
+        'Mount',
+        'defineStream',
+        'execute',
+      ),
+    )
+
+    expect(commandResult).toHaveLength(0)
+    expect(mountResult).toHaveLength(0)
+    expect(mountStreamResult).toHaveLength(0)
+  })
+
+  it('allows only the deferred Subscription and ManagedResource callbacks', () => {
+    const subscriptionResult = run(
+      inNestedLifecycleConfig(
+        Testing.callOfMember('Date', 'now'),
+        'Subscription',
+        'dependenciesToStream',
+      ),
+    )
+    const managedResourceResult = run(
+      inNestedLifecycleConfig(
+        Testing.callOfMember('crypto', 'randomUUID'),
+        'ManagedResource',
+        'acquire',
+      ),
+    )
+    const dependencyResult = run(
+      inNestedLifecycleConfig(
+        Testing.callOfMember('Date', 'now'),
+        'Subscription',
+        'modelToDependencies',
+      ),
+    )
+
+    expect(subscriptionResult).toHaveLength(0)
+    expect(managedResourceResult).toHaveLength(0)
+    expect(dependencyResult).toHaveLength(1)
+  })
+})

--- a/packages/website/src/page/toolingLinting.md
+++ b/packages/website/src/page/toolingLinting.md
@@ -16,7 +16,7 @@ Override an individual rule in the project's `rules` block when an application n
 
 ### foldkit/no-nonportable-server-globals {#no-nonportable-server-globals}
 
-The recommended and all presets enable this rule in `entry.server.ts`, `entry.server.tsx`, TypeScript files under a `server` directory, and `prerender.ts`. Files ending in `.test.ts`, `.test.tsx`, `.spec.ts`, or `.spec.tsx` are excluded.
+The recommended and all presets enable this rule in `entry.server.ts`, `entry.server.tsx`, TypeScript files under a `server` directory, and `prerender.ts` or `prerender.tsx`. Files ending in `.test.ts`, `.test.tsx`, `.spec.ts`, or `.spec.tsx` are excluded.
 
 The rule catches direct runtime reads of common browser-only globals: `document`, `window`, `navigator`, `localStorage`, `sessionStorage`, `history`, `location`, `alert`, `confirm`, `prompt`, `requestAnimationFrame`, `cancelAnimationFrame`, `requestIdleCallback`, `cancelIdleCallback`, `getComputedStyle`, `matchMedia`, `customElements`, `screen`, `IntersectionObserver`, `ResizeObserver`, and `MutationObserver`. It also catches static property reads and destructuring from the global `globalThis` object.
 
@@ -123,6 +123,38 @@ Catches an inline empty array in the children slot, on element builders and on k
 ::Snippet{name="lintNoEmptyChildrenArray" label="foldkit/no-empty-children-array example"}
 
 ## Purity Boundaries {#purity-rules}
+
+### foldkit/no-impure-call-at-decision-time {#no-impure-call-at-decision-time}
+
+Flags these direct calls unless they appear inside a recognized callback that Effect or a Foldkit lifecycle primitive defers until execution:
+
+- `Date.now()`
+- `Date()` (which ignores its arguments)
+- zero-argument `new Date()`
+- `Math.random()`
+- `performance.now()`
+- `crypto.randomUUID()`
+- `crypto.getRandomValues()`
+
+The rule reports the call wherever it is written. Assigning its result to a local variable before passing that variable to a Command does not defer it. Neither does writing the call directly in the Command args. JavaScript obtains the value before constructing the Command in both cases.
+
+Obtain time or randomness inside the Command's `execute` callback instead. Use `Clock` or `Random` for time and ordinary randomness. For UUIDs and cryptographic randomness, use the `Crypto.Crypto` service with the platform's Crypto layer. Return the value in the result Message.
+
+The rule recognizes the deferred callback positions in Effect and Stream. It also recognizes these Foldkit lifecycle callbacks when they are declared inline:
+
+- `execute` in `Command.define`, `Mount.define`, and `Mount.defineStream`
+- `dependenciesToStream` in `Subscription.make`
+- `acquire` and `release` in `ManagedResource.make`
+
+Not every function passed to Effect is deferred. The rule still checks functions stored as Effect values, `Effect.fromOption`'s `onNone`, callbacks passed to `Effect.run*`, transform callbacks after the body of `Effect.fn` or `Effect.fnUntraced`, and callbacks passed to Effect APIs whose names end in `Eager`. It also checks the surrounding lifecycle builders and their synchronous Model projections. For example, `Subscription.make`'s builder and `modelToDependencies` are not execution callbacks.
+
+The recommended and all presets disable this rule in runtime entry files (`entry.ts`, `entry.tsx`, `entry.client.ts`, `entry.client.tsx`, `entry.server.ts`, and `entry.server.tsx`), where Flags and host integrations obtain outside values. The `.tsx` forms support JSX hosts, such as a React application that embeds Foldkit; Foldkit views still use the Html builder.
+
+The presets also disable the rule in TypeScript files under a `server` directory and in `prerender.ts` or `prerender.tsx`. Those files belong to the host rather than the Foldkit application state machine, so their request handlers and build scripts do not return values through Messages. Test files remain excluded with the rest of the Foldkit rules.
+
+This direct-call catalog does not prove that a file is pure. It recognizes static global member paths and ignores locally shadowed globals. It does not follow a method alias such as `const now = Date.now` to a later `now()` call, nor does it inspect a helper's call graph.
+
+::Snippet{name="lintNoImpureCallAtDecisionTime" label="foldkit/no-impure-call-at-decision-time example"}
 
 ### foldkit/no-module-level-mutable-state {#no-module-level-mutable-state}
 

--- a/packages/website/src/snippet/index.ts
+++ b/packages/website/src/snippet/index.ts
@@ -100,6 +100,8 @@ export { default as lintCommandBindingMatchesNameRaw } from './lintCommandBindin
 export { default as lintCommandBindingMatchesNameHighlighted } from './lintCommandBindingMatchesName.ts?highlighted'
 export { default as lintNoModuleLevelMutableStateRaw } from './lintNoModuleLevelMutableState.ts?raw'
 export { default as lintNoModuleLevelMutableStateHighlighted } from './lintNoModuleLevelMutableState.ts?highlighted'
+export { default as lintNoImpureCallAtDecisionTimeRaw } from './lintNoImpureCallAtDecisionTime.ts?raw'
+export { default as lintNoImpureCallAtDecisionTimeHighlighted } from './lintNoImpureCallAtDecisionTime.ts?highlighted'
 export { default as lintCommandDefinePascalConstRaw } from './lintCommandDefinePascalConst.ts?raw'
 export { default as lintCommandDefinePascalConstHighlighted } from './lintCommandDefinePascalConst.ts?highlighted'
 export { default as lintGotWrapperCarriesOnlyRoutingRaw } from './lintGotWrapperCarriesOnlyRouting.ts?raw'

--- a/packages/website/src/snippet/lintNoImpureCallAtDecisionTime.ts
+++ b/packages/website/src/snippet/lintNoImpureCallAtDecisionTime.ts
@@ -1,0 +1,32 @@
+import { Crypto, Effect, Schema as S } from 'effect'
+import { Command } from 'foldkit'
+
+import { BrowserCrypto } from '@effect/platform-browser'
+
+const SaveDraftWithId = Command.define('SaveDraftWithId', {
+  args: { body: S.String, draftId: S.String },
+  messages: [Message.CompletedSaveDraftWithId],
+  execute: ({ draftId }) =>
+    Effect.succeed(Message.CompletedSaveDraftWithId({ draftId })),
+})
+
+// ❌ Bad: assigning the UUID first does not defer the call.
+const saveBad = (body: string) => {
+  const draftId = crypto.randomUUID()
+
+  return SaveDraftWithId({ body, draftId })
+}
+
+// ✅ Good: the runtime obtains the UUID when it executes the Command.
+const SaveDraft = Command.define('SaveDraft', {
+  args: { body: S.String },
+  messages: [Message.CompletedSaveDraft],
+  execute: ({ body: _body }) =>
+    Effect.gen(function* () {
+      const crypto = yield* Crypto.Crypto
+      const draftId = yield* Effect.orDie(crypto.randomUUIDv4)
+      return Message.CompletedSaveDraft({ draftId })
+    }).pipe(Effect.provide(BrowserCrypto.layer)),
+})
+
+const saveGood = (body: string) => SaveDraft({ body })


### PR DESCRIPTION
JavaScript evaluates Command arguments before constructing the Command. Add `foldkit/no-impure-call-at-decision-time` to detect known time and randomness calls whether they appear inline in args or are assigned to a local variable first. Allow them only inside recognized deferred Effect and lifecycle callbacks, including transparently wrapped callback and config expressions.

Keep tests, runtime entries, and host server files outside this application rule. Recommend the Effect v4 Clock, Random, and Crypto services, and share the AST and scope helpers used to resolve static names and shadowed globals.

The presets enable the rule by default, so existing consumers may need to move reported calls behind an execution boundary or temporarily disable the rule. Document the exact boundary and teach new scaffolds to return generated values through Messages.

Closes #1214.

Related to #892.
