### PR TITLE
fix: close dialog and combobox accessibility gaps

### DIFF
--- a/.changeset/quiet-dialogs-focus.md
+++ b/.changeset/quiet-dialogs-focus.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Move focus into dialogs when the requested initial target is missing or cannot receive focus.

--- a/packages/foldkit/src/dom/dom.ts
+++ b/packages/foldkit/src/dom/dom.ts
@@ -35,6 +35,38 @@ const FOCUSABLE_SELECTOR = Array.join(
   ', ',
 )
 
+const isFocusableElement = (element: Element): element is HTMLElement => {
+  if (!(element instanceof HTMLElement)) {
+    return false
+  }
+
+  if (element.matches(':disabled')) {
+    return false
+  }
+
+  if (element instanceof HTMLInputElement && element.type === 'hidden') {
+    return false
+  }
+
+  if (element.tabIndex < 0 && !element.hasAttribute('tabindex')) {
+    return false
+  }
+
+  if (element.closest('[hidden], [inert]') !== null) {
+    return false
+  }
+
+  return element.checkVisibility({ visibilityProperty: true })
+}
+
+const focusableElementsWithin = (
+  root: ParentNode,
+): ReadonlyArray<HTMLElement> =>
+  Array.filter(
+    Array.fromIterable(root.querySelectorAll(FOCUSABLE_SELECTOR)),
+    isFocusableElement,
+  )
+
 const queryHTMLElement = (
   selector: string,
 ): Effect.Effect<HTMLElement, ElementNotFound> =>
@@ -114,6 +146,8 @@ export const focus = (
  * Fails with `ElementNotFound` if the selector does not match an `HTMLDialogElement`.
  *
  * Pass `focusSelector` to focus an element inside the dialog when it opens.
+ * When it does not match a focusable element, or when none is provided, focus
+ * falls back to the first focusable descendant and then to the dialog itself.
  *
  * Records the element that had focus when the dialog opened so `closeDialog`
  * can return focus there, the way `showModal()` would natively.
@@ -194,21 +228,35 @@ export const showDialog = (
       returnFocus,
     })
 
-    if (options?.focusSelector) {
-      const focusTarget = element.querySelector(options.focusSelector)
-      if (focusTarget instanceof HTMLElement) {
-        focusTarget.focus()
-      }
-    }
+    const focusTarget = findDialogFocusTarget(element, options?.focusSelector)
+    focusTarget.focus()
   })
+
+const findDialogFocusTarget = (
+  dialog: HTMLDialogElement,
+  focusSelector: string | undefined,
+): HTMLElement => {
+  if (focusSelector !== undefined) {
+    const requestedFocusTarget = dialog.querySelector(focusSelector)
+    if (
+      requestedFocusTarget !== null &&
+      isFocusableElement(requestedFocusTarget)
+    ) {
+      return requestedFocusTarget
+    }
+  }
+
+  return Option.match(Array.head(focusableElementsWithin(dialog)), {
+    onSome: Function.identity,
+    onNone: () => dialog,
+  })
+}
 
 const trapFocusWithinDialog = (
   event: KeyboardEvent,
   dialog: HTMLDialogElement,
 ): void => {
-  const focusable = Array.fromIterable(
-    dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-  )
+  const focusable = focusableElementsWithin(dialog)
   if (Array.isReadonlyArrayNonEmpty(focusable)) {
     const first = Array.headNonEmpty(focusable)
     const last = Array.lastNonEmpty(focusable)
@@ -220,6 +268,9 @@ const trapFocusWithinDialog = (
       event.preventDefault()
       first.focus()
     }
+  } else {
+    event.preventDefault()
+    dialog.focus()
   }
 }
 
