### PR TITLE
fix(oxlint-plugin)!: resolve APIs through scope bindings

### DIFF
--- a/.changeset/calm-scopes-resolve.md
+++ b/.changeset/calm-scopes-resolve.md
@@ -1,0 +1,10 @@
+---
+'@foldkit/oxlint-plugin': minor
+'@foldkit/ui': minor
+---
+
+Resolve imported Foldkit, UI, Effect, and child Message APIs through Oxlint's scope manager. Rules now recognize aliased imports, ignore local shadows, and distinguish Submodel Message payloads from unrelated `message` fields without requiring TypeScript parser services.
+
+This can introduce lint failures where an alias previously hid parent-owned construction of a child Message. Expose an update capability from the child and invoke it through `Update.foldChild` or `Update.foldChildStep` instead.
+
+Expose Animation `show` and `hide` update capabilities so parents can drive visibility through `Update.foldChildStep` without constructing child Messages.

--- a/examples/ui-showcase/src/main.ts
+++ b/examples/ui-showcase/src/main.ts
@@ -20,10 +20,10 @@ import { Dialog, Nav } from '@foldkit/ui'
 
 import * as Icon from './icon'
 import { uiInit } from './ui/init'
-import { UiMessage } from './ui/message'
+import { Message as UiMessage } from './ui/message'
 import { UiModel } from './ui/model'
 import * as UiSubscriptions from './ui/subscriptions'
-import { uiUpdate } from './ui/update'
+import { closeMobileMenu, openMobileMenu, uiUpdate } from './ui/update'
 import * as View from './ui/view'
 
 // ROUTE
@@ -158,6 +158,7 @@ export const Message = defineMessageUnion({
   CompletedLoadExternal: {},
   ClickedLink: { request: UrlRequest },
   ChangedUrl: { url: Url },
+  ClickedOpenMobileMenu: {},
   GotUiMessage: { message: UiMessage },
 })
 
@@ -211,13 +212,8 @@ export const init: Runtime.RoutingApplicationInit<Model, Message, Flags> = (
 
 // UPDATE
 
-const toUiMessage = (message: typeof UiMessage.Type): Message =>
+const toUiMessage = (message: UiMessage): Message =>
   Message.GotUiMessage({ message })
-
-const toMobileMenuDialogMessage = (message: Dialog.Message): Message =>
-  Message.GotUiMessage({
-    message: UiMessage.GotMobileMenuDialogMessage({ message }),
-  })
 
 const foldUi = Update.foldChild({
   update: uiUpdate,
@@ -226,22 +222,18 @@ const foldUi = Update.foldChild({
   toParentMessage: toUiMessage,
 })
 
-const foldMobileMenuDialogOutMessage = Dialog.OutMessage.match<
-  Update.Step<Model, Message>
->({
-  Opened: () => model => ({ model }),
-  Closed: () => model => ({ model }),
+const foldUiOpenMobileMenu = Update.foldChildStep({
+  update: openMobileMenu,
+  read: (model: Model) => Option.some(model.uiModel),
+  write: (model, nextUiModel) => evo(model, { uiModel: () => nextUiModel }),
+  toParentMessage: toUiMessage,
 })
 
-const foldMobileMenuDialogClose = Update.foldChildStep({
-  update: Dialog.close,
-  read: (model: Model) => Option.some(model.uiModel.mobileMenuDialog),
-  write: (model, nextMobileMenuDialog) =>
-    evo(model, {
-      uiModel: evo({ mobileMenuDialog: () => nextMobileMenuDialog }),
-    }),
-  toParentMessage: toMobileMenuDialogMessage,
-  foldOutMessage: foldMobileMenuDialogOutMessage,
+const foldUiCloseMobileMenu = Update.foldChildStep({
+  update: closeMobileMenu,
+  read: (model: Model) => Option.some(model.uiModel),
+  write: (model, nextUiModel) => evo(model, { uiModel: () => nextUiModel }),
+  toParentMessage: toUiMessage,
 })
 
 type UpdateReturn = Update.Return<Model, Message>
@@ -268,8 +260,10 @@ export const update = (model: Model, message: Message) =>
         stepModel => ({
           model: evo(stepModel, { route: () => urlToAppRoute(url) }),
         }),
-        foldMobileMenuDialogClose,
+        foldUiCloseMobileMenu,
       ]),
+
+    ClickedOpenMobileMenu: () => foldUiOpenMobileMenu(model),
 
     GotUiMessage: ({ message }) => foldUi(model, message),
   })
@@ -347,7 +341,7 @@ const componentNav = (
     toView,
   })
 
-const navListView = (
+const navListView = <Message>(
   items: ReadonlyArray<Nav.ItemInfo>,
   linkClassName: (isActive: boolean) => string,
   h: HtmlBuilder<Message>,
@@ -420,7 +414,7 @@ const sidebarView = (currentRoute: AppRoute, h: HtmlBuilder<Message>): Html =>
 const mobileMenuContent = (
   currentRoute: AppRoute,
   closeButton: Dialog.RenderInfo['closeButton'],
-  h: HtmlBuilder<Message>,
+  h: HtmlBuilder<UiMessage>,
 ): Html =>
   h.div(
     [h.Class('flex flex-col h-full')],
@@ -509,17 +503,25 @@ const mobileHeaderView = (model: Model, h: HtmlBuilder<Message>): Html =>
           ),
           h.AriaExpanded(model.uiModel.mobileMenuDialog.isOpen),
           h.AriaLabel('Toggle menu'),
-          h.OnClick(toUiMessage(UiMessage.ClickedOpenMobileMenu())),
+          h.OnClick(Message.ClickedOpenMobileMenu()),
         ],
         [Icon.menu('w-6 h-6')],
       ),
     ],
   )
 
-const mobileMenuView = (model: Model, h: HtmlBuilder<Message>): Html =>
+type MobileMenuViewInputs = Readonly<{
+  currentRoute: AppRoute
+}>
+
+const mobileMenuDialogView = Submodel.defineView<
+  UiModel,
+  UiMessage,
+  MobileMenuViewInputs
+>((model, { currentRoute }, h): Html =>
   h.submodel({
-    slotId: model.uiModel.mobileMenuDialog.id,
-    model: model.uiModel.mobileMenuDialog,
+    slotId: model.mobileMenuDialog.id,
+    model: model.mobileMenuDialog,
     view: Dialog.view,
     viewInputs: {
       toView: ({ dialog, backdrop, panel, closeButton, isVisible }) =>
@@ -533,13 +535,24 @@ const mobileMenuView = (model: Model, h: HtmlBuilder<Message>): Html =>
                     ...panel,
                     h.Class('fixed inset-0 z-[60] bg-white flex flex-col'),
                   ],
-                  [mobileMenuContent(model.route, closeButton, h)],
+                  [mobileMenuContent(currentRoute, closeButton, h)],
                 ),
               ]
             : [],
         ),
     },
-    toParentMessage: message => toMobileMenuDialogMessage(message),
+    toParentMessage: message =>
+      UiMessage.GotMobileMenuDialogMessage({ message }),
+  }),
+)
+
+const mobileMenuView = (model: Model, h: HtmlBuilder<Message>): Html =>
+  h.submodel({
+    slotId: 'mobile-menu',
+    model: model.uiModel,
+    view: mobileMenuDialogView,
+    viewInputs: { currentRoute: model.route },
+    toParentMessage: toUiMessage,
   })
 
 const homeView = (h: HtmlBuilder<Message>): Html =>

--- a/examples/ui-showcase/src/ui/init.ts
+++ b/examples/ui-showcase/src/ui/init.ts
@@ -20,7 +20,7 @@ import {
   VirtualList,
 } from '@foldkit/ui'
 
-import type { UiMessage } from './message'
+import type { Message as UiMessage } from './message'
 import type { UiModel } from './model'
 import { Toast } from './toast'
 

