### PR TITLE
refactor(website): centralize demo styling

### DIFF
--- a/packages/website/src/page/ui/animation.ts
+++ b/packages/website/src/page/ui/animation.ts
@@ -7,8 +7,7 @@ import { Message } from './message'
 
 // DEMO CONTENT
 
-const triggerClassName =
-  'px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
+const triggerClassName = 'demo-neutral-button'
 
 const contentClassName =
   'mt-4 rounded-lg bg-accent-100 dark:bg-accent-900/30 border border-accent-300 dark:border-accent-700 p-4 transition duration-200 ease-out data-[closed]:opacity-0 data-[closed]:scale-95 data-[closed]:-translate-y-2'

--- a/packages/website/src/page/ui/calendar.ts
+++ b/packages/website/src/page/ui/calendar.ts
@@ -1,9 +1,8 @@
-import { Match as M } from 'effect'
-import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
+import type { HtmlBuilder } from 'foldkit/html'
 
 import { Calendar } from '@foldkit/ui'
 
-import { Icon } from '../../icon'
+import { calendarView } from './calendarView'
 import { Message } from './message'
 import type { Model } from './model'
 
@@ -11,167 +10,6 @@ import type { Model } from './model'
 
 const containerClassName =
   'inline-flex flex-col gap-3 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 p-4 shadow-sm select-none min-w-[304px] min-h-[324px]'
-
-const headerClassName = 'flex items-center justify-between gap-2'
-
-const headingButtonClassName =
-  'inline-flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white tabular-nums px-2 py-1 rounded-md cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800'
-
-const headingTextClassName =
-  'text-sm font-semibold text-gray-900 dark:text-white tabular-nums'
-
-const navButtonClassName =
-  'inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer'
-
-const gridClassName = 'flex flex-col gap-1 outline-none'
-
-const rowClassName = 'grid grid-cols-7 gap-1'
-
-const columnHeaderClassName =
-  'text-center text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 py-1'
-
-const cellClassName = 'group flex items-center justify-center'
-
-const dayButtonClassName =
-  'flex h-9 w-9 items-center justify-center rounded-full text-sm font-normal text-gray-900 dark:text-gray-100 tabular-nums cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 dark:group-data-[today]:ring-gray-500 group-data-[selected]:bg-accent-600 group-data-[selected]:dark:bg-accent-500 group-data-[selected]:text-white! group-data-[selected]:dark:text-accent-900! group-data-[selected]:hover:bg-accent-700 group-data-[selected]:dark:hover:bg-accent-600 group-data-[selected]:active:bg-accent-800 group-data-[selected]:dark:active:bg-accent-700 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-500 group-data-[outside-month]:text-gray-400 dark:group-data-[outside-month]:text-gray-600 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
-
-const monthYearGridClassName =
-  'grid grid-cols-3 grid-rows-4 gap-1 outline-none flex-1'
-
-const monthYearButtonClassName =
-  'flex h-full w-full items-center justify-center rounded-md text-sm font-normal text-gray-900 dark:text-gray-100 tabular-nums cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 dark:group-data-[today]:ring-gray-500 group-data-[selected]:bg-accent-600 group-data-[selected]:dark:bg-accent-500 group-data-[selected]:text-white! group-data-[selected]:dark:text-accent-900! group-data-[selected]:hover:bg-accent-700 group-data-[selected]:dark:hover:bg-accent-600 group-data-[selected]:active:bg-accent-800 group-data-[selected]:dark:active:bg-accent-700 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-500 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
-
-// PIECES
-
-const navButton = (
-  attributes: ReadonlyArray<ChildAttribute>,
-  icon: Html,
-  h: HtmlBuilder<Message>,
-): Html => h.button([...attributes, h.Class(navButtonClassName)], [icon])
-
-const headingButton = (
-  heading: Calendar.DaysModeAttributes['heading'],
-  attributes: ReadonlyArray<ChildAttribute>,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.button(
-    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
-    [heading.text, Icon.chevronDown('w-3 h-3')],
-  )
-
-const weekRow = (week: Calendar.Week, h: HtmlBuilder<Message>): Html =>
-  h.div(
-    [...week.attributes, h.Class(rowClassName)],
-    week.cells.map(cell =>
-      h.div(
-        [...cell.cellAttributes, h.Class(cellClassName)],
-        [
-          h.button(
-            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
-            [cell.label],
-          ),
-        ],
-      ),
-    ),
-  )
-
-// MODES
-
-const daysView = (
-  days: Calendar.DaysModeAttributes,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.div(
-    [...days.root, h.Class(containerClassName)],
-    [
-      h.div(
-        [h.Class(headerClassName)],
-        [
-          navButton(days.previousMonthButton, Icon.chevronLeft('w-5 h-5'), h),
-          headingButton(days.heading, days.headingButton, h),
-          navButton(days.nextMonthButton, Icon.chevronRight('w-5 h-5'), h),
-        ],
-      ),
-      h.div(
-        [...days.grid, h.Class(gridClassName)],
-        [
-          h.div(
-            [...days.headerRow, h.Class(rowClassName)],
-            days.columnHeaders.map(header =>
-              h.div(
-                [...header.attributes, h.Class(columnHeaderClassName)],
-                [header.name],
-              ),
-            ),
-          ),
-          ...days.weeks.map(week => weekRow(week, h)),
-        ],
-      ),
-    ],
-  )
-
-const monthsView = (
-  months: Calendar.MonthsModeAttributes,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.div(
-    [...months.root, h.Class(containerClassName)],
-    [
-      h.div(
-        [h.Class(`${headerClassName} justify-center`)],
-        [headingButton(months.heading, months.headingButton, h)],
-      ),
-      h.div(
-        [...months.grid, h.Class(monthYearGridClassName)],
-        months.cells.map(cell =>
-          h.div(
-            [...cell.cellAttributes, h.Class(cellClassName)],
-            [
-              h.button(
-                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
-                [cell.shortLabel],
-              ),
-            ],
-          ),
-        ),
-      ),
-    ],
-  )
-
-const yearsView = (
-  years: Calendar.YearsModeAttributes,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.div(
-    [...years.root, h.Class(containerClassName)],
-    [
-      h.div(
-        [h.Class(headerClassName)],
-        [
-          navButton(years.previousPageButton, Icon.chevronLeft('w-5 h-5'), h),
-          h.h2(
-            [h.Id(years.heading.id), h.Class(headingTextClassName)],
-            [years.heading.text],
-          ),
-          navButton(years.nextPageButton, Icon.chevronRight('w-5 h-5'), h),
-        ],
-      ),
-      h.div(
-        [...years.grid, h.Class(monthYearGridClassName)],
-        years.cells.map(cell =>
-          h.div(
-            [...cell.cellAttributes, h.Class(cellClassName)],
-            [
-              h.button(
-                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
-                [cell.label],
-              ),
-            ],
-          ),
-        ),
-      ),
-    ],
-  )
 
 // VIEW
 
@@ -183,13 +21,7 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
       view: Calendar.view,
       viewInputs: {
         maybeSelectedDate: model.maybeCalendarBasicDemoSelectedDate,
-        toView: M.type<Calendar.CalendarAttributes>().pipe(
-          M.tagsExhaustive({
-            Days: days => daysView(days, h),
-            Months: months => monthsView(months, h),
-            Years: years => yearsView(years, h),
-          }),
-        ),
+        toView: calendarView(containerClassName, h),
       },
       toParentMessage: message =>
         Message.GotCalendarBasicDemoMessage({ message }),

--- a/packages/website/src/page/ui/calendarView.ts
+++ b/packages/website/src/page/ui/calendarView.ts
@@ -1,0 +1,178 @@
+import { Match as M } from 'effect'
+import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
+
+import type { Calendar } from '@foldkit/ui'
+
+import { Icon } from '../../icon'
+
+const headerClassName = 'flex items-center justify-between gap-2'
+
+const headingButtonClassName =
+  'inline-flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white tabular-nums px-2 py-1 rounded-md cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800'
+
+const headingTextClassName =
+  'text-sm font-semibold text-gray-900 dark:text-white tabular-nums'
+
+const navButtonClassName =
+  'inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer'
+
+const gridClassName = 'flex flex-col gap-1 outline-none'
+
+const rowClassName = 'grid grid-cols-7 gap-1'
+
+const columnHeaderClassName =
+  'text-center text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 py-1'
+
+const cellClassName = 'group flex items-center justify-center'
+
+const dayButtonClassName =
+  'flex h-9 w-9 items-center justify-center rounded-full text-sm font-normal text-gray-900 dark:text-gray-100 tabular-nums cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 dark:group-data-[today]:ring-gray-500 group-data-[selected]:bg-accent-600 group-data-[selected]:dark:bg-accent-500 group-data-[selected]:text-white! group-data-[selected]:dark:text-accent-900! group-data-[selected]:hover:bg-accent-700 group-data-[selected]:dark:hover:bg-accent-600 group-data-[selected]:active:bg-accent-800 group-data-[selected]:dark:active:bg-accent-700 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-600 group-data-[focused]:dark:outline-accent-400 group-data-[outside-month]:text-gray-400 dark:group-data-[outside-month]:text-gray-600 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
+
+const monthYearGridClassName =
+  'grid grid-cols-3 grid-rows-4 gap-1 outline-none flex-1'
+
+const monthYearButtonClassName =
+  'flex h-full w-full items-center justify-center rounded-md text-sm font-normal text-gray-900 dark:text-gray-100 tabular-nums cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 dark:group-data-[today]:ring-gray-500 group-data-[selected]:bg-accent-600 group-data-[selected]:dark:bg-accent-500 group-data-[selected]:text-white! group-data-[selected]:dark:text-accent-900! group-data-[selected]:hover:bg-accent-700 group-data-[selected]:dark:hover:bg-accent-600 group-data-[selected]:active:bg-accent-800 group-data-[selected]:dark:active:bg-accent-700 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-600 group-data-[focused]:dark:outline-accent-400 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
+
+const navButton = <Message>(
+  attributes: ReadonlyArray<ChildAttribute>,
+  icon: Html,
+  h: HtmlBuilder<Message>,
+): Html => h.button([...attributes, h.Class(navButtonClassName)], [icon])
+
+const headingButton = <Message>(
+  heading: Calendar.DaysModeAttributes['heading'],
+  attributes: ReadonlyArray<ChildAttribute>,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.button(
+    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
+    [heading.text, Icon.chevronDown('w-3 h-3')],
+  )
+
+const weekRow = <Message>(week: Calendar.Week, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [...week.attributes, h.Class(rowClassName)],
+    week.cells.map(cell =>
+      h.div(
+        [...cell.cellAttributes, h.Class(cellClassName)],
+        [
+          h.button(
+            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
+            [cell.label],
+          ),
+        ],
+      ),
+    ),
+  )
+
+const daysView = <Message>(
+  days: Calendar.DaysModeAttributes,
+  rootClassName: string,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...days.root, h.Class(rootClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(days.previousMonthButton, Icon.chevronLeft('w-5 h-5'), h),
+          headingButton(days.heading, days.headingButton, h),
+          navButton(days.nextMonthButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...days.grid, h.Class(gridClassName)],
+        [
+          h.div(
+            [...days.headerRow, h.Class(rowClassName)],
+            days.columnHeaders.map(header =>
+              h.div(
+                [...header.attributes, h.Class(columnHeaderClassName)],
+                [header.name],
+              ),
+            ),
+          ),
+          ...days.weeks.map(week => weekRow(week, h)),
+        ],
+      ),
+    ],
+  )
+
+const monthsView = <Message>(
+  months: Calendar.MonthsModeAttributes,
+  rootClassName: string,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...months.root, h.Class(rootClassName)],
+    [
+      h.div(
+        [h.Class(`${headerClassName} justify-center`)],
+        [headingButton(months.heading, months.headingButton, h)],
+      ),
+      h.div(
+        [...months.grid, h.Class(monthYearGridClassName)],
+        months.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.shortLabel],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+const yearsView = <Message>(
+  years: Calendar.YearsModeAttributes,
+  rootClassName: string,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.div(
+    [...years.root, h.Class(rootClassName)],
+    [
+      h.div(
+        [h.Class(headerClassName)],
+        [
+          navButton(years.previousPageButton, Icon.chevronLeft('w-5 h-5'), h),
+          h.h2(
+            [h.Id(years.heading.id), h.Class(headingTextClassName)],
+            [years.heading.text],
+          ),
+          navButton(years.nextPageButton, Icon.chevronRight('w-5 h-5'), h),
+        ],
+      ),
+      h.div(
+        [...years.grid, h.Class(monthYearGridClassName)],
+        years.cells.map(cell =>
+          h.div(
+            [...cell.cellAttributes, h.Class(cellClassName)],
+            [
+              h.button(
+                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
+                [cell.label],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  )
+
+export const calendarView = <Message>(
+  rootClassName: string,
+  h: HtmlBuilder<Message>,
+) =>
+  M.type<Calendar.CalendarAttributes>().pipe(
+    M.tagsExhaustive({
+      Days: days => daysView(days, rootClassName, h),
+      Months: months => monthsView(months, rootClassName, h),
+      Years: years => yearsView(years, rootClassName, h),
+    }),
+  )

--- a/packages/website/src/page/ui/checkbox.ts
+++ b/packages/website/src/page/ui/checkbox.ts
@@ -16,21 +16,10 @@ const wrapperClassName = 'flex flex-col gap-1'
 
 const topRowClassName = 'flex items-center gap-2'
 
-const checkboxClassName =
-  'flex h-5 w-5 shrink-0 items-center justify-center rounded border border-gray-400 dark:border-gray-500 cursor-pointer data-[checked]:bg-accent-600 data-[checked]:dark:bg-accent-500 data-[checked]:border-accent-600 data-[checked]:dark:border-accent-500 data-[indeterminate]:bg-accent-600 data-[indeterminate]:dark:bg-accent-500 data-[indeterminate]:border-accent-600 data-[indeterminate]:dark:border-accent-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
-
-const labelClassName =
-  'text-sm font-normal text-gray-900 dark:text-white cursor-pointer select-none'
-
-const descriptionClassName = 'text-sm text-gray-500 dark:text-gray-400'
-
 // VIEW
 
 export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
-  const checkmark = h.span(
-    [h.Class('text-white dark:text-accent-900 text-xs font-normal')],
-    ['✓'],
-  )
+  const checkmark = h.span([h.Class('demo-checkbox-mark')], ['✓'])
 
   return [
     Checkbox.view(
@@ -46,17 +35,17 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
                 [h.Class(topRowClassName)],
                 [
                   h.button(
-                    [...attributes.checkbox, h.Class(checkboxClassName)],
+                    [...attributes.checkbox, h.Class('demo-checkbox')],
                     model.isCheckboxBasicDemoChecked ? [checkmark] : [],
                   ),
                   h.label(
-                    [...attributes.label, h.Class(labelClassName)],
+                    [...attributes.label, h.Class('demo-toggle-label')],
                     ['Accept terms and conditions'],
                   ),
                 ],
               ),
               h.p(
-                [...attributes.description, h.Class(descriptionClassName)],
+                [...attributes.description, h.Class('demo-description')],
                 ['You agree to our Terms of Service and Privacy Policy.'],
               ),
             ],
@@ -68,14 +57,8 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
 }
 
 export const indeterminateDemo = (model: Model, h: HtmlBuilder<Message>) => {
-  const checkmark = h.span(
-    [h.Class('text-white dark:text-accent-900 text-xs font-normal')],
-    ['✓'],
-  )
-  const indeterminateMark = h.span(
-    [h.Class('text-white dark:text-accent-900 text-xs font-normal')],
-    ['—'],
-  )
+  const checkmark = h.span([h.Class('demo-checkbox-mark')], ['✓'])
+  const indeterminateMark = h.span([h.Class('demo-checkbox-mark')], ['—'])
 
   const isAllChecked =
     model.isCheckboxOptionADemoChecked && model.isCheckboxOptionBDemoChecked
@@ -109,11 +92,11 @@ export const indeterminateDemo = (model: Model, h: HtmlBuilder<Message>) => {
                 [h.Class(topRowClassName)],
                 [
                   h.button(
-                    [...attributes.checkbox, h.Class(checkboxClassName)],
+                    [...attributes.checkbox, h.Class('demo-checkbox')],
                     resolveSelectAllMark(),
                   ),
                   h.label(
-                    [...attributes.label, h.Class(labelClassName)],
+                    [...attributes.label, h.Class('demo-toggle-label')],
                     ['All notifications'],
                   ),
                 ],
@@ -135,11 +118,11 @@ export const indeterminateDemo = (model: Model, h: HtmlBuilder<Message>) => {
                     [h.Class(topRowClassName)],
                     [
                       h.button(
-                        [...attributes.checkbox, h.Class(checkboxClassName)],
+                        [...attributes.checkbox, h.Class('demo-checkbox')],
                         model.isCheckboxOptionADemoChecked ? [checkmark] : [],
                       ),
                       h.label(
-                        [...attributes.label, h.Class(labelClassName)],
+                        [...attributes.label, h.Class('demo-toggle-label')],
                         ['Email notifications'],
                       ),
                     ],
@@ -158,11 +141,11 @@ export const indeterminateDemo = (model: Model, h: HtmlBuilder<Message>) => {
                     [h.Class(topRowClassName)],
                     [
                       h.button(
-                        [...attributes.checkbox, h.Class(checkboxClassName)],
+                        [...attributes.checkbox, h.Class('demo-checkbox')],
                         model.isCheckboxOptionBDemoChecked ? [checkmark] : [],
                       ),
                       h.label(
-                        [...attributes.label, h.Class(labelClassName)],
+                        [...attributes.label, h.Class('demo-toggle-label')],
                         ['Push notifications'],
                       ),
                     ],

--- a/packages/website/src/page/ui/combobox.ts
+++ b/packages/website/src/page/ui/combobox.ts
@@ -28,14 +28,12 @@ const CITIES: ReadonlyArray<City> = [
   'Zurich',
 ]
 
-const inputClassName =
-  'w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white pl-3 pr-10 py-2 text-base outline-none focus:ring-2 focus:ring-accent-500'
+const inputClassName = 'demo-field-input pr-10'
 
 const buttonClassName =
   'absolute inset-y-0 right-0 flex items-center px-4 cursor-pointer text-gray-400 dark:text-gray-500 hover:text-gray-900 dark:hover:text-white transition-colors'
 
-const itemsClassName =
-  'w-(--button-width) rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none'
+const itemsClassName = 'demo-popup-surface w-(--button-width) overflow-hidden'
 
 const COMBOBOX_ANCHOR: AnchorConfig = {
   placement: 'bottom-start',
@@ -43,8 +41,7 @@ const COMBOBOX_ANCHOR: AnchorConfig = {
   padding: 8,
 }
 
-const itemClassName =
-  'px-3 py-2 text-base text-gray-700 dark:text-gray-200 cursor-pointer data-[active]:bg-gray-100 dark:data-[active]:bg-gray-700/50 data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed'
+const itemClassName = 'demo-option'
 
 const backdropClassName = 'fixed inset-0 z-0'
 
@@ -113,13 +110,10 @@ export const comboboxDemo = (
 ) => {
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
-          [
-            h.For(Combobox.inputId(comboboxModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
-          ],
+          [h.For(Combobox.inputId(comboboxModel.id)), h.Class('demo-label')],
           ['City'],
         ),
         h.div(
@@ -156,12 +150,12 @@ export const nullableDemo = (
 ) => {
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
           [
             h.For(Combobox.inputId(comboboxNullableModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+            h.Class('demo-label'),
           ],
           ['City'],
         ),
@@ -199,12 +193,12 @@ export const selectOnFocusDemo = (
 ) => {
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
           [
             h.For(Combobox.inputId(comboboxSelectOnFocusModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+            h.Class('demo-label'),
           ],
           ['City'],
         ),
@@ -248,12 +242,12 @@ export const placementLockDemo = (
     ],
     [
       h.div(
-        [h.Class('flex flex-col gap-1.5')],
+        [h.Class('demo-field')],
         [
           h.label(
             [
               h.For(Combobox.inputId(comboboxPlacementLockModel.id)),
-              h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+              h.Class('demo-label'),
             ],
             ['City'],
           ),
@@ -303,12 +297,12 @@ export const multiDemo = (
 ) => {
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
           [
             h.For(Combobox.inputId(comboboxMultiModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+            h.Class('demo-label'),
           ],
           ['Cities'],
         ),

--- a/packages/website/src/page/ui/datePicker.ts
+++ b/packages/website/src/page/ui/datePicker.ts
@@ -1,24 +1,25 @@
-import { Match as M, Option } from 'effect'
-import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
+import { Option } from 'effect'
+import type { HtmlBuilder } from 'foldkit/html'
 
-import { Calendar, DatePicker } from '@foldkit/ui'
+import { DatePicker } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/popover'
 
 import { Icon } from '../../icon'
+import { calendarView } from './calendarView'
 import { Message } from './message'
 import type { Model } from './model'
 
 // DEMO CONTENT
 
 const triggerClassName =
-  'inline-flex items-center justify-between gap-2 min-w-48 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
+  'demo-neutral-button inline-flex min-w-48 items-center justify-between gap-2'
 
 const triggerContentClassName = 'flex w-full items-center justify-between gap-4'
 
 const placeholderClassName = 'text-gray-500 dark:text-gray-400'
 
 const panelClassName =
-  'rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 p-4 shadow-lg z-10 outline-none'
+  'demo-popup-surface rounded-xl bg-white p-4 dark:border-gray-800 dark:bg-gray-950'
 
 const backdropClassName = 'fixed inset-0 z-0'
 
@@ -26,167 +27,6 @@ const wrapperClassName = 'relative inline-block'
 
 const calendarWrapperClassName =
   'flex flex-col gap-3 select-none min-w-[268px] min-h-[284px]'
-
-const headerClassName = 'flex items-center justify-between gap-2'
-
-const headingButtonClassName =
-  'inline-flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white tabular-nums px-2 py-1 rounded-md cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800'
-
-const headingTextClassName =
-  'text-sm font-semibold text-gray-900 dark:text-white tabular-nums'
-
-const navButtonClassName =
-  'inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer'
-
-const gridClassName = 'flex flex-col gap-1 outline-none'
-
-const rowClassName = 'grid grid-cols-7 gap-1'
-
-const columnHeaderClassName =
-  'text-center text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 py-1'
-
-const cellClassName = 'group flex items-center justify-center'
-
-const dayButtonClassName =
-  'flex h-9 w-9 items-center justify-center rounded-full text-sm font-normal text-gray-900 dark:text-gray-100 tabular-nums cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 dark:group-data-[today]:ring-gray-500 group-data-[selected]:bg-accent-600 group-data-[selected]:dark:bg-accent-500 group-data-[selected]:text-white! group-data-[selected]:dark:text-accent-900! group-data-[selected]:hover:bg-accent-700 group-data-[selected]:dark:hover:bg-accent-600 group-data-[selected]:active:bg-accent-800 group-data-[selected]:dark:active:bg-accent-700 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-500 group-data-[outside-month]:text-gray-400 dark:group-data-[outside-month]:text-gray-600 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
-
-const monthYearGridClassName =
-  'grid grid-cols-3 grid-rows-4 gap-1 outline-none flex-1'
-
-const monthYearButtonClassName =
-  'flex h-full w-full items-center justify-center rounded-md text-sm font-normal text-gray-900 dark:text-gray-100 tabular-nums cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 group-data-[today]:ring-1 group-data-[today]:ring-gray-400 dark:group-data-[today]:ring-gray-500 group-data-[selected]:bg-accent-600 group-data-[selected]:dark:bg-accent-500 group-data-[selected]:text-white! group-data-[selected]:dark:text-accent-900! group-data-[selected]:hover:bg-accent-700 group-data-[selected]:dark:hover:bg-accent-600 group-data-[selected]:active:bg-accent-800 group-data-[selected]:dark:active:bg-accent-700 group-data-[focused]:outline-2 group-data-[focused]:outline-offset-2 group-data-[focused]:outline-accent-500 group-data-[disabled]:cursor-not-allowed group-data-[disabled]:opacity-40'
-
-// PIECES
-
-const navButton = (
-  attributes: ReadonlyArray<ChildAttribute>,
-  icon: Html,
-  h: HtmlBuilder<Message>,
-): Html => h.button([...attributes, h.Class(navButtonClassName)], [icon])
-
-const headingButton = (
-  heading: Calendar.DaysModeAttributes['heading'],
-  attributes: ReadonlyArray<ChildAttribute>,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.button(
-    [h.Id(heading.id), ...attributes, h.Class(headingButtonClassName)],
-    [heading.text, Icon.chevronDown('w-3 h-3')],
-  )
-
-const weekRow = (week: Calendar.Week, h: HtmlBuilder<Message>): Html =>
-  h.div(
-    [...week.attributes, h.Class(rowClassName)],
-    week.cells.map(cell =>
-      h.div(
-        [...cell.cellAttributes, h.Class(cellClassName)],
-        [
-          h.button(
-            [...cell.buttonAttributes, h.Class(dayButtonClassName)],
-            [cell.label],
-          ),
-        ],
-      ),
-    ),
-  )
-
-// MODES
-
-const daysView = (
-  days: Calendar.DaysModeAttributes,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.div(
-    [...days.root, h.Class(calendarWrapperClassName)],
-    [
-      h.div(
-        [h.Class(headerClassName)],
-        [
-          navButton(days.previousMonthButton, Icon.chevronLeft('w-5 h-5'), h),
-          headingButton(days.heading, days.headingButton, h),
-          navButton(days.nextMonthButton, Icon.chevronRight('w-5 h-5'), h),
-        ],
-      ),
-      h.div(
-        [...days.grid, h.Class(gridClassName)],
-        [
-          h.div(
-            [...days.headerRow, h.Class(rowClassName)],
-            days.columnHeaders.map(header =>
-              h.div(
-                [...header.attributes, h.Class(columnHeaderClassName)],
-                [header.name],
-              ),
-            ),
-          ),
-          ...days.weeks.map(week => weekRow(week, h)),
-        ],
-      ),
-    ],
-  )
-
-const monthsView = (
-  months: Calendar.MonthsModeAttributes,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.div(
-    [...months.root, h.Class(calendarWrapperClassName)],
-    [
-      h.div(
-        [h.Class(`${headerClassName} justify-center`)],
-        [headingButton(months.heading, months.headingButton, h)],
-      ),
-      h.div(
-        [...months.grid, h.Class(monthYearGridClassName)],
-        months.cells.map(cell =>
-          h.div(
-            [...cell.cellAttributes, h.Class(cellClassName)],
-            [
-              h.button(
-                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
-                [cell.shortLabel],
-              ),
-            ],
-          ),
-        ),
-      ),
-    ],
-  )
-
-const yearsView = (
-  years: Calendar.YearsModeAttributes,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.div(
-    [...years.root, h.Class(calendarWrapperClassName)],
-    [
-      h.div(
-        [h.Class(headerClassName)],
-        [
-          navButton(years.previousPageButton, Icon.chevronLeft('w-5 h-5'), h),
-          h.h2(
-            [h.Id(years.heading.id), h.Class(headingTextClassName)],
-            [years.heading.text],
-          ),
-          navButton(years.nextPageButton, Icon.chevronRight('w-5 h-5'), h),
-        ],
-      ),
-      h.div(
-        [...years.grid, h.Class(monthYearGridClassName)],
-        years.cells.map(cell =>
-          h.div(
-            [...cell.cellAttributes, h.Class(cellClassName)],
-            [
-              h.button(
-                [...cell.buttonAttributes, h.Class(monthYearButtonClassName)],
-                [cell.label],
-              ),
-            ],
-          ),
-        ),
-      ),
-    ],
-  )
 
 // VIEW
 
@@ -221,12 +61,12 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
 
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
           [
             h.For(DatePicker.triggerId(model.datePickerBasicDemo.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+            h.Class('demo-label'),
           ],
           ['Due date'],
         ),
@@ -242,13 +82,7 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
             panelClassName,
             backdropClassName,
             className: wrapperClassName,
-            toCalendarView: M.type<Calendar.CalendarAttributes>().pipe(
-              M.tagsExhaustive({
-                Days: days => daysView(days, h),
-                Months: months => monthsView(months, h),
-                Years: years => yearsView(years, h),
-              }),
-            ),
+            toCalendarView: calendarView(calendarWrapperClassName, h),
           },
           toParentMessage: message =>
             Message.GotDatePickerBasicDemoMessage({ message }),

--- a/packages/website/src/page/ui/dialog.ts
+++ b/packages/website/src/page/ui/dialog.ts
@@ -9,8 +9,7 @@ import type { City } from './model'
 
 // DEMO CONTENT
 
-const triggerClassName =
-  'px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
+const triggerClassName = 'demo-neutral-button'
 
 const backdropClassName = 'fixed inset-0 bg-black/50'
 
@@ -38,8 +37,7 @@ const dialogClassName =
 
 const actionsClassName = 'flex gap-2 justify-end'
 
-const cancelButtonClassName =
-  'px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+const cancelButtonClassName = 'demo-neutral-button'
 
 const confirmButtonClassName =
   'button-accent px-4 py-2 text-base cursor-pointer rounded-lg'

--- a/packages/website/src/page/ui/fieldset.ts
+++ b/packages/website/src/page/ui/fieldset.ts
@@ -15,36 +15,12 @@ const fieldsetClassName = 'w-full p-6'
 const legendClassName =
   'float-left w-full text-base font-semibold text-gray-900 dark:text-white'
 
-const descriptionClassName = 'text-sm text-gray-500 dark:text-gray-400'
-
-const labelClassName =
-  'block text-sm font-medium text-gray-700 dark:text-gray-300'
-
-const inputClassName =
-  'block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-base text-gray-900 transition-colors placeholder:text-gray-400 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-accent-400 dark:focus:ring-accent-400 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
-
-const textareaClassName =
-  'block w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-base text-gray-900 transition-colors placeholder:text-gray-400 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-accent-400 dark:focus:ring-accent-400 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
-
-const checkboxClassName =
-  'flex h-5 w-5 shrink-0 items-center justify-center rounded border border-gray-400 dark:border-gray-500 cursor-pointer data-[checked]:bg-accent-600 data-[checked]:dark:bg-accent-500 data-[checked]:border-accent-600 data-[checked]:dark:border-accent-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
-
-const checkboxLabelClassName =
-  'text-sm font-normal text-gray-900 dark:text-white cursor-pointer select-none'
-
-const checkboxDescriptionClassName = 'text-sm text-gray-500 dark:text-gray-400'
-
-const fieldClassName = 'flex flex-col gap-1.5'
-
 const fieldsClassName = 'mt-4 flex flex-col gap-4'
 
 // FIELDS
 
 const checkmark = (h: HtmlBuilder<Message>): Html =>
-  h.span(
-    [h.Class('text-white dark:text-accent-900 text-xs font-normal')],
-    ['✓'],
-  )
+  h.span([h.Class('demo-checkbox-mark')], ['✓'])
 
 const nameInput = (value: string, h: HtmlBuilder<Message>): Html =>
   Input.view(
@@ -56,12 +32,12 @@ const nameInput = (value: string, h: HtmlBuilder<Message>): Html =>
       placeholder: 'Enter your full name',
       toView: attributes =>
         h.div(
-          [h.Class(fieldClassName)],
+          [h.Class('demo-field')],
           [
-            h.label([...attributes.label, h.Class(labelClassName)], ['Name']),
-            h.input([...attributes.input, h.Class(inputClassName)]),
+            h.label([...attributes.label, h.Class('demo-label')], ['Name']),
+            h.input([...attributes.input, h.Class('demo-field-input')]),
             h.span(
-              [...attributes.description, h.Class(descriptionClassName)],
+              [...attributes.description, h.Class('demo-description')],
               ['As it appears on your government-issued ID.'],
             ),
           ],
@@ -81,12 +57,15 @@ const bioTextarea = (value: string, h: HtmlBuilder<Message>): Html =>
       rows: 3,
       toView: attributes =>
         h.div(
-          [h.Class(fieldClassName)],
+          [h.Class('demo-field')],
           [
-            h.label([...attributes.label, h.Class(labelClassName)], ['Bio']),
-            h.textarea([...attributes.textarea, h.Class(textareaClassName)]),
+            h.label([...attributes.label, h.Class('demo-label')], ['Bio']),
+            h.textarea([
+              ...attributes.textarea,
+              h.Class('demo-field-textarea'),
+            ]),
             h.span(
-              [...attributes.description, h.Class(descriptionClassName)],
+              [...attributes.description, h.Class('demo-description')],
               ['A brief introduction about yourself.'],
             ),
           ],
@@ -110,20 +89,17 @@ const termsCheckbox = (isChecked: boolean, h: HtmlBuilder<Message>): Html =>
               [h.Class('flex items-center gap-2')],
               [
                 h.button(
-                  [...attributes.checkbox, h.Class(checkboxClassName)],
+                  [...attributes.checkbox, h.Class('demo-checkbox')],
                   isChecked ? [checkmark(h)] : [],
                 ),
                 h.label(
-                  [...attributes.label, h.Class(checkboxLabelClassName)],
+                  [...attributes.label, h.Class('demo-toggle-label')],
                   ['I agree to the terms and conditions'],
                 ),
               ],
             ),
             h.p(
-              [
-                ...attributes.description,
-                h.Class(checkboxDescriptionClassName),
-              ],
+              [...attributes.description, h.Class('demo-description')],
               ['You agree to our Terms of Service and Privacy Policy.'],
             ),
           ],
@@ -142,10 +118,10 @@ const disabledNameInput = (h: HtmlBuilder<Message>): Html =>
       value: 'Ada Lovelace',
       toView: attributes =>
         h.div(
-          [h.Class(fieldClassName)],
+          [h.Class('demo-field')],
           [
-            h.label([...attributes.label, h.Class(labelClassName)], ['Name']),
-            h.input([...attributes.input, h.Class(inputClassName)]),
+            h.label([...attributes.label, h.Class('demo-label')], ['Name']),
+            h.input([...attributes.input, h.Class('demo-field-input')]),
           ],
         ),
     },
@@ -162,10 +138,13 @@ const disabledBioTextarea = (h: HtmlBuilder<Message>): Html =>
       rows: 3,
       toView: attributes =>
         h.div(
-          [h.Class(fieldClassName)],
+          [h.Class('demo-field')],
           [
-            h.label([...attributes.label, h.Class(labelClassName)], ['Bio']),
-            h.textarea([...attributes.textarea, h.Class(textareaClassName)]),
+            h.label([...attributes.label, h.Class('demo-label')], ['Bio']),
+            h.textarea([
+              ...attributes.textarea,
+              h.Class('demo-field-textarea'),
+            ]),
           ],
         ),
     },
@@ -184,11 +163,11 @@ const disabledTermsCheckbox = (h: HtmlBuilder<Message>): Html =>
           [h.Class('flex items-center gap-2')],
           [
             h.button(
-              [...attributes.checkbox, h.Class(checkboxClassName)],
+              [...attributes.checkbox, h.Class('demo-checkbox')],
               [checkmark(h)],
             ),
             h.label(
-              [...attributes.label, h.Class(checkboxLabelClassName)],
+              [...attributes.label, h.Class('demo-toggle-label')],
               ['I agree to the terms and conditions'],
             ),
           ],
@@ -213,10 +192,7 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
                 ['Personal Information'],
               ),
               h.span(
-                [
-                  ...attributes.description,
-                  h.Class(`${descriptionClassName} mt-1`),
-                ],
+                [...attributes.description, h.Class('demo-description mt-1')],
                 ['We just need a few details.'],
               ),
               h.div(
@@ -250,10 +226,7 @@ export const disabledDemo = (_model: Model, h: HtmlBuilder<Message>) => {
                 ['Personal Information'],
               ),
               h.span(
-                [
-                  ...attributes.description,
-                  h.Class(`${descriptionClassName} mt-1`),
-                ],
+                [...attributes.description, h.Class('demo-description mt-1')],
                 ['This fieldset is disabled.'],
               ),
               h.div(

--- a/packages/website/src/page/ui/fileDrop.ts
+++ b/packages/website/src/page/ui/fileDrop.ts
@@ -10,7 +10,7 @@ import type { Model } from './model'
 // DEMO CONTENT
 
 const dropZoneClassName =
-  'flex flex-col items-center gap-2 cursor-pointer rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 px-6 py-10 text-center hover:border-accent-400 select-none data-[drag-over]:border-accent-500 data-[drag-over]:bg-accent-50 dark:data-[drag-over]:bg-accent-950/30 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
+  'flex flex-col items-center gap-2 cursor-pointer rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 px-6 py-10 text-center hover:border-accent-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-400 select-none data-[drag-over]:border-accent-500 data-[drag-over]:bg-accent-50 dark:data-[drag-over]:bg-accent-950/30 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
 
 const primaryTextClassName =
   'text-base font-medium text-gray-900 dark:text-white'

--- a/packages/website/src/page/ui/input.ts
+++ b/packages/website/src/page/ui/input.ts
@@ -5,16 +5,6 @@ import { Input } from '@foldkit/ui'
 import { Message } from './message'
 import type { Model } from './model'
 
-// DEMO CONTENT
-
-const inputClassName =
-  'block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-base text-gray-900 transition-colors placeholder:text-gray-400 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-accent-400 dark:focus:ring-accent-400 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
-
-const labelClassName =
-  'block text-sm font-medium text-gray-700 dark:text-gray-300'
-
-const descriptionClassName = 'text-sm text-gray-500 dark:text-gray-400'
-
 // VIEW
 
 export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
@@ -30,15 +20,15 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
             placeholder: 'Enter your full name',
             toView: attributes =>
               h.div(
-                [h.Class('flex flex-col gap-1.5 w-full')],
+                [h.Class('demo-field w-full')],
                 [
                   h.label(
-                    [...attributes.label, h.Class(labelClassName)],
+                    [...attributes.label, h.Class('demo-label')],
                     ['Name'],
                   ),
-                  h.input([...attributes.input, h.Class(inputClassName)]),
+                  h.input([...attributes.input, h.Class('demo-field-input')]),
                   h.span(
-                    [...attributes.description, h.Class(descriptionClassName)],
+                    [...attributes.description, h.Class('demo-description')],
                     ['As it appears on your government-issued ID.'],
                   ),
                 ],
@@ -60,12 +50,12 @@ export const disabledDemo = (_model: Model, h: HtmlBuilder<Message>) => {
         value: 'Ada Lovelace',
         toView: attributes =>
           h.div(
-            [h.Class('flex flex-col gap-1.5 w-full max-w-md')],
+            [h.Class('demo-field w-full max-w-md')],
             [
-              h.label([...attributes.label, h.Class(labelClassName)], ['Name']),
-              h.input([...attributes.input, h.Class(inputClassName)]),
+              h.label([...attributes.label, h.Class('demo-label')], ['Name']),
+              h.input([...attributes.input, h.Class('demo-field-input')]),
               h.span(
-                [...attributes.description, h.Class(descriptionClassName)],
+                [...attributes.description, h.Class('demo-description')],
                 ['This input is disabled.'],
               ),
             ],

--- a/packages/website/src/page/ui/listbox.ts
+++ b/packages/website/src/page/ui/listbox.ts
@@ -45,19 +45,13 @@ const GROUPED_CHARACTERS: ReadonlyArray<Character> = [
 ]
 
 const triggerClassName =
-  'inline-flex items-center justify-between gap-2 min-w-48 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
+  'demo-neutral-button inline-flex min-w-48 items-center justify-between gap-2'
 
-const itemsClassName =
-  'w-(--button-width) rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none'
+const itemsClassName = 'demo-popup-surface w-(--button-width) overflow-hidden'
 
-const itemClassName =
-  'group px-3 py-2 text-base text-gray-700 dark:text-gray-200 cursor-pointer data-[active]:bg-gray-100 dark:data-[active]:bg-gray-700/50'
+const itemClassName = 'demo-option group'
 
-const groupedItemClassName =
-  'group px-3 py-2 text-base text-gray-700 dark:text-gray-200 cursor-pointer data-[active]:bg-gray-100 dark:data-[active]:bg-gray-700/50'
-
-const groupHeadingClassName =
-  'px-3 pt-3 pb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500'
+const groupHeadingClassName = 'demo-option-heading'
 
 const separatorClassName = 'border-t border-gray-200 dark:border-gray-700'
 
@@ -85,13 +79,10 @@ export const basicDemo = (
 
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
-          [
-            h.For(Listbox.buttonId(listboxModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
-          ],
+          [h.For(Listbox.buttonId(listboxModel.id)), h.Class('demo-label')],
           ['Family member'],
         ),
         h.div(
@@ -153,12 +144,12 @@ export const multiSelectDemo = (
 
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
           [
             h.For(Listbox.Multi.buttonId(listboxModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+            h.Class('demo-label'),
           ],
           ['Family members'],
         ),
@@ -218,13 +209,10 @@ export const groupedDemo = (
 
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
-          [
-            h.For(Listbox.buttonId(listboxModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
-          ],
+          [h.For(Listbox.buttonId(listboxModel.id)), h.Class('demo-label')],
           ['Character'],
         ),
         h.div(
@@ -248,7 +236,7 @@ export const groupedDemo = (
                   h.Class(separatorClassName),
                 ]),
                 itemToConfig: character => ({
-                  className: groupedItemClassName,
+                  className: itemClassName,
                   content: h.div(
                     [h.Class('flex items-center gap-2')],
                     [

--- a/packages/website/src/page/ui/menu.ts
+++ b/packages/website/src/page/ui/menu.ts
@@ -14,24 +14,19 @@ import { Message } from './message'
 
 // DEMO CONTENT
 
-const triggerClassName =
-  'inline-flex items-center gap-1.5 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
+const triggerClassName = 'demo-neutral-button inline-flex items-center gap-1.5'
 
-const basicItemsClassName =
-  'w-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none'
+const basicItemsClassName = 'demo-popup-surface w-48 overflow-hidden'
 
-const animatedItemsClassName =
-  'w-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg overflow-hidden z-10 outline-none transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0'
+const animatedItemsClassName = `${basicItemsClassName} transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0`
 
-const itemClassName =
-  'px-3 py-2 text-base text-gray-700 dark:text-gray-200 cursor-pointer data-[active]:bg-gray-100 dark:data-[active]:bg-gray-700/50 data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed'
+const itemClassName = 'demo-option'
 
 const backdropClassName = 'fixed inset-0 z-0'
 
 const wrapperClassName = 'relative inline-block'
 
-const headingClassName =
-  'px-3 pt-3 pb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500'
+const headingClassName = 'demo-option-heading'
 
 const ICON_SIZE = 'w-4 h-4'
 
@@ -110,13 +105,10 @@ const menuViewConfig = (itemsClassName: string) => {
 export const basicDemo = (menuModel: Menu.Model, h: HtmlBuilder<Message>) => {
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
-          [
-            h.For(Menu.buttonId(menuModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
-          ],
+          [h.For(Menu.buttonId(menuModel.id)), h.Class('demo-label')],
           ['Row actions'],
         ),
         h.div(
@@ -145,13 +137,10 @@ export const animatedDemo = (
 ) => {
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
-          [
-            h.For(Menu.buttonId(menuModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
-          ],
+          [h.For(Menu.buttonId(menuModel.id)), h.Class('demo-label')],
           ['Row actions'],
         ),
         h.div(

--- a/packages/website/src/page/ui/popover.ts
+++ b/packages/website/src/page/ui/popover.ts
@@ -7,14 +7,11 @@ import { Message } from './message'
 
 // DEMO CONTENT
 
-const triggerClassName =
-  'inline-flex items-center gap-1.5 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
+const triggerClassName = 'demo-neutral-button inline-flex items-center gap-1.5'
 
-const basicPanelClassName =
-  'w-64 rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg p-4 z-10 outline-none'
+const basicPanelClassName = 'demo-popup-surface w-64 p-4'
 
-const animatedPanelClassName =
-  'w-64 rounded-lg border border-gray-200 dark:border-gray-700 bg-cream dark:bg-gray-800 shadow-lg p-4 z-10 outline-none transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0'
+const animatedPanelClassName = `${basicPanelClassName} transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0`
 
 type PanelVariant = 'Basic' | 'Animated' | 'Arrow'
 
@@ -146,13 +143,10 @@ const labeledPopoverDemo = (
   h: HtmlBuilder<Message>,
 ): Array<Html> => [
   h.div(
-    [h.Class('flex flex-col gap-1.5')],
+    [h.Class('demo-field')],
     [
       h.label(
-        [
-          h.For(Popover.buttonId(popoverModel.id)),
-          h.Class('text-sm font-medium text-gray-900 dark:text-white'),
-        ],
+        [h.For(Popover.buttonId(popoverModel.id)), h.Class('demo-label')],
         ['Product menu'],
       ),
       h.div(
@@ -253,12 +247,12 @@ export const nestedDemo = (
 ) => {
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
           [
             h.For(Popover.buttonId(parentPopoverModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
+            h.Class('demo-label'),
           ],
           ['Account'],
         ),

--- a/packages/website/src/page/ui/radioGroup.ts
+++ b/packages/website/src/page/ui/radioGroup.ts
@@ -26,12 +26,12 @@ const planPrices: Record<Plan, string> = {
 const verticalGroupClassName = 'flex flex-col gap-3 w-full'
 
 const verticalOptionClassName =
-  'relative flex cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 data-[checked]:border-accent-600 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900'
+  'relative flex cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 data-[checked]:border-accent-600 dark:data-[checked]:border-accent-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 outline-none focus-visible:ring-2 focus-visible:ring-accent-600 dark:focus-visible:ring-accent-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900'
 
 const horizontalGroupClassName = 'flex flex-row gap-3 w-full'
 
 const horizontalOptionClassName =
-  'relative flex flex-col flex-1 cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 data-[checked]:border-accent-600 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900'
+  'relative flex flex-col flex-1 cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 data-[checked]:border-accent-600 dark:data-[checked]:border-accent-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 outline-none focus-visible:ring-2 focus-visible:ring-accent-600 dark:focus-visible:ring-accent-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900'
 
 const labelClassName = 'text-sm font-medium text-gray-900 dark:text-white'
 

--- a/packages/website/src/page/ui/select.ts
+++ b/packages/website/src/page/ui/select.ts
@@ -8,18 +8,10 @@ import type { Model } from './model'
 
 // DEMO CONTENT
 
-const selectClassName =
-  'appearance-none inline-flex items-center gap-2 w-full px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:focus:border-accent-400 dark:focus:ring-accent-400 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
-
 const selectWrapperClassName = 'relative w-full'
 
 const chevronClassName =
   'pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500'
-
-const labelClassName =
-  'block text-sm font-medium text-gray-700 dark:text-gray-300'
-
-const descriptionClassName = 'text-sm text-gray-500 dark:text-gray-400'
 
 // VIEW
 
@@ -35,17 +27,17 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
             onChange: value => Message.UpdatedSelectDemoValue({ value }),
             toView: attributes =>
               h.div(
-                [h.Class('flex flex-col gap-1.5 w-full')],
+                [h.Class('demo-field w-full')],
                 [
                   h.label(
-                    [...attributes.label, h.Class(labelClassName)],
+                    [...attributes.label, h.Class('demo-label')],
                     ['Country'],
                   ),
                   h.div(
                     [h.Class(selectWrapperClassName)],
                     [
                       h.select(
-                        [...attributes.select, h.Class(selectClassName)],
+                        [...attributes.select, h.Class('demo-field-select')],
                         [
                           h.option([h.Value('us')], ['United States']),
                           h.option([h.Value('ca')], ['Canada']),
@@ -60,7 +52,7 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
                     ],
                   ),
                   h.span(
-                    [...attributes.description, h.Class(descriptionClassName)],
+                    [...attributes.description, h.Class('demo-description')],
                     ['Where you currently reside.'],
                   ),
                 ],
@@ -82,17 +74,17 @@ export const disabledDemo = (_model: Model, h: HtmlBuilder<Message>) => {
         value: 'us',
         toView: attributes =>
           h.div(
-            [h.Class('flex flex-col gap-1.5 w-full max-w-md')],
+            [h.Class('demo-field w-full max-w-md')],
             [
               h.label(
-                [...attributes.label, h.Class(labelClassName)],
+                [...attributes.label, h.Class('demo-label')],
                 ['Country'],
               ),
               h.div(
                 [h.Class(selectWrapperClassName)],
                 [
                   h.select(
-                    [...attributes.select, h.Class(selectClassName)],
+                    [...attributes.select, h.Class('demo-field-select')],
                     [
                       h.option([h.Value('us')], ['United States']),
                       h.option([h.Value('ca')], ['Canada']),
@@ -107,7 +99,7 @@ export const disabledDemo = (_model: Model, h: HtmlBuilder<Message>) => {
                 ],
               ),
               h.span(
-                [...attributes.description, h.Class(descriptionClassName)],
+                [...attributes.description, h.Class('demo-description')],
                 ['This select is disabled.'],
               ),
             ],

--- a/packages/website/src/page/ui/slider.ts
+++ b/packages/website/src/page/ui/slider.ts
@@ -23,10 +23,10 @@ const trackClassName =
   'h-1.5 w-full rounded-full bg-gray-200 dark:bg-gray-700 data-[disabled]:cursor-not-allowed'
 
 const filledTrackClassName =
-  'h-full rounded-full bg-accent-600 data-[disabled]:bg-gray-400'
+  'h-full rounded-full bg-accent-600 dark:bg-accent-500 data-[disabled]:bg-gray-400'
 
 const thumbClassName =
-  'h-5 w-5 rounded-full bg-white border-2 border-accent-600 shadow cursor-grab focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-600 focus-visible:ring-offset-2 data-[dragging]:cursor-grabbing data-[disabled]:cursor-not-allowed data-[disabled]:border-gray-400'
+  'h-5 w-5 rounded-full bg-white border-2 border-accent-600 dark:border-accent-500 shadow cursor-grab focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-600 dark:focus-visible:ring-accent-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 data-[dragging]:cursor-grabbing data-[disabled]:cursor-not-allowed data-[disabled]:border-gray-400'
 
 // VIEW
 

--- a/packages/website/src/page/ui/switch.ts
+++ b/packages/website/src/page/ui/switch.ts
@@ -11,12 +11,7 @@ export const SWITCH_DEMO_ID = 'switch-demo'
 const wrapperClassName = 'flex items-center gap-3'
 
 const buttonClassName =
-  'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors cursor-pointer bg-gray-300 dark:bg-gray-600 data-[checked]:bg-accent-600 data-[checked]:dark:bg-accent-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
-
-const labelClassName =
-  'text-sm font-normal text-gray-900 dark:text-white cursor-pointer select-none'
-
-const descriptionClassName = 'text-sm text-gray-500 dark:text-gray-400'
+  'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors cursor-pointer bg-gray-300 dark:bg-gray-600 data-[checked]:bg-accent-600 data-[checked]:dark:bg-accent-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-400 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
 
 // VIEW
 
@@ -49,11 +44,11 @@ export const basicDemo = (
                 [],
                 [
                   h.label(
-                    [...attributes.label, h.Class(labelClassName)],
+                    [...attributes.label, h.Class('demo-toggle-label')],
                     ['Enable notifications'],
                   ),
                   h.p(
-                    [...attributes.description, h.Class(descriptionClassName)],
+                    [...attributes.description, h.Class('demo-description')],
                     ['Get notified when something important happens.'],
                   ),
                 ],

--- a/packages/website/src/page/ui/textarea.ts
+++ b/packages/website/src/page/ui/textarea.ts
@@ -5,16 +5,6 @@ import { Textarea } from '@foldkit/ui'
 import { Message } from './message'
 import type { Model } from './model'
 
-// DEMO CONTENT
-
-const textareaClassName =
-  'block w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-base text-gray-900 transition-colors placeholder:text-gray-400 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-accent-400 dark:focus:ring-accent-400 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50'
-
-const labelClassName =
-  'block text-sm font-medium text-gray-700 dark:text-gray-300'
-
-const descriptionClassName = 'text-sm text-gray-500 dark:text-gray-400'
-
 // VIEW
 
 export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
@@ -31,18 +21,18 @@ export const basicDemo = (model: Model, h: HtmlBuilder<Message>) => {
             rows: 4,
             toView: attributes =>
               h.div(
-                [h.Class('flex flex-col gap-1.5 w-full')],
+                [h.Class('demo-field w-full')],
                 [
                   h.label(
-                    [...attributes.label, h.Class(labelClassName)],
+                    [...attributes.label, h.Class('demo-label')],
                     ['Bio'],
                   ),
                   h.textarea([
                     ...attributes.textarea,
-                    h.Class(textareaClassName),
+                    h.Class('demo-field-textarea'),
                   ]),
                   h.span(
-                    [...attributes.description, h.Class(descriptionClassName)],
+                    [...attributes.description, h.Class('demo-description')],
                     ['A brief introduction about yourself.'],
                   ),
                 ],
@@ -66,12 +56,15 @@ export const disabledDemo = (_model: Model, h: HtmlBuilder<Message>) => {
         rows: 3,
         toView: attributes =>
           h.div(
-            [h.Class('flex flex-col gap-1.5 w-full max-w-md')],
+            [h.Class('demo-field w-full max-w-md')],
             [
-              h.label([...attributes.label, h.Class(labelClassName)], ['Bio']),
-              h.textarea([...attributes.textarea, h.Class(textareaClassName)]),
+              h.label([...attributes.label, h.Class('demo-label')], ['Bio']),
+              h.textarea([
+                ...attributes.textarea,
+                h.Class('demo-field-textarea'),
+              ]),
               h.span(
-                [...attributes.description, h.Class(descriptionClassName)],
+                [...attributes.description, h.Class('demo-description')],
                 ['This textarea is disabled.'],
               ),
             ],

--- a/packages/website/src/page/ui/toast.ts
+++ b/packages/website/src/page/ui/toast.ts
@@ -40,7 +40,7 @@ const variantClassName = (variant: Variant): string =>
 const entryClassName = 'w-80'
 
 const buttonClassName =
-  'inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
+  'demo-neutral-button inline-flex items-center gap-1.5 text-sm'
 
 // VIEW
 

--- a/packages/website/src/page/ui/tooltip.ts
+++ b/packages/website/src/page/ui/tooltip.ts
@@ -7,8 +7,7 @@ import { Message } from './message'
 
 // DEMO CONTENT
 
-const triggerClassName =
-  'inline-flex items-center gap-1.5 px-4 py-2 text-base font-normal cursor-pointer transition rounded-lg border border-gray-300 dark:border-gray-700 bg-cream dark:bg-gray-800 text-gray-900 dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 select-none'
+const triggerClassName = 'demo-neutral-button inline-flex items-center gap-1.5'
 
 const panelClassName =
   'rounded-md bg-gray-900 dark:bg-gray-700 px-3 py-1.5 text-sm text-white shadow-lg'
@@ -26,13 +25,10 @@ const TOOLTIP_ANCHOR: AnchorConfig = {
 export const demo = (tooltipModel: Tooltip.Model, h: HtmlBuilder<Message>) => {
   return [
     h.div(
-      [h.Class('flex flex-col gap-1.5')],
+      [h.Class('demo-field')],
       [
         h.label(
-          [
-            h.For(Tooltip.triggerId(tooltipModel.id)),
-            h.Class('text-sm font-medium text-gray-900 dark:text-white'),
-          ],
+          [h.For(Tooltip.triggerId(tooltipModel.id)), h.Class('demo-label')],
           ['Tooltip trigger'],
         ),
         h.div(

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -46,6 +46,7 @@
   --color-gray-850: #232129;
   --color-gray-900: #1e1c21;
   --color-gray-950: #13121a;
+  --color-accent-50: #f4fae8;
   --color-accent-100: #e8f5d0;
   --color-accent-200: #c8e494;
   --color-accent-300: #a3d154;
@@ -55,6 +56,7 @@
   --color-accent-700: #416812;
   --color-accent-800: #365610;
   --color-accent-900: #253b0a;
+  --color-accent-950: #152205;
   --font-sans: 'ABC Favorit', ui-sans-serif, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
   --font-weight-normal: 350;
@@ -215,23 +217,96 @@
 
   .button-accent,
   .cta-primary {
-    @apply bg-accent-600 dark:bg-accent-500 text-white dark:text-accent-900 font-normal transition hover:not-data-[disabled]:bg-accent-700 dark:hover:not-data-[disabled]:bg-accent-600 active:not-data-[disabled]:bg-accent-800 dark:active:not-data-[disabled]:bg-accent-700;
+    @apply bg-accent-600 dark:bg-accent-500 text-white dark:text-accent-900 hover:not-data-[disabled]:bg-accent-700 dark:hover:not-data-[disabled]:bg-accent-600 active:not-data-[disabled]:bg-accent-800 dark:active:not-data-[disabled]:bg-accent-700;
   }
 
-  .cta-primary {
-    @apply inline-flex items-center gap-2 px-6 py-3 rounded-lg text-base;
+  .button-accent {
+    @apply font-normal transition-colors;
+  }
+
+  .cta-primary,
+  .cta-secondary,
+  .cta-amber,
+  .cta-amber-sm {
+    @apply inline-flex items-center gap-2 rounded-lg font-normal transition-colors;
+  }
+
+  .cta-primary,
+  .cta-secondary,
+  .cta-amber {
+    @apply px-6 py-3 text-base;
   }
 
   .cta-secondary {
-    @apply inline-flex items-center gap-2 px-6 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-cream dark:bg-gray-900 text-gray-900 dark:text-white font-normal text-base transition hover:bg-gray-200 hover:border-gray-400 dark:hover:bg-gray-800 dark:hover:border-gray-400;
+    @apply border border-gray-300 dark:border-gray-600 bg-cream dark:bg-gray-900 text-gray-900 dark:text-white hover:bg-gray-200 hover:border-gray-400 dark:hover:bg-gray-800 dark:hover:border-gray-400;
   }
 
-  .cta-amber {
-    @apply inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-amber-500 dark:bg-amber-400 text-amber-950 font-normal text-base transition hover:bg-amber-400 dark:hover:bg-amber-300 active:bg-amber-600 dark:active:bg-amber-500;
+  .cta-amber,
+  .cta-amber-sm {
+    @apply bg-amber-500 dark:bg-amber-400 text-amber-950 hover:bg-amber-400 dark:hover:bg-amber-300 active:bg-amber-600 dark:active:bg-amber-500;
   }
 
   .cta-amber-sm {
-    @apply inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-500 dark:bg-amber-400 text-amber-950 font-normal text-sm transition hover:bg-amber-400 dark:hover:bg-amber-300 active:bg-amber-600 dark:active:bg-amber-500;
+    @apply px-4 py-2 text-sm;
+  }
+
+  .demo-field {
+    @apply flex flex-col gap-1.5;
+  }
+
+  .demo-label {
+    @apply text-sm font-normal text-gray-900 dark:text-white;
+  }
+
+  .demo-description {
+    @apply text-sm text-gray-500 dark:text-gray-400;
+  }
+
+  .demo-field-input,
+  .demo-field-textarea,
+  .demo-field-select {
+    @apply block w-full rounded-lg border border-gray-300 bg-white px-3 text-base text-gray-900 transition-colors placeholder:text-gray-400 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus:border-accent-400 dark:focus:ring-accent-400 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50;
+  }
+
+  .demo-field-input,
+  .demo-field-select {
+    @apply py-2;
+  }
+
+  .demo-field-textarea {
+    @apply py-2.5;
+  }
+
+  .demo-field-select {
+    @apply appearance-none cursor-pointer pr-10 select-none hover:not-data-[disabled]:bg-gray-50 dark:hover:not-data-[disabled]:bg-gray-700;
+  }
+
+  .demo-neutral-button {
+    @apply rounded-lg border border-gray-300 bg-cream px-4 py-2 text-base font-normal text-gray-900 transition-colors select-none cursor-pointer hover:not-data-[disabled]:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:not-data-[disabled]:bg-gray-700 dark:focus-visible:outline-accent-400;
+  }
+
+  .demo-popup-surface {
+    @apply z-10 rounded-lg border border-gray-200 bg-cream shadow-lg outline-none dark:border-gray-700 dark:bg-gray-800;
+  }
+
+  .demo-option {
+    @apply cursor-pointer px-3 py-2 text-base text-gray-700 data-[active]:bg-gray-100 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 dark:text-gray-200 dark:data-[active]:bg-gray-700/50;
+  }
+
+  .demo-option-heading {
+    @apply px-3 pt-3 pb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500;
+  }
+
+  .demo-checkbox {
+    @apply flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded border border-gray-400 data-[checked]:border-accent-600 data-[checked]:bg-accent-600 data-[indeterminate]:border-accent-600 data-[indeterminate]:bg-accent-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 dark:border-gray-500 dark:data-[checked]:border-accent-500 dark:data-[checked]:bg-accent-500 dark:data-[indeterminate]:border-accent-500 dark:data-[indeterminate]:bg-accent-500 dark:focus-visible:outline-accent-400;
+  }
+
+  .demo-checkbox-mark {
+    @apply text-xs font-normal text-white dark:text-accent-900;
+  }
+
+  .demo-toggle-label {
+    @apply cursor-pointer text-sm font-normal text-gray-900 select-none dark:text-white;
   }
 
   .landing-card {


### PR DESCRIPTION
Share repeated CTA, form, popup, option, and toggle styles across the live UI demos, and render Calendar and Date Picker through one calendar view.

Complete the accent scale and align interactive states across light and dark themes.