@@ -476,9 +527,7 @@ export const advanceFocus = (
 
     const reference = yield* queryHTMLElement(selector)
 
-    const focusableElements = Array.fromIterable(
-      document.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-    )
+    const focusableElements = focusableElementsWithin(document)
 
     const referenceElementIndex = Array.findFirstIndex(
       focusableElements,

--- a/packages/foldkit/src/dom/index.test.ts
+++ b/packages/foldkit/src/dom/index.test.ts
@@ -469,6 +469,143 @@ describe('showDialog', () => {
   }
 
   it.effect(
+    'falls back to the first focusable descendant when focusSelector misses',
+    () =>
+      Effect.gen(function* () {
+        const dialog = makeDialog('solo')
+        const button = dialog.querySelector('button')
+
+        yield* showDialog('#solo', { focusSelector: '#missing' })
+
+        expect(document.activeElement).toBe(button)
+
+        yield* closeDialog('#solo')
+        document.body.innerHTML = ''
+      }),
+  )
+
+  it.effect(
+    'falls back when focusSelector matches an element that cannot receive focus',
+    () =>
+      Effect.gen(function* () {
+        const dialog = makeDialog('solo')
+        const nonFocusable = document.createElement('div')
+        nonFocusable.id = 'non-focusable'
+        dialog.prepend(nonFocusable)
+        const button = dialog.querySelector('button')
+
+        yield* showDialog('#solo', { focusSelector: '#non-focusable' })
+
+        expect(document.activeElement).toBe(button)
+
+        yield* closeDialog('#solo')
+        document.body.innerHTML = ''
+      }),
+  )
+
+  it.effect('focuses the first focusable descendant by default', () =>
+    Effect.gen(function* () {
+      const dialog = makeDialog('solo')
+      const button = dialog.querySelector('button')
+
+      yield* showDialog('#solo')
+
+      expect(document.activeElement).toBe(button)
+
+      yield* closeDialog('#solo')
+      document.body.innerHTML = ''
+    }),
+  )
+
+  it.effect('skips descendants that cannot receive focus', () =>
+    Effect.gen(function* () {
+      const dialog = document.createElement('dialog')
+      dialog.id = 'solo'
+
+      const hiddenInput = document.createElement('input')
+      hiddenInput.type = 'hidden'
+
+      const hiddenButton = document.createElement('button')
+      hiddenButton.style.display = 'none'
+
+      const disabledButton = document.createElement('button')
+      disabledButton.disabled = true
+
+      const visibleButton = document.createElement('button')
+
+      dialog.append(hiddenInput, hiddenButton, disabledButton, visibleButton)
+      document.body.appendChild(dialog)
+
+      yield* showDialog('#solo')
+
+      expect(document.activeElement).toBe(visibleButton)
+      expect(pressTab().defaultPrevented).toBe(true)
+      expect(document.activeElement).toBe(visibleButton)
+
+      yield* closeDialog('#solo')
+      document.body.innerHTML = ''
+    }),
+  )
+
+  it.effect('ignores nonfocusable descendants when trapping Tab', () =>
+    Effect.gen(function* () {
+      const dialog = document.createElement('dialog')
+      dialog.id = 'solo'
+
+      const visibleButton = document.createElement('button')
+
+      const hiddenInput = document.createElement('input')
+      hiddenInput.type = 'hidden'
+
+      const hiddenButton = document.createElement('button')
+      hiddenButton.style.display = 'none'
+
+      dialog.append(visibleButton, hiddenInput, hiddenButton)
+      document.body.appendChild(dialog)
+
+      yield* showDialog('#solo')
+
+      expect(document.activeElement).toBe(visibleButton)
+      expect(pressTab().defaultPrevented).toBe(true)
+      expect(document.activeElement).toBe(visibleButton)
+
+      yield* closeDialog('#solo')
+      document.body.innerHTML = ''
+    }),
+  )
+
+  it.effect('focuses the dialog when it has no focusable descendants', () =>
+    Effect.gen(function* () {
+      const dialog = document.createElement('dialog')
+      dialog.id = 'solo'
+      document.body.appendChild(dialog)
+
+      yield* showDialog('#solo')
+
+      expect(document.activeElement).toBe(dialog)
+
+      yield* closeDialog('#solo')
+      document.body.innerHTML = ''
+    }),
+  )
+
+  it.effect('traps Tab on a dialog with no focusable descendants', () =>
+    Effect.gen(function* () {
+      const dialog = document.createElement('dialog')
+      dialog.id = 'solo'
+      document.body.appendChild(dialog)
+
+      yield* showDialog('#solo')
+
+      expect(pressTab().defaultPrevented).toBe(true)
+      expect(document.activeElement).toBe(dialog)
+
+      yield* closeDialog('#solo')
+      document.body.innerHTML = ''
+    }),
+  )
+
+  it.effect(
     'closeDialog reports whether it released the hygiene showDialog installed',
     () =>
       Effect.gen(function* () {

--- a/packages/website/e2e/smoke.spec.ts
+++ b/packages/website/e2e/smoke.spec.ts
@@ -39,6 +39,25 @@ test('closes the hover-intent menu without navigating', async ({ page }) => {
   await expect(page).toHaveURL(/\/ui\/hover-intent$/)
 })
 
+test('names the mobile menu and moves focus into it', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto('/ui/dialog')
+
+  const trigger = page.getByRole('button', { name: 'Toggle menu' })
+  await trigger.click()
+
+  const dialog = page.getByRole('dialog', { name: 'Navigation menu' })
+  await expect(dialog).toHaveAccessibleDescription(
+    'Browse Foldkit documentation',
+  )
+  await expect(
+    dialog.getByRole('navigation', { name: 'Documentation' }),
+  ).toBeFocused()
+
+  await dialog.getByRole('button', { name: 'Close menu' }).click()
+  await expect(trigger).toBeFocused()
+})
+
 test('selects an item from the combobox', async ({ page }) => {
   await page.goto('/')
 
@@ -54,9 +73,11 @@ test('selects an item from the combobox', async ({ page }) => {
   await docsNav.getByRole('link', { name: 'Combobox', exact: true }).click()
   await expect(page).toHaveURL(/\/ui\/combobox$/)
 
-  const combobox = page
-    .getByRole('region', { name: 'Single-Select' })
-    .getByRole('combobox')
+  const singleSelect = page.getByRole('region', { name: 'Single-Select' })
+  const combobox = singleSelect.getByRole('combobox')
+  await expect(
+    singleSelect.getByRole('button', { name: 'Show suggestions' }),
+  ).toBeVisible()
 
   await combobox.click()
   await combobox.pressSequentially('Oxf')

--- a/packages/website/src/page/ui/demo/combobox.ts
+++ b/packages/website/src/page/ui/demo/combobox.ts
@@ -96,7 +96,10 @@ export const comboboxViewInputs = ({
     attributes: childAttributes([ih.Class(wrapperClass)]),
     inputWrapperAttributes: childAttributes([ih.Class('relative')]),
     buttonContent: Icon.chevronDown('w-4 h-4'),
-    buttonAttributes: childAttributes([ih.Class(buttonClassName)]),
+    buttonAttributes: childAttributes([
+      ih.AriaLabel('Show suggestions'),
+      ih.Class(buttonClassName),
+    ]),
     anchor,
   }
 }

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -302,12 +302,20 @@ export const mobileMenuView = (model: Model, h: HtmlBuilder<Message>): Html => {
     h,
   ])
 
-  const mobileMenuContent = (
-    closeButton: Dialog.RenderInfo['closeButton'],
-  ): Html =>
+  const mobileMenuContent = ({
+    closeButton,
+    description,
+    initialFocus,
+    title,
+  }: Dialog.RenderInfo): Html =>
     h.div(
       [h.Class('flex flex-col h-full')],
       [
+        h.span([...title, h.Class('sr-only')], ['Navigation menu']),
+        h.span(
+          [...description, h.Class('sr-only')],
+          ['Browse Foldkit documentation'],
+        ),
         h.div(
           [
             h.Class(
@@ -347,7 +355,7 @@ export const mobileMenuView = (model: Model, h: HtmlBuilder<Message>): Html => {
             h.Id(MOBILE_MENU_NAV_ID),
             h.Class('flex-1 overflow-y-auto'),
             h.Tabindex(-1),
-            h.Autofocus(true),
+            ...initialFocus,
           ],
           [blogSection(model.route, h), mobileNavLinks],
         ),
@@ -381,20 +389,23 @@ export const mobileMenuView = (model: Model, h: HtmlBuilder<Message>): Html => {
     model: model.mobileMenuDialog,
     view: Dialog.view,
     viewInputs: {
-      toView: ({ dialog, backdrop, panel, closeButton, isVisible }) =>
+      toView: renderInfo =>
         h.dialog(
-          [...dialog, h.Class('md:hidden')],
-          isVisible
+          [...renderInfo.dialog, h.Class('md:hidden')],
+          renderInfo.isVisible
             ? [
-                h.div([...backdrop, h.Class('fixed inset-0 z-[59]')]),
+                h.div([
+                  ...renderInfo.backdrop,
+                  h.Class('fixed inset-0 z-[59]'),
+                ]),
                 h.div(
                   [
-                    ...panel,
+                    ...renderInfo.panel,
                     h.Class(
                       'fixed inset-0 z-[60] bg-cream dark:bg-gray-900 flex flex-col',
                     ),
                   ],
-                  [mobileMenuContent(closeButton)],
+                  [mobileMenuContent(renderInfo)],
                 ),
               ]
             : [],


### PR DESCRIPTION
Move focus inside opened dialogs when the requested target is missing or cannot receive focus, and keep empty dialogs from leaking Tab focus.

Label the website mobile menu and demo combobox toggle buttons so their accessible names match their documented behavior.

Fixes #802