### PR TITLE
docs: clarify HoverIntent guidance

### DIFF
--- a/examples/ui-showcase/src/ui/view/hoverIntent.ts
+++ b/examples/ui-showcase/src/ui/view/hoverIntent.ts
@@ -26,7 +26,7 @@ export const view = Submodel.defineView<UiModel, UiMessage>((model, h): Html =>
       h.p(
         [h.Class('mb-4 max-w-xl text-sm text-gray-600')],
         [
-          'Hover the trigger, then move the pointer into the panel. Focus the trigger and press Escape to close it.',
+          'Hover over or focus the “More information” trigger, then move the pointer into the card. Move the pointer or focus away from both elements, or press Escape, to close it.',
         ],
       ),
       h.submodel({

--- a/packages/website/src/page/blog/post/foldkit-0-155-0.md
+++ b/packages/website/src/page/blog/post/foldkit-0-155-0.md
@@ -64,13 +64,13 @@ Thank you to [@hdoro](https://github.com/hdoro) for suggesting this API change!
 
 ## HoverIntent joins @foldkit/ui
 
-`@foldkit/ui` now includes `HoverIntent`, a behavior-only Submodel for interactions that reveal a panel from a trigger.
+`@foldkit/ui` now includes `HoverIntent`, a headless Submodel for interactions that reveal a panel from a trigger.
 
-It opens after a configurable pointer delay, stays open while pointer or focus moves between the trigger and panel, and closes after a configurable grace period. Focus opens immediately. Escape closes immediately and suppresses reopening until the interaction fully disengages.
+It opens after a configurable pointer delay, stays open while the pointer or focus moves between the trigger and panel, and closes after a configurable grace period. Focus opens immediately. Escape closes immediately and prevents reopening until the pointer and focus have both left.
 
-HoverIntent returns headless trigger and panel event bundles. It does not create markup, choose an ARIA role, position the panel, or style anything. A Hover Card can pair it with Anchor. A Navigation Menu can coordinate several HoverIntent Models around one shared viewport. The behavior is reusable because those product decisions remain yours.
+HoverIntent returns trigger and panel event bundles. It does not create markup, choose ARIA roles, position the panel, or style anything. A Hover Card can pair it with Anchor. A hover menu can use it to keep its items available as the pointer moves from the trigger into the panel.
 
-The new [HoverIntent docs](/ui/hover-intent) include live Hover Card and Navigation Menu examples.
+The [HoverIntent docs](/ui/hover-intent) have current examples and API details.
 
 Thank you to [@SyahrulBhudiF](https://github.com/foldkit/foldkit/pull/1179) for contributing it!
 

--- a/packages/website/src/page/ui/hoverIntentPage.md
+++ b/packages/website/src/page/ui/hoverIntentPage.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-HoverIntent is a behavior-only Submodel for a trigger and its related panel. It opens after pointer entry and stays open while the pointer or focus moves between both elements. Pointer departure uses a configurable grace delay; focus departure closes without that pointer delay. Focus opens immediately. Escape closes the panel and suppresses reopening until pointer and focus have both left.
+HoverIntent keeps a related panel open while the pointer or focus moves between it and a trigger. Pointer entry and departure use configurable delays. Focus opens the panel immediately; if focus is the last thing keeping it open, moving focus away closes it without the pointer grace period. Escape also closes immediately and prevents reopening until the pointer and focus have both left.
 
-It does not create elements, position a panel, assign an ARIA role, or choose a styling hook. Use it when those choices belong to the component you are building. For example, a Hover Card can combine HoverIntent with [Anchor](/ui/anchor), while a hover menu can use it to keep its items available as the pointer leaves the trigger.
+HoverIntent is headless. It does not render elements, position the panel, assign ARIA roles, or choose styles. Use it when those choices belong to the component you are building. For example, a Hover Card can pair HoverIntent with [Anchor](/ui/anchor), while a hover menu can keep its items available as the pointer moves from the trigger into the panel.
 
 ## Examples
 
 ### Hover Card
 
-Hover or focus More information, then move into the card. Press Escape or move focus away to close it.
+Hover over or focus the “More information” trigger, then move the pointer into the card. Move the pointer or focus away from both elements, or press Escape, to close it.
 
 ::Demo{name="hover-card"}
 
@@ -18,21 +18,21 @@ Hover or focus More information, then move into the card. Press Escape or move f
 
 ### Hover Menu
 
-Hover or focus Actions, then move into the menu. Choosing an item closes it without navigating or changing other page state.
+Hover over or focus the “Actions” trigger, then move the pointer into the menu. Choosing an item closes the menu; the demo items do not navigate or change other page state.
 
 ::Demo{name="hover-menu"}
 
 ::Snippet{name="uiHoverIntentMenu" label="hover menu example"}
 
-HoverIntent's trigger and panel bundles carry child Messages through `h.submodel`. Spreading them into the wrong element changes the interaction model, so put `trigger` on the activator and `panel` on the content that must keep the intent alive.
+Spread `trigger` onto the trigger element and `panel` onto the panel element. Each bundle supplies the hover, focus, and Escape handlers for that element. The `h.submodel` boundary routes the resulting child Messages back to the parent.
 
 ## Timing and Dismissal
 
-Pointer entry starts `openDelay`, which defaults to 200 milliseconds. Leaving the last hovered element starts `closeDelay`, which defaults to 300 milliseconds. Entering either element again cancels a pending close. Each wait carries a version, so a completion from an earlier interaction cannot change current visibility.
+Pointer entry starts `openDelay`, which defaults to 200 milliseconds. When the pointer leaves both elements and neither holds focus, `closeDelay` starts; it defaults to 300 milliseconds. Entering either element again before the delay expires keeps the panel open. Versioning prevents an old wait from changing visibility after a newer interaction.
 
-Focus opens immediately. Focus departure schedules a zero-delay close, so clicking or tabbing away does not inherit the pointer grace period. When focus moves from the trigger into the panel, the panel focus handler cancels that close before it resolves, so keyboard users can enter interactive panel content.
+Focus opens immediately. If focus is the last thing keeping the panel open, moving it outside both elements starts a zero-delay close, so clicking or tabbing away does not use the pointer grace period. When focus moves from the trigger into the panel, the panel focus handler cancels that close before it resolves. Keyboard users can therefore move into focusable panel content without closing it.
 
-Escape closes immediately. When panel content can hold focus, set `focusTriggerSelector` so Escape returns focus to the trigger before removing the panel. If the selector is omitted or does not resolve to a focusable element, HoverIntent does not move focus; removing the focused panel leaves the browser to choose its fallback focus target. It does not reopen while the pointer or focus still engages the trigger or panel. After both disengage, a fresh entry can open it again.
+Escape closes immediately. When panel content can hold focus, set `focusTriggerSelector` so Escape returns focus to the trigger before removing the panel. If the selector is omitted or does not resolve to a focusable element, HoverIntent does not move focus; removing the focused panel leaves the browser to choose its fallback focus target. After Escape, the panel does not reopen until the pointer and focus have both left the trigger and panel. A later entry can open it again.
 
 ## API Reference
 
@@ -53,7 +53,7 @@ Creates a closed HoverIntent Model. `init` takes no `id` because HoverIntent own
 
 `(model: Model) => Update.ReturnWithOutMessage<Model, Message, OutMessage>`
 
-Closes HoverIntent immediately for a parent domain event, such as choosing an item in a hover menu. It invalidates pending transitions, clears panel engagement, and emits `Closed` when visibility changes.
+Closes HoverIntent immediately, for example after the parent handles a hover-menu item click. It invalidates pending waits and emits `Closed` only when visibility changes. If the trigger is still hovered or focused, the panel stays closed until both hover and focus leave it.
 
 ### update
 
@@ -69,18 +69,18 @@ Builds headless trigger and panel event bundles, then calls `ViewInputs.toView`.
 
 ### ViewInputs {#view-inputs}
 
-| Name                   | Type                           | Description                                                                               |
-| ---------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
-| `focusTriggerSelector` | `string \| undefined`          | Selector for the trigger that receives focus when Escape dismisses focused panel content. |
-| `toView`               | `(render: RenderInfo) => Html` | Renders the consumer-owned markup from HoverIntent's event bundles and visibility state.  |
+| Name                   | Type                           | Description                                                                    |
+| ---------------------- | ------------------------------ | ------------------------------------------------------------------------------ |
+| `focusTriggerSelector` | `string \| undefined`          | Selector for the trigger to focus before Escape removes focused panel content. |
+| `toView`               | `(render: RenderInfo) => Html` | Renders consumer-owned markup from the event bundles and visibility state.     |
 
 ### RenderInfo {#render-info}
 
-| Name        | Type                            | Description                                                                  |
-| ----------- | ------------------------------- | ---------------------------------------------------------------------------- |
-| `trigger`   | `ReadonlyArray<ChildAttribute>` | Hover, focus, and Escape attributes for the trigger element.                 |
-| `panel`     | `ReadonlyArray<ChildAttribute>` | Hover, focus, and Escape attributes for the panel element.                   |
-| `isVisible` | `boolean`                       | Whether the HoverIntent Model is open. Render the panel conditionally on it. |
+| Name        | Type                            | Description                                                           |
+| ----------- | ------------------------------- | --------------------------------------------------------------------- |
+| `trigger`   | `ReadonlyArray<ChildAttribute>` | Hover, focus, and Escape attributes for the trigger element.          |
+| `panel`     | `ReadonlyArray<ChildAttribute>` | Hover, focus, and Escape attributes for the panel element.            |
+| `isVisible` | `boolean`                       | Whether the panel is open. The consumer decides whether to render it. |
 
 ### Message
 
@@ -95,4 +95,4 @@ Builds headless trigger and panel event bundles, then calls `ViewInputs.toView`.
 
 ### WaitBeforeOpening and WaitBeforeClosing {#wait-commands}
 
-These Commands wait for the configured delay and emit their matching completion Message with its scheduling version. They are exported for Story tests. Application code should let `update` issue and resolve them through the normal Runtime.
+These Commands wait for the configured delay and emit their matching completion Message with the version that scheduled the wait. `update` ignores stale versions. The Commands are exported for Story tests; application code should let `update` issue and resolve them through the normal Runtime.

--- a/packages/website/src/page/ui/overviewPage.md
+++ b/packages/website/src/page/ui/overviewPage.md
@@ -46,7 +46,7 @@ The Kind column below identifies each component category.
 | [Calendar](/ui/calendar)           | Submodel | Inline calendar grid with 2D keyboard navigation, locale-aware headers, min/max constraints, and disabled-date support. Foundation for date pickers.                                                 |
 | [Date Picker](/ui/date-picker)     | Submodel | Input paired with a popover Calendar. Inherits the calendar’s constraint and keyboard-navigation support, with programmatic open/close and setters.                                                  |
 | [Animation](/ui/animation)         | Submodel | Coordinates CSS enter/leave animations via a state machine and data attributes. Works with both CSS transitions and CSS keyframe animations. Sends an OutMessage when the leave animation completes. |
-| [Hover Intent](/ui/hover-intent)   | Submodel | Behavior-only delayed hover and focus reveal across a trigger and panel. It leaves semantics, positioning, and styling to the composed component.                                                    |
+| [Hover Intent](/ui/hover-intent)   | Submodel | Headless hover and focus behavior for a trigger and panel, with delayed pointer opening and a closing grace period. The consumer owns semantics, positioning, and styling.                           |
 
 Underneath the floating components sits [Anchor](/ui/anchor), the positioning runtime Listbox, Combobox, Menu, Popover, Tooltip, and Date Picker share. It is neither a helper nor a Submodel, so it has no row above. Reach for it directly only when you are building an anchored component none of those cover.
 

--- a/packages/website/src/snippet/uiHoverIntentBasic.ts
+++ b/packages/website/src/snippet/uiHoverIntentBasic.ts
@@ -49,9 +49,8 @@ const foldHoverIntent = Update.foldChild({
 
 GotHoverIntentMessage: ({ message }) => foldHoverIntent(model, message)
 
-// Spread trigger attributes on the activator. Spread panel attributes on the
-// content. HoverIntent owns events only, so this component chooses the role,
-// anchor, and styles around those elements.
+// Spread each attribute bundle onto the element it names. HoverIntent owns the
+// interaction; this view owns the markup, semantics, positioning, and styles.
 const triggerId = 'more-information-trigger'
 const panelId = 'more-information-panel'
 


### PR DESCRIPTION
Name the demo triggers explicitly and explain pointer, focus, and dismissal behavior in plain language.

Align the overview, showcase, snippet guidance, and release post with the current documentation and examples.