--- a/examples/ui-showcase/src/ui/message.ts
+++ b/examples/ui-showcase/src/ui/message.ts
@@ -22,9 +22,8 @@ import {
 
 import { Toast } from './toast'
 
-export const UiMessage = defineMessageUnion({
+export const Message = defineMessageUnion({
   GotMobileMenuDialogMessage: { message: Dialog.Message },
-  ClickedOpenMobileMenu: {},
   ClickedButtonDemo: {},
   GotAnimationDemoMessage: { message: Animation.Message },
   ToggledAnimationDemo: {},
@@ -93,4 +92,4 @@ export const UiMessage = defineMessageUnion({
   ClickedVirtualListVariableScrollToMiddle: {},
 })
 
-export type UiMessage = typeof UiMessage.Type
+export type Message = typeof Message.Type

--- a/examples/ui-showcase/src/ui/subscriptions.ts
+++ b/examples/ui-showcase/src/ui/subscriptions.ts
@@ -2,7 +2,7 @@ import { Subscription } from 'foldkit'
 
 import { DragAndDrop, Slider, VirtualList } from '@foldkit/ui'
 
-import { UiMessage } from './message'
+import { Message as UiMessage } from './message'
 import type { UiModel } from './model'
 
 const dragAndDropSubscriptions = Subscription.lift({

--- a/examples/ui-showcase/src/ui/update.ts
+++ b/examples/ui-showcase/src/ui/update.ts
@@ -21,7 +21,7 @@ import {
   VirtualList,
 } from '@foldkit/ui'
 
-import { UiMessage } from './message'
+import { Message as UiMessage } from './message'
 import type {
   City,
   DemoColumn,
@@ -134,6 +134,15 @@ const foldMobileMenuDialog = Update.foldChild({
 
 const foldMobileMenuDialogOpen = Update.foldChildStep({
   update: Dialog.open,
+  read: (model: UiModel) => Option.some(model.mobileMenuDialog),
+  write: (model, nextMobileMenuDialog) =>
+    evo(model, { mobileMenuDialog: () => nextMobileMenuDialog }),
+  toParentMessage: message => UiMessage.GotMobileMenuDialogMessage({ message }),
+  foldOutMessage: foldDialogOutMessage,
+})
+
+const foldMobileMenuDialogClose = Update.foldChildStep({
+  update: Dialog.close,
   read: (model: UiModel) => Option.some(model.mobileMenuDialog),
   write: (model, nextMobileMenuDialog) =>
     evo(model, { mobileMenuDialog: () => nextMobileMenuDialog }),
@@ -829,8 +838,16 @@ const foldAnimationDemo = Update.foldChild({
   foldOutMessage: foldAnimationDemoOutMessage,
 })
 
-const foldAnimationDemoToggle = Update.foldChildStep({
-  update: Animation.toggle,
+const foldAnimationDemoShow = Update.foldChildStep({
+  update: Animation.show,
+  read: (model: UiModel) => Option.some(model.animationDemo),
+  write: (model, nextAnimationDemo) =>
+    evo(model, { animationDemo: () => nextAnimationDemo }),
+  toParentMessage: message => UiMessage.GotAnimationDemoMessage({ message }),
+})
+
+const foldAnimationDemoHide = Update.foldChildStep({
+  update: Animation.hide,
   read: (model: UiModel) => Option.some(model.animationDemo),
   write: (model, nextAnimationDemo) =>
     evo(model, { animationDemo: () => nextAnimationDemo }),
@@ -879,8 +896,6 @@ const foldVirtualListVariableDemoScrollToIndex = Update.foldChild({
 
 export const uiUpdate = (model: UiModel, message: UiMessage) =>
   UiMessage.match<Update.Return<UiModel, UiMessage>>(message, {
-    ClickedOpenMobileMenu: () => foldMobileMenuDialogOpen(model),
-
     GotMobileMenuDialogMessage: ({ message }) =>
       foldMobileMenuDialog(model, message),
 
@@ -1127,7 +1142,10 @@ export const uiUpdate = (model: UiModel, message: UiMessage) =>
 
     GotAnimationDemoMessage: ({ message }) => foldAnimationDemo(model, message),
 
-    ToggledAnimationDemo: () => foldAnimationDemoToggle(model),
+    ToggledAnimationDemo: () =>
+      model.animationDemo.isShowing
+        ? foldAnimationDemoHide(model)
+        : foldAnimationDemoShow(model),
 
     GotVirtualListDemoMessage: ({ message }) =>
       foldVirtualListDemo(model, message),
@@ -1147,3 +1165,9 @@ export const uiUpdate = (model: UiModel, message: UiMessage) =>
         Math.floor(VIRTUAL_LIST_ROW_COUNT / 2),
       ),
   })
+
+export const openMobileMenu = (model: UiModel) =>
+  foldMobileMenuDialogOpen(model)
+
+export const closeMobileMenu = (model: UiModel) =>
+  foldMobileMenuDialogClose(model)

--- a/examples/ui-showcase/src/ui/view/animation.ts
+++ b/examples/ui-showcase/src/ui/view/animation.ts
@@ -3,7 +3,7 @@ import type { Html } from 'foldkit/html'
 
 import { Animation } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const triggerClassName =

--- a/examples/ui-showcase/src/ui/view/button.ts
+++ b/examples/ui-showcase/src/ui/view/button.ts
@@ -3,7 +3,7 @@ import type { Html } from 'foldkit/html'
 
 import { Button } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const buttonClassName =

--- a/examples/ui-showcase/src/ui/view/calendar.ts
+++ b/examples/ui-showcase/src/ui/view/calendar.ts
@@ -5,7 +5,7 @@ import type { ChildAttribute, Html, HtmlBuilder } from 'foldkit/html'
 import { Calendar } from '@foldkit/ui'
 
 import * as Icon from '../../icon'
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const containerClassName =

--- a/examples/ui-showcase/src/ui/view/checkbox.ts
+++ b/examples/ui-showcase/src/ui/view/checkbox.ts
@@ -3,7 +3,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Checkbox } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const CHECKBOX_BASIC_DEMO_ID = 'checkbox-basic-demo'

--- a/examples/ui-showcase/src/ui/view/combobox.ts
+++ b/examples/ui-showcase/src/ui/view/combobox.ts
@@ -7,7 +7,7 @@ import { Combobox } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/combobox'
 
 import * as Icon from '../../icon'
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { City, UiModel } from '../model'
 
 export const CityCombobox = Combobox.create<City>()

--- a/examples/ui-showcase/src/ui/view/datePicker.ts
+++ b/examples/ui-showcase/src/ui/view/datePicker.ts
@@ -6,7 +6,7 @@ import { Calendar, DatePicker } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/popover'
 
 import * as Icon from '../../icon'
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const triggerClassName =

--- a/examples/ui-showcase/src/ui/view/dialog.ts
+++ b/examples/ui-showcase/src/ui/view/dialog.ts
@@ -4,7 +4,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Combobox, Dialog } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { City, UiModel } from '../model'
 import { CityCombobox, comboboxInputs } from './combobox'
 

--- a/examples/ui-showcase/src/ui/view/disclosure.ts
+++ b/examples/ui-showcase/src/ui/view/disclosure.ts
@@ -5,7 +5,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 import { Disclosure } from '@foldkit/ui'
 
 import * as Icon from '../../icon'
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const DISCLOSURE_BASIC_DEMO_ID = 'disclosure-basic-demo'

--- a/examples/ui-showcase/src/ui/view/dragAndDrop.ts
+++ b/examples/ui-showcase/src/ui/view/dragAndDrop.ts
@@ -5,7 +5,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { DragAndDrop } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { DemoCard, DemoColumn, UiModel } from '../model'
 
 const cardClassName =

--- a/examples/ui-showcase/src/ui/view/fieldset.ts
+++ b/examples/ui-showcase/src/ui/view/fieldset.ts
@@ -3,7 +3,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Checkbox, Fieldset, Input, Textarea } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const FIELDSET_CHECKBOX_DEMO_ID = 'fieldset-checkbox-demo'

--- a/examples/ui-showcase/src/ui/view/fileDrop.ts
+++ b/examples/ui-showcase/src/ui/view/fileDrop.ts
@@ -4,7 +4,7 @@ import type { Html } from 'foldkit/html'
 
 import { FileDrop } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const dropZoneClassName =

--- a/examples/ui-showcase/src/ui/view/hoverIntent.ts
+++ b/examples/ui-showcase/src/ui/view/hoverIntent.ts
@@ -3,7 +3,7 @@ import type { Html } from 'foldkit/html'
 
 import { HoverIntent } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const triggerClassName =

--- a/examples/ui-showcase/src/ui/view/input.ts
+++ b/examples/ui-showcase/src/ui/view/input.ts
@@ -3,7 +3,7 @@ import type { Html } from 'foldkit/html'
 
 import { Input } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const inputClassName =

--- a/examples/ui-showcase/src/ui/view/listbox.ts
+++ b/examples/ui-showcase/src/ui/view/listbox.ts
@@ -5,7 +5,7 @@ import { type Html, type HtmlBuilder, childAttributes } from 'foldkit/html'
 import { Listbox } from '@foldkit/ui'
 
 import * as Icon from '../../icon'
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { ListboxItem, UiModel } from '../model'
 
 const LISTBOX_ITEMS: ReadonlyArray<ListboxItem> = [

--- a/examples/ui-showcase/src/ui/view/menu.ts
+++ b/examples/ui-showcase/src/ui/view/menu.ts
@@ -5,7 +5,7 @@ import { type Html, type HtmlBuilder, childAttributes } from 'foldkit/html'
 import { Menu } from '@foldkit/ui'
 
 import * as Icon from '../../icon'
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const triggerClassName =

--- a/examples/ui-showcase/src/ui/view/popover.ts
+++ b/examples/ui-showcase/src/ui/view/popover.ts
@@ -3,7 +3,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Popover } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const triggerClassName =

--- a/examples/ui-showcase/src/ui/view/radioGroup.ts
+++ b/examples/ui-showcase/src/ui/view/radioGroup.ts
@@ -3,7 +3,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { RadioGroup } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import { type Plan, type UiModel } from '../model'
 
 export const PlanRadioGroup = RadioGroup.create<Plan>()

--- a/examples/ui-showcase/src/ui/view/select.ts
+++ b/examples/ui-showcase/src/ui/view/select.ts
@@ -4,7 +4,7 @@ import type { Html } from 'foldkit/html'
 import { Select } from '@foldkit/ui'
 
 import * as Icon from '../../icon'
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const selectClassName =

--- a/examples/ui-showcase/src/ui/view/slider.ts
+++ b/examples/ui-showcase/src/ui/view/slider.ts
@@ -3,7 +3,7 @@ import type { Html } from 'foldkit/html'
 
 import { Slider } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const rowClassName = 'flex flex-col gap-2 w-full max-w-sm'

--- a/examples/ui-showcase/src/ui/view/switch.ts
+++ b/examples/ui-showcase/src/ui/view/switch.ts
@@ -4,7 +4,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Switch } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const SWITCH_DEMO_ID = 'switch-demo'

--- a/examples/ui-showcase/src/ui/view/tabs.ts
+++ b/examples/ui-showcase/src/ui/view/tabs.ts
@@ -4,7 +4,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { Tabs } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import { type DemoTab, type UiModel } from '../model'
 
 const demoTabs: ReadonlyArray<DemoTab> = ['Foldkit', 'React', 'Elm']

--- a/examples/ui-showcase/src/ui/view/textarea.ts
+++ b/examples/ui-showcase/src/ui/view/textarea.ts
@@ -3,7 +3,7 @@ import type { Html } from 'foldkit/html'
 
 import { Textarea } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const textareaClassName =

--- a/examples/ui-showcase/src/ui/view/toast.ts
+++ b/examples/ui-showcase/src/ui/view/toast.ts
@@ -5,7 +5,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 import type { EntryHandlers, Variant } from '@foldkit/ui/toast'
 
 import * as Icon from '../../icon'
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 import { Toast } from '../toast'
 

--- a/examples/ui-showcase/src/ui/view/tooltip.ts
+++ b/examples/ui-showcase/src/ui/view/tooltip.ts
@@ -4,7 +4,7 @@ import type { Html } from 'foldkit/html'
 import { Tooltip } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/tooltip'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 const triggerClassName =

--- a/examples/ui-showcase/src/ui/view/virtualList.ts
+++ b/examples/ui-showcase/src/ui/view/virtualList.ts
@@ -4,7 +4,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { VirtualList } from '@foldkit/ui'
 
-import { UiMessage } from '../message'
+import { Message as UiMessage } from '../message'
 import type { UiModel } from '../model'
 
 type Activity = Readonly<{

--- a/packages/oxlint-plugin-foldkit/src/guards.ts
+++ b/packages/oxlint-plugin-foldkit/src/guards.ts
@@ -1,5 +1,10 @@
 import { Array, Option } from 'effect'
-import { type ESTree, type OxlintScope, type Reference } from 'effect-oxlint'
+import {
+  type ESTree,
+  type OxlintScope,
+  type Reference,
+  type Variable,
+} from 'effect-oxlint'
 
 export const isIdentifier = (
   node: unknown,
@@ -96,6 +101,68 @@ export const helperCalleeName = (callee: unknown): Option.Option<string> => {
   return Option.none()
 }
 
+type TransparentExpression =
+  | ESTree.ChainExpression
+  | ESTree.ParenthesizedExpression
+  | ESTree.TSAsExpression
+  | ESTree.TSInstantiationExpression
+  | ESTree.TSNonNullExpression
+  | ESTree.TSSatisfiesExpression
+  | ESTree.TSTypeAssertion
+
+const isTransparentExpression = (
+  node: unknown,
+): node is TransparentExpression =>
+  typeof node === 'object' &&
+  node !== null &&
+  'type' in node &&
+  (node.type === 'ChainExpression' ||
+    node.type === 'ParenthesizedExpression' ||
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSInstantiationExpression' ||
+    node.type === 'TSNonNullExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSTypeAssertion')
+
+const innermostExpression = (node: unknown): unknown =>
+  isTransparentExpression(node) ? innermostExpression(node.expression) : node
+
+const isTSQualifiedName = (node: unknown): node is ESTree.TSQualifiedName =>
+  typeof node === 'object' &&
+  node !== null &&
+  'type' in node &&
+  node.type === 'TSQualifiedName'
+
+export type StaticMemberPath = Readonly<{
+  root: ESTree.IdentifierReference
+  members: ReadonlyArray<string>
+}>
+
+export const staticMemberPath = (
+  node: unknown,
+): Option.Option<StaticMemberPath> => {
+  const expression = innermostExpression(node)
+  if (isIdentifierReference(expression)) {
+    return Option.some({ root: expression, members: [] })
+  }
+  if (isTSQualifiedName(expression)) {
+    return Option.map(staticMemberPath(expression.left), path => ({
+      root: path.root,
+      members: [...path.members, expression.right.name],
+    }))
+  }
+  if (!isMemberExpression(expression)) {
+    return Option.none()
+  }
+
+  return Option.flatMap(staticMemberPath(expression.object), path =>
+    Option.map(staticMemberName(expression), member => ({
+      root: path.root,
+      members: [...path.members, member],
+    })),
+  )
+}
+
 export const calleeMatchesHelperName = (
   callee: unknown,
   helperName: string,
@@ -146,6 +213,222 @@ export const indexReferences = (
     }
   }
   return references
+}
+
+export const resolvedVariable = (
+  references: WeakMap<ESTree.Node, Reference>,
+  node: ESTree.IdentifierReference,
+): Option.Option<Variable> =>
+  Option.flatMap(Option.fromNullishOr(references.get(node)), reference =>
+    Option.fromNullishOr(reference.resolved),
+  )
+
+export type ImportedPath = Readonly<{
+  source: string
+  members: ReadonlyArray<string>
+  localMembers: ReadonlyArray<string>
+}>
+
+const importedName = (specifier: ESTree.ImportSpecifier): string =>
+  specifier.imported.type === 'Identifier'
+    ? specifier.imported.name
+    : specifier.imported.value
+
+export const resolveImportedPath = (
+  references: WeakMap<ESTree.Node, Reference>,
+  node: unknown,
+): Option.Option<ImportedPath> =>
+  Option.gen(function* () {
+    const path = yield* staticMemberPath(node)
+    const variable = yield* resolvedVariable(references, path.root)
+    const definition = yield* Array.findFirst(
+      variable.defs,
+      definition => definition.type === 'ImportBinding',
+    )
+
+    if (definition.parent?.type !== 'ImportDeclaration') {
+      return yield* Option.none()
+    }
+
+    const localMembers = [path.root.name, ...path.members]
+    if (definition.node.type === 'ImportNamespaceSpecifier') {
+      return {
+        source: definition.parent.source.value,
+        members: path.members,
+        localMembers,
+      }
+    }
+    if (definition.node.type !== 'ImportSpecifier') {
+      return yield* Option.none()
+    }
+
+    return {
+      source: definition.parent.source.value,
+      members: [importedName(definition.node), ...path.members],
+      localMembers,
+    }
+  })
+
+const foldkitNamespaceBySource: Readonly<Record<string, string>> = {
+  'foldkit/command': 'Command',
+  'foldkit/html': 'Html',
+  'foldkit/managedResource': 'ManagedResource',
+  'foldkit/message': 'Message',
+  'foldkit/mount': 'Mount',
+  'foldkit/navigation': 'Navigation',
+  'foldkit/route': 'Route',
+  'foldkit/runtime': 'Runtime',
+  'foldkit/schema': 'Schema',
+  'foldkit/struct': 'Struct',
+  'foldkit/submodel': 'Submodel',
+  'foldkit/subscription': 'Subscription',
+}
+
+export const resolveFoldkitApiPath = (
+  references: WeakMap<ESTree.Node, Reference>,
+  node: unknown,
+): Option.Option<ReadonlyArray<string>> =>
+  Option.flatMap(resolveImportedPath(references, node), path => {
+    if (path.source === 'foldkit') {
+      return Option.some(path.members)
+    }
+
+    const namespace = foldkitNamespaceBySource[path.source]
+    return namespace === undefined
+      ? Option.none()
+      : Option.some([namespace, ...path.members])
+  })
+
+const isTypeAnnotatedIdentifier = (
+  node: unknown,
+): node is Readonly<{
+  type: 'Identifier'
+  typeAnnotation?: ESTree.TSTypeAnnotation | null
+}> => isIdentifier(node)
+
+const isFunctionWithParameters = (
+  node: unknown,
+): node is ESTree.ArrowFunctionExpression | ESTree.Function =>
+  typeof node === 'object' &&
+  node !== null &&
+  'type' in node &&
+  (node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression')
+
+const isFoldkitDefineViewCallback = (
+  references: WeakMap<ESTree.Node, Reference>,
+  functionNode: ESTree.ArrowFunctionExpression | ESTree.Function,
+): boolean => {
+  const parent = functionNode.parent
+  if (!isCallExpression(parent) || !parent.arguments.includes(functionNode)) {
+    return false
+  }
+
+  return Option.exists(
+    resolveFoldkitApiPath(references, parent.callee),
+    path => {
+      const [namespace, helperName, extraMember] = path
+
+      return (
+        namespace === 'Submodel' &&
+        helperName === 'defineView' &&
+        extraMember === undefined
+      )
+    },
+  )
+}
+
+const hasHtmlBuilderTypeAnnotation = (
+  references: WeakMap<ESTree.Node, Reference>,
+  identifier: Readonly<{
+    type: 'Identifier'
+    typeAnnotation?: ESTree.TSTypeAnnotation | null
+  }>,
+): boolean => {
+  const typeAnnotation = identifier.typeAnnotation?.typeAnnotation
+  if (typeAnnotation?.type !== 'TSTypeReference') {
+    return false
+  }
+
+  return Option.exists(
+    resolveFoldkitApiPath(references, typeAnnotation.typeName),
+    path => {
+      const [namespace, typeName, extraMember] = path
+
+      return (
+        namespace === 'Html' &&
+        typeName === 'HtmlBuilder' &&
+        extraMember === undefined
+      )
+    },
+  )
+}
+
+const isHtmlBuilderParameter = (
+  references: WeakMap<ESTree.Node, Reference>,
+  root: ESTree.IdentifierReference,
+): boolean =>
+  Option.exists(resolvedVariable(references, root), variable =>
+    variable.defs.some(definition => {
+      if (
+        definition.type !== 'Parameter' ||
+        !isTypeAnnotatedIdentifier(definition.name)
+      ) {
+        return false
+      }
+
+      if (hasHtmlBuilderTypeAnnotation(references, definition.name)) {
+        return true
+      }
+
+      if (!isFunctionWithParameters(definition.node)) {
+        return false
+      }
+
+      return (
+        Option.exists(
+          Array.last(definition.node.params),
+          parameter => parameter === definition.name,
+        ) && isFoldkitDefineViewCallback(references, definition.node)
+      )
+    }),
+  )
+
+export const isFoldkitHtmlBuilderMember = (
+  callee: unknown,
+  memberName: string,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return calleeMatchesHelperName(callee, memberName)
+  }
+
+  const isFoldkitInertHtmlMember = Option.exists(
+    resolveFoldkitApiPath(references, callee),
+    path => {
+      const [namespace, builderName, importedMember, extraImportedMember] = path
+      return (
+        namespace === 'Html' &&
+        builderName === 'inertHtml' &&
+        importedMember === memberName &&
+        extraImportedMember === undefined
+      )
+    },
+  )
+  if (isFoldkitInertHtmlMember) {
+    return true
+  }
+
+  return Option.exists(staticMemberPath(callee), path => {
+    const [member, extraMember] = path.members
+
+    return (
+      member === memberName &&
+      extraMember === undefined &&
+      isHtmlBuilderParameter(references, path.root)
+    )
+  })
 }
 
 export const isUnshadowedReference = (

--- a/packages/oxlint-plugin-foldkit/src/message.ts
+++ b/packages/oxlint-plugin-foldkit/src/message.ts
@@ -1,10 +1,12 @@
 import { Option } from 'effect'
-import { type ESTree } from 'effect-oxlint'
+import { type ESTree, type Reference } from 'effect-oxlint'
 
 import {
   isIdentifier,
   isObjectExpression,
   isStringLiteral,
+  resolveFoldkitApiPath,
+  resolveImportedPath,
   staticPropertyName,
 } from './guards.ts'
 
@@ -47,11 +49,32 @@ export const recordFoldkitMessageUnionBindings = (
   }
 }
 
+export const isFoldkitMessageUnionCall = (
+  node: ESTree.CallExpression,
+  bindings: ReadonlySet<string>,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return isIdentifier(node.callee) && bindings.has(node.callee.name)
+  }
+
+  return Option.exists(resolveFoldkitApiPath(references, node.callee), path => {
+    const [namespace, helperName, extraMember] = path
+
+    return (
+      namespace === 'Message' &&
+      helperName === 'defineMessageUnion' &&
+      extraMember === undefined
+    )
+  })
+}
+
 export const messageCases = (
   node: ESTree.CallExpression,
   bindings: ReadonlySet<string>,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): ReadonlyArray<MessageCase> => {
-  if (!isIdentifier(node.callee) || !bindings.has(node.callee.name)) {
+  if (!isFoldkitMessageUnionCall(node, bindings, references)) {
     return []
   }
 
@@ -89,3 +112,61 @@ export const hasMessagePayloadProperty = (
       (isIdentifier(property.key, 'message') ||
         (isStringLiteral(property.key) && property.key.value === 'message')),
   )
+
+const containsImportedMessageReference = (
+  node: unknown,
+  references: WeakMap<ESTree.Node, Reference>,
+  visited: WeakSet<object>,
+): boolean => {
+  if (typeof node !== 'object' || node === null || visited.has(node)) {
+    return false
+  }
+
+  visited.add(node)
+  if (
+    Option.exists(resolveImportedPath(references, node), path => {
+      const [messageName] = path.members.slice(-1)
+
+      return messageName === 'Message'
+    })
+  ) {
+    return true
+  }
+
+  return Object.entries(node).some(
+    ([key, value]) =>
+      key !== 'parent' &&
+      (Array.isArray(value)
+        ? value.some(element =>
+            containsImportedMessageReference(element, references, visited),
+          )
+        : containsImportedMessageReference(value, references, visited)),
+  )
+}
+
+export const hasSubmodelMessagePayload = (
+  fields: ESTree.ObjectExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return hasMessagePayloadProperty(fields)
+  }
+
+  return fields.properties.some(property => {
+    if (
+      property.type !== 'Property' ||
+      !(
+        isIdentifier(property.key, 'message') ||
+        (isStringLiteral(property.key) && property.key.value === 'message')
+      )
+    ) {
+      return false
+    }
+
+    return containsImportedMessageReference(
+      property.value,
+      references,
+      new WeakSet(),
+    )
+  })
+}

--- a/packages/oxlint-plugin-foldkit/src/rules/command-binding-matches-name.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/command-binding-matches-name.ts
@@ -1,23 +1,52 @@
-import { Effect } from 'effect'
-import { AST, Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import { Effect, Option } from 'effect'
+import {
+  AST,
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
 import {
   firstStringArgument,
+  indexReferences,
   isCallExpression,
   isIdentifier,
   isVariableDeclarator,
+  resolveFoldkitApiPath,
 } from '../guards.ts'
+
+const isCommandDefineCall = (
+  node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return AST.isCallOf(node, 'Command', 'define')
+  }
+
+  return Option.exists(resolveFoldkitApiPath(references, node.callee), path => {
+    const [namespace, methodName, extraMember] = path
+
+    return (
+      namespace === 'Command' &&
+      methodName === 'define' &&
+      extraMember === undefined
+    )
+  })
+}
 
 const innerCommandDefineCall = (
   node: ESTree.Node,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): ESTree.CallExpression | undefined => {
   if (!isCallExpression(node)) return undefined
-  if (AST.isCallOf(node, 'Command', 'define')) {
+  if (isCommandDefineCall(node, references)) {
     return node
   }
   const callee = node.callee
   if (!isCallExpression(callee)) return undefined
-  if (!AST.isCallOf(callee, 'Command', 'define')) return undefined
+  if (!isCommandDefineCall(callee, references)) return undefined
   return callee
 }
 
@@ -34,12 +63,15 @@ export const commandBindingMatchesName = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       VariableDeclarator: (node: ESTree.Node) => {
         if (!isVariableDeclarator(node)) return Effect.void
         const init = node.init
         if (init === null || init === undefined) return Effect.void
-        const innerCall = innerCommandDefineCall(init)
+        const innerCall = innerCommandDefineCall(init, references)
         if (innerCall === undefined) return Effect.void
         const nameArgument = firstStringArgument(innerCall)
         if (

--- a/packages/oxlint-plugin-foldkit/src/rules/command-define-pascal-const.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/command-define-pascal-const.ts
@@ -1,12 +1,21 @@
 import { Effect, Option } from 'effect'
-import { AST, Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  AST,
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
 import {
+  indexReferences,
   isCallExpression,
   isIdentifier,
   isStringLiteral,
   isVariableDeclaration,
   isVariableDeclarator,
+  resolveFoldkitApiPath,
 } from '../guards.ts'
 
 const PASCAL_CASE_NAME = /^[A-Z][A-Za-z0-9]*$/
@@ -32,16 +41,36 @@ const nearestVariableDeclarator = (
     : Option.none()
 }
 
+const isCommandDefineCall = (
+  node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return AST.isCallOf(node, 'Command', 'define')
+  }
+
+  return Option.exists(resolveFoldkitApiPath(references, node.callee), path => {
+    const [namespace, methodName, extraMember] = path
+
+    return (
+      namespace === 'Command' &&
+      methodName === 'define' &&
+      extraMember === undefined
+    )
+  })
+}
+
 const headCommandDefineCall = (
   node: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<ESTree.CallExpression> => {
   if (!isCallExpression(node)) {
     return Option.none()
   }
-  if (AST.isCallOf(node, 'Command', 'define')) {
+  if (isCommandDefineCall(node, references)) {
     return Option.some(node)
   }
-  return headCommandDefineCall(node.callee)
+  return headCommandDefineCall(node.callee, references)
 }
 
 const missingLiteralNameMessage =
@@ -61,6 +90,7 @@ const notConstMessage = (name: string): string =>
 
 const diagnosticMessage = (
   node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<string> => {
   const [firstArgument] = node.arguments
   if (!isStringLiteral(firstArgument)) {
@@ -74,7 +104,7 @@ const diagnosticMessage = (
     onNone: () => Option.some(notAssignedMessage(name)),
     onSome: declarator => {
       const headsInitializer = Option.exists(
-        headCommandDefineCall(declarator.init),
+        headCommandDefineCall(declarator.init, references),
         call => call === node,
       )
       if (!headsInitializer) {
@@ -105,15 +135,15 @@ export const commandDefinePascalConst = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
-        if (
-          !isCallExpression(node) ||
-          !AST.isCallOf(node, 'Command', 'define')
-        ) {
+        if (!isCallExpression(node) || !isCommandDefineCall(node, references)) {
           return Effect.void
         }
-        return Option.match(diagnosticMessage(node), {
+        return Option.match(diagnosticMessage(node, references), {
           onNone: () => Effect.void,
           onSome: message => ctx.report(Diagnostic.make({ node, message })),
         })

--- a/packages/oxlint-plugin-foldkit/src/rules/got-prefix-requires-submodel-payload.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/got-prefix-requires-submodel-payload.ts
@@ -1,9 +1,9 @@
 import { Effect } from 'effect'
 import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
 
-import { isCallExpression } from '../guards.ts'
+import { indexReferences, isCallExpression } from '../guards.ts'
 import {
-  hasMessagePayloadProperty,
+  hasSubmodelMessagePayload,
   messageCases,
   recordFoldkitMessageUnionBindings,
 } from '../message.ts'
@@ -21,6 +21,9 @@ export const gotPrefixRequiresSubmodelPayload = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     const messageUnionBindings = new Set<string>()
     return {
       Program: (node: ESTree.Node) => {
@@ -31,10 +34,10 @@ export const gotPrefixRequiresSubmodelPayload = Rule.define({
         if (!isCallExpression(node)) return Effect.void
 
         return Effect.forEach(
-          messageCases(node, messageUnionBindings),
+          messageCases(node, messageUnionBindings, references),
           messageCase =>
             /^Got[A-Z]/.test(messageCase.name) &&
-            !hasMessagePayloadProperty(messageCase.fields)
+            !hasSubmodelMessagePayload(messageCase.fields, references)
               ? ctx.report(
                   Diagnostic.make({
                     node: messageCase.nameNode,

--- a/packages/oxlint-plugin-foldkit/src/rules/got-submodel-message-name.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/got-submodel-message-name.ts
@@ -1,9 +1,9 @@
 import { Effect } from 'effect'
 import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
 
-import { isCallExpression } from '../guards.ts'
+import { indexReferences, isCallExpression } from '../guards.ts'
 import {
-  hasMessagePayloadProperty,
+  hasSubmodelMessagePayload,
   messageCases,
   recordFoldkitMessageUnionBindings,
 } from '../message.ts'
@@ -21,6 +21,9 @@ export const gotSubmodelMessageName = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     const messageUnionBindings = new Set<string>()
     return {
       Program: (node: ESTree.Node) => {
@@ -31,9 +34,9 @@ export const gotSubmodelMessageName = Rule.define({
         if (!isCallExpression(node)) return Effect.void
 
         return Effect.forEach(
-          messageCases(node, messageUnionBindings),
+          messageCases(node, messageUnionBindings, references),
           messageCase =>
-            hasMessagePayloadProperty(messageCase.fields) &&
+            hasSubmodelMessagePayload(messageCase.fields, references) &&
             !/^Got[A-Z].*Message$/.test(messageCase.name)
               ? ctx.report(
                   Diagnostic.make({

--- a/packages/oxlint-plugin-foldkit/src/rules/got-wrapper-carries-only-routing.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/got-wrapper-carries-only-routing.ts
@@ -7,7 +7,12 @@ import {
   RuleContext,
 } from 'effect-oxlint'
 
-import { isCallExpression, isIdentifier, isStringLiteral } from '../guards.ts'
+import {
+  indexReferences,
+  isCallExpression,
+  isIdentifier,
+  isStringLiteral,
+} from '../guards.ts'
 import { messageCases, recordFoldkitMessageUnionBindings } from '../message.ts'
 
 const gotWrapperTagPattern = /^Got[A-Z]/
@@ -55,6 +60,9 @@ export const gotWrapperCarriesOnlyRouting = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     const messageUnionBindings = new Set<string>()
     return {
       Program: (node: ESTree.Node) => {
@@ -67,7 +75,7 @@ export const gotWrapperCarriesOnlyRouting = Rule.define({
         }
 
         return Effect.forEach(
-          messageCases(node, messageUnionBindings),
+          messageCases(node, messageUnionBindings, references),
           messageCase =>
             gotWrapperTagPattern.test(messageCase.name)
               ? Effect.forEach(

--- a/packages/oxlint-plugin-foldkit/src/rules/keyed-required-for-mapped-rows.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/keyed-required-for-mapped-rows.ts
@@ -1,13 +1,24 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+  type Variable,
+} from 'effect-oxlint'
 
 import {
   calleeMatchesHelperName,
   helperCalleeName,
+  indexReferences,
   isArrayExpression,
   isCallExpression,
+  isFoldkitHtmlBuilderMember,
   isIdentifier,
   isMemberExpression,
+  resolveImportedPath,
+  resolvedVariable,
 } from '../guards.ts'
 
 const rowElementTagNames = ['li', 'div', 'tr', 'article', 'section']
@@ -65,12 +76,64 @@ const isObjectPattern = (
   'type' in node &&
   node.type === 'ObjectPattern'
 
-const isSingleValueMapCallee = (callee: unknown): boolean =>
-  isMemberExpression(callee) &&
-  !callee.computed &&
-  isIdentifier(callee.property, 'map') &&
-  isIdentifier(callee.object) &&
-  singleValueMapNamespaces.includes(callee.object.name)
+const isSingleValueMapCallee = (
+  callee: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return (
+      isMemberExpression(callee) &&
+      !callee.computed &&
+      isIdentifier(callee.property, 'map') &&
+      isIdentifier(callee.object) &&
+      singleValueMapNamespaces.includes(callee.object.name)
+    )
+  }
+
+  return Option.exists(resolveImportedPath(references, callee), path => {
+    const isEffectModule =
+      path.source === 'effect' || path.source.startsWith('effect/')
+    const members = path.source.startsWith('effect/')
+      ? [path.source.slice('effect/'.length), ...path.members]
+      : path.members
+    const [namespace, methodName, extraMember] = members
+
+    return (
+      isEffectModule &&
+      namespace !== undefined &&
+      singleValueMapNamespaces.includes(namespace) &&
+      methodName === 'map' &&
+      extraMember === undefined
+    )
+  })
+}
+
+const isMapCallee = (
+  callee: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (calleeMatchesHelperName(callee, 'map')) {
+    return true
+  }
+  if (references === undefined) {
+    return false
+  }
+
+  return Option.exists(resolveImportedPath(references, callee), path => {
+    if (path.source !== 'effect' && !path.source.startsWith('effect/')) {
+      return false
+    }
+
+    const members = path.source.startsWith('effect/')
+      ? [path.source.slice('effect/'.length), ...path.members]
+      : path.members
+    const [namespace, methodName, extraMember] = members
+
+    return (
+      namespace === 'Array' && methodName === 'map' && extraMember === undefined
+    )
+  })
+}
 
 const arrowCallback = (
   node: ESTree.CallExpression,
@@ -88,10 +151,17 @@ const arrowCallback = (
 const referencesIdOfParameter = (
   value: unknown,
   parameterName: string,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  parameterVariable: Variable | undefined,
 ): boolean => {
   if (Array.isArray(value)) {
     return value.some(element =>
-      referencesIdOfParameter(element, parameterName),
+      referencesIdOfParameter(
+        element,
+        parameterName,
+        references,
+        parameterVariable,
+      ),
     )
   }
   if (typeof value !== 'object' || value === null) {
@@ -100,7 +170,13 @@ const referencesIdOfParameter = (
   if (
     isMemberExpression(value) &&
     isIdentifier(value.object, parameterName) &&
-    isIdentifier(value.property, 'id')
+    isIdentifier(value.property, 'id') &&
+    (references === undefined ||
+      (parameterVariable !== undefined &&
+        Option.exists(
+          resolvedVariable(references, value.object),
+          variable => variable === parameterVariable,
+        )))
   ) {
     return true
   }
@@ -108,7 +184,12 @@ const referencesIdOfParameter = (
   return fieldEntries.some(
     ([fieldName, fieldValue]) =>
       fieldName !== 'parent' &&
-      referencesIdOfParameter(fieldValue, parameterName),
+      referencesIdOfParameter(
+        fieldValue,
+        parameterName,
+        references,
+        parameterVariable,
+      ),
   )
 }
 
@@ -123,10 +204,23 @@ const destructuresId = (
       isIdentifier(property.key, 'id'),
   )
 
-const isIdentityBearing = (callback: ArrowCallback): boolean => {
+const isIdentityBearing = (
+  callback: ArrowCallback,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  declaredVariables: ReadonlyArray<Variable>,
+): boolean => {
   const [firstParameter] = callback.params
   if (isIdentifier(firstParameter)) {
-    return referencesIdOfParameter(callback.body, firstParameter.name)
+    const parameterVariable = declaredVariables.find(variable =>
+      variable.identifiers.some(identifier => identifier === firstParameter),
+    )
+
+    return referencesIdOfParameter(
+      callback.body,
+      firstParameter.name,
+      references,
+      parameterVariable,
+    )
   }
   if (isObjectPattern(firstParameter)) {
     return destructuresId(firstParameter)
@@ -149,11 +243,17 @@ const callbackReturnExpression = (
   )
 }
 
-const isKeyedWrapped = (node: ESTree.CallExpression): boolean =>
+const isKeyedWrapped = (
+  node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean =>
   isCallExpression(node.callee) &&
-  calleeMatchesHelperName(node.callee.callee, 'keyed')
+  isFoldkitHtmlBuilderMember(node.callee.callee, 'keyed', references)
 
-const hasKeyAttribute = (rowElementCall: ESTree.CallExpression): boolean => {
+const hasKeyAttribute = (
+  rowElementCall: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
   const [attributesArgument] = rowElementCall.arguments
   if (!isArrayExpression(attributesArgument)) {
     return false
@@ -161,7 +261,7 @@ const hasKeyAttribute = (rowElementCall: ESTree.CallExpression): boolean => {
   return attributesArgument.elements.some(
     element =>
       isCallExpression(element) &&
-      calleeMatchesHelperName(element.callee, 'Key'),
+      isFoldkitHtmlBuilderMember(element.callee, 'Key', references),
   )
 }
 
@@ -172,16 +272,23 @@ type UnkeyedRow = Readonly<{
 
 const unkeyedRowElement = (
   returnExpression: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<UnkeyedRow> => {
   if (!isCallExpression(returnExpression)) {
     return Option.none()
   }
-  if (isKeyedWrapped(returnExpression) || hasKeyAttribute(returnExpression)) {
+  if (
+    isKeyedWrapped(returnExpression, references) ||
+    hasKeyAttribute(returnExpression, references)
+  ) {
     return Option.none()
   }
   return pipe(
     helperCalleeName(returnExpression.callee),
     Option.filter(tagName => rowElementTagNames.includes(tagName)),
+    Option.filter(tagName =>
+      isFoldkitHtmlBuilderMember(returnExpression.callee, tagName, references),
+    ),
     Option.map(tagName => ({ rowElementCall: returnExpression, tagName })),
   )
 }
@@ -202,20 +309,33 @@ export const keyedRequiredForMappedRows = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopeManager = ctx.sourceCode.scopeManager
+    const references =
+      scopeManager === undefined
+        ? undefined
+        : indexReferences(scopeManager.scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
         if (
           !isCallExpression(node) ||
-          !calleeMatchesHelperName(node.callee, 'map') ||
-          isSingleValueMapCallee(node.callee)
+          !isMapCallee(node.callee, references) ||
+          isSingleValueMapCallee(node.callee, references)
         ) {
           return Effect.void
         }
         return pipe(
           arrowCallback(node),
-          Option.filter(isIdentityBearing),
+          Option.filter(callback =>
+            isIdentityBearing(
+              callback,
+              references,
+              scopeManager?.getDeclaredVariables(callback as ESTree.Node) ?? [],
+            ),
+          ),
           Option.flatMap(callbackReturnExpression),
-          Option.flatMap(unkeyedRowElement),
+          Option.flatMap(returnExpression =>
+            unkeyedRowElement(returnExpression, references),
+          ),
           Option.match({
             onNone: () => Effect.void,
             onSome: ({ rowElementCall, tagName }) =>

--- a/packages/oxlint-plugin-foldkit/src/rules/lazy-view-stable-references.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/lazy-view-stable-references.ts
@@ -1,5 +1,20 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+  type ScopeManager,
+  type Variable,
+} from 'effect-oxlint'
+
+import {
+  indexReferences,
+  isIdentifierReference,
+  resolveFoldkitApiPath,
+  resolvedVariable,
+} from '../guards.ts'
 
 type LazyFactoryName = 'createLazy' | 'createKeyedLazy'
 
@@ -70,16 +85,29 @@ type LazyFactoryCall = Readonly<{
 
 const matchLazyFactoryCall = (
   node: ESTree.Node,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<LazyFactoryCall> => {
   const unwrapped = unwrapExpression(node)
   if (unwrapped.type !== 'CallExpression') {
     return Option.none()
   }
   const callee = unwrapExpression(unwrapped.callee)
-  if (callee.type !== 'Identifier' || !isLazyFactoryName(callee.name)) {
-    return Option.none()
+  if (references === undefined) {
+    return callee.type === 'Identifier' && isLazyFactoryName(callee.name)
+      ? Option.some({ call: unwrapped, factoryName: callee.name })
+      : Option.none()
   }
-  return Option.some({ call: unwrapped, factoryName: callee.name })
+
+  return Option.flatMap(resolveFoldkitApiPath(references, callee), path => {
+    const [namespace, factoryName, extraMember] = path
+
+    return namespace === 'Html' &&
+      factoryName !== undefined &&
+      isLazyFactoryName(factoryName) &&
+      extraMember === undefined
+      ? Option.some({ call: unwrapped, factoryName })
+      : Option.none()
+  })
 }
 
 const declarationOf = (
@@ -100,12 +128,15 @@ const declarationOf = (
 
 type RegisteredSlot = Readonly<{
   slotName: string
+  variable: Variable | undefined
   viewArgumentIndex: number
   initializerCall: ESTree.CallExpression
 }>
 
 const registeredSlotsOf = (
   program: ESTree.Program,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+  scopeManager: ScopeManager | undefined,
 ): ReadonlyArray<RegisteredSlot> =>
   pipe(
     program.body,
@@ -125,12 +156,15 @@ const registeredSlotsOf = (
       }
       const slotName = declarator.id.name
       return pipe(
-        matchLazyFactoryCall(declarator.init),
+        matchLazyFactoryCall(declarator.init, references),
         Option.match({
           onNone: () => [],
           onSome: factoryCall => [
             {
               slotName,
+              variable: scopeManager
+                ?.getDeclaredVariables(declarator)
+                .find(variable => variable.name === slotName),
               viewArgumentIndex:
                 VIEW_ARGUMENT_INDEX_BY_FACTORY[factoryCall.factoryName],
               initializerCall: factoryCall.call,
@@ -202,6 +236,21 @@ const isFunctionScopedName = (
   functionScopes: ReadonlyArray<ReadonlySet<string>>,
 ): boolean => functionScopes.some(scope => scope.has(name))
 
+const isNestedInFunctionScope = (scope: Variable['scope']): boolean =>
+  scope.type === 'function' ||
+  (scope.upper !== null && isNestedInFunctionScope(scope.upper))
+
+const isFunctionScopedView = (
+  identifier: ESTree.IdentifierReference,
+  context: AnalysisContext,
+): boolean =>
+  context.references === undefined
+    ? isFunctionScopedName(identifier.name, context.functionScopes)
+    : Option.exists(
+        resolvedVariable(context.references, identifier),
+        variable => isNestedInFunctionScope(variable.scope),
+      )
+
 const MISPLACED_CREATION_MESSAGE =
   '`createLazy()` and `createKeyedLazy()` must be assigned directly to a module-scope `const`. A slot recreated inside a function starts with a cold cache on every call, so the memoization never hits.'
 
@@ -223,14 +272,14 @@ type AnalysisContext = Readonly<{
   slotsByName: ReadonlyMap<string, RegisteredSlot>
   registeredInitializers: ReadonlySet<ESTree.CallExpression>
   functionScopes: ReadonlyArray<ReadonlySet<string>>
+  references: WeakMap<ESTree.Node, Reference> | undefined
 }>
 
 const misplacedCreationOffenses = (
   node: ESTree.CallExpression,
   context: AnalysisContext,
 ): ReadonlyArray<Offense> => {
-  const callee = unwrapExpression(node.callee)
-  if (callee.type !== 'Identifier' || !isLazyFactoryName(callee.name)) {
+  if (Option.isNone(matchLazyFactoryCall(node, context.references))) {
     return []
   }
   if (context.registeredInitializers.has(node)) {
@@ -244,7 +293,7 @@ const unstableViewOffenses = (
   context: AnalysisContext,
 ): ReadonlyArray<Offense> => {
   const callee = unwrapExpression(node.callee)
-  if (callee.type !== 'Identifier') {
+  if (!isIdentifierReference(callee)) {
     return []
   }
   const maybeSlot = Option.fromNullishOr(context.slotsByName.get(callee.name))
@@ -252,6 +301,16 @@ const unstableViewOffenses = (
     return []
   }
   const { value: slot } = maybeSlot
+  if (
+    context.references !== undefined &&
+    (slot.variable === undefined ||
+      !Option.exists(
+        resolvedVariable(context.references, callee),
+        variable => variable === slot.variable,
+      ))
+  ) {
+    return []
+  }
   const maybeViewArgument = Array.get(node.arguments, slot.viewArgumentIndex)
   if (Option.isNone(maybeViewArgument)) {
     return []
@@ -267,8 +326,8 @@ const unstableViewOffenses = (
     ]
   }
   if (
-    unwrappedViewArgument.type === 'Identifier' &&
-    isFunctionScopedName(unwrappedViewArgument.name, context.functionScopes)
+    isIdentifierReference(unwrappedViewArgument) &&
+    isFunctionScopedView(unwrappedViewArgument, context)
   ) {
     return [
       {
@@ -340,12 +399,19 @@ export const lazyViewStableReferences = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       'Program:exit': (node: ESTree.Node) => {
         if (!isProgram(node)) {
           return Effect.void
         }
-        const registeredSlots = registeredSlotsOf(node)
+        const registeredSlots = registeredSlotsOf(
+          node,
+          references,
+          ctx.sourceCode.scopeManager,
+        )
         const slotsByName = new Map(
           Array.map(
             registeredSlots,
@@ -359,6 +425,7 @@ export const lazyViewStableReferences = Rule.define({
           slotsByName,
           registeredInitializers,
           functionScopes: [],
+          references,
         })
         return Effect.forEach(
           offenses,

--- a/packages/oxlint-plugin-foldkit/src/rules/mount-factory-must-use-element.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/mount-factory-must-use-element.ts
@@ -1,9 +1,41 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { AST, Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  AST,
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
-import { isCallExpression, isObjectExpression } from '../guards.ts'
+import {
+  indexReferences,
+  isCallExpression,
+  isObjectExpression,
+  resolveFoldkitApiPath,
+} from '../guards.ts'
 
 const MOUNT_DEFINITION_METHODS = ['define', 'defineStream']
+
+const isMountDefinitionCall = (
+  node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return AST.isCallOf(node, 'Mount', MOUNT_DEFINITION_METHODS)
+  }
+
+  return Option.exists(resolveFoldkitApiPath(references, node.callee), path => {
+    const [namespace, methodName, extraMember] = path
+
+    return (
+      namespace === 'Mount' &&
+      methodName !== undefined &&
+      MOUNT_DEFINITION_METHODS.includes(methodName) &&
+      extraMember === undefined
+    )
+  })
+}
 
 const ELEMENT_FIELD = 'element'
 
@@ -225,11 +257,14 @@ export const mountFactoryMustUseElement = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
         if (
           !isCallExpression(node) ||
-          !AST.isCallOf(node, 'Mount', MOUNT_DEFINITION_METHODS)
+          !isMountDefinitionCall(node, references)
         ) {
           return Effect.void
         }

--- a/packages/oxlint-plugin-foldkit/src/rules/no-array-index-view-keys.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-array-index-view-keys.ts
@@ -1,13 +1,26 @@
 import { Array, Effect, Option, Ref } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+  type ScopeManager,
+  type Variable,
+} from 'effect-oxlint'
 
 import {
   calleeMatchesHelperName,
+  indexReferences,
   isCallExpression,
+  isFoldkitHtmlBuilderMember,
   isIdentifier,
+  isIdentifierReference,
   isMemberExpression,
   isObjectExpression,
   isStringLiteral,
+  resolveFoldkitApiPath,
+  resolvedVariable,
 } from '../guards.ts'
 
 // GUARDS
@@ -41,9 +54,34 @@ const isVariableDeclarator = (
   node: ESTree.Node,
 ): node is ESTree.VariableDeclarator => node.type === 'VariableDeclarator'
 
-const mapCallbackIndexParameterName = (
+type MapIndexBinding = Readonly<{
+  name: string
+  variable: Variable | undefined
+}>
+
+const isCreateKeyedLazyCall = (
+  node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return calleeMatchesHelperName(node.callee, 'createKeyedLazy')
+  }
+
+  return Option.exists(resolveFoldkitApiPath(references, node.callee), path => {
+    const [namespace, factoryName, extraMember] = path
+
+    return (
+      namespace === 'Html' &&
+      factoryName === 'createKeyedLazy' &&
+      extraMember === undefined
+    )
+  })
+}
+
+const mapCallbackIndexParameter = (
   node: ESTree.Node,
-): Option.Option<string> => {
+  scopeManager: ScopeManager | undefined,
+): Option.Option<MapIndexBinding> => {
   if (!isArrowFunctionExpression(node)) {
     return Option.none()
   }
@@ -66,7 +104,12 @@ const mapCallbackIndexParameterName = (
   if (!isIdentifier(secondParameter)) {
     return Option.none()
   }
-  return Option.some(secondParameter.name)
+  const name = secondParameter.name
+  const variable = scopeManager
+    ?.getDeclaredVariables(node)
+    .find(candidate => candidate.name === name)
+
+  return Option.some({ name, variable })
 }
 
 const firstNonSpreadArgument = (
@@ -98,75 +141,113 @@ const slotIdValue = (
     property => property.value,
   )
 
+type KeyedLazySlot = Readonly<{
+  name: string
+  variable: Variable | undefined
+}>
+
 const keySinkExpression = (
   node: ESTree.CallExpression,
-  slotNames: ReadonlyArray<string>,
+  slots: ReadonlyArray<KeyedLazySlot>,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<ESTree.Expression> => {
   if (
     isCallExpression(node.callee) &&
-    calleeMatchesHelperName(node.callee.callee, 'keyed')
+    isFoldkitHtmlBuilderMember(node.callee.callee, 'keyed', references)
   ) {
     return firstNonSpreadArgument(node)
   }
-  if (calleeMatchesHelperName(node.callee, 'Key')) {
+  if (isFoldkitHtmlBuilderMember(node.callee, 'Key', references)) {
     return firstNonSpreadArgument(node)
   }
-  if (calleeMatchesHelperName(node.callee, 'submodel')) {
+  if (isFoldkitHtmlBuilderMember(node.callee, 'submodel', references)) {
     const [configArgument] = node.arguments
     if (isObjectExpression(configArgument)) {
       return slotIdValue(configArgument)
     }
   }
-  if (isIdentifier(node.callee) && slotNames.includes(node.callee.name)) {
-    return firstNonSpreadArgument(node)
+  if (isIdentifierReference(node.callee)) {
+    const slotCallee = node.callee
+    const isRegisteredSlot = slots.some(
+      slot =>
+        slot.name === slotCallee.name &&
+        (references === undefined ||
+          (slot.variable !== undefined &&
+            Option.exists(
+              resolvedVariable(references, slotCallee),
+              variable => variable === slot.variable,
+            ))),
+    )
+    if (isRegisteredSlot) {
+      return firstNonSpreadArgument(node)
+    }
   }
   return Option.none()
 }
 
-const referencesIndexName = (value: unknown, indexName: string): boolean => {
+const referencesIndexBinding = (
+  value: unknown,
+  indexBinding: MapIndexBinding,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
   if (Array.isArray(value)) {
-    return value.some(element => referencesIndexName(element, indexName))
+    return value.some(element =>
+      referencesIndexBinding(element, indexBinding, references),
+    )
   }
   if (typeof value !== 'object' || value === null) {
     return false
   }
-  if (isIdentifier(value, indexName)) {
-    return true
+  if (isIdentifierReference(value) && value.name === indexBinding.name) {
+    return (
+      references === undefined ||
+      (indexBinding.variable !== undefined &&
+        Option.exists(
+          resolvedVariable(references, value),
+          variable => variable === indexBinding.variable,
+        ))
+    )
   }
   if (isMemberExpression(value)) {
-    if (referencesIndexName(value.object, indexName)) {
+    if (referencesIndexBinding(value.object, indexBinding, references)) {
       return true
     }
     return (
-      value.computed === true && referencesIndexName(value.property, indexName)
+      value.computed === true &&
+      referencesIndexBinding(value.property, indexBinding, references)
     )
   }
   if (isProperty(value)) {
-    if (value.computed === true && referencesIndexName(value.key, indexName)) {
+    if (
+      value.computed === true &&
+      referencesIndexBinding(value.key, indexBinding, references)
+    ) {
       return true
     }
-    return referencesIndexName(value.value, indexName)
+    return referencesIndexBinding(value.value, indexBinding, references)
   }
-  if (isArrowFunctionExpression(value)) {
+  if (references === undefined && isArrowFunctionExpression(value)) {
     const parameters = value.params
     const isShadowed = parameters.some(parameter =>
-      isIdentifier(parameter, indexName),
+      isIdentifier(parameter, indexBinding.name),
     )
     if (isShadowed) {
       return false
     }
   }
-  return referencesIndexNameAcrossFields(value, indexName)
+  return referencesIndexBindingAcrossFields(value, indexBinding, references)
 }
 
-const referencesIndexNameAcrossFields = (
+const referencesIndexBindingAcrossFields = (
   value: object,
-  indexName: string,
+  indexBinding: MapIndexBinding,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): boolean => {
   const fieldEntries = Object.entries(value)
   return fieldEntries.some(
     ([fieldName, fieldValue]) =>
-      fieldName !== 'parent' && referencesIndexName(fieldValue, indexName),
+      fieldName !== 'parent' &&
+      referencesIndexBinding(fieldValue, indexBinding, references),
   )
 }
 
@@ -187,32 +268,42 @@ export const noArrayIndexViewKeys = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
-    const indexNameStack = yield* Ref.make<ReadonlyArray<string>>([])
-    const slotNames = yield* Ref.make<ReadonlyArray<string>>([])
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const scopeManager = ctx.sourceCode.scopeManager
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
+    const indexBindingStack = yield* Ref.make<ReadonlyArray<MapIndexBinding>>(
+      [],
+    )
+    const slots = yield* Ref.make<ReadonlyArray<KeyedLazySlot>>([])
     return {
       VariableDeclarator: (node: ESTree.Node) => {
         if (
           !isVariableDeclarator(node) ||
-          !isIdentifier(node.id) ||
+          node.id.type !== 'Identifier' ||
           !isCallExpression(node.init) ||
-          !calleeMatchesHelperName(node.init.callee, 'createKeyedLazy')
+          !isCreateKeyedLazyCall(node.init, references)
         ) {
           return Effect.void
         }
-        return Ref.update(slotNames, Array.append(node.id.name))
+        const slotName = node.id.name
+        const variable = scopeManager
+          ?.getDeclaredVariables(node)
+          .find(candidate => candidate.name === slotName)
+        return Ref.update(slots, Array.append({ name: slotName, variable }))
       },
       ArrowFunctionExpression: (node: ESTree.Node) =>
-        Option.match(mapCallbackIndexParameterName(node), {
+        Option.match(mapCallbackIndexParameter(node, scopeManager), {
           onNone: () => Effect.void,
-          onSome: indexName =>
-            Ref.update(indexNameStack, Array.append(indexName)),
+          onSome: indexBinding =>
+            Ref.update(indexBindingStack, Array.append(indexBinding)),
         }),
       'ArrowFunctionExpression:exit': (node: ESTree.Node) =>
-        Option.match(mapCallbackIndexParameterName(node), {
+        Option.match(mapCallbackIndexParameter(node, scopeManager), {
           onNone: () => Effect.void,
           onSome: () =>
-            Ref.update(indexNameStack, activeIndexNames =>
-              Array.dropRight(activeIndexNames, 1),
+            Ref.update(indexBindingStack, activeIndexBindings =>
+              Array.dropRight(activeIndexBindings, 1),
             ),
         }),
       CallExpression: (node: ESTree.Node) => {
@@ -220,29 +311,32 @@ export const noArrayIndexViewKeys = Rule.define({
           return Effect.void
         }
         return Effect.gen(function* () {
-          const activeIndexNames = yield* Ref.get(indexNameStack)
-          if (Array.isReadonlyArrayEmpty(activeIndexNames)) {
+          const activeIndexBindings = yield* Ref.get(indexBindingStack)
+          if (Array.isReadonlyArrayEmpty(activeIndexBindings)) {
             return
           }
-          const registeredSlotNames = yield* Ref.get(slotNames)
+          const registeredSlots = yield* Ref.get(slots)
           const maybeKeyExpression = keySinkExpression(
             node,
-            registeredSlotNames,
+            registeredSlots,
+            references,
           )
           if (Option.isNone(maybeKeyExpression)) {
             return
           }
           const { value: keyExpression } = maybeKeyExpression
-          const maybeIndexName = Array.findFirst(activeIndexNames, indexName =>
-            referencesIndexName(keyExpression, indexName),
+          const maybeIndexBinding = Array.findFirst(
+            activeIndexBindings,
+            indexBinding =>
+              referencesIndexBinding(keyExpression, indexBinding, references),
           )
-          if (Option.isNone(maybeIndexName)) {
+          if (Option.isNone(maybeIndexBinding)) {
             return
           }
           yield* ctx.report(
             Diagnostic.make({
               node: keyExpression,
-              message: `The array index parameter \`${maybeIndexName.value}\` is used as a view key. Positions shift when the list reorders or loses an item, so the runtime patches the wrong rows. Key this row or Submodel by a stable Model identifier such as \`item.id\` instead.`,
+              message: `The array index parameter \`${maybeIndexBinding.value.name}\` is used as a view key. Positions shift when the list reorders or loses an item, so the runtime patches the wrong rows. Key this row or Submodel by a stable Model identifier such as \`item.id\` instead.`,
             }),
           )
         })

--- a/packages/oxlint-plugin-foldkit/src/rules/no-child-message-construction-in-root.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-child-message-construction-in-root.ts
@@ -1,15 +1,350 @@
-import { Effect, Option, pipe } from 'effect'
-import { AST, Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import { Array, Effect, Option, pipe } from 'effect'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
-import { isCallExpression } from '../guards.ts'
+import {
+  type ImportedPath,
+  indexReferences,
+  isCallExpression,
+  isIdentifier,
+  isMemberExpression,
+  resolveFoldkitApiPath,
+  resolveImportedPath,
+  staticMemberPath,
+} from '../guards.ts'
 
 const pascalIdentifierPattern = /^[A-Z][A-Za-z0-9]*$/
 
-const childMessageConstructionMessage = (
-  namespace: string,
-  constructorName: string,
-): string =>
-  `Do not construct the child Message \`${namespace}.Message.${constructorName}(...)\` from outside the child. Have the child export a helper that produces or applies this Message, and route child output back through the parent's Got*Message wrapper.`
+const childMessageConstructionMessage = (calleeLabel: string): string =>
+  `Do not construct the child Message \`${calleeLabel}(...)\` from a parent. Expose a child update capability that applies this fact, then invoke it with Update.foldChild or Update.foldChildStep. Child-owned views, Commands, and Subscriptions may construct their own Messages.`
+
+type ImportedMessagePath = Pick<ImportedPath, 'source' | 'members'>
+
+type ChildMessageConstruction = Readonly<{
+  calleeLabel: string
+  messagePath?: ImportedMessagePath
+}>
+
+const moduleExtensionPattern = /\.(?:cjs|cts|js|jsx|mjs|mts|ts|tsx)$/
+
+const moduleSegmentName = (segment: string): string =>
+  segment.replace(moduleExtensionPattern, '')
+
+const messageModuleSegmentNames: ReadonlySet<string> = new Set([
+  'index',
+  'main',
+  'message',
+  'schema',
+])
+
+const isMessageModuleSegment = (segment: string | undefined): boolean =>
+  segment !== undefined &&
+  messageModuleSegmentNames.has(moduleSegmentName(segment).toLowerCase())
+
+const isFunction = (
+  node: unknown,
+): node is ESTree.ArrowFunctionExpression | ESTree.Function =>
+  typeof node === 'object' &&
+  node !== null &&
+  'type' in node &&
+  (node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression')
+
+const isTypeReference = (node: unknown): node is ESTree.TSTypeReference =>
+  typeof node === 'object' &&
+  node !== null &&
+  'type' in node &&
+  node.type === 'TSTypeReference'
+
+const isTypeAnnotatedIdentifier = (
+  node: unknown,
+): node is Readonly<{
+  type: 'Identifier'
+  typeAnnotation?: ESTree.TSTypeAnnotation | null
+}> => isIdentifier(node)
+
+const importedMessagePath = (
+  references: WeakMap<ESTree.Node, Reference>,
+  node: unknown,
+): Option.Option<ImportedMessagePath> =>
+  isTypeReference(node)
+    ? Option.map(resolveImportedPath(references, node.typeName), path => ({
+        source: path.source,
+        members: path.members,
+      }))
+    : Option.none()
+
+const pascalCaseModuleSegment = (segment: string): string =>
+  moduleSegmentName(segment)
+    .split(/[-_]/)
+    .map(part => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join('')
+
+const messageModuleSegments = (
+  path: ImportedMessagePath,
+): ReadonlyArray<string> => {
+  const sourceSegments = path.source
+    .split('/')
+    .filter(segment => segment !== '.')
+  const [lastSourceSegment] = sourceSegments.slice(-1)
+  const moduleSourceSegments = isMessageModuleSegment(lastSourceSegment)
+    ? sourceSegments.slice(0, -1)
+    : sourceSegments
+  const namespaceMembers = path.members.slice(0, -1)
+  const [firstNamespaceMember] = namespaceMembers
+  const [moduleSourceName] = moduleSourceSegments.slice(-1)
+  const remainingNamespaceMembers =
+    firstNamespaceMember !== undefined &&
+    moduleSourceName !== undefined &&
+    pascalCaseModuleSegment(firstNamespaceMember) ===
+      pascalCaseModuleSegment(moduleSourceName)
+      ? namespaceMembers.slice(1)
+      : namespaceMembers
+
+  return [...moduleSourceSegments, ...remainingNamespaceMembers].map(
+    pascalCaseModuleSegment,
+  )
+}
+
+const sameSegments = (
+  a: ReadonlyArray<string>,
+  b: ReadonlyArray<string>,
+): boolean =>
+  Array.length(a) === Array.length(b) &&
+  Array.every(Array.zip(a, b), ([aSegment, bSegment]) => aSegment === bSegment)
+
+const sameImportedMessagePath = (
+  a: ImportedMessagePath,
+  b: ImportedMessagePath,
+): boolean => {
+  if (a.source === b.source && sameSegments(a.members, b.members)) {
+    return true
+  }
+
+  const aSegments = messageModuleSegments(a)
+  const bSegments = messageModuleSegments(b)
+
+  return sameSegments(aSegments, bSegments)
+}
+
+const htmlBuilderMessagePath = (
+  references: WeakMap<ESTree.Node, Reference>,
+  parameter: unknown,
+): Option.Option<ImportedMessagePath> => {
+  if (!isTypeAnnotatedIdentifier(parameter)) {
+    return Option.none()
+  }
+
+  const typeAnnotation = parameter.typeAnnotation?.typeAnnotation
+  if (!isTypeReference(typeAnnotation)) {
+    return Option.none()
+  }
+
+  const isHtmlBuilder = Option.exists(
+    resolveFoldkitApiPath(references, typeAnnotation.typeName),
+    path => {
+      const [namespace, typeName, extraMember] = path
+      return (
+        namespace === 'Html' &&
+        typeName === 'HtmlBuilder' &&
+        extraMember === undefined
+      )
+    },
+  )
+  if (!isHtmlBuilder) {
+    return Option.none()
+  }
+
+  return Option.gen(function* () {
+    const typeArguments = yield* Option.fromNullishOr(
+      typeAnnotation.typeArguments,
+    )
+    const messageType = yield* Option.fromNullishOr(typeArguments.params[0])
+    return yield* importedMessagePath(references, messageType)
+  })
+}
+
+const defineViewMessagePath = (
+  references: WeakMap<ESTree.Node, Reference>,
+  functionNode: ESTree.ArrowFunctionExpression | ESTree.Function,
+): Option.Option<ImportedMessagePath> => {
+  const parent = functionNode.parent
+  if (!isCallExpression(parent) || !parent.arguments.includes(functionNode)) {
+    return Option.none()
+  }
+
+  const isDefineView = Option.exists(
+    resolveFoldkitApiPath(references, parent.callee),
+    path => {
+      const [namespace, helperName, extraMember] = path
+      return (
+        namespace === 'Submodel' &&
+        helperName === 'defineView' &&
+        extraMember === undefined
+      )
+    },
+  )
+  if (!isDefineView) {
+    return Option.none()
+  }
+
+  return Option.gen(function* () {
+    const typeArguments = yield* Option.fromNullishOr(parent.typeArguments)
+    const messageType = yield* Option.fromNullishOr(typeArguments.params[1])
+    return yield* importedMessagePath(references, messageType)
+  })
+}
+
+const isOwnedByEnclosingView = (
+  node: ESTree.Node,
+  references: WeakMap<ESTree.Node, Reference>,
+  messagePath: ImportedMessagePath,
+): boolean => {
+  const ownsMessage = (ancestor: ESTree.Node | null | undefined): boolean => {
+    if (ancestor === null || ancestor === undefined) {
+      return false
+    }
+
+    if (isFunction(ancestor)) {
+      const ownsAnnotatedBuilder = ancestor.params.some(parameter =>
+        Option.exists(
+          htmlBuilderMessagePath(references, parameter),
+          builderMessagePath =>
+            sameImportedMessagePath(builderMessagePath, messagePath),
+        ),
+      )
+      if (ownsAnnotatedBuilder) {
+        return true
+      }
+
+      const ownsDefinedView = Option.exists(
+        defineViewMessagePath(references, ancestor),
+        viewMessagePath =>
+          sameImportedMessagePath(viewMessagePath, messagePath),
+      )
+      if (ownsDefinedView) {
+        return true
+      }
+    }
+
+    return ownsMessage(ancestor.parent)
+  }
+
+  return ownsMessage(node.parent)
+}
+
+const hasComputedMember = (node: unknown): boolean =>
+  isMemberExpression(node) && (node.computed || hasComputedMember(node.object))
+
+const relativeModuleSegments = (source: string): ReadonlyArray<string> =>
+  source.split('/').filter(segment => segment !== '.' && segment !== '..')
+
+const isTopLevelRootAlias = (source: string): boolean => {
+  if (!source.startsWith('@/') && !source.startsWith('~/')) {
+    return false
+  }
+
+  return !source.slice(2).includes('/')
+}
+
+const isRootMessageModule = (source: string): boolean => {
+  const sourceSegments = relativeModuleSegments(source)
+  const [lastSourceSegment] = sourceSegments.slice(-1)
+  const [parentSourceSegment] = sourceSegments.slice(-2, -1)
+
+  if (lastSourceSegment === undefined) {
+    return true
+  }
+
+  if (!isMessageModuleSegment(lastSourceSegment)) {
+    return false
+  }
+
+  return source.startsWith('.')
+    ? parentSourceSegment === undefined
+    : isTopLevelRootAlias(source)
+}
+
+const childNamespace = (
+  source: string,
+  importedMembers: ReadonlyArray<string>,
+  localMembers: ReadonlyArray<string>,
+): string => {
+  const namespaceMembers = importedMembers.slice(0, -2)
+  const [importedNamespace] = namespaceMembers.slice(-1)
+  if (importedNamespace !== undefined) {
+    return importedNamespace
+  }
+
+  const sourceSegments = relativeModuleSegments(source)
+  const [lastSourceSegment] = sourceSegments.slice(-1)
+  const [parentSourceSegment] = sourceSegments.slice(-2, -1)
+  const sourceNamespace = isMessageModuleSegment(lastSourceSegment)
+    ? parentSourceSegment
+    : lastSourceSegment
+  if (sourceNamespace !== undefined) {
+    return pascalCaseModuleSegment(sourceNamespace)
+  }
+
+  const [localRoot] = localMembers
+  return localRoot ?? 'Child'
+}
+
+const childMessageConstruction = (
+  callee: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): Option.Option<ChildMessageConstruction> => {
+  if (hasComputedMember(callee)) {
+    return Option.none()
+  }
+
+  if (references === undefined) {
+    return Option.flatMap(staticMemberPath(callee), path => {
+      const [namespace, middle, constructorName, extraSegment] = [
+        path.root.name,
+        ...path.members,
+      ]
+      return namespace !== undefined &&
+        middle === 'Message' &&
+        constructorName !== undefined &&
+        constructorName !== 'Message' &&
+        extraSegment === undefined &&
+        pascalIdentifierPattern.test(namespace) &&
+        pascalIdentifierPattern.test(constructorName)
+        ? Option.some({
+            calleeLabel: `${namespace}.Message.${constructorName}`,
+          })
+        : Option.none()
+    })
+  }
+
+  return Option.flatMap(resolveImportedPath(references, callee), path => {
+    const [messageNamespace, constructorName] = path.members.slice(-2)
+    if (
+      messageNamespace !== 'Message' ||
+      constructorName === undefined ||
+      constructorName === 'Message' ||
+      !pascalIdentifierPattern.test(constructorName) ||
+      isRootMessageModule(path.source)
+    ) {
+      return Option.none()
+    }
+
+    return Option.some({
+      calleeLabel: `${childNamespace(path.source, path.members, path.localMembers)}.Message.${constructorName}`,
+      messagePath: {
+        source: path.source,
+        members: path.members.slice(0, -1),
+      },
+    })
+  })
+}
 
 /**
  * Flags direct construction of a child Submodel Message variant from outside
@@ -20,43 +355,35 @@ export const noChildMessageConstructionInRoot = Rule.define({
   meta: Rule.meta({
     type: 'suggestion',
     description:
-      'Construct child Submodel Messages through child-exported helpers instead of reaching into the child Message namespace.',
+      'Drive child Submodels through child-owned update capabilities instead of constructing their Messages from a parent.',
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
         if (!isCallExpression(node)) {
           return Effect.void
         }
-        const callee = node.callee
-        if (callee.type !== 'MemberExpression') {
-          return Effect.void
-        }
         return pipe(
-          AST.memberPath(callee),
+          childMessageConstruction(node.callee, references),
           Option.match({
             onNone: () => Effect.void,
-            onSome: path => {
-              const [namespace, middle, constructorName, extraSegment] = path
+            onSome: ({ calleeLabel, messagePath }) => {
               if (
-                namespace === undefined ||
-                middle !== 'Message' ||
-                constructorName === undefined ||
-                constructorName === 'Message' ||
-                extraSegment !== undefined ||
-                !pascalIdentifierPattern.test(namespace) ||
-                !pascalIdentifierPattern.test(constructorName)
+                references !== undefined &&
+                messagePath !== undefined &&
+                isOwnedByEnclosingView(node, references, messagePath)
               ) {
                 return Effect.void
               }
+
               return ctx.report(
                 Diagnostic.make({
                   node,
-                  message: childMessageConstructionMessage(
-                    namespace,
-                    constructorName,
-                  ),
+                  message: childMessageConstructionMessage(calleeLabel),
                 }),
               )
             },

--- a/packages/oxlint-plugin-foldkit/src/rules/no-disabling-dev-guardrails.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-disabling-dev-guardrails.ts
@@ -1,7 +1,18 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { AST, Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  AST,
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
-import { isCallExpression } from '../guards.ts'
+import {
+  indexReferences,
+  isCallExpression,
+  resolveFoldkitApiPath,
+} from '../guards.ts'
 
 const FACTORY_NAMES = ['makeApplication', 'makeElement']
 
@@ -11,7 +22,23 @@ const FREEZE_MODEL_MESSAGE =
 const SLOW_MESSAGE =
   "`slow: false` turns off Foldkit's dev performance warnings, which flag update, view, and patch phases that blow their budgets. Tune instead of disabling: pass an object with thresholdOverrides, measuredPhases, show, or onSlow. A deliberate disable belongs behind an oxlint-disable comment at this line."
 
-const isFactoryCallee = (callee: ESTree.Expression): boolean => {
+const isFactoryCallee = (
+  callee: ESTree.Expression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references !== undefined) {
+    return Option.exists(resolveFoldkitApiPath(references, callee), path => {
+      const [namespace, factoryName, extraMember] = path
+
+      return (
+        namespace === 'Runtime' &&
+        factoryName !== undefined &&
+        FACTORY_NAMES.includes(factoryName) &&
+        extraMember === undefined
+      )
+    })
+  }
+
   if (callee.type === 'Identifier') {
     return FACTORY_NAMES.includes(callee.name)
   }
@@ -68,9 +95,15 @@ export const noDisablingDevGuardrails = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
-        if (!isCallExpression(node) || !isFactoryCallee(node.callee)) {
+        if (
+          !isCallExpression(node) ||
+          !isFactoryCallee(node.callee, references)
+        ) {
           return Effect.void
         }
         const disabledGuardrails = node.arguments.flatMap(argument => {

--- a/packages/oxlint-plugin-foldkit/src/rules/no-duplicate-onmount-per-element.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-duplicate-onmount-per-element.ts
@@ -1,28 +1,33 @@
-import { Array, Effect, Option } from 'effect'
-import { AST, Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import { Effect } from 'effect'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
-import { isArrayExpression } from '../guards.ts'
+import {
+  indexReferences,
+  isArrayExpression,
+  isFoldkitHtmlBuilderMember,
+} from '../guards.ts'
 
 const DUPLICATE_ON_MOUNT_MESSAGE =
   'Only one OnMount attribute can attach to an element. Foldkit installs a single insert hook and tracks a single Mount fiber per element, so a later OnMount replaces the earlier one and its `execute` never runs. Combine the behaviors into one Mount definition.'
 
-const isOnMountCallee = (callee: ESTree.Expression): boolean => {
-  if (callee.type === 'Identifier') {
-    return callee.name === 'OnMount'
-  }
-  if (callee.type === 'MemberExpression') {
-    return Option.match(AST.memberPath(callee), {
-      onNone: () => false,
-      onSome: path => Array.lastNonEmpty(path) === 'OnMount',
-    })
-  }
-  return false
-}
+const isOnMountCallee = (
+  callee: ESTree.Expression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => isFoldkitHtmlBuilderMember(callee, 'OnMount', references)
 
-const isOnMountCall = (element: ESTree.ArrayExpressionElement): boolean =>
+const isOnMountCall = (
+  element: ESTree.ArrayExpressionElement,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean =>
   element !== null &&
   element.type === 'CallExpression' &&
-  isOnMountCallee(element.callee)
+  isOnMountCallee(element.callee, references)
 
 /** Flags array literals carrying two or more top-level OnMount attributes. Foldkit installs a single insert hook and tracks a single Mount fiber per element, so a later OnMount silently replaces the earlier one. */
 export const noDuplicateOnmountPerElement = Rule.define({
@@ -33,10 +38,15 @@ export const noDuplicateOnmountPerElement = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       ArrayExpression: (node: ESTree.Node) => {
         if (!isArrayExpression(node)) return Effect.void
-        const onMountCallCount = node.elements.filter(isOnMountCall).length
+        const onMountCallCount = node.elements.filter(element =>
+          isOnMountCall(element, references),
+        ).length
         if (onMountCallCount <= 1) return Effect.void
         return ctx.report(
           Diagnostic.make({ node, message: DUPLICATE_ON_MOUNT_MESSAGE }),

--- a/packages/oxlint-plugin-foldkit/src/rules/no-empty-children-array.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-empty-children-array.ts
@@ -1,12 +1,21 @@
 import { Array, Effect, Option } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
 import { ELEMENT_BUILDER_NAMES } from '../elementBuilderNames.ts'
 import {
+  indexReferences,
   isArrayExpression,
   isCallExpression,
+  isFoldkitHtmlBuilderMember,
   isIdentifier,
   isMemberExpression,
+  staticMemberPath,
 } from '../guards.ts'
 
 // The builder bindings Foldkit views use: the `h` a view receives, and
@@ -19,28 +28,43 @@ const KEYED_PROPERTY = 'keyed'
 
 type BuilderCallee = Readonly<{ binding: string; property: string }>
 
-const builderCallee = (callee: unknown): Option.Option<BuilderCallee> => {
+const builderCallee = (
+  callee: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): Option.Option<BuilderCallee> => {
   if (!isMemberExpression(callee) || callee.computed === true) {
     return Option.none()
   }
+  if (!isIdentifier(callee.property)) {
+    return Option.none()
+  }
+  const maybePath = staticMemberPath(callee)
+  if (Option.isNone(maybePath)) {
+    return Option.none()
+  }
+  const path = maybePath.value
+  const binding = [path.root.name, ...Array.dropRight(path.members, 1)].join(
+    '.',
+  )
   if (
-    !isIdentifier(callee.object) ||
-    !BUILDER_BINDINGS.has(callee.object.name) ||
-    !isIdentifier(callee.property)
+    references === undefined
+      ? !BUILDER_BINDINGS.has(binding)
+      : !isFoldkitHtmlBuilderMember(callee, callee.property.name, references)
   ) {
     return Option.none()
   }
   return Option.some({
-    binding: callee.object.name,
+    binding,
     property: callee.property.name,
   })
 }
 
 const elementCallTarget = (
   node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<string> =>
   node.arguments.length === 2
-    ? builderCallee(node.callee).pipe(
+    ? builderCallee(node.callee, references).pipe(
         Option.filter(({ property }) => ELEMENT_BUILDER_NAMES.has(property)),
         Option.map(({ binding, property }) => `${binding}.${property}([...])`),
       )
@@ -50,11 +74,12 @@ const elementCallTarget = (
 // the third argument of the outer call rather than the second.
 const keyedCallTarget = (
   node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<string> => {
   if (node.arguments.length !== 3 || !isCallExpression(node.callee)) {
     return Option.none()
   }
-  return builderCallee(node.callee.callee).pipe(
+  return builderCallee(node.callee.callee, references).pipe(
     Option.filter(({ property }) => property === KEYED_PROPERTY),
     Option.map(
       ({ binding }) => `${binding}.${KEYED_PROPERTY}(tag)(key, [...])`,
@@ -79,13 +104,17 @@ export const noEmptyChildrenArray = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
         if (!isCallExpression(node)) {
           return Effect.void
         }
-        const maybeTarget = Option.orElse(elementCallTarget(node), () =>
-          keyedCallTarget(node),
+        const maybeTarget = Option.orElse(
+          elementCallTarget(node, references),
+          () => keyedCallTarget(node, references),
         )
         if (Option.isNone(maybeTarget)) {
           return Effect.void

--- a/packages/oxlint-plugin-foldkit/src/rules/no-empty-object-tagged-call.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-empty-object-tagged-call.ts
@@ -1,13 +1,24 @@
-import { Effect } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import { Effect, Option } from 'effect'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+  type Variable,
+} from 'effect-oxlint'
 
 import {
+  indexReferences,
   isCallExpression,
   isIdentifier,
+  isIdentifierReference,
   isMemberExpression,
   isObjectExpression,
   isStringLiteral,
   isVariableDeclarator,
+  resolveFoldkitApiPath,
+  resolvedVariable,
 } from '../guards.ts'
 
 const PASCAL_CASE = /^[A-Z][A-Za-z0-9]*$/
@@ -56,9 +67,36 @@ const recordUnionHelperBindings = (
 const isConventionalUnionNamespace = (name: string): boolean =>
   PASCAL_CASE.test(name) && /(?:Message|Route|State)$/.test(name)
 
+const isUnionHelperCall = (
+  node: ESTree.CallExpression,
+  bindings: ReadonlySet<string>,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references === undefined) {
+    return isIdentifier(node.callee) && bindings.has(node.callee.name)
+  }
+
+  return Option.exists(resolveFoldkitApiPath(references, node.callee), path => {
+    const [namespace, helperName, extraMember] = path
+    const expectedHelperByNamespace: Readonly<Record<string, string>> = {
+      Message: 'defineMessageUnion',
+      Route: 'defineRouteUnion',
+      Schema: 'defineTaggedUnion',
+    }
+
+    return (
+      namespace !== undefined &&
+      expectedHelperByNamespace[namespace] === helperName &&
+      extraMember === undefined
+    )
+  })
+}
+
 const constructorName = (
   callee: unknown,
-  unionNamespaces: ReadonlySet<string>,
+  unionNamespaceNames: ReadonlySet<string>,
+  unionNamespaceVariables: ReadonlySet<Variable>,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): string | undefined => {
   if (isIdentifier(callee) && PASCAL_CASE.test(callee.name)) {
     return callee.name
@@ -66,13 +104,28 @@ const constructorName = (
   if (
     isMemberExpression(callee) &&
     callee.computed !== true &&
-    isIdentifier(callee.object) &&
-    (unionNamespaces.has(callee.object.name) ||
-      isConventionalUnionNamespace(callee.object.name)) &&
+    isIdentifierReference(callee.object) &&
     isIdentifier(callee.property) &&
     PASCAL_CASE.test(callee.property.name)
   ) {
-    return `${callee.object.name}.${callee.property.name}`
+    const namespace = callee.object
+    const isUnionNamespace =
+      references === undefined
+        ? unionNamespaceNames.has(namespace.name) ||
+          isConventionalUnionNamespace(namespace.name)
+        : Option.exists(resolvedVariable(references, namespace), variable => {
+            return (
+              unionNamespaceVariables.has(variable) ||
+              (isConventionalUnionNamespace(namespace.name) &&
+                variable.defs.some(
+                  definition => definition.type === 'ImportBinding',
+                ))
+            )
+          })
+
+    return isUnionNamespace
+      ? `${namespace.name}.${callee.property.name}`
+      : undefined
   }
   return undefined
 }
@@ -86,8 +139,12 @@ export const noEmptyObjectTaggedCall = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     const unionHelperBindings = new Set<string>()
-    const unionNamespaces = new Set<string>()
+    const unionNamespaceNames = new Set<string>()
+    const unionNamespaceVariables = new Set<Variable>()
 
     return {
       Program: (node: ESTree.Node) => {
@@ -97,12 +154,18 @@ export const noEmptyObjectTaggedCall = Rule.define({
       VariableDeclarator: (node: ESTree.Node) => {
         if (
           isVariableDeclarator(node) &&
-          isIdentifier(node.id) &&
+          node.id.type === 'Identifier' &&
           isCallExpression(node.init) &&
-          isIdentifier(node.init.callee) &&
-          unionHelperBindings.has(node.init.callee.name)
+          isUnionHelperCall(node.init, unionHelperBindings, references)
         ) {
-          unionNamespaces.add(node.id.name)
+          const unionName = node.id.name
+          unionNamespaceNames.add(unionName)
+          const unionVariable = ctx.sourceCode.scopeManager
+            ?.getDeclaredVariables(node)
+            .find(variable => variable.name === unionName)
+          if (unionVariable !== undefined) {
+            unionNamespaceVariables.add(unionVariable)
+          }
         }
 
         return Effect.void
@@ -111,7 +174,12 @@ export const noEmptyObjectTaggedCall = Rule.define({
         if (!isCallExpression(node)) {
           return Effect.void
         }
-        const name = constructorName(node.callee, unionNamespaces)
+        const name = constructorName(
+          node.callee,
+          unionNamespaceNames,
+          unionNamespaceVariables,
+          references,
+        )
         if (name === undefined || node.arguments.length !== 1) {
           return Effect.void
         }

--- a/packages/oxlint-plugin-foldkit/src/rules/no-hardcoded-route-strings.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-hardcoded-route-strings.ts
@@ -1,7 +1,19 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
-import { helperCalleeName, isStringLiteral } from '../guards.ts'
+import {
+  helperCalleeName,
+  indexReferences,
+  isFoldkitHtmlBuilderMember,
+  isStringLiteral,
+  resolveFoldkitApiPath,
+} from '../guards.ts'
 
 // GUARDS
 
@@ -37,6 +49,33 @@ const INTERNAL_NAVIGATION_FUNCTION_NAMES: ReadonlyArray<string> = [
 
 const INTERNAL_PATH_PATTERN = /^\//
 const ABSOLUTE_URL_PATTERN = /^https?:\/\//
+
+const routingFunctionName = (
+  callee: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): Option.Option<string> => {
+  if (references === undefined) {
+    return pipe(
+      helperCalleeName(callee),
+      Option.filter(name => Array.contains(ROUTING_FUNCTION_NAMES, name)),
+    )
+  }
+
+  if (isFoldkitHtmlBuilderMember(callee, 'Href', references)) {
+    return Option.some('Href')
+  }
+
+  return Option.flatMap(resolveFoldkitApiPath(references, callee), path => {
+    const [namespace, functionName, extraMember] = path
+
+    return namespace === 'Navigation' &&
+      functionName !== undefined &&
+      Array.contains(INTERNAL_NAVIGATION_FUNCTION_NAMES, functionName) &&
+      extraMember === undefined
+      ? Option.some(functionName)
+      : Option.none()
+  })
+}
 
 const isHardcodedRouteString = (functionName: string, value: string): boolean =>
   INTERNAL_PATH_PATTERN.test(value) ||
@@ -79,15 +118,15 @@ export const noHardcodedRouteStrings = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
         if (!isCallExpression(node)) {
           return Effect.void
         }
-        const maybeFunctionName = pipe(
-          helperCalleeName(node.callee),
-          Option.filter(name => Array.contains(ROUTING_FUNCTION_NAMES, name)),
-        )
+        const maybeFunctionName = routingFunctionName(node.callee, references)
         if (Option.isNone(maybeFunctionName)) {
           return Effect.void
         }

--- a/packages/oxlint-plugin-foldkit/src/rules/no-impure-call-at-decision-time.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-impure-call-at-decision-time.ts
@@ -14,6 +14,7 @@ import {
   isObjectExpression,
   isObjectProperty,
   isUnshadowedReference,
+  resolveImportedPath,
   staticMemberName,
   staticPropertyName,
 } from '../guards.ts'
@@ -167,52 +168,19 @@ const globalPathKey = (
     return Option.some(members.join('.'))
   })
 
-const importedName = (node: ESTree.ImportSpecifier): Option.Option<string> =>
-  node.imported.type === 'Identifier'
-    ? Option.some(node.imported.name)
-    : Option.some(node.imported.value)
-
 const importedPath = (
   references: WeakMap<ESTree.Node, Reference> | undefined,
   node: unknown,
 ): Option.Option<ImportedPath> =>
-  Option.flatMap(staticPath(node), path => {
-    if (references === undefined) {
-      return Option.some({
+  references === undefined
+    ? Option.map(staticPath(node), path => ({
         source: '',
         members: [path.root.name, ...path.members],
-      })
-    }
-
-    const reference = references.get(path.root)
-    const maybeDefinition = Option.flatMap(
-      Option.fromNullishOr(reference?.resolved),
-      variable =>
-        Array.findFirst(
-          variable.defs,
-          definition => definition.type === 'ImportBinding',
-        ),
-    )
-
-    return Option.flatMap(maybeDefinition, definition => {
-      if (definition.parent?.type !== 'ImportDeclaration') {
-        return Option.none()
-      }
-
-      const source = definition.parent.source.value
-      if (definition.node.type === 'ImportNamespaceSpecifier') {
-        return Option.some({ source, members: path.members })
-      }
-      if (definition.node.type !== 'ImportSpecifier') {
-        return Option.none()
-      }
-
-      return Option.map(importedName(definition.node), name => ({
-        source,
-        members: [name, ...path.members],
       }))
-    })
-  })
+    : Option.map(resolveImportedPath(references, node), path => ({
+        source: path.source,
+        members: path.members,
+      }))
 
 const normalizedApiPath = (
   path: ImportedPath,

--- a/packages/oxlint-plugin-foldkit/src/rules/no-noop-message.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-noop-message.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect'
 import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
 
-import { isCallExpression } from '../guards.ts'
+import { indexReferences, isCallExpression } from '../guards.ts'
 import { messageCases, recordFoldkitMessageUnionBindings } from '../message.ts'
 
 /**
@@ -17,6 +17,9 @@ export const noNoopMessage = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     const messageUnionBindings = new Set<string>()
     return {
       Program: (node: ESTree.Node) => {
@@ -27,7 +30,7 @@ export const noNoopMessage = Rule.define({
         if (!isCallExpression(node)) return Effect.void
 
         return Effect.forEach(
-          messageCases(node, messageUnionBindings),
+          messageCases(node, messageUnionBindings, references),
           messageCase =>
             ['NoOp', 'Noop', 'NoOperation'].includes(messageCase.name)
               ? ctx.report(

--- a/packages/oxlint-plugin-foldkit/src/rules/no-raw-dom-event-attributes.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-raw-dom-event-attributes.ts
@@ -1,9 +1,16 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
 import {
-  calleeMatchesHelperName,
+  indexReferences,
   isCallExpression,
+  isFoldkitHtmlBuilderMember,
   isIdentifier,
   isObjectExpression,
   isStringLiteral,
@@ -156,16 +163,20 @@ const keyPropertyValue = (
 
 const attributeEventName = (
   node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<string> => {
-  if (!calleeMatchesHelperName(node.callee, 'Attribute')) {
+  if (!isFoldkitHtmlBuilderMember(node.callee, 'Attribute', references)) {
     return Option.none()
   }
   const [firstArgument] = node.arguments
   return Option.filter(staticStringValue(firstArgument), isRawEventName)
 }
 
-const propEventName = (node: ESTree.CallExpression): Option.Option<string> => {
-  if (!calleeMatchesHelperName(node.callee, 'Prop')) {
+const propEventName = (
+  node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): Option.Option<string> => {
+  if (!isFoldkitHtmlBuilderMember(node.callee, 'Prop', references)) {
     return Option.none()
   }
   const [configArgument] = node.arguments
@@ -196,14 +207,17 @@ export const noRawDomEventAttributes = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
         if (!isCallExpression(node)) {
           return Effect.void
         }
         return pipe(
-          attributeEventName(node),
-          Option.orElse(() => propEventName(node)),
+          attributeEventName(node, references),
+          Option.orElse(() => propEventName(node, references)),
           Option.match({
             onNone: () => Effect.void,
             onSome: attributeName =>

--- a/packages/oxlint-plugin-foldkit/src/rules/no-spread-in-evo.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/no-spread-in-evo.ts
@@ -1,12 +1,41 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
-import { isCallExpression, isObjectExpression } from '../guards.ts'
+import {
+  indexReferences,
+  isCallExpression,
+  isObjectExpression,
+  resolveFoldkitApiPath,
+} from '../guards.ts'
 
 const nestedEvoMessage = (fieldName: string): string =>
   `The updater for field \`${fieldName}\` rebuilds the record with a spread, stepping outside the strict Model update path. Use a nested \`evo\` instead: \`${fieldName}: () => evo(model.${fieldName}, { ... })\`.`
 
-const isEvoCall = (node: ESTree.CallExpression): boolean => {
+const isEvoCall = (
+  node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): boolean => {
+  if (references !== undefined) {
+    return Option.exists(
+      resolveFoldkitApiPath(references, node.callee),
+      path => {
+        const [namespace, methodName, extraMember] = path
+
+        return (
+          namespace === 'Struct' &&
+          methodName === 'evo' &&
+          extraMember === undefined
+        )
+      },
+    )
+  }
+
   const callee = node.callee
   if (callee.type === 'Identifier') {
     return callee.name === 'evo'
@@ -60,10 +89,11 @@ const updaterFieldName = (property: ESTree.ObjectProperty): string =>
 
 const spreadRebuiltFields = (
   node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): ReadonlyArray<
   Readonly<{ fieldName: string; bodyObject: ESTree.ObjectExpression }>
 > => {
-  if (!isEvoCall(node)) return []
+  if (!isEvoCall(node, references)) return []
   const [, updates] = node.arguments
   if (updates === undefined || updates.type !== 'ObjectExpression') return []
   return updates.properties.flatMap(property => {
@@ -93,11 +123,14 @@ export const noSpreadInEvo = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       CallExpression: (node: ESTree.Node) => {
         if (!isCallExpression(node)) return Effect.void
         return Effect.forEach(
-          spreadRebuiltFields(node),
+          spreadRebuiltFields(node, references),
           ({ fieldName, bodyObject }) =>
             ctx.report(
               Diagnostic.make({

--- a/packages/oxlint-plugin-foldkit/src/rules/require-rel-for-external-link.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/require-rel-for-external-link.ts
@@ -1,10 +1,17 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+} from 'effect-oxlint'
 
 import {
-  calleeMatchesHelperName,
+  indexReferences,
   isArrayExpression,
   isCallExpression,
+  isFoldkitHtmlBuilderMember,
   isSpreadElement,
   isStringLiteral,
   staticStringValue,
@@ -16,10 +23,11 @@ const protectiveRelSubstrings = ['noopener', 'noreferrer']
 
 const isTargetBlankElement = (
   element: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): element is ESTree.CallExpression => {
   if (
     !isCallExpression(element) ||
-    !calleeMatchesHelperName(element.callee, 'Target')
+    !isFoldkitHtmlBuilderMember(element.callee, 'Target', references)
   ) {
     return false
   }
@@ -27,8 +35,12 @@ const isTargetBlankElement = (
   return isStringLiteral(firstArgument) && firstArgument.value === '_blank'
 }
 
-const isRelElement = (element: unknown): element is ESTree.CallExpression =>
-  isCallExpression(element) && calleeMatchesHelperName(element.callee, 'Rel')
+const isRelElement = (
+  element: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): element is ESTree.CallExpression =>
+  isCallExpression(element) &&
+  isFoldkitHtmlBuilderMember(element.callee, 'Rel', references)
 
 const relStaticValue = (
   relElement: ESTree.CallExpression,
@@ -62,6 +74,9 @@ export const requireRelForExternalLink = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return {
       ArrayExpression: (node: ESTree.Node) => {
         if (!isArrayExpression(node)) {
@@ -70,14 +85,15 @@ export const requireRelForExternalLink = Rule.define({
         if (Array.some(node.elements, isSpreadElement)) {
           return Effect.void
         }
-        const maybeTargetBlank = Array.findFirst(
-          node.elements,
-          isTargetBlankElement,
+        const maybeTargetBlank = Array.findFirst(node.elements, element =>
+          isTargetBlankElement(element, references),
         )
         if (Option.isNone(maybeTargetBlank)) {
           return Effect.void
         }
-        const relElements = Array.filter(node.elements, isRelElement)
+        const relElements = Array.filter(node.elements, element =>
+          isRelElement(element, references),
+        )
         if (Array.isArrayEmpty(relElements)) {
           return ctx.report(
             Diagnostic.make({

--- a/packages/oxlint-plugin-foldkit/src/rules/selection-submodel-factory-at-module-scope.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/selection-submodel-factory-at-module-scope.ts
@@ -2,16 +2,19 @@ import { Array, Effect, Option, pipe } from 'effect'
 import {
   Diagnostic,
   type ESTree,
+  type Reference,
   Rule,
   RuleContext,
   Visitor,
 } from 'effect-oxlint'
 
 import {
+  indexReferences,
   isCallExpression,
   isIdentifier,
   isMemberExpression,
   isProgram,
+  resolveImportedPath,
 } from '../guards.ts'
 
 const factoryWrapperTypes: ReadonlyArray<string> = [
@@ -74,9 +77,7 @@ const resolveMemberPath = (
   return Option.none()
 }
 
-const isSelectionFactoryPath = (
-  path: Array.NonEmptyReadonlyArray<string>,
-): boolean => {
+const isSelectionFactoryPath = (path: ReadonlyArray<string>): boolean => {
   const [first, second, third, fourth, fifth] = path
   if (fifth !== undefined) {
     return false
@@ -93,6 +94,7 @@ const isSelectionFactoryPath = (
   if (third !== undefined) {
     const isMultiForm =
       second === 'Multi' &&
+      first !== undefined &&
       multiSelectComponents.includes(first) &&
       third === 'create'
     const isUiNamespaceForm =
@@ -102,17 +104,46 @@ const isSelectionFactoryPath = (
       third === 'create'
     return isMultiForm || isUiNamespaceForm
   }
-  return second === 'create' && singleSelectComponents.includes(first)
+  return (
+    first !== undefined &&
+    second === 'create' &&
+    singleSelectComponents.includes(first)
+  )
 }
 
 const selectionFactoryLabel = (
   call: ESTree.CallExpression,
-): Option.Option<string> =>
-  pipe(
-    resolveMemberPath(call.callee),
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): Option.Option<string> => {
+  const maybePath =
+    references === undefined
+      ? resolveMemberPath(call.callee)
+      : pipe(
+          resolveImportedPath(references, call.callee),
+          Option.flatMap(path => {
+            if (path.source === '@foldkit/ui') {
+              return Option.some(path.members)
+            }
+
+            const componentBySource: Readonly<Record<string, string>> = {
+              '@foldkit/ui/combobox': 'Combobox',
+              '@foldkit/ui/listbox': 'Listbox',
+              '@foldkit/ui/menu': 'Menu',
+              '@foldkit/ui/tabs': 'Tabs',
+            }
+            const component = componentBySource[path.source]
+            return component === undefined
+              ? Option.none()
+              : Option.some([component, ...path.members])
+          }),
+        )
+
+  return pipe(
+    maybePath,
     Option.filter(isSelectionFactoryPath),
     Option.map(Array.join('.')),
   )
+}
 
 type SelectionFactoryCall = Readonly<{
   call: ESTree.CallExpression
@@ -121,13 +152,14 @@ type SelectionFactoryCall = Readonly<{
 
 const selectionFactorySelfMatch = (
   value: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): ReadonlyArray<SelectionFactoryCall> => {
   if (!isCallExpression(value)) {
     return []
   }
   const call = value
   return pipe(
-    selectionFactoryLabel(call),
+    selectionFactoryLabel(call, references),
     Option.match({
       onNone: () => [],
       onSome: label => [{ call, label }],
@@ -137,15 +169,16 @@ const selectionFactorySelfMatch = (
 
 const collectSelectionFactoryCalls = (
   value: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): ReadonlyArray<SelectionFactoryCall> => {
   if (typeof value !== 'object' || value === null) {
     return []
   }
   const childEntries = Object.entries(value)
   const childMatches = childEntries.flatMap(([key, child]) =>
-    key === 'parent' ? [] : collectSelectionFactoryCalls(child),
+    key === 'parent' ? [] : collectSelectionFactoryCalls(child, references),
   )
-  return [...selectionFactorySelfMatch(value), ...childMatches]
+  return [...selectionFactorySelfMatch(value, references), ...childMatches]
 }
 
 const topLevelInitializerCalls = (
@@ -185,12 +218,15 @@ export const selectionSubmodelFactoryAtModuleScope = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopes = ctx.sourceCode.scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     return Visitor.onExit('Program', (node: ESTree.Node) => {
       if (!isProgram(node)) {
         return Effect.void
       }
       const allowedCalls = topLevelInitializerCalls(node)
-      const factoryCalls = collectSelectionFactoryCalls(node)
+      const factoryCalls = collectSelectionFactoryCalls(node, references)
       const offendingCalls = factoryCalls.filter(
         factoryCall => !allowedCalls.includes(factoryCall.call),
       )

--- a/packages/oxlint-plugin-foldkit/src/rules/wrap-child-output-in-got-message.ts
+++ b/packages/oxlint-plugin-foldkit/src/rules/wrap-child-output-in-got-message.ts
@@ -1,13 +1,27 @@
 import { Array, Effect, Option, pipe } from 'effect'
-import { Diagnostic, type ESTree, Rule, RuleContext } from 'effect-oxlint'
+import {
+  Diagnostic,
+  type ESTree,
+  type Reference,
+  Rule,
+  RuleContext,
+  type Variable,
+} from 'effect-oxlint'
 
 import {
+  indexReferences,
   isCallExpression,
   isIdentifier,
   isMemberExpression,
   isObjectExpression,
   isStringLiteral,
+  isVariableDeclarator,
+  resolveFoldkitApiPath,
+  resolveImportedPath,
+  resolvedVariable,
+  staticMemberPath,
 } from '../guards.ts'
+import { isFoldkitMessageUnionCall } from '../message.ts'
 
 const mapperWrapperTypes: ReadonlyArray<string> = [
   'ChainExpression',
@@ -27,6 +41,8 @@ const commandMapperPaths: ReadonlyArray<string> = [
 const gotMessagePattern = /^Got\w*Message$/
 
 const dynamicCalleeLabel = '<dynamic call>'
+
+const emptyMessageUnionBindings: ReadonlySet<string> = new Set()
 
 const isWrapperExpression = (
   node: unknown,
@@ -84,11 +100,23 @@ const resolveMemberPath = (
 const isPropertyKeyNamed = (key: unknown, name: string): boolean =>
   isIdentifier(key, name) || (isStringLiteral(key) && key.value === name)
 
+const foldkitApiPath = (
+  node: unknown,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
+): Option.Option<ReadonlyArray<string>> => {
+  if (references === undefined) {
+    return resolveMemberPath(node)
+  }
+
+  return resolveFoldkitApiPath(references, node)
+}
+
 const commandMapperArrow = (
   node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<ESTree.ArrowFunctionExpression> =>
   pipe(
-    resolveMemberPath(node.callee),
+    foldkitApiPath(node.callee, references),
     Option.map(Array.join('.')),
     Option.filter(calleePath => commandMapperPaths.includes(calleePath)),
     Option.flatMap(() => {
@@ -101,13 +129,14 @@ const commandMapperArrow = (
 
 const subscriptionLiftMapperArrow = (
   node: ESTree.CallExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<ESTree.ArrowFunctionExpression> => {
   const innerCall = unwrapExpression(node.callee)
   if (!isCallExpression(innerCall)) {
     return Option.none()
   }
   return pipe(
-    resolveMemberPath(innerCall.callee),
+    foldkitApiPath(innerCall.callee, references),
     Option.map(Array.join('.')),
     Option.filter(calleePath => calleePath === 'Subscription.lift'),
     Option.flatMap(() => {
@@ -172,26 +201,73 @@ type MapperOffense = Readonly<{
   calleeLabel: string
 }>
 
+const isFoldkitMessageUnionVariable = (
+  variable: Variable,
+  references: WeakMap<ESTree.Node, Reference>,
+): boolean =>
+  variable.defs.some(
+    definition =>
+      definition.type === 'Variable' &&
+      isVariableDeclarator(definition.node) &&
+      isCallExpression(definition.node.init) &&
+      isFoldkitMessageUnionCall(
+        definition.node.init,
+        emptyMessageUnionBindings,
+        references,
+      ),
+  )
+
 const nonGotMapperOffense = (
   arrow: ESTree.ArrowFunctionExpression,
+  references: WeakMap<ESTree.Node, Reference> | undefined,
 ): Option.Option<MapperOffense> =>
   pipe(
     analyzableMapperCall(arrow),
-    Option.flatMap(call =>
-      pipe(
-        resolveMemberPath(call.callee),
-        Option.match({
-          onNone: () => Option.some({ call, calleeLabel: dynamicCalleeLabel }),
-          onSome: calleePath =>
-            gotMessagePattern.test(Array.lastNonEmpty(calleePath))
-              ? Option.none()
-              : Option.some({
-                  call,
-                  calleeLabel: `${Array.join(calleePath, '.')}(...)`,
-                }),
+    Option.flatMap(call => {
+      const maybeCalleePath = resolveMemberPath(call.callee)
+      const isGotWrapper =
+        references === undefined
+          ? Option.exists(maybeCalleePath, calleePath =>
+              gotMessagePattern.test(Array.lastNonEmpty(calleePath)),
+            )
+          : Option.exists(
+              resolveImportedPath(references, call.callee),
+              importedPath => {
+                const [constructorName] = importedPath.members.slice(-1)
+
+                return (
+                  constructorName !== undefined &&
+                  gotMessagePattern.test(constructorName)
+                )
+              },
+            ) ||
+            Option.exists(staticMemberPath(call.callee), calleePath => {
+              const [constructorName, extraMember] = calleePath.members
+
+              return (
+                constructorName !== undefined &&
+                extraMember === undefined &&
+                gotMessagePattern.test(constructorName) &&
+                Option.exists(
+                  resolvedVariable(references, calleePath.root),
+                  variable =>
+                    isFoldkitMessageUnionVariable(variable, references),
+                )
+              )
+            })
+
+      if (isGotWrapper) {
+        return Option.none()
+      }
+
+      return Option.some({
+        call,
+        calleeLabel: Option.match(maybeCalleePath, {
+          onNone: () => dynamicCalleeLabel,
+          onSome: calleePath => `${Array.join(calleePath, '.')}(...)`,
         }),
-      ),
-    ),
+      })
+    }),
   )
 
 const commandMapperMessage = (calleeLabel: string): string =>
@@ -217,6 +293,10 @@ export const wrapChildOutputInGotMessage = Rule.define({
   }),
   create: function* () {
     const ctx = yield* RuleContext
+    const scopeManager = ctx.sourceCode.scopeManager
+    const scopes = scopeManager?.scopes
+    const references =
+      scopes === undefined ? undefined : indexReferences(scopes)
     const reportOffense = (
       offense: MapperOffense,
       renderMessage: (calleeLabel: string) => string,
@@ -233,14 +313,14 @@ export const wrapChildOutputInGotMessage = Rule.define({
           return Effect.void
         }
         return pipe(
-          commandMapperArrow(node),
-          Option.flatMap(nonGotMapperOffense),
+          commandMapperArrow(node, references),
+          Option.flatMap(arrow => nonGotMapperOffense(arrow, references)),
           Option.match({
             onSome: offense => reportOffense(offense, commandMapperMessage),
             onNone: () =>
               pipe(
-                subscriptionLiftMapperArrow(node),
-                Option.flatMap(nonGotMapperOffense),
+                subscriptionLiftMapperArrow(node, references),
+                Option.flatMap(arrow => nonGotMapperOffense(arrow, references)),
                 Option.match({
                   onSome: offense =>
                     reportOffense(offense, subscriptionMapperMessage),

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/command-binding-matches-name/invalid/command.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/command-binding-matches-name/invalid/command.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { Command } from 'foldkit'
+import { Command as Commands } from 'foldkit'
 import { defineMessageUnion } from 'foldkit/message'
 
 const Message = defineMessageUnion({
@@ -7,7 +7,7 @@ const Message = defineMessageUnion({
 })
 
 
-export const SaveUser = Command.define('FetchUser', {
+export const SaveUser = Commands.define('FetchUser', {
   messages: [Message.CompletedFetchUser],
   execute: Effect.succeed(Message.CompletedFetchUser()),
 })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/command-binding-matches-name/valid/command.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/command-binding-matches-name/valid/command.ts
@@ -11,3 +11,9 @@ export const FetchUser = Command.define('FetchUser', {
   messages: [Message.CompletedFetchUser],
   execute: Effect.succeed(Message.CompletedFetchUser()),
 })
+
+export const defineLocal = (Command: { define: (name: string) => string }) => {
+  const LocalCommand = Command.define('DifferentName')
+
+  return LocalCommand
+}

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/command-define-pascal-const/invalid/command.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/command-define-pascal-const/invalid/command.ts
@@ -1,5 +1,5 @@
 import { Effect } from 'effect'
-import { Command } from 'foldkit'
+import { Command as Commands } from 'foldkit'
 import { defineMessageUnion } from 'foldkit/message'
 
 const Message = defineMessageUnion({
@@ -8,7 +8,7 @@ const Message = defineMessageUnion({
 
 const fetchWeatherEffect = Effect.succeed(Message.CompletedFetchWeather())
 
-export const fetchWeather = Command.define('FetchWeather', {
+export const fetchWeather = Commands.define('FetchWeather', {
   messages: [Message.CompletedFetchWeather],
   execute: fetchWeatherEffect,
 })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/command-define-pascal-const/valid/command.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/command-define-pascal-const/valid/command.ts
@@ -12,3 +12,6 @@ export const FetchWeather = Command.define('FetchWeather', {
   messages: [Message.CompletedFetchWeather],
   execute: fetchWeatherEffect,
 })
+
+export const defineLocal = (Command: { define: (name: string) => string }) =>
+  Command.define('not-pascal-case')

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-prefix-requires-submodel-payload/invalid/message.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-prefix-requires-submodel-payload/invalid/message.ts
@@ -1,6 +1,14 @@
 import { Schema } from 'effect'
+import { Message as MessageApi } from 'foldkit'
 import { defineMessageUnion } from 'foldkit/message'
+
+import { ValidationMessage } from './validation'
 
 const Message = defineMessageUnion({
   GotWeather: { temperature: Schema.Number, },
+  GotValidation: { message: ValidationMessage, },
+})
+
+const RootMessage = MessageApi.defineMessageUnion({
+  GotRootApi: { message: Schema.String },
 })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-submodel-message-name/invalid/message.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-submodel-message-name/invalid/message.ts
@@ -1,8 +1,8 @@
 import { defineMessageUnion } from 'foldkit/message'
 
-import * as Child from './child'
+import { Message as ChildMessage } from './child'
 
 const Message = defineMessageUnion({
   OpenedChild: {},
-  ChildChanged: { message: Child.Message, },
+  ChildChanged: { message: ChildMessage, },
 })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-submodel-message-name/valid/message.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-submodel-message-name/valid/message.ts
@@ -1,8 +1,18 @@
+import { Schema as S } from 'effect'
 import { defineMessageUnion } from 'foldkit/message'
 
 import * as Child from './child'
+import { ValidationMessage } from './validation'
 
 const Message = defineMessageUnion({
   OpenedChild: {},
+  ReceivedMessage: { message: S.String, },
+  ReceivedValidation: { message: ValidationMessage, },
   GotChildMessage: { message: Child.Message, },
 })
+
+export const localUnion = () => {
+  const defineMessageUnion = (cases: unknown) => cases
+
+  return defineMessageUnion({ ChildChanged: { message: Child.Message } })
+}

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-wrapper-carries-only-routing/invalid/alias.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-wrapper-carries-only-routing/invalid/alias.ts
@@ -1,0 +1,10 @@
+import { Schema } from 'effect'
+import { Message as MessageApi } from 'foldkit'
+import { Settings } from './settings'
+
+const Message = MessageApi.defineMessageUnion({
+  GotSettingsMessage: {
+    message: Settings.Message,
+    timestamp: Schema.Number,
+  },
+})

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-wrapper-carries-only-routing/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/got-wrapper-carries-only-routing/valid/local-shadow.ts
@@ -1,0 +1,12 @@
+const MessageApi = {
+  defineMessageUnion: <Cases>(cases: Cases): Cases => cases,
+}
+
+const Message = MessageApi.defineMessageUnion({
+  GotSettingsMessage: {
+    message: 'settings',
+    timestamp: 'now',
+  },
+})
+
+export { Message }

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/keyed-required-for-mapped-rows/invalid/effect-array-alias.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/keyed-required-for-mapped-rows/invalid/effect-array-alias.ts
@@ -1,0 +1,10 @@
+import { map as renderEach } from 'effect/Array'
+import type { Html, HtmlBuilder } from 'foldkit/html'
+
+type Task = Readonly<{ id: string }>
+
+export const taskRows = (
+  tasks: ReadonlyArray<Task>,
+  h: HtmlBuilder<never>,
+): ReadonlyArray<Html> =>
+  renderEach(tasks, task => h.li([], [task.id]))

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/keyed-required-for-mapped-rows/invalid/scope-resolution.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/keyed-required-for-mapped-rows/invalid/scope-resolution.ts
@@ -1,0 +1,16 @@
+import type { Html, HtmlBuilder as Builder } from 'foldkit/html'
+
+type Task = Readonly<{ id: string }>
+
+const Option = {
+  map: <Value, Result>(
+    values: ReadonlyArray<Value>,
+    toResult: (value: Value) => Result,
+  ): ReadonlyArray<Result> => values.map(toResult),
+}
+
+export const taskRows = (
+  tasks: ReadonlyArray<Task>,
+  h: Builder<never>,
+): ReadonlyArray<Html> =>
+  Option.map(tasks, task => h.li([], [task.id]))

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/keyed-required-for-mapped-rows/valid/scope-resolution.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/keyed-required-for-mapped-rows/valid/scope-resolution.ts
@@ -1,0 +1,16 @@
+import { Option as O } from 'effect'
+import type { Html, HtmlBuilder as Builder } from 'foldkit/html'
+
+type Task = Readonly<{ id: string }>
+
+const localRenderer = {
+  div: (...values: ReadonlyArray<unknown>) => values,
+}
+
+export const maybeTaskRow = (
+  maybeTask: O.Option<Task>,
+  h: Builder<never>,
+): O.Option<Html> => O.map(maybeTask, task => h.div([], [task.id]))
+
+export const localRows = (tasks: ReadonlyArray<Task>) =>
+  tasks.map(task => localRenderer.div([], [task.id]))

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/lazy-view-stable-references/invalid/view.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/lazy-view-stable-references/invalid/view.ts
@@ -1,8 +1,8 @@
-import { createLazy } from 'foldkit/html'
+import { createLazy as makeLazy } from 'foldkit/html'
 
 import { renderHeader } from './header'
 
 export const view = (model: Model) => {
-  const lazyHeader = createLazy()
+  const lazyHeader = makeLazy()
   return lazyHeader(renderHeader, [model.title])
 }

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/lazy-view-stable-references/valid/view.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/lazy-view-stable-references/valid/view.ts
@@ -4,4 +4,26 @@ import { renderHeader } from './header'
 
 const lazyHeader = createLazy()
 
+const stableHeader = () => undefined
+
 export const view = (model: Model) => lazyHeader(renderHeader, [model.title])
+
+export const makeLocal = (createLazy: () => () => unknown) => {
+  const localLazy = createLazy()
+
+  return localLazy()
+}
+
+export const callShadow = (
+  lazyHeader: (view: () => unknown, dependencies: ReadonlyArray<unknown>) =>
+    unknown,
+) => lazyHeader(() => undefined, [])
+
+export const blockShadow = () => {
+  {
+    const stableHeader = 'shadow'
+    void stableHeader
+  }
+
+  return lazyHeader(stableHeader, [])
+}

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/mount-factory-must-use-element/invalid/mount.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/mount-factory-must-use-element/invalid/mount.ts
@@ -1,9 +1,9 @@
 import { Effect } from 'effect'
-import { Mount } from 'foldkit'
+import { Mount as Mounts } from 'foldkit'
 
 import { CompletedMountAnalytics } from './message'
 
-export const MountAnalytics = Mount.define('MountAnalytics', {
+export const MountAnalytics = Mounts.define('MountAnalytics', {
   messages: [CompletedMountAnalytics],
   execute: () => Effect.sync(() => startAnalytics()),
 })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/mount-factory-must-use-element/valid/mount.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/mount-factory-must-use-element/valid/mount.ts
@@ -7,3 +7,6 @@ export const MountResize = Mount.define('MountResize', {
   messages: [CompletedMountResize],
   execute: ({ element }) => Effect.sync(() => resizeObserver.observe(element)),
 })
+
+export const defineLocal = (Mount: { define: (name: string) => string }) =>
+  Mount.define('LocalMount')

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-array-index-view-keys/invalid/view.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-array-index-view-keys/invalid/view.ts
@@ -1,9 +1,11 @@
-import { inertHtml as ih } from 'foldkit/html'
+import { createKeyedLazy as makeKeyedLazy, inertHtml as ih } from 'foldkit/html'
 
 import type { Task } from './model'
+
+const lazyTask = makeKeyedLazy()
 
 export const taskList = (tasks: ReadonlyArray<Task>) =>
   ih.ul(
     [],
-    tasks.map((task, index) => ih.keyed('li')(index, [], [task.title])),
+    tasks.map((task, index) => lazyTask(index, viewTask, task)),
   )

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-array-index-view-keys/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-array-index-view-keys/valid/local-shadow.ts
@@ -1,0 +1,6 @@
+const createKeyedLazy = () => (key: number) => key
+
+const localLazy = createKeyedLazy()
+
+export const localKeys = (values: ReadonlyArray<string>) =>
+  values.map((_value, index) => localLazy(index))

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-array-index-view-keys/valid/nested-index-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-array-index-view-keys/valid/nested-index-shadow.ts
@@ -1,0 +1,6 @@
+import { inertHtml as ih } from 'foldkit/html'
+
+export const nestedIndexShadow = (values: ReadonlyArray<string>) =>
+  values.map((_value, index) =>
+    [index].map(index => ih.div([ih.Key(index)])),
+  )

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-array-index-view-keys/valid/slot-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-array-index-view-keys/valid/slot-shadow.ts
@@ -1,0 +1,10 @@
+import { createKeyedLazy } from 'foldkit/html'
+
+const keyedRow = createKeyedLazy()
+
+export const localKeys = (values: ReadonlyArray<string>) =>
+  values.map((_value, index) => {
+    const keyedRow = (key: number) => key
+
+    return keyedRow(index)
+  })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-child-message-construction-in-root/invalid/main.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-child-message-construction-in-root/invalid/main.ts
@@ -1,10 +1,68 @@
-import { Child } from './child'
-import { GotChildMessage } from './message'
+import { Child as WorkspaceChild } from '@app/child'
+import { Message as FeatureMessage } from 'feature/message'
+import { Submodel } from 'foldkit'
+import { CommandPalette } from '@foldkit/ui'
+
+import { Child, Message as ChildMessage } from './child'
+import { Message as NestedMainMessage } from './child/main'
+import { Message as ServerChildMessage } from './child.server'
+import { Message } from './directChild'
+import * as Features from './features'
+import { GotChildMessage, Message as ParentMessage } from './message'
 import { Model } from './model'
+import { Message as SearchMessage } from '../search'
 
 // UPDATE
 
 export const update = (model: Model) => {
-  const command = GotChildMessage({ message: Child.Message.ClickedSave() })
-  return { model, commands: [command] }
+  const command = GotChildMessage({
+    message: Child.Message.ClickedBarrelSave(),
+  })
+  const directCommand = GotChildMessage({
+    message: ChildMessage.ClickedDirectBarrelSave(),
+  })
+  const unaliasedCommand = GotChildMessage({
+    message: Message.ClickedDirectChildSave(),
+  })
+  const nestedCommand = GotChildMessage({
+    message: Features.Account.Profile.Message.ClickedProfileSave(),
+  })
+  const nestedMainCommand = GotChildMessage({
+    message: NestedMainMessage.ClickedNestedSave(),
+  })
+  const workspaceCommand = GotChildMessage({
+    message: WorkspaceChild.Message.ClickedWorkspaceSave(),
+  })
+  const featureCommand = GotChildMessage({
+    message: FeatureMessage.ClickedFeatureSave(),
+  })
+  const searchCommand = GotChildMessage({
+    message: SearchMessage.ClickedSearchResult(),
+  })
+  const uiCommand = GotChildMessage({
+    message: CommandPalette.Message.OpenedCommandPalette(),
+  })
+  return {
+    model,
+    commands: [
+      command,
+      directCommand,
+      unaliasedCommand,
+      nestedCommand,
+      nestedMainCommand,
+      workspaceCommand,
+      featureCommand,
+      searchCommand,
+      uiCommand,
+    ],
+  }
 }
+
+export const view = Submodel.defineView<Model, ParentMessage>((_model, h) =>
+  h.button([h.OnClick(Child.Message.ClickedParentViewSave())]),
+)
+
+export const serverChildView = Submodel.defineView<Child.Model, Child.Message>(
+  (_model, h) =>
+    h.button([h.OnClick(ServerChildMessage.ClickedServerChildSave())]),
+)

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-child-message-construction-in-root/valid/command/command.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-child-message-construction-in-root/valid/command/command.ts
@@ -1,0 +1,3 @@
+import { Message } from '../message.js'
+
+export const completedWork = () => Message.CompletedWork()

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-child-message-construction-in-root/valid/main.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-child-message-construction-in-root/valid/main.ts
@@ -1,10 +1,47 @@
+import { Option } from 'effect'
+import { Submodel, Update } from 'foldkit'
+import type { HtmlBuilder } from 'foldkit/html'
+
 import { Child } from './child'
-import { GotChildMessage } from './message'
+import { Message as NestedMainMessage } from './child/main'
+import { Message as DirectChildMessage } from './child/message'
+import { GotChildMessage, Message as OwnMessage } from './message.js'
 import { Model } from './model'
+import { Message as AliasMessage } from '@/message'
 
 // UPDATE
 
-export const update = (model: Model) => {
-  const command = GotChildMessage({ message: Child.clickedSave() })
-  return { model, commands: [command] }
-}
+const foldChildSave = Update.foldChildStep({
+  update: Child.save,
+  read: (model: Model) => Option.some(model.child),
+  write: (model, child) => ({ ...model, child }),
+  toParentMessage: message => GotChildMessage({ message }),
+})
+
+export const update = (model: Model) => foldChildSave(model)
+
+// CHILD VIEW
+
+const saveButton = (h: HtmlBuilder<Child.Message>) =>
+  h.button([h.OnClick(Child.Message.ClickedSave())])
+
+export const view = Submodel.defineView<Child.Model, Child.Message>(
+  (_model, h) => saveButton(h),
+)
+
+export const directMessageView = Submodel.defineView<
+  Child.Model,
+  Child.Message
+>((_model, h) => h.button([h.OnClick(DirectChildMessage.ClickedSave())]))
+
+export const nestedMainMessageView = Submodel.defineView<
+  Child.Model,
+  Child.Message
+>((_model, h) => h.button([h.OnClick(NestedMainMessage.ClickedSave())]))
+
+export const ownMessage = () => OwnMessage.ClickedSave()
+
+export const aliasMessage = () => AliasMessage.ClickedSave()
+
+export const localMessage = (Child: unknown) =>
+  (Child as { Message: { ClickedSave: () => unknown } }).Message.ClickedSave()

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-disabling-dev-guardrails/invalid/main.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-disabling-dev-guardrails/invalid/main.ts
@@ -1,8 +1,8 @@
-import { Runtime } from 'foldkit'
+import { Runtime as AppRuntime } from 'foldkit'
 
 import { init, Model, update, view } from './app'
 
-export const app = Runtime.makeApplication({
+export const app = AppRuntime.makeApplication({
   Model,
   init,
   update,

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-disabling-dev-guardrails/valid/main.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-disabling-dev-guardrails/valid/main.ts
@@ -3,3 +3,7 @@ import { Runtime } from 'foldkit'
 import { init, Model, update, view } from './app'
 
 export const app = Runtime.makeApplication({ Model, init, update, view })
+
+export const makeLocal = (Runtime: {
+  makeApplication: (config: unknown) => unknown
+}) => Runtime.makeApplication({ freezeModel: false })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-duplicate-onmount-per-element/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-duplicate-onmount-per-element/valid/local-shadow.ts
@@ -1,0 +1,5 @@
+const h = {
+  OnMount: (name: string): string => name,
+}
+
+export const attributes = [h.OnMount('AnchorPopover'), h.OnMount('SyncScroll')]

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/invalid/contextual-view.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/invalid/contextual-view.ts
@@ -1,0 +1,5 @@
+import { Submodel } from 'foldkit'
+
+export const view = Submodel.defineView<Model, Message>((_model, h) =>
+  h.div([], []),
+)

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/invalid/namespace-type.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/invalid/namespace-type.ts
@@ -1,0 +1,4 @@
+import * as Html from 'foldkit/html'
+
+export const divider = (h: Html.HtmlBuilder<Message>): Html.Html =>
+  h.div([], [])

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/invalid/root-inert.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/invalid/root-inert.ts
@@ -1,0 +1,3 @@
+import { Html } from 'foldkit'
+
+export const divider = Html.inertHtml.div([], [])

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/invalid/root-namespace-type.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/invalid/root-namespace-type.ts
@@ -1,0 +1,4 @@
+import { Html } from 'foldkit'
+
+export const divider = (h: Html.HtmlBuilder<Message>): Html.Html =>
+  h.div([], [])

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-children-array/valid/local-shadow.ts
@@ -1,0 +1,8 @@
+const h = {
+  div: (
+    attributes: ReadonlyArray<unknown>,
+    children: ReadonlyArray<unknown>,
+  ): ReadonlyArray<unknown> => [...attributes, ...children],
+}
+
+export const divider = h.div([], [])

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-object-tagged-call/invalid/message.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-object-tagged-call/invalid/message.ts
@@ -1,4 +1,9 @@
+import { defineMessageUnion } from 'foldkit/message'
 import { defineTaggedUnion } from 'foldkit/schema'
+
+const Message = defineMessageUnion({
+  Root: {},
+})
 
 const Submission = defineTaggedUnion({
   NotSubmitted: {},
@@ -6,3 +11,13 @@ const Submission = defineTaggedUnion({
 })
 
 const badSubmission = Submission.NotSubmitted({})
+
+const local = () => {
+  const Message = defineMessageUnion({
+    Local: {},
+  })
+
+  return Message.Local({})
+}
+
+const badRootAfterLocal = Message.Root({})

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-object-tagged-call/valid/message.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-empty-object-tagged-call/valid/message.ts
@@ -17,3 +17,17 @@ const Library = {
 const goodMessage = Message.ClickedSave()
 const goodSubmission = Submission.NotSubmitted()
 const config = Library.Configure({})
+
+export const localUnion = (
+  defineTaggedUnion: (cases: unknown) => {
+    Empty: (fields: object) => object
+  },
+) => {
+  const LocalUnion = defineTaggedUnion({ Empty: {} })
+
+  return LocalUnion.Empty({})
+}
+
+export const localMessage = (
+  Message: Readonly<{ ClickedSave: (fields: object) => object }>,
+) => Message.ClickedSave({})

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-hardcoded-route-strings/invalid/navigation.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-hardcoded-route-strings/invalid/navigation.ts
@@ -1,0 +1,3 @@
+import { pushUrl as navigate } from 'foldkit/navigation'
+
+export const goToTasks = () => navigate('/tasks')

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-hardcoded-route-strings/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-hardcoded-route-strings/valid/local-shadow.ts
@@ -1,0 +1,5 @@
+const ih = {
+  Href: (value: string): string => value,
+}
+
+export const tasksHref = ih.Href('/tasks')

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-noop-message/invalid/alias.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-noop-message/invalid/alias.ts
@@ -1,0 +1,5 @@
+import { Message as MessageApi } from 'foldkit'
+
+const Message = MessageApi.defineMessageUnion({
+  NoOp: {},
+})

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-noop-message/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-noop-message/valid/local-shadow.ts
@@ -1,0 +1,9 @@
+const MessageApi = {
+  defineMessageUnion: <Cases>(cases: Cases): Cases => cases,
+}
+
+const Message = MessageApi.defineMessageUnion({
+  NoOp: {},
+})
+
+export { Message }

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-raw-dom-event-attributes/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-raw-dom-event-attributes/valid/local-shadow.ts
@@ -1,0 +1,8 @@
+const ih = {
+  Attribute: (name: string, value: string): ReadonlyArray<string> => [
+    name,
+    value,
+  ],
+}
+
+export const reloadAttribute = ih.Attribute('onclick', 'location.reload()')

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-spread-in-evo/invalid/update.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-spread-in-evo/invalid/update.ts
@@ -1,9 +1,9 @@
-import { evo } from 'foldkit/struct'
+import { evo as evolve } from 'foldkit/struct'
 import { Model } from './model'
 
 // UPDATE
 
 export const update = (model: Model): Model =>
-  evo(model, {
+  evolve(model, {
     user: () => ({ ...model.user, name: 'Ada' }),
   })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-spread-in-evo/valid/update.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/no-spread-in-evo/valid/update.ts
@@ -7,3 +7,8 @@ export const update = (model: Model): Model =>
   evo(model, {
     user: (user) => evo(user, { name: () => 'Ada' }),
   })
+
+export const updateLocal = (
+  model: Model,
+  evo: (model: Model, updates: unknown) => Model,
+): Model => evo(model, { user: () => ({ ...model.user, name: 'Ada' }) })

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/require-rel-for-external-link/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/require-rel-for-external-link/valid/local-shadow.ts
@@ -1,0 +1,5 @@
+const ih = {
+  Target: (value: string): string => value,
+}
+
+export const externalLinkAttributes = [ih.Target('_blank')]

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/selection-submodel-factory-at-module-scope/invalid/update.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/selection-submodel-factory-at-module-scope/invalid/update.ts
@@ -1,10 +1,10 @@
-import { Listbox } from '@foldkit/ui'
+import { Listbox as Selection } from '@foldkit/ui'
 import { Message } from './message'
 import { Model } from './model'
 
 // UPDATE
 
 export const update = (model: Model, message: Message) => {
-  const listbox = Listbox.create()
+  const listbox = Selection.create()
   return listbox.update(model.sort, message)
 }

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/selection-submodel-factory-at-module-scope/valid/update.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/selection-submodel-factory-at-module-scope/valid/update.ts
@@ -8,3 +8,6 @@ const sortListbox = Listbox.create()
 
 export const update = (model: Model, message: Message) =>
   sortListbox.update(model.sort, message)
+
+export const createLocalSelection = (Listbox: { create: () => unknown }) =>
+  Listbox.create()

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/wrap-child-output-in-got-message/invalid/update.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/wrap-child-output-in-got-message/invalid/update.ts
@@ -1,19 +1,25 @@
-import { Command } from 'foldkit'
+import { Command as ChildCommand } from 'foldkit'
 import { evo } from 'foldkit/struct'
 import { Child } from './child'
 import { ForwardedChildMessage } from './message'
 import { Model } from './model'
 
+const GotLocallyShadowedMessage = (input: { message: Child.Message }) => input
+
 // UPDATE
 
 export const update = (model: Model, message: Child.Message) => {
   const childUpdate = Child.update(model.child, message)
-  const commands = Command.mapMessages(
+  const commands = ChildCommand.mapMessages(
     childUpdate.commands,
     childMessage => ForwardedChildMessage({ message: childMessage }),
   )
+  const shadowedCommands = ChildCommand.mapMessages(
+    childUpdate.commands,
+    childMessage => GotLocallyShadowedMessage({ message: childMessage }),
+  )
   return {
     model: evo(model, { child: () => childUpdate.model }),
-    commands,
+    commands: [...commands, ...shadowedCommands],
   }
 }

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/wrap-child-output-in-got-message/valid/local-message.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/wrap-child-output-in-got-message/valid/local-message.ts
@@ -1,0 +1,10 @@
+import { Command } from 'foldkit'
+import { Schema as S } from 'effect'
+import { defineMessageUnion } from 'foldkit/message'
+
+export const mapMessages = (messages: ReadonlyArray<unknown>) =>
+  Command.mapMessages(messages, message => Message.GotChildMessage({ message }))
+
+const Message = defineMessageUnion({
+  GotChildMessage: { message: S.Unknown },
+})

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/wrap-child-output-in-got-message/valid/local-shadow.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/wrap-child-output-in-got-message/valid/local-shadow.ts
@@ -1,0 +1,11 @@
+const Command = {
+  mapMessages: (
+    messages: ReadonlyArray<unknown>,
+    toMessage: (message: unknown) => unknown,
+  ) => messages.map(toMessage),
+}
+
+const ForwardedMessage = (message: unknown) => message
+
+export const mapLocalMessages = (messages: ReadonlyArray<unknown>) =>
+  Command.mapMessages(messages, message => ForwardedMessage(message))

--- a/packages/oxlint-plugin-foldkit/test/integration/fixtures/wrap-child-output-in-got-message/valid/update.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/fixtures/wrap-child-output-in-got-message/valid/update.ts
@@ -1,8 +1,8 @@
-import { Update } from 'foldkit'
+import { Command, Update } from 'foldkit'
 import { Option } from 'effect'
 import { evo } from 'foldkit/struct'
 import { Child } from './child'
-import { GotChildMessage } from './message'
+import { GotChildMessage as wrap } from './message'
 import { Model } from './model'
 
 // UPDATE
@@ -11,5 +11,8 @@ export const update = Update.foldChild({
   update: Child.update,
   read: (model: Model) => Option.some(model.child),
   write: (model, nextChild) => evo(model, { child: () => nextChild }),
-  toParentMessage: message => GotChildMessage({ message }),
+  toParentMessage: message => wrap({ message }),
 })
+
+export const mapMessages = (messages: ReadonlyArray<Child.Message>) =>
+  Command.mapMessages(messages, message => wrap({ message }))

--- a/packages/oxlint-plugin-foldkit/test/integration/real-oxlint.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/real-oxlint.test.ts
@@ -13,7 +13,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { runOxlint } from './run-oxlint.ts'
+import { type LintDiagnostic, runOxlint } from './run-oxlint.ts'
 
 // Runs every rule through real oxlint against fixtures written in real
 // Foldkit idioms. `invalid/` must produce at least one diagnostic and
@@ -45,7 +45,10 @@ afterAll(() => {
 
 type FixtureKind = 'valid' | 'invalid'
 
-const countDiagnostics = (rule: string, kind: FixtureKind): number => {
+const diagnosticsFor = (
+  rule: string,
+  kind: FixtureKind,
+): ReadonlyArray<LintDiagnostic> => {
   const targetDir = join(fixturesRoot, rule, kind)
   const config = {
     plugins: ['typescript'],
@@ -70,7 +73,28 @@ const countDiagnostics = (rule: string, kind: FixtureKind): number => {
       )
     }
   }
-  return diagnostics.length
+  return diagnostics
+}
+
+const countDiagnostics = (rule: string, kind: FixtureKind): number =>
+  diagnosticsFor(rule, kind).length
+
+const reportedCalleeLabel = (diagnostic: LintDiagnostic): string => {
+  const match = diagnostic.message.match(/`([^`]+)\(\.\.\.\)`/)
+  if (match === null) {
+    throw new Error(
+      `Diagnostic does not contain a callee label: ${diagnostic.message}`,
+    )
+  }
+
+  const [, label] = match
+  if (label === undefined) {
+    throw new Error(
+      `Diagnostic has an empty callee label: ${diagnostic.message}`,
+    )
+  }
+
+  return label
 }
 
 const ruleFixtures = readdirSync(fixturesRoot, { withFileTypes: true })
@@ -101,6 +125,54 @@ describe('real-oxlint rule fixtures', () => {
     expect(countDiagnostics('no-impure-call-at-decision-time', 'invalid')).toBe(
       23,
     )
+  })
+
+  it('reports every direct child Message import form', () => {
+    const diagnostics = diagnosticsFor(
+      'no-child-message-construction-in-root',
+      'invalid',
+    )
+
+    expect(diagnostics.map(reportedCalleeLabel).sort()).toEqual(
+      [
+        'Child.Message.ClickedBarrelSave',
+        'Child.Message.ClickedDirectBarrelSave',
+        'Child.Message.ClickedNestedSave',
+        'Child.Message.ClickedParentViewSave',
+        'Child.Message.ClickedWorkspaceSave',
+        'Child.server.Message.ClickedServerChildSave',
+        'CommandPalette.Message.OpenedCommandPalette',
+        'DirectChild.Message.ClickedDirectChildSave',
+        'Feature.Message.ClickedFeatureSave',
+        'Profile.Message.ClickedProfileSave',
+        'Search.Message.ClickedSearchResult',
+      ].sort(),
+    )
+  })
+
+  it('resolves aliased constructors and helpers to their imported APIs', () => {
+    expect(countDiagnostics('no-hardcoded-route-strings', 'invalid')).toBe(2)
+    expect(countDiagnostics('keyed-required-for-mapped-rows', 'invalid')).toBe(
+      3,
+    )
+    expect(
+      countDiagnostics('got-prefix-requires-submodel-payload', 'invalid'),
+    ).toBe(3)
+    expect(
+      countDiagnostics('wrap-child-output-in-got-message', 'invalid'),
+    ).toBe(2)
+    expect(
+      countDiagnostics('got-wrapper-carries-only-routing', 'invalid'),
+    ).toBe(2)
+    expect(countDiagnostics('no-noop-message', 'invalid')).toBe(2)
+  })
+
+  it('recognizes explicit and contextual HtmlBuilder parameters', () => {
+    expect(countDiagnostics('no-empty-children-array', 'invalid')).toBe(6)
+  })
+
+  it('tracks same-named tagged unions by binding', () => {
+    expect(countDiagnostics('no-empty-object-tagged-call', 'invalid')).toBe(3)
   })
 
   it('fixes only structurally safe empty commands properties', async () => {

--- a/packages/oxlint-plugin-foldkit/test/integration/run-oxlint.ts
+++ b/packages/oxlint-plugin-foldkit/test/integration/run-oxlint.ts
@@ -5,6 +5,7 @@ import { isAbsolute, relative } from 'node:path'
 export type LintDiagnostic = Readonly<{
   code: string
   filename: string
+  message: string
 }>
 
 const parseDiagnostic = (cwd: string, value: unknown): LintDiagnostic => {
@@ -14,14 +15,20 @@ const parseDiagnostic = (cwd: string, value: unknown): LintDiagnostic => {
     !('code' in value) ||
     typeof value.code !== 'string' ||
     !('filename' in value) ||
-    typeof value.filename !== 'string'
+    typeof value.filename !== 'string' ||
+    !('message' in value) ||
+    typeof value.message !== 'string'
   ) {
     throw new Error('Oxlint returned an invalid diagnostic')
   }
   const filename = isAbsolute(value.filename)
     ? relative(cwd, value.filename)
     : value.filename
-  return { code: value.code, filename: filename.replaceAll('\\', '/') }
+  return {
+    code: value.code,
+    filename: filename.replaceAll('\\', '/'),
+    message: value.message,
+  }
 }
 
 const parseDiagnostics = (

--- a/packages/oxlint-plugin-foldkit/test/rules/no-child-message-construction-in-root.test.ts
+++ b/packages/oxlint-plugin-foldkit/test/rules/no-child-message-construction-in-root.test.ts
@@ -24,6 +24,7 @@ describe('no-child-message-construction-in-root', () => {
 
     expect(result).toHaveLength(1)
     expect(result[0]?.diagnostic.message).toContain('Chat.Message.ClickedOpen')
+    expect(result[0]?.diagnostic.message).toContain('Update.foldChildStep')
   })
 
   it('flags widget-style namespaces', () => {

--- a/packages/ui/src/animation/index.ts
+++ b/packages/ui/src/animation/index.ts
@@ -7,6 +7,8 @@ import {
   WaitForAnimationSettled,
   WaitForPaint,
   defaultLeaveCommand,
+  hide,
+  show,
   toggle,
   update,
 } from './update.js'
@@ -18,6 +20,8 @@ export {
   WaitForAnimationSettled,
   WaitForPaint,
   defaultLeaveCommand,
+  hide,
+  show,
   toggle,
   update,
 }

--- a/packages/ui/src/animation/public.ts
+++ b/packages/ui/src/animation/public.ts
@@ -1,5 +1,7 @@
 export {
   init,
+  show,
+  hide,
   update,
   toggle,
   view,

--- a/packages/ui/src/animation/story.test.ts
+++ b/packages/ui/src/animation/story.test.ts
@@ -8,7 +8,9 @@ import {
   OutMessage,
   WaitForAnimationSettled,
   WaitForPaint,
+  hide,
   init,
+  show,
   toggle,
   update,
 } from './index.js'
@@ -178,6 +180,24 @@ describe('Animation', () => {
       expect(animationToggle.model.isShowing).toBe(false)
       expect(animationToggle.model.transitionState).toBe('LeaveStart')
       expect(animationToggle.commands).toHaveLength(1)
+    })
+  })
+
+  describe('programmatic capabilities', () => {
+    it('shows a hidden Animation', () => {
+      const animationShow = show(init({ id: 'test' }))
+
+      expect(animationShow.model.isShowing).toBe(true)
+      expect(animationShow.model.transitionState).toBe('EnterStart')
+      expect(animationShow.commands).toHaveLength(1)
+    })
+
+    it('hides a showing Animation', () => {
+      const animationHide = hide(init({ id: 'test', isShowing: true }))
+
+      expect(animationHide.model.isShowing).toBe(false)
+      expect(animationHide.model.transitionState).toBe('LeaveStart')
+      expect(animationHide.commands).toHaveLength(1)
     })
   })
 })

--- a/packages/ui/src/animation/update.ts
+++ b/packages/ui/src/animation/update.ts
@@ -113,12 +113,20 @@ export function update(model: Model, message: Message): UpdateReturn {
   })
 }
 
+/** Programmatically starts the enter lifecycle. */
+export const show = (model: Model): Update.Return<Model, Message> =>
+  update(model, Message.Showed())
+
+/** Programmatically starts the leave lifecycle. */
+export const hide = (model: Model): Update.Return<Model, Message> =>
+  update(model, Message.Hid())
+
 /** Toggles the animation between its shown and hidden states. */
 export const toggle = (model: Model): Update.Return<Model, Message> => {
   if (model.isShowing) {
-    return update(model, Message.Hid())
+    return hide(model)
   } else {
-    return update(model, Message.Showed())
+    return show(model)
   }
 }
 

--- a/packages/ui/src/combobox/shared.ts
+++ b/packages/ui/src/combobox/shared.ts
@@ -17,7 +17,11 @@ import {
 // dependency: animation → html → runtime → devtools → combobox → animation.
 // The barrel (../animation) imports from html, which starts the cycle.
 import * as Animation from '../animation/schema.js'
-import { update as animationUpdate } from '../animation/update.js'
+import {
+  hide as animationHide,
+  show as animationShow,
+  update as animationUpdate,
+} from '../animation/update.js'
 import { groupContiguous } from '../group.js'
 import * as OptionExt from '../internal/optionExtensions.js'
 import { idSelector } from '../internal/selectors.js'
@@ -347,6 +351,22 @@ export const makeUpdate = <Model extends BaseModel>(
     foldOutMessage: foldAnimationOutMessage,
   })
 
+  const foldAnimationShow = Update.foldChildStep({
+    update: animationShow,
+    read: (model: Model) => Option.some(model.animation),
+    write: (model, nextAnimation) =>
+      constrainedEvo(model, { animation: () => nextAnimation }),
+    toParentMessage: message => Message.GotAnimationMessage({ message }),
+  })
+
+  const foldAnimationHide = Update.foldChildStep({
+    update: animationHide,
+    read: (model: Model) => Option.some(model.animation),
+    write: (model, nextAnimation) =>
+      constrainedEvo(model, { animation: () => nextAnimation }),
+    toParentMessage: message => Message.GotAnimationMessage({ message }),
+  })
+
   const internalUpdate = (model: Model, message: Message): UpdateReturn => {
     const maybeLockScroll = OptionExt.when(model.isModal, LockScroll())
     const maybeUnlockScroll = OptionExt.when(model.isModal, UnlockScroll())
@@ -383,7 +403,7 @@ export const makeUpdate = <Model extends BaseModel>(
           nextModel,
           Update.combine([
             stepModel => ({ model: stepModel, commands }),
-            foldAnimation(Animation.Message.Hid()),
+            foldAnimationHide,
           ]),
           Update.withOutMessage(outMessage),
         )
@@ -399,7 +419,7 @@ export const makeUpdate = <Model extends BaseModel>(
             model: stepModel,
             commands: Array.getSomes([maybeLockScroll, maybeInertOthers]),
           }),
-          foldAnimation(Animation.Message.Showed()),
+          foldAnimationShow,
           stepModel => ({
             model: constrainedEvo(stepModel, { isOpen: () => true }),
           }),
@@ -429,7 +449,7 @@ export const makeUpdate = <Model extends BaseModel>(
           comboboxClose.model,
           Update.combine([
             stepModel => ({ model: stepModel, commands }),
-            foldAnimation(Animation.Message.Hid()),
+            foldAnimationHide,
           ]),
           Update.withOutMessage(comboboxClose.outMessage),
         )

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -13,6 +13,8 @@ import * as Update from 'foldkit/update'
 import * as Animation from '../animation/schema.js'
 import {
   defaultLeaveCommand as animationDefaultLeaveCommand,
+  hide as animationHide,
+  show as animationShow,
   update as animationUpdate,
 } from '../animation/update.js'
 import { idSelector } from '../internal/selectors.js'
@@ -216,6 +218,22 @@ const foldAnimation = Update.foldChild({
   foldOutMessage: foldAnimationOutMessage,
 })
 
+const foldAnimationShow = Update.foldChildStep({
+  update: animationShow,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
+    evo(model, { animation: () => nextAnimation }),
+  toParentMessage: wrapAnimationMessage,
+})
+
+const foldAnimationHide = Update.foldChildStep({
+  update: animationHide,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
+    evo(model, { animation: () => nextAnimation }),
+  toParentMessage: wrapAnimationMessage,
+})
+
 /** Processes a Dialog Message and returns the next Model and optional Commands. */
 export const update = (model: Model, message: Message) =>
   Message.match<UpdateReturn>(message, {
@@ -235,7 +253,7 @@ export const update = (model: Model, message: Message) =>
       const dialogOpen: Update.Return<Model, Message> = model.isAnimated
         ? Update.combine(model, [
             stepModel => ({ model: stepModel, commands }),
-            foldAnimation(Animation.Message.Showed()),
+            foldAnimationShow,
             stepModel => ({
               model: evo(stepModel, { isOpen: () => true }),
             }),
@@ -258,7 +276,7 @@ export const update = (model: Model, message: Message) =>
           stepModel => ({
             model: evo(stepModel, { isOpen: () => false }),
           }),
-          foldAnimation(Animation.Message.Hid()),
+          foldAnimationHide,
         ])
 
         return wasOpen

--- a/packages/ui/src/listbox/shared.ts
+++ b/packages/ui/src/listbox/shared.ts
@@ -28,7 +28,11 @@ import {
 // dependency: animation → html → runtime → devtools → listbox → animation.
 // The barrel (../animation) imports from html, which starts the cycle.
 import * as Animation from '../animation/schema.js'
-import { update as animationUpdate } from '../animation/update.js'
+import {
+  hide as animationHide,
+  show as animationShow,
+  update as animationUpdate,
+} from '../animation/update.js'
 import { groupContiguous } from '../group.js'
 import * as OptionExt from '../internal/optionExtensions.js'
 import { idSelector } from '../internal/selectors.js'
@@ -353,6 +357,22 @@ export const makeUpdate = <Model extends BaseModel>(
     foldOutMessage: foldAnimationOutMessage,
   })
 
+  const foldAnimationShow = Update.foldChildStep({
+    update: animationShow,
+    read: (model: Model) => Option.some(model.animation),
+    write: (model, nextAnimation) =>
+      constrainedEvo(model, { animation: () => nextAnimation }),
+    toParentMessage: message => Message.GotAnimationMessage({ message }),
+  })
+
+  const foldAnimationHide = Update.foldChildStep({
+    update: animationHide,
+    read: (model: Model) => Option.some(model.animation),
+    write: (model, nextAnimation) =>
+      constrainedEvo(model, { animation: () => nextAnimation }),
+    toParentMessage: message => Message.GotAnimationMessage({ message }),
+  })
+
   const openListbox = (
     baseModel: Model,
     openCommands: ReadonlyArray<Command.Command<Message>>,
@@ -363,7 +383,7 @@ export const makeUpdate = <Model extends BaseModel>(
           model: stepModel,
           commands: openCommands,
         }),
-        foldAnimation(Animation.Message.Showed()),
+        foldAnimationShow,
         stepModel => ({
           model: constrainedEvo(stepModel, { isOpen: () => true }),
         }),
@@ -389,7 +409,7 @@ export const makeUpdate = <Model extends BaseModel>(
     if (baseModel.isAnimated) {
       return Update.combine(closed, [
         stepModel => ({ model: stepModel, commands }),
-        foldAnimation(Animation.Message.Hid()),
+        foldAnimationHide,
       ])
     }
 

--- a/packages/ui/src/menu/index.ts
+++ b/packages/ui/src/menu/index.ts
@@ -27,7 +27,11 @@ import {
 // dependency: animation → html → runtime → devtools → menu → animation.
 // The barrel (../animation) imports from html, which starts the cycle.
 import * as Animation from '../animation/schema.js'
-import { update as animationUpdate } from '../animation/update.js'
+import {
+  hide as animationHide,
+  show as animationShow,
+  update as animationUpdate,
+} from '../animation/update.js'
 import { groupContiguous } from '../group.js'
 import * as OptionExt from '../internal/optionExtensions.js'
 import { idSelector } from '../internal/selectors.js'
@@ -331,6 +335,22 @@ const foldAnimation = Update.foldChild({
   foldOutMessage: foldAnimationOutMessage,
 })
 
+const foldAnimationShow = Update.foldChildStep({
+  update: animationShow,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
+    evo(model, { animation: () => nextAnimation }),
+  toParentMessage: message => Message.GotAnimationMessage({ message }),
+})
+
+const foldAnimationHide = Update.foldChildStep({
+  update: animationHide,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
+    evo(model, { animation: () => nextAnimation }),
+  toParentMessage: message => Message.GotAnimationMessage({ message }),
+})
+
 /** Processes a Menu Message and returns the next Model, optional Commands, and
  *  an optional OutMessage. */
 export const update = (model: Model, message: Message) => {
@@ -365,7 +385,7 @@ export const update = (model: Model, message: Message) => {
     if (model.isAnimated) {
       return Update.combine(baseModel, [
         stepModel => ({ model: stepModel, commands: openCommands }),
-        foldAnimation(Animation.Message.Showed()),
+        foldAnimationShow,
         stepModel => ({
           model: evo(stepModel, { isOpen: () => true }),
         }),
@@ -391,7 +411,7 @@ export const update = (model: Model, message: Message) => {
     if (model.isAnimated) {
       return Update.combine(closed, [
         stepModel => ({ model: stepModel, commands }),
-        foldAnimation(Animation.Message.Hid()),
+        foldAnimationHide,
       ])
     }
 

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -26,7 +26,11 @@ import {
 // dependency: animation → html → runtime → devtools → popover → animation.
 // The barrel (../animation) imports from html, which starts the cycle.
 import * as Animation from '../animation/schema.js'
-import { update as animationUpdate } from '../animation/update.js'
+import {
+  hide as animationHide,
+  show as animationShow,
+  update as animationUpdate,
+} from '../animation/update.js'
 import * as OptionExt from '../internal/optionExtensions.js'
 import { idSelector } from '../internal/selectors.js'
 
@@ -231,6 +235,22 @@ const foldAnimation = Update.foldChild({
   foldOutMessage: foldAnimationOutMessage,
 })
 
+const foldAnimationShow = Update.foldChildStep({
+  update: animationShow,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
+    evo(model, { animation: () => nextAnimation }),
+  toParentMessage: message => Message.GotAnimationMessage({ message }),
+})
+
+const foldAnimationHide = Update.foldChildStep({
+  update: animationHide,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
+    evo(model, { animation: () => nextAnimation }),
+  toParentMessage: message => Message.GotAnimationMessage({ message }),
+})
+
 /** Processes a Popover Message and returns the next Model, optional Commands,
  *  and an optional OutMessage. */
 export const update = (model: Model, message: Message) => {
@@ -264,7 +284,7 @@ export const update = (model: Model, message: Message) => {
     if (model.isAnimated) {
       const popoverOpen = Update.combine(baseModel, [
         stepModel => ({ model: stepModel, commands: openCommands }),
-        foldAnimation(Animation.Message.Showed()),
+        foldAnimationShow,
         stepModel => ({
           model: evo(stepModel, { isOpen: () => true }),
         }),
@@ -292,7 +312,7 @@ export const update = (model: Model, message: Message) => {
     if (model.isAnimated) {
       return Update.combine(closed, [
         stepModel => ({ model: stepModel, commands }),
-        foldAnimation(Animation.Message.Hid()),
+        foldAnimationHide,
       ])
     }
 

--- a/packages/ui/src/toast/update.ts
+++ b/packages/ui/src/toast/update.ts
@@ -6,6 +6,8 @@ import * as Update from 'foldkit/update'
 import * as Animation from '../animation/schema.js'
 import {
   defaultLeaveCommand as animationDefaultLeaveCommand,
+  hide as animationHide,
+  show as animationShow,
   update as animationUpdate,
 } from '../animation/update.js'
 import * as OptionExt from '../internal/optionExtensions.js'
@@ -180,8 +182,7 @@ export const makeRuntime = <A, I>(payloadSchema: Schema.Codec<A, I>) => {
 
   const foldEntryAnimationShow = (entry: Entry) =>
     Update.foldChildStep({
-      update: (animation: Animation.Model) =>
-        animationUpdate(animation, Animation.Message.Showed()),
+      update: animationShow,
       read: readEntryAnimation(entry.id),
       write: writeEntryAnimation(entry.id),
       toParentMessage: toGotAnimationMessage(entry.id),
@@ -189,8 +190,7 @@ export const makeRuntime = <A, I>(payloadSchema: Schema.Codec<A, I>) => {
 
   const foldEntryAnimationHide = (entry: Entry) =>
     Update.foldChildStep({
-      update: (animation: Animation.Model) =>
-        animationUpdate(animation, Animation.Message.Hid()),
+      update: animationHide,
       read: readEntryAnimation(entry.id),
       write: writeEntryAnimation(entry.id),
       toParentMessage: toGotAnimationMessage(entry.id),

--- a/packages/website/src/page/toolingLinting.md
+++ b/packages/website/src/page/toolingLinting.md
@@ -226,7 +226,7 @@ Keeps a Got wrapper payload to the child Message plus routing keys: message, id,
 
 ### foldkit/no-child-message-construction-in-root {#no-child-message-construction-in-root}
 
-Rejects constructing a child Message variant from outside the child. Call a child-exported helper and route its output through the wrapper.
+Rejects constructing a child Message variant from a parent. Expose a child-owned update capability that applies the internal fact, then integrate it with `Update.foldChild` or `Update.foldChildStep`. A child-owned view, Command, or Subscription may still construct that child's Messages; the boundary is ownership, not file spelling. See [Informing Submodels](/patterns/informing-submodels) for the complete pattern.
 
 ::Snippet{name="lintNoChildMessageConstructionInRoot" label="foldkit/no-child-message-construction-in-root example"}
 

--- a/packages/website/src/page/ui/animationPage.md
+++ b/packages/website/src/page/ui/animationPage.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Animation coordinates CSS enter and leave phases with a state machine and data attributes. A parent Message calls the child-owned `Animation.toggle` entry point through `Update.foldChildStep`, Animation records each lifecycle phase in its Model, and your CSS styles those phases. The transitions stay visible in DevTools and can be tested through update without waiting for a browser animation.
+Animation coordinates CSS enter and leave phases with a state machine and data attributes. A parent invokes the child-owned `show`, `hide`, or `toggle` update capability through `Update.foldChildStep`; Animation applies its internal `Showed` or `Hid` fact, records each lifecycle phase in its Model, and exposes the resulting Commands through the fold. The transitions stay visible in DevTools and can be tested through update without waiting for a browser animation.
 
 Animation uses the [OutMessage](/core/submodel#surfacing-facts) pattern. The `foldOutMessage` of your [`Update.foldChild`](/core/submodel#fold-child) config handles `StartedLeaveAnimating` by providing a Command that detects settlement, then handles `TransitionedOut` when post-animation cleanup can begin. Dialog, Menu, Popover, Listbox, and Combobox use the same Submodel internally when `isAnimated` is true.
 
@@ -24,7 +24,7 @@ Check out how Animation is wired up in a [real Foldkit app](https://github.com/f
 
 ## Examples
 
-Dispatch a parent Message that applies `Animation.toggle` through `Update.foldChildStep`. Style with Tailwind data-attribute selectors like `data-[closed]:opacity-0`.
+Fold `Animation.show` with `Update.foldChildStep` to start the enter animation and fold `Animation.hide` to start the leave animation. Style with Tailwind data-attribute selectors like `data-[closed]:opacity-0`.
 
 ::Demo{name="animation"}
 
@@ -34,13 +34,13 @@ Dispatch a parent Message that applies `Animation.toggle` through `Update.foldCh
 
 Animation drives the enter phase to completion on its own. The leave phase hands control back to the parent halfway through so the parent can decide how settlement is detected. For example, Foldkit's [Dialog](/ui/dialog) just waits for CSS, while its [Popover](/ui/popover) races CSS against the anchor button scrolling off-screen. The asymmetry exists because leave detection varies by consumer, while enter detection does not.
 
-Internally, `Animation.toggle` applies the `Showed` or `Hid` Message according to the current Animation Model.
+Internally, the `show`, `hide`, and `toggle` capabilities apply the `Showed` or `Hid` Message according to the current Animation Model and requested transition.
 
 ```diagram
 ENTER                                LEAVE
 Animation drives completion          Parent detects settlement
 
-Showed (internal Message)             Hid (internal Message)
+show()                                hide()
    |                                    |
    v                                    v
 EnterStart                           LeaveStart
@@ -81,7 +81,7 @@ The `animateSize` option uses CSS grid (`grid-template-rows: 0fr` → `1fr`) for
 
 ### toggle
 
-`Animation.toggle(model)` returns the Animation update result that starts the enter or leave lifecycle according to `model.isShowing`. Use it as the `update` entry point of `Update.foldChildStep` when a parent Message toggles visibility.
+`Animation.toggle(model)` returns the Animation update result that starts the enter or leave lifecycle according to `model.isShowing`. Use it as the `update` entry point of `Update.foldChildStep` when the parent does not need to choose a directional capability.
 
 ### InitConfig {#init-config}
 
@@ -91,6 +91,10 @@ Configuration object passed to `Animation.init()`.
 | ----------- | --------- | ------- | ------------------------------------- |
 | `id`        | `string`  | —       | Unique ID for the animation instance. |
 | `isShowing` | `boolean` | `false` | Initial visibility state.             |
+
+### show and hide
+
+`Animation.show(model)` and `Animation.hide(model)` return the next Animation Model and any Commands. Fold these child entry points into the parent with `Update.foldChildStep`; do not construct `Animation.Message.Showed()` or `Animation.Message.Hid()` from the parent.
 
 ### ViewConfig {#view-config}
 

--- a/packages/website/src/page/ui/demo/animation.ts
+++ b/packages/website/src/page/ui/demo/animation.ts
@@ -16,36 +16,34 @@ const contentClassName =
 export const view = (
   animationModel: Animation.Model,
   h: HtmlBuilder<Message>,
-) => {
-  return [
-    h.div(
-      [h.Class('flex flex-col items-center')],
-      [
-        h.button(
-          [
-            h.Class(triggerClassName),
-            h.OnClick(Message.ToggledAnimationDemo()),
-          ],
-          [animationModel.isShowing ? 'Hide Content' : 'Show Content'],
-        ),
-        h.submodel({
-          slotId: animationModel.id,
-          model: animationModel,
-          view: Animation.view,
-          viewInputs: {
-            className: contentClassName,
-            animateSize: true,
-            content: h.p(
-              [h.Class('text-accent-800 dark:text-accent-200')],
-              [
-                'This content fades in and out using CSS transitions coordinated by the Animation component. The data attributes (data-closed, data-enter, data-leave, data-transition) drive the animation via Tailwind selectors.',
-              ],
-            ),
-          },
-          toParentMessage: message =>
-            Message.GotAnimationDemoMessage({ message }),
-        }),
-      ],
-    ),
-  ]
-}
+) => [
+  h.div(
+    [h.Class('flex flex-col items-center')],
+    [
+      h.button(
+        [
+          h.Class(triggerClassName),
+          h.OnClick(Message.ClickedToggleAnimationDemo()),
+        ],
+        [animationModel.isShowing ? 'Hide Content' : 'Show Content'],
+      ),
+      h.submodel({
+        slotId: animationModel.id,
+        model: animationModel,
+        view: Animation.view,
+        viewInputs: {
+          className: contentClassName,
+          animateSize: true,
+          content: h.p(
+            [h.Class('text-accent-800 dark:text-accent-200')],
+            [
+              'This content fades in and out using CSS transitions coordinated by the Animation component. The data attributes (data-closed, data-enter, data-leave, data-transition) drive the animation via Tailwind selectors.',
+            ],
+          ),
+        },
+        toParentMessage: message =>
+          Message.GotAnimationDemoMessage({ message }),
+      }),
+    ],
+  ),
+]

--- a/packages/website/src/page/ui/message.ts
+++ b/packages/website/src/page/ui/message.ts
@@ -84,7 +84,7 @@ export const Message = defineMessageUnion({
   GotHoverIntentMenuDemoMessage: { message: HoverIntent.Message },
   ClickedHoverIntentMenuItem: {},
   GotAnimationDemoMessage: { message: Animation.Message },
-  ToggledAnimationDemo: {},
+  ClickedToggleAnimationDemo: {},
   GotVirtualListDemoMessage: { message: VirtualList.Message },
   ClickedVirtualListScrollToMiddle: {},
   GotVirtualListVariableDemoMessage: { message: VirtualList.Message },

--- a/packages/website/src/page/ui/update.ts
+++ b/packages/website/src/page/ui/update.ts
@@ -794,8 +794,16 @@ const foldAnimationDemo = Update.foldChild({
   foldOutMessage: foldAnimationDemoOutMessage,
 })
 
-const foldAnimationDemoToggle = Update.foldChildStep({
-  update: Animation.toggle,
+const foldAnimationDemoShow = Update.foldChildStep({
+  update: Animation.show,
+  read: (model: Model) => Option.some(model.animationDemo),
+  write: (model, nextAnimationDemo) =>
+    evo(model, { animationDemo: () => nextAnimationDemo }),
+  toParentMessage: message => Message.GotAnimationDemoMessage({ message }),
+})
+
+const foldAnimationDemoHide = Update.foldChildStep({
+  update: Animation.hide,
   read: (model: Model) => Option.some(model.animationDemo),
   write: (model, nextAnimationDemo) =>
     evo(model, { animationDemo: () => nextAnimationDemo }),
@@ -1148,7 +1156,10 @@ export const update = (model: Model, message: Message) =>
 
     GotAnimationDemoMessage: ({ message }) => foldAnimationDemo(model, message),
 
-    ToggledAnimationDemo: () => foldAnimationDemoToggle(model),
+    ClickedToggleAnimationDemo: () =>
+      model.animationDemo.isShowing
+        ? foldAnimationDemoHide(model)
+        : foldAnimationDemoShow(model),
 
     GotFileDropBasicDemoMessage: ({ message }) =>
       foldFileDropBasicDemo(model, message),

--- a/packages/website/src/snippet/lintNoChildMessageConstructionInRoot.ts
+++ b/packages/website/src/snippet/lintNoChildMessageConstructionInRoot.ts
@@ -4,5 +4,13 @@ const badRouting = () =>
   GotChildMessage({ message: Child.Message.ClickedSave() })
 
 // ✅ Good
-// The child exports a helper; the root routes its output through the wrapper.
-const goodRouting = () => GotChildMessage({ message: Child.clickedSave() })
+// The child exports an update capability. The parent folds the complete child
+// result without importing or constructing its internal Message.
+const foldChildSave = Update.foldChildStep({
+  update: Child.save,
+  read: model => Option.some(model.child),
+  write: (model, nextChild) => evo(model, { child: () => nextChild }),
+  toParentMessage: message => GotChildMessage({ message }),
+})
+
+const goodRouting = model => foldChildSave(model)

--- a/packages/website/src/snippet/uiAnimationBasic.ts
+++ b/packages/website/src/snippet/uiAnimationBasic.ts
@@ -27,7 +27,7 @@ const init = () => ({
 // Embed the Animation Message in your parent Message:
 const Message = defineMessageUnion({
   GotAnimationMessage: { message: Animation.Message },
-  ToggledAnimation: {},
+  ClickedToggleAnimation: {},
 })
 type Message = typeof Message.Type
 
@@ -77,32 +77,44 @@ const foldAnimation = Update.foldChild({
   foldOutMessage: foldAnimationOutMessage,
 })
 
-// Animation.toggle is the child-owned entry point for changing visibility.
-// Update.foldChildStep applies it without constructing a child Message in the
-// parent:
-const foldAnimationToggle = Update.foldChildStep({
-  update: Animation.toggle,
+// Programmatic child capabilities take the child Model and return its next
+// Model and Commands. foldChildStep integrates that result without exposing
+// the internal Showed or Hid Message constructors to the parent.
+const foldAnimationShow = Update.foldChildStep({
+  update: Animation.show,
   read: (model: Model) => Option.some(model.animation),
   write: (model, nextAnimation) =>
     evo(model, { animation: () => nextAnimation }),
   toParentMessage: message => Message.GotAnimationMessage({ message }),
 })
 
-// In the corresponding Message.match handlers, call the folds:
-GotAnimationMessage: ({ message }) => foldAnimation(model, message)
-ToggledAnimation: () => foldAnimationToggle(model)
+const foldAnimationHide = Update.foldChildStep({
+  update: Animation.hide,
+  read: (model: Model) => Option.some(model.animation),
+  write: (model, nextAnimation) =>
+    evo(model, { animation: () => nextAnimation }),
+  toParentMessage: message => Message.GotAnimationMessage({ message }),
+})
 
-// Inside your view function, toggle visibility by dispatching your parent
-// Message. model.animation.isShowing is your source of truth for whether
-// content is currently visible. The Animation view wraps your content. Data
-// attributes drive the CSS transitions or keyframe animations defined in
-// className:
+// In the corresponding Message.match handlers, route child Messages through
+// the regular fold and parent-owned actions through the child capabilities:
+GotAnimationMessage: ({ message }) => foldAnimation(model, message)
+ClickedToggleAnimation: () =>
+  model.animation.isShowing
+    ? foldAnimationHide(model)
+    : foldAnimationShow(model)
+
+// Inside your view function, dispatch a parent-owned fact. The parent update
+// invokes the child capability. model.animation.isShowing is your source of
+// truth for whether content is currently visible. The Animation view wraps
+// your content. Data attributes drive the CSS transitions or keyframe
+// animations defined in className:
 const view = (h: HtmlBuilder<Message>) =>
   h.div(
     [],
     [
       h.button(
-        [h.OnClick(Message.ToggledAnimation())],
+        [h.OnClick(Message.ClickedToggleAnimation())],
         [model.animation.isShowing ? 'Hide' : 'Show'],
       ),
       h.submodel({


### PR DESCRIPTION
Resolve imported Foldkit, Effect, UI, and child Message APIs from scope bindings so aliases and local shadows behave correctly.

Enforce the child boundary by allowing owned views to construct their Messages while requiring parents to invoke update capabilities through Update.foldChild or Update.foldChildStep. Add Animation show and hide capabilities and migrate consumers to that pattern.

BREAKING CHANGE: Foldkit lint presets now diagnose child Message construction that alias resolution previously missed. Expose a child update capability and invoke it through Update.foldChild or Update.foldChildStep.

Fixes #891