### PR TITLE
docs(website): build the engine Layer in the Managed Resource snippet

### DIFF
--- a/packages/website/src/snippet/managedResourcesLayer.ts
+++ b/packages/website/src/snippet/managedResourcesLayer.ts
@@ -1,7 +1,7 @@
 import { Context, Effect, Layer, Option, Schema as S } from 'effect'
 import { ManagedResource } from 'foldkit'
 
-// A heavy engine whose init and teardown are packaged as an Effect Layer.
+// A FEN string is a text description of a chess position.
 interface ChessEngine {
   readonly bestMove: (fen: string) => Effect.Effect<string>
 }
@@ -11,7 +11,25 @@ class ChessEngineService extends Context.Service<
   ChessEngine
 >()('ChessEngineService') {}
 
-declare const engineLayer: Layer.Layer<ChessEngineService>
+// A heavy engine whose init and teardown are packaged as an Effect Layer.
+// Building the Layer spawns the worker, and the finalizer registered by
+// acquireRelease terminates it.
+const engineLayer: Layer.Layer<ChessEngineService> = Layer.effect(
+  ChessEngineService,
+  Effect.gen(function* () {
+    const worker = yield* Effect.acquireRelease(
+      Effect.sync(() => new Worker('/chess-engine-worker.js')),
+      worker => Effect.sync(() => worker.terminate()),
+    )
+
+    return {
+      bestMove: (fen: string): Effect.Effect<string> => {
+        // Your engine protocol goes here: post the FEN to the worker and
+        // resolve with its best-move reply.
+      },
+    }
+  }),
+)
 
 // 1. The Managed Resource holds the bare service value, with no wrapper.
 const Engine = ManagedResource.tag<ChessEngine>()('ChessEngine')


### PR DESCRIPTION
The Layer-backed Managed Resource snippet declared engineLayer away with declare const, leaving the section's subject invisible. Construct the Layer in the snippet instead: Layer.effect spawns the engine worker through Effect.acquireRelease, so the finalizer that Layer.build registers on the resource Scope is visible in the code the page explains. bestMove closes over the worker and is a stub whose body says where the engine protocol goes, and a comment above ChessEngine says what FEN is.