### PR TITLE
style(website): simplify the landing glyph before examples

### DIFF
--- a/packages/website/src/page/landing.ts
+++ b/packages/website/src/page/landing.ts
@@ -111,7 +111,7 @@ export const view = (
       trustSection(),
       glyph('[ ]'),
       includedSection(),
-      glyph('[*]'),
+      glyph('*'),
       examplesSection,
       glyph('::'),
       testingSection(renderCopyButton),


### PR DESCRIPTION
Replace the `[*]` divider between Included and Examples with `*` so it no longer reads as a filled counterpart to the `[ ]` glyph above it.