### PR TITLE
docs(website): rename Manifesto page to Why Foldkit

### DIFF
--- a/.changeset/bright-waves-fold.md
+++ b/.changeset/bright-waves-fold.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Rename the Foldkit philosophy page to “Why Foldkit” and update its URL in the package README.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <h3 align="center">The frontend framework for correctness.</h3>
 
 <p align="center">
-  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/get-started/manifesto"><strong>Manifesto</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/get-started/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqGm"><strong>Discord</strong></a>
+  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/get-started/why-foldkit"><strong>Why Foldkit</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/get-started/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqGm"><strong>Discord</strong></a>
 </p>
 
 ---

--- a/packages/foldkit/README.md
+++ b/packages/foldkit/README.md
@@ -13,7 +13,7 @@
 <h3 align="center">The frontend framework for correctness.</h3>
 
 <p align="center">
-  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/get-started/manifesto"><strong>Manifesto</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/get-started/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqGm"><strong>Discord</strong></a>
+  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/get-started/why-foldkit"><strong>Why Foldkit</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/get-started/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqGm"><strong>Discord</strong></a>
 </p>
 
 ---

--- a/packages/website/scripts/metadata.ts
+++ b/packages/website/scripts/metadata.ts
@@ -56,7 +56,7 @@ const METADATA_BY_TAG: Record<StaticRouteTag, PageMetadata> = {
     section: '',
   },
   Manifesto: docs(
-    'Manifesto',
+    'Why Foldkit',
     'Why Foldkit exists and the principles behind its design.',
     'Docs',
   ),

--- a/packages/website/src/docsNav.ts
+++ b/packages/website/src/docsNav.ts
@@ -144,7 +144,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
         {
           _tag: 'Manifesto',
           href: manifestoRouter(),
-          label: 'Manifesto',
+          label: 'Why Foldkit',
         },
         {
           _tag: 'GettingStarted',

--- a/packages/website/src/page/about.md
+++ b/packages/website/src/page/about.md
@@ -31,5 +31,5 @@ The site is also built to be read by agents. Every page is available as Markdown
 ## Where to Go Next
 
 - [Getting Started](/get-started/getting-started) creates a project and walks through the generated structure.
-- [Manifesto](/get-started/manifesto) explains why Foldkit exists and the principles behind its design.
+- [Why Foldkit](/get-started/why-foldkit) explains why Foldkit exists and the principles behind its design.
 - [Contact](/contact) lists the ways to reach the project.

--- a/packages/website/src/page/manifesto.md
+++ b/packages/website/src/page/manifesto.md
@@ -1,4 +1,4 @@
-# Manifesto
+# Why Foldkit
 
 ## The Architecture Problem
 

--- a/packages/website/src/route.test.ts
+++ b/packages/website/src/route.test.ts
@@ -46,6 +46,10 @@ describe('route table', () => {
       expect(parsed._tag).toBe(expectedTag(name))
     },
   )
+
+  test('builds the Why Foldkit page at its renamed URL', () => {
+    expect(Route.manifestoRouter()).toBe('/get-started/why-foldkit')
+  })
 })
 
 describe('blog routes', () => {

--- a/packages/website/src/route.ts
+++ b/packages/website/src/route.ts
@@ -262,7 +262,7 @@ const ai = section('ai')
 
 export const homeRouter = pipe(root, mapTo(AppRoute.Home))
 
-export const manifestoRouter = getStarted('manifesto', AppRoute.Manifesto)
+export const manifestoRouter = getStarted('why-foldkit', AppRoute.Manifesto)
 export const gettingStartedRouter = getStarted(
   'getting-started',
   AppRoute.GettingStarted,

--- a/scripts/deploy-website-workflow.test.mjs
+++ b/scripts/deploy-website-workflow.test.mjs
@@ -659,6 +659,27 @@ test('the developer portal path redirects to the AI overview', () => {
   )
 })
 
+test('the old manifesto paths redirect to Why Foldkit', () => {
+  for (const pathname of [
+    '/manifesto',
+    '/manifesto/',
+    '/get-started/manifesto',
+    '/get-started/manifesto/',
+  ]) {
+    const result = resolveRequest(productionConfig, pathname)
+    assert.equal(result.kind, 'redirect', pathname)
+    assert.equal(result.status, 308, pathname)
+    assert.equal(result.location, '/get-started/why-foldkit', pathname)
+  }
+
+  for (const pathname of ['/manifesto.md', '/get-started/manifesto.md']) {
+    const result = resolveRequest(productionConfig, pathname)
+    assert.equal(result.kind, 'redirect', pathname)
+    assert.equal(result.status, 308, pathname)
+    assert.equal(result.location, '/get-started/why-foldkit.md', pathname)
+  }
+})
+
 test('the MCP manifest and OpenAPI description are served as JSON', () => {
   const manifest = resolveRequest(productionConfig, '/.well-known/mcp')
   assert.equal(manifest.status, 200)

--- a/scripts/website-vercel-config.mjs
+++ b/scripts/website-vercel-config.mjs
@@ -175,7 +175,7 @@ export const websiteVercelConfig = channel => {
       {
         src: '^/$',
         headers: {
-          Link: '</sitemap.xml>; rel="sitemap", </get-started/manifesto>; rel="about", </get-started/getting-started>; rel="help", </example-apps>; rel="related", </ai/overview>; rel="describedby", </openapi.json>; rel="service-desc"',
+          Link: '</sitemap.xml>; rel="sitemap", </get-started/why-foldkit>; rel="about", </get-started/getting-started>; rel="help", </example-apps>; rel="related", </ai/overview>; rel="describedby", </openapi.json>; rel="service-desc"',
         },
         continue: true,
       },
@@ -252,14 +252,24 @@ export const websiteVercelConfig = channel => {
         headers: { Location: '/ai/overview' },
       },
       {
-        src: '^/manifesto$',
+        src: '^/manifesto/?$',
         status: 308,
-        headers: { Location: '/get-started/manifesto' },
+        headers: { Location: '/get-started/why-foldkit' },
       },
       {
         src: '^/manifesto\\.md$',
         status: 308,
-        headers: { Location: '/get-started/manifesto.md' },
+        headers: { Location: '/get-started/why-foldkit.md' },
+      },
+      {
+        src: '^/get-started/manifesto/?$',
+        status: 308,
+        headers: { Location: '/get-started/why-foldkit' },
+      },
+      {
+        src: '^/get-started/manifesto\\.md$',
+        status: 308,
+        headers: { Location: '/get-started/why-foldkit.md' },
       },
       {
         src: '^/getting-started$',


### PR DESCRIPTION
Use a name that describes the page's role without presenting it as a manifesto. Move the canonical page to /get-started/why-foldkit and permanently redirect both old manifesto URL forms, including their Markdown variants.