### PR TITLE
fix(foldkit)!: preserve Story and Scene step types

### DIFF
--- a/.changeset/story-scene-step-types.md
+++ b/.changeset/story-scene-step-types.md
@@ -1,0 +1,34 @@
+---
+'foldkit': minor
+---
+
+Preserve Message and OutMessage type safety across Story and Scene steps.
+
+`Story.message`, `Story.expectOutMessage`, `Scene.Subscription.emit`, `Scene.expectOutMessage`, and `Scene.expectOutMessages` are now typed data steps rather than callable simulation transforms. Story and Scene validate those values against the Message and OutMessage types of the update under test, including narrow variants of a wider union.
+
+## Migration
+
+Passing these steps directly to `story` or `scene` is unchanged. Any code that treated one of these returned steps as a function must migrate, including direct invocation, storing it as a simulation transform, or composition through Effect's `flow` or another helper in either Story or Scene.
+
+Use the new `Story.steps` API for a reusable Story sequence. It accepts the same steps as `story`, preserves their Model, Message, and OutMessage constraints, and can itself be passed anywhere a Story step is accepted.
+
+Scene has no grouped-step API. Pass `Subscription.emit` and OutMessage assertion steps as separate arguments to `scene`; do not compose them as functions.
+
+Before:
+
+```ts
+import { flow } from 'effect'
+import { given, message } from 'foldkit/story'
+
+const givenIncremented = flow(given({ count: 0 }), message(ClickedIncrement()))
+```
+
+After:
+
+```ts
+import { given, message, steps } from 'foldkit/story'
+
+const givenIncremented = steps(given({ count: 0 }), message(ClickedIncrement()))
+```
+
+Remove the `flow` import when it was used only to group Story steps. This is not a general deprecation of Effect's `flow`; continue to use it for ordinary function composition outside the Story step API.

--- a/packages/foldkit/src/test/scene.test.ts
+++ b/packages/foldkit/src/test/scene.test.ts
@@ -1,5 +1,5 @@
 import { Option, pipe } from 'effect'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, expectTypeOf, test } from 'vitest'
 
 import {
   type HtmlBuilder,
@@ -2719,6 +2719,17 @@ describe('Scene.Subscription.emit', () => {
     )
   })
 
+  test('requires the Message to belong to the tested update', () => {
+    expectTypeOf(() =>
+      Scene.scene(
+        { update: counterUpdate, view: counterView },
+        Scene.given(counterInitialModel),
+        // @ts-expect-error CompletedAction is not a Counter Message
+        Scene.Subscription.emit(LogoutButtonMessage.CompletedAction()),
+      ),
+    ).toBeFunction()
+  })
+
   test('Commands produced by an emitted Message become pending', () => {
     Scene.scene(
       { update: counterUpdate, view: counterView },
@@ -3101,14 +3112,48 @@ describe('Scene OutMessage assertions', () => {
   test('expectOutMessage fails with expected and actual values when the OutMessage is wrong', () => {
     expect(() =>
       Scene.scene(
-        { update: logoutUpdate, view: logoutView },
-        Scene.given(logoutInitialModel),
-        Scene.click(Scene.role('button', { name: 'Log out' })),
-        Scene.expectOutMessage(LogoutButtonMessage.CompletedAction()),
+        { update: multipleOutMessagesUpdate, view: multipleOutMessagesView },
+        Scene.given(interactionInitialModel),
+        Scene.Subscription.emit(InteractionMessage.ClickedExpand()),
+        Scene.expectOutMessage(InteractionOutMessage.RequestedSelection()),
       ),
     ).toThrow(
-      `Expected OutMessage:\n\n    ${JSON.stringify(LogoutButtonMessage.CompletedAction())}\n\nBut got:\n\n    ${JSON.stringify(OutMessage.RequestedLogout())}`,
+      `Expected OutMessage:\n\n    ${JSON.stringify(InteractionOutMessage.RequestedSelection())}\n\nBut got:\n\n    ${JSON.stringify(InteractionOutMessage.RequestedExpand())}`,
     )
+  })
+
+  test('requires expected OutMessages to belong to the tested update', () => {
+    expectTypeOf(() =>
+      Scene.scene(
+        // @ts-expect-error CompletedAction is not an Interaction OutMessage
+        { update: multipleOutMessagesUpdate, view: multipleOutMessagesView },
+        Scene.given(interactionInitialModel),
+        Scene.expectOutMessage(LogoutButtonMessage.CompletedAction()),
+      ),
+    ).toBeFunction()
+
+    expectTypeOf(() =>
+      Scene.scene(
+        // @ts-expect-error CompletedAction is not an Interaction OutMessage
+        { update: multipleOutMessagesUpdate, view: multipleOutMessagesView },
+        Scene.given(interactionInitialModel),
+        Scene.expectOutMessages(
+          InteractionOutMessage.RequestedExpand(),
+          LogoutButtonMessage.CompletedAction(),
+        ),
+      ),
+    ).toBeFunction()
+  })
+
+  test('rejects an OutMessage assertion when update cannot emit one', () => {
+    expectTypeOf(() =>
+      Scene.scene(
+        { update: counterUpdate, view: counterView },
+        Scene.given(counterInitialModel),
+        // @ts-expect-error counter update cannot emit an OutMessage
+        Scene.expectOutMessage(OutMessage.RequestedLogout()),
+      ),
+    ).toBeFunction()
   })
 
   test('expectNoOutMessage fails when an OutMessage is present', () => {

--- a/packages/foldkit/src/test/scene.ts
+++ b/packages/foldkit/src/test/scene.ts
@@ -182,12 +182,47 @@ type GivenStep<Model> = Readonly<{ _phantomModel: Model }> &
     simulation: SceneSimulation<M, Message, OutMessage>,
   ) => SceneSimulation<M, Message, OutMessage>)
 
-/** A single step in a scene: either a `given` step or a scene simulation transform. */
+/** A typed Subscription Message step. */
+export type SubscriptionMessageStep<Message> = Readonly<{
+  _tag: 'SubscriptionMessageStep'
+  message: Message
+}>
+
+/** A typed OutMessage assertion step. */
+export type OutMessageStep<OutMessage> = Readonly<{
+  _tag: 'OutMessageStep'
+  expected: OutMessage
+}>
+
+/** A typed OutMessage sequence assertion step. */
+export type OutMessagesStep<OutMessage> = Readonly<{
+  _tag: 'OutMessagesStep'
+  expected: readonly [OutMessage, OutMessage, ...ReadonlyArray<OutMessage>]
+}>
+
+/** A single step in a scene: a `given` step, typed Message or OutMessage step,
+ *  or scene simulation transform. */
 export type SceneStep<Model, Message, OutMessage> =
   | GivenStep<NoInfer<Model>>
+  | Readonly<{
+      _tag: 'SubscriptionMessageStep'
+      message: NoInfer<Message>
+    }>
+  | Readonly<{
+      _tag: 'OutMessageStep'
+      expected: NoInfer<OutMessage>
+    }>
+  | Readonly<{
+      _tag: 'OutMessagesStep'
+      expected: readonly [
+        NoInfer<OutMessage>,
+        NoInfer<OutMessage>,
+        ...ReadonlyArray<NoInfer<OutMessage>>,
+      ]
+    }>
   | ((
-      simulation: SceneSimulation<Model, Message, OutMessage>,
-    ) => SceneSimulation<Model, Message, OutMessage>)
+      simulation: SceneSimulation<any, any, any>,
+    ) => SceneSimulation<any, any, any>)
 
 // INTERNAL
 
@@ -616,11 +651,10 @@ const applyMessageWithoutBoundaryChecks = <Model, Message, OutMessage>(
   /* eslint-enable @typescript-eslint/consistent-type-assertions */
 }
 
-const applyExternalMessages = <Model, Message, OutMessage>(
+const assertExternalMessageBoundary = <Model, Message, OutMessage>(
   simulation: SceneSimulation<Model, Message, OutMessage>,
-  messages: ReadonlyArray<unknown>,
   context: string,
-): SceneSimulation<Model, Message, OutMessage> => {
+): void => {
   const internal = toInternal(simulation)
 
   assertNoUnresolvedCommands(internal.commands, context)
@@ -629,8 +663,37 @@ const applyExternalMessages = <Model, Message, OutMessage>(
     unacknowledgedEndedMountsOf(internal.mountSlots),
     context,
   )
+}
+
+const applyExternalMessages = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  messages: ReadonlyArray<unknown>,
+  context: string,
+): SceneSimulation<Model, Message, OutMessage> => {
+  assertExternalMessageBoundary(simulation, context)
 
   return Array.reduce(messages, simulation, applyMessageWithoutBoundaryChecks)
+}
+
+const applySubscriptionMessage = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  message: Message,
+): SceneSimulation<Model, Message, OutMessage> => {
+  const internal = toInternal(simulation)
+  const context = 'when a Subscription emitted a new Message'
+
+  assertExternalMessageBoundary(simulation, context)
+
+  const messageUpdate = internal.updateFn(internal.model, message)
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  return {
+    ...internal,
+    model: messageUpdate.model,
+    message,
+    commands: Array.appendAll(internal.commands, messageUpdate.commands ?? []),
+    outMessage: messageUpdate.outMessage,
+  } as SceneSimulation<Model, Message, OutMessage>
 }
 
 /** Clears the pending fall-through, marking it acknowledged. Paired with
@@ -1186,16 +1249,12 @@ const applyExternalMessage = <Model, Message, OutMessage>(
  *  the test exercises the handler wiring this step skips. Like an
  *  interaction, it throws if unresolved Commands, unresolved Mounts, or
  *  unacknowledged unmounts are pending. */
-const emitSubscriptionMessage =
-  <MessageInput>(message: MessageInput) =>
-  <Model, Message, OutMessage = undefined>(
-    simulation: SceneSimulation<Model, Message, OutMessage>,
-  ): SceneSimulation<Model, Message, OutMessage> =>
-    applyExternalMessage(
-      simulation,
-      message,
-      'when a Subscription emitted a new Message',
-    )
+const emitSubscriptionMessage = <Message>(
+  message: Message,
+): SubscriptionMessageStep<Message> => ({
+  _tag: 'SubscriptionMessageStep',
+  message,
+})
 
 const MANAGED_RESOURCE_CONTEXT =
   'when a ManagedResource dispatched a new Message'
@@ -1479,54 +1538,62 @@ export const CustomElement = {
 
 /** Asserts by structural equality that the latest update-producing Scene step
  *  emitted exactly the expected OutMessage. */
-export const expectOutMessage =
-  <Expected>(expected: Expected) =>
-  <Model, Message, OutMessage>(
-    simulation: SceneSimulation<Model, Message, OutMessage>,
-  ): SceneSimulation<Model, Message, OutMessage> => {
-    const internal = toInternal(simulation)
-    const maybeOutMessage = Array.head(internal.outMessages)
+export const expectOutMessage = <OutMessage>(
+  expected: OutMessage,
+): OutMessageStep<OutMessage> => ({
+  _tag: 'OutMessageStep',
+  expected,
+})
 
-    if (Option.isNone(maybeOutMessage)) {
-      throw new Error(
-        `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    undefined`,
-      )
-    }
+const assertOutMessage = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  expected: unknown,
+): void => {
+  const internal = toInternal(simulation)
+  const maybeOutMessage = Array.head(internal.outMessages)
 
-    if (Array.isReadonlyArrayNonEmpty(Array.drop(internal.outMessages, 1))) {
-      throw new Error(
-        `Expected exactly one OutMessage but got multiple:\n\n    ${JSON.stringify(internal.outMessages)}`,
-      )
-    }
-
-    if (!Equal.equals(maybeOutMessage.value, expected)) {
-      throw new Error(
-        `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(maybeOutMessage.value)}`,
-      )
-    }
-
-    return simulation
+  if (Option.isNone(maybeOutMessage)) {
+    throw new Error(
+      `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    undefined`,
+    )
   }
+
+  if (Array.isReadonlyArrayNonEmpty(Array.drop(internal.outMessages, 1))) {
+    throw new Error(
+      `Expected exactly one OutMessage but got multiple:\n\n    ${JSON.stringify(internal.outMessages)}`,
+    )
+  }
+
+  if (!Equal.equals(maybeOutMessage.value, expected)) {
+    throw new Error(
+      `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(maybeOutMessage.value)}`,
+    )
+  }
+}
 
 /** Asserts by structural equality that the latest update-producing Scene
  *  step emitted two or more expected OutMessages in runtime order. */
-export const expectOutMessages =
-  <Expected extends readonly [unknown, unknown, ...ReadonlyArray<unknown>]>(
-    ...expected: Expected
-  ) =>
-  <Model, Message, OutMessage>(
-    simulation: SceneSimulation<Model, Message, OutMessage>,
-  ): SceneSimulation<Model, Message, OutMessage> => {
-    const actual = toInternal(simulation).outMessages
+export const expectOutMessages = <
+  Expected extends readonly [unknown, unknown, ...ReadonlyArray<unknown>],
+>(
+  ...expected: Expected
+): OutMessagesStep<Expected[number]> => ({
+  _tag: 'OutMessagesStep',
+  expected,
+})
 
-    if (!Equal.equals(actual, expected)) {
-      throw new Error(
-        `Expected OutMessages:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(actual)}`,
-      )
-    }
+const assertOutMessages = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  expected: ReadonlyArray<unknown>,
+): void => {
+  const actual = toInternal(simulation).outMessages
 
-    return simulation
+  if (!Equal.equals(actual, expected)) {
+    throw new Error(
+      `Expected OutMessages:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(actual)}`,
+    )
   }
+}
 
 /** Asserts that the latest update-producing Scene step emitted no OutMessages. */
 export const expectNoOutMessage =
@@ -1652,6 +1719,31 @@ export const tap =
     return simulation
   }
 
+const applySceneStep = <Model, Message, OutMessage>(
+  simulation: SceneSimulation<Model, Message, OutMessage>,
+  step: SceneStep<Model, Message, OutMessage>,
+): SceneSimulation<Model, Message, OutMessage> => {
+  if (Predicate.isTagged(step, 'SubscriptionMessageStep')) {
+    return applySubscriptionMessage(simulation, step.message)
+  }
+
+  if (Predicate.isTagged(step, 'OutMessageStep')) {
+    assertOutMessage(simulation, step.expected)
+    return simulation
+  }
+
+  if (Predicate.isTagged(step, 'OutMessagesStep')) {
+    assertOutMessages(simulation, step.expected)
+    return simulation
+  }
+
+  if (Predicate.isFunction(step)) {
+    return step(simulation)
+  }
+
+  return simulation
+}
+
 const runSteps = <Model, Message, OutMessage>(
   seed: SceneSimulation<Model, Message, OutMessage>,
   steps: ReadonlyArray<SceneStep<Model, Message, OutMessage>>,
@@ -1664,11 +1756,7 @@ const runSteps = <Model, Message, OutMessage>(
       ...currentInternal,
       updateFn: outMessageCapture.updateFn,
     } as unknown as SceneSimulation<Model, Message, OutMessage>
-    const stepResult = (
-      step as (
-        simulation: SceneSimulation<Model, Message, OutMessage>,
-      ) => SceneSimulation<Model, Message, OutMessage>
-    )(capturingSimulation)
+    const stepResult = applySceneStep(capturingSimulation, step)
     const restoredSimulation = {
       ...toInternal(stepResult),
       updateFn: currentInternal.updateFn,
@@ -2829,7 +2917,7 @@ export const withViewInputs =
  *  unresolved, any unmount is unacknowledged, or any interaction fell
  *  through unacknowledged. */
 export const scene: {
-  <Model, Message, OutMessage>(
+  <Model, Message, OutMessage = never>(
     config: Readonly<{
       update: (
         model: Model,
@@ -2841,7 +2929,9 @@ export const scene: {
       }>
       view: (model: Model, h: HtmlBuilder<Message>) => Html | Document
     }>,
-    ...steps: ReadonlyArray<SceneStep<Model, Message, OutMessage>>
+    ...steps: ReadonlyArray<
+      SceneStep<NoInfer<Model>, NoInfer<Message>, NoInfer<OutMessage>>
+    >
   ): void
   <Model, Message>(
     config: Readonly<{
@@ -2855,7 +2945,9 @@ export const scene: {
       }>
       view: (model: Model, h: HtmlBuilder<Message>) => Html | Document
     }>,
-    ...steps: ReadonlyArray<SceneStep<Model, Message, undefined>>
+    ...steps: ReadonlyArray<
+      SceneStep<NoInfer<Model>, NoInfer<Message>, undefined>
+    >
   ): void
 } = <Model, Message, OutMessage = undefined>(
   config: Readonly<{

--- a/packages/foldkit/src/test/story.test.ts
+++ b/packages/foldkit/src/test/story.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, expectTypeOf, test } from 'vitest'
 import * as Interruptible from '../command/interruptible/index.js'
 import {
   Message as CounterMessage,
+  type Model as CounterModel,
   FetchCount,
   FetchCountById,
   update,
@@ -61,6 +62,68 @@ describe('message', () => {
         CounterMessage.SucceededFetchCount({ count: 42 }),
       ]),
     )
+  })
+
+  test('requires the Message to belong to the tested update', () => {
+    expectTypeOf(() =>
+      Story.story(
+        update,
+        Story.given({ count: 0, log: [] }),
+        // @ts-expect-error SubmittedForm is not a Counter Message
+        Story.message(FormChildJsChildMessage.SubmittedForm()),
+      ),
+    ).toBeFunction()
+  })
+})
+
+describe('steps', () => {
+  test('runs a reusable group in order', () => {
+    const givenIncremented = Story.steps(
+      Story.given({ count: 0, log: [] }),
+      Story.message(CounterMessage.ClickedIncrement()),
+      Story.message(CounterMessage.ClickedDecrement()),
+      Story.message(CounterMessage.ClickedIncrement()),
+    )
+
+    Story.story(
+      update,
+      givenIncremented,
+      Story.model(model => {
+        expect(model.count).toBe(1)
+      }),
+    )
+  })
+
+  test('preserves grouped Message types at the story boundary', () => {
+    const givenSubmittedForm = Story.steps(
+      Story.given({ count: 0, log: [] }),
+      Story.message(FormChildJsChildMessage.SubmittedForm()),
+    )
+
+    expectTypeOf(() =>
+      Story.story(
+        update,
+        // @ts-expect-error SubmittedForm is not a Counter Message
+        givenSubmittedForm,
+      ),
+    ).toBeFunction()
+  })
+
+  test('preserves grouped Model assertion types at the story boundary', () => {
+    const assertExtendedModel = Story.steps(
+      Story.model((model: CounterModel & { note: string }) => {
+        expect(model.note).toBe('ready')
+      }),
+    )
+
+    expectTypeOf(() =>
+      Story.story(
+        update,
+        Story.given({ count: 0, log: [] }),
+        // @ts-expect-error Counter Model does not have a note field
+        assertExtendedModel,
+      ),
+    ).toBeFunction()
   })
 })
 
@@ -823,6 +886,29 @@ describe('outMessage', () => {
       Story.message(FormChildJsChildMessage.CancelledForm()),
       Story.expectOutMessage(FormChildJsChildOutMessage.RequestedCancel()),
     )
+  })
+
+  test('requires the expected OutMessage to belong to the tested update', () => {
+    expectTypeOf(() =>
+      Story.story(
+        // @ts-expect-error ClickedIncrement is not a child OutMessage
+        childUpdate,
+        Story.given({ status: 'Idle' }),
+        Story.message(FormChildJsChildMessage.CancelledForm()),
+        Story.expectOutMessage(CounterMessage.ClickedIncrement()),
+      ),
+    ).toBeFunction()
+  })
+
+  test('rejects an OutMessage assertion when update cannot emit one', () => {
+    expectTypeOf(() =>
+      Story.story(
+        update,
+        Story.given({ count: 0, log: [] }),
+        // @ts-expect-error counter update cannot emit an OutMessage
+        Story.expectOutMessage(FormChildJsChildOutMessage.RequestedCancel()),
+      ),
+    ).toBeFunction()
   })
 })
 

--- a/packages/foldkit/src/test/story.ts
+++ b/packages/foldkit/src/test/story.ts
@@ -47,12 +47,50 @@ export type ModelStep<Model> = Readonly<{
   readonly assert: (model: Model) => void
 }>
 
-/** A single step in a story: a {@link GivenStep}, a {@link ModelStep},
- *  or a simulation transform. */
-export type StoryStep<Model> =
+/** A typed Message-dispatch step produced by {@link message}. */
+export type MessageStep<Message> = Readonly<{
+  _tag: 'MessageStep'
+  message: Message
+}>
+
+/** A typed OutMessage assertion step produced by {@link expectOutMessage}. */
+export type OutMessageStep<OutMessage> = Readonly<{
+  _tag: 'OutMessageStep'
+  expected: OutMessage
+}>
+
+/** A grouped sequence of Story steps produced by {@link steps}. */
+export type StoryStepsStep<GivenModel, ModelAssertion, Message, OutMessage> =
+  Readonly<{
+    _tag: 'StoryStepsStep'
+    /** @internal Carries the produced Model type through a reusable step group. */
+    _phantomGivenModel?: GivenModel
+    /** @internal Carries Model assertion types through a reusable step group. */
+    _phantomModelAssertion?: ModelAssertion
+    /** @internal Carries the Message type through a reusable step group. */
+    _phantomMessage?: Message
+    /** @internal Carries the OutMessage type through a reusable step group. */
+    _phantomOutMessage?: OutMessage
+    steps: ReadonlyArray<StoryStep<any, any, any>>
+  }>
+
+/** A single step in a story: a {@link GivenStep}, {@link ModelStep},
+ *  {@link MessageStep}, {@link OutMessageStep}, {@link StoryStepsStep}, or
+ *  simulation transform. */
+export type StoryStep<Model, Message = unknown, OutMessage = unknown> =
   | GivenStep<NoInfer<Model>>
   | ModelStep<NoInfer<Model>>
-  | ((sim: StorySimulation<any, any, any>) => StorySimulation<any, any, any>)
+  | MessageStep<NoInfer<Message>>
+  | OutMessageStep<NoInfer<OutMessage>>
+  | StoryStepsStep<
+      NoInfer<Model>,
+      (model: NoInfer<Model>) => void,
+      NoInfer<Message>,
+      NoInfer<OutMessage>
+    >
+  | ((
+      simulation: StorySimulation<any, any, any>,
+    ) => StorySimulation<any, any, any>)
 
 // INTERNAL
 
@@ -98,32 +136,32 @@ export const given = <Model>(model: Model): GivenStep<Model> => {
   /* eslint-enable @typescript-eslint/consistent-type-assertions */
 }
 
+const applyMessage = <Model, Message, OutMessage>(
+  simulation: StorySimulation<Model, Message, OutMessage>,
+  message_: Message,
+): StorySimulation<Model, Message, OutMessage> => {
+  const internal = toInternal(simulation)
+
+  assertNoUnresolvedCommands(internal.commands, 'when you sent a new Message')
+
+  const messageUpdate = internal.updateFn(internal.model, message_)
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  return {
+    ...internal,
+    model: messageUpdate.model,
+    message: message_,
+    commands: Array.appendAll(internal.commands, messageUpdate.commands ?? []),
+    outMessage: messageUpdate.outMessage,
+  } as StorySimulation<Model, Message, OutMessage>
+}
+
 /** Sends a Message through update. Commands stay pending until resolve or
  *  resolveAll. */
-export const message =
-  <MessageInput>(message_: MessageInput) =>
-  <Model, Message, OutMessage>(
-    simulation: StorySimulation<Model, Message, OutMessage>,
-  ): StorySimulation<Model, Message, OutMessage> => {
-    const internal = toInternal(simulation)
-
-    assertNoUnresolvedCommands(internal.commands, 'when you sent a new Message')
-
-    /* eslint-disable @typescript-eslint/consistent-type-assertions */
-    const messageAsParent = message_ as unknown as Message
-    const messageUpdate = internal.updateFn(internal.model, messageAsParent)
-    return {
-      ...internal,
-      model: messageUpdate.model,
-      message: messageAsParent,
-      commands: Array.appendAll(
-        internal.commands,
-        messageUpdate.commands ?? [],
-      ),
-      outMessage: messageUpdate.outMessage,
-    } as StorySimulation<Model, Message, OutMessage>
-    /* eslint-enable @typescript-eslint/consistent-type-assertions */
-  }
+export const message = <Message>(message_: Message): MessageStep<Message> => ({
+  _tag: 'MessageStep',
+  message: message_,
+})
 
 /** Resolves a pending Command with the given result Message. Accepts either
  *  a Command Definition (matches by name; any pending Command of that name)
@@ -212,6 +250,44 @@ export const model = <Model>(f: (model: Model) => void): ModelStep<Model> => ({
   assert: f,
 })
 
+/** Groups Story steps so a reusable setup can remain type-safe without
+ *  erasing its Message or OutMessage types through function composition. */
+export const steps = <Steps extends ReadonlyArray<StoryStep<any, any, any>>>(
+  ...storySteps: Steps
+): StoryStepsStep<
+  Steps[number] extends infer Step
+    ? Step extends GivenStep<infer Model>
+      ? Model
+      : Step extends StoryStepsStep<infer Model, any, any, any>
+        ? Model
+        : never
+    : never,
+  Steps[number] extends infer Step
+    ? Step extends ModelStep<infer Model>
+      ? (model: Model) => void
+      : Step extends StoryStepsStep<any, infer ModelAssertion, any, any>
+        ? ModelAssertion
+        : never
+    : never,
+  Steps[number] extends infer Step
+    ? Step extends MessageStep<infer Message>
+      ? Message
+      : Step extends StoryStepsStep<any, any, infer Message, any>
+        ? Message
+        : never
+    : never,
+  Steps[number] extends infer Step
+    ? Step extends OutMessageStep<infer OutMessage>
+      ? OutMessage
+      : Step extends StoryStepsStep<any, any, any, infer OutMessage>
+        ? OutMessage
+        : never
+    : never
+> => ({
+  _tag: 'StoryStepsStep',
+  steps: storySteps,
+})
+
 /** Asserts that every given matcher matches a pending Command. Definition
  *  matchers match by name only; Instance matchers match by name + args. */
 const expectHasCommandsStep =
@@ -270,24 +346,28 @@ export const Command = {
   expectNone: expectNoCommandsStep,
 } as const
 
+const assertOutMessage = <Model, Message, OutMessage>(
+  simulation: StorySimulation<Model, Message, OutMessage>,
+  expected: unknown,
+): void => {
+  const internal = toInternal(simulation)
+  const outMessage = internal.outMessage
+
+  if (outMessage === undefined || !Equal.equals(outMessage, expected)) {
+    throw new Error(
+      `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(outMessage)}`,
+    )
+  }
+}
+
 /** Asserts by structural equality that update emitted the expected OutMessage,
  *  so callers can pass a freshly constructed expected value. */
-export const expectOutMessage =
-  <Expected>(expected: Expected) =>
-  <Model, Message, OutMessage>(
-    simulation: StorySimulation<Model, Message, OutMessage>,
-  ): StorySimulation<Model, Message, OutMessage> => {
-    const internal = toInternal(simulation)
-    const outMessage = internal.outMessage
-
-    if (outMessage === undefined || !Equal.equals(outMessage, expected)) {
-      throw new Error(
-        `Expected OutMessage:\n\n    ${JSON.stringify(expected)}\n\nBut got:\n\n    ${JSON.stringify(outMessage)}`,
-      )
-    }
-
-    return simulation
-  }
+export const expectOutMessage = <OutMessage>(
+  expected: OutMessage,
+): OutMessageStep<OutMessage> => ({
+  _tag: 'OutMessageStep',
+  expected,
+})
 
 /** Asserts that update emitted no OutMessage. */
 export const expectNoOutMessage =
@@ -309,9 +389,38 @@ export const expectNoOutMessage =
 
 // STORY
 
+const applyStoryStep = <Model, Message, OutMessage>(
+  current: StorySimulation<Model, Message, OutMessage>,
+  step: StoryStep<Model, Message, OutMessage>,
+): StorySimulation<Model, Message, OutMessage> => {
+  if (Predicate.isTagged(step, 'ModelStep')) {
+    step.assert(toInternal(current).model)
+    return current
+  }
+
+  if (Predicate.isTagged(step, 'MessageStep')) {
+    return applyMessage(current, step.message)
+  }
+
+  if (Predicate.isTagged(step, 'OutMessageStep')) {
+    assertOutMessage(current, step.expected)
+    return current
+  }
+
+  if (Predicate.isTagged(step, 'StoryStepsStep')) {
+    return Array.reduce(step.steps, current, applyStoryStep)
+  }
+
+  if (Predicate.isFunction(step)) {
+    return step(current)
+  }
+
+  return current
+}
+
 /** Executes a test story. Throws if any Commands remain unresolved. */
 export const story: {
-  <Model, Message, OutMessage>(
+  <Model, Message, OutMessage = never>(
     updateFn: (
       model: Model,
       message: Message,
@@ -320,7 +429,9 @@ export const story: {
       commands?: ReadonlyArray<AnyCommand>
       outMessage?: OutMessage
     }>,
-    ...steps: ReadonlyArray<StoryStep<NoInfer<Model>>>
+    ...steps: ReadonlyArray<
+      StoryStep<NoInfer<Model>, NoInfer<Message>, NoInfer<OutMessage>>
+    >
   ): void
   <Model, Message>(
     updateFn: (
@@ -331,14 +442,16 @@ export const story: {
       commands?: ReadonlyArray<AnyCommand>
       outMessage?: never
     }>,
-    ...steps: ReadonlyArray<StoryStep<NoInfer<Model>>>
+    ...steps: ReadonlyArray<
+      StoryStep<NoInfer<Model>, NoInfer<Message>, undefined>
+    >
   ): void
 } = <Model, Message, OutMessage = undefined>(
   updateFn: (
     model: Model,
     message: Message,
   ) => SimulationUpdateReturn<Model, OutMessage>,
-  ...steps: ReadonlyArray<StoryStep<Model>>
+  ...steps: ReadonlyArray<StoryStep<Model, Message, OutMessage>>
 ): void => {
   /* eslint-disable @typescript-eslint/consistent-type-assertions */
   const seed = {
@@ -350,23 +463,7 @@ export const story: {
     resolvers: [],
   } as unknown as StorySimulation<Model, Message, OutMessage>
 
-  const result = steps.reduce<StorySimulation<Model, Message, OutMessage>>(
-    (current, step) => {
-      if (typeof step === 'function') {
-        return (
-          step as (
-            simulation: StorySimulation<Model, Message, OutMessage>,
-          ) => StorySimulation<Model, Message, OutMessage>
-        )(current)
-      }
-      if ('_tag' in step && step._tag === 'ModelStep') {
-        step.assert(toInternal(current).model)
-        return current
-      }
-      return current
-    },
-    seed,
-  )
+  const result = Array.reduce(steps, seed, applyStoryStep)
   /* eslint-enable @typescript-eslint/consistent-type-assertions */
 
   const internal = toInternal(result)

--- a/packages/ui/src/combobox/multi.test.ts
+++ b/packages/ui/src/combobox/multi.test.ts
@@ -1,4 +1,4 @@
-import { Option, flow } from 'effect'
+import { Option } from 'effect'
 import { type HtmlBuilder, inertHtml as ih } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
 import * as Story from 'foldkit/story'
@@ -42,7 +42,7 @@ const acknowledgePreventBlur = Scene.Mount.resolve(
 
 const givenClosed = Story.given(init({ id: 'test' }))
 
-const givenOpenMulti = flow(
+const givenOpenMulti = Story.steps(
   givenClosed,
   Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
 )
@@ -278,7 +278,7 @@ describe('Combobox.Multi', () => {
   })
 
   describe('modal commands', () => {
-    const givenOpenModal = flow(
+    const givenOpenModal = Story.steps(
       Story.given(init({ id: 'test', isModal: true })),
       Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
       Story.Command.resolveAllExact(

--- a/packages/ui/src/combobox/single.test.ts
+++ b/packages/ui/src/combobox/single.test.ts
@@ -1,4 +1,4 @@
-import { Option, flow } from 'effect'
+import { Option } from 'effect'
 import { type HtmlBuilder, inertHtml as ih } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
 import * as Story from 'foldkit/story'
@@ -48,14 +48,14 @@ const animationEndMessage = Message.GotAnimationMessage({
 
 const givenClosed = Story.given(init({ id: 'test' }))
 
-const givenOpen = flow(
+const givenOpen = Story.steps(
   givenClosed,
   Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
 )
 
 const givenClosedAnimated = Story.given(init({ id: 'test', isAnimated: true }))
 
-const givenOpenAnimated = flow(
+const givenOpenAnimated = Story.steps(
   givenClosedAnimated,
   Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
   Story.Command.resolveAll(
@@ -1064,7 +1064,7 @@ describe('Combobox', () => {
   describe('modal commands', () => {
     const givenClosedModal = Story.given(init({ id: 'test', isModal: true }))
 
-    const givenOpenModal = flow(
+    const givenOpenModal = Story.steps(
       givenClosedModal,
       Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
       Story.Command.resolveAllExact(

--- a/packages/ui/src/datePicker/story.test.ts
+++ b/packages/ui/src/datePicker/story.test.ts
@@ -1,4 +1,4 @@
-import { Option, flow } from 'effect'
+import { Option } from 'effect'
 import * as Calendar from 'foldkit/calendar'
 import * as Story from 'foldkit/story'
 import { expect } from 'vitest'
@@ -27,7 +27,7 @@ const today = Calendar.make(2026, 4, 13)
 
 const givenClosed = Story.given(init({ id: 'picker', today }))
 
-const givenOpen = flow(givenClosed, Story.message(Message.Opened()))
+const givenOpen = Story.steps(givenClosed, Story.message(Message.Opened()))
 
 describe('DatePicker', () => {
   describe('init', () => {
@@ -277,7 +277,7 @@ describe('DatePicker', () => {
         })
         Story.story(
           update,
-          flow(Story.given(seeded), Story.message(Message.Opened())),
+          Story.steps(Story.given(seeded), Story.message(Message.Opened())),
           Story.message(Message.Cleared()),
           Story.Command.expectNone(),
           Story.model(model => {

--- a/packages/ui/src/hoverIntent/story.test.ts
+++ b/packages/ui/src/hoverIntent/story.test.ts
@@ -1,4 +1,4 @@
-import { Duration, Option, flow } from 'effect'
+import { Duration, Option } from 'effect'
 import * as Story from 'foldkit/story'
 import { expect } from 'vitest'
 
@@ -28,7 +28,7 @@ const resolveStaleClose = Story.Command.resolve(
 
 const withHidden = Story.given(init())
 
-const withPointerOpen = flow(
+const withPointerOpen = Story.steps(
   withHidden,
   Story.message(Message.EnteredTrigger()),
   Story.Command.resolve(
@@ -37,7 +37,7 @@ const withPointerOpen = flow(
   ),
 )
 
-const withFocusedOpen = flow(
+const withFocusedOpen = Story.steps(
   withHidden,
   Story.message(Message.FocusedTrigger()),
 )

--- a/packages/ui/src/listbox/multi.test.ts
+++ b/packages/ui/src/listbox/multi.test.ts
@@ -1,4 +1,4 @@
-import { Option, flow } from 'effect'
+import { Option } from 'effect'
 import type { HtmlBuilder } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
 import * as Story from 'foldkit/story'
@@ -33,7 +33,7 @@ const acknowledgeBackdrop = Scene.Mount.resolve(
 
 const givenClosed = Story.given(init({ id: 'test' }))
 
-const givenOpenMulti = flow(
+const givenOpenMulti = Story.steps(
   givenClosed,
   Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
   Story.Command.resolve(FocusItems, Message.CompletedFocusItems()),

--- a/packages/ui/src/listbox/single.test.ts
+++ b/packages/ui/src/listbox/single.test.ts
@@ -1,4 +1,4 @@
-import { Option, flow } from 'effect'
+import { Option } from 'effect'
 import type { HtmlBuilder } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
 import * as Story from 'foldkit/story'
@@ -47,7 +47,7 @@ const STALE_CLEAR_SEARCH_VERSION = 9999
 
 const givenClosed = Story.given(init({ id: 'test' }))
 
-const givenOpen = flow(
+const givenOpen = Story.steps(
   givenClosed,
   Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
   Story.Command.resolve(FocusItems, Message.CompletedFocusItems()),
@@ -55,7 +55,7 @@ const givenOpen = flow(
 
 const givenClosedAnimated = Story.given(init({ id: 'test', isAnimated: true }))
 
-const givenOpenAnimated = flow(
+const givenOpenAnimated = Story.steps(
   givenClosedAnimated,
   Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
   Story.Command.resolveAll(
@@ -1200,7 +1200,7 @@ describe('Listbox', () => {
   describe('modal commands', () => {
     const givenClosedModal = Story.given(init({ id: 'test', isModal: true }))
 
-    const givenOpenModal = flow(
+    const givenOpenModal = Story.steps(
       givenClosedModal,
       Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
       Story.Command.resolveAll(

--- a/packages/ui/src/menu/story.test.ts
+++ b/packages/ui/src/menu/story.test.ts
@@ -1,4 +1,4 @@
-import { Option, flow } from 'effect'
+import { Option } from 'effect'
 import type { HtmlBuilder } from 'foldkit/html'
 import * as Scene from 'foldkit/scene'
 import * as Story from 'foldkit/story'
@@ -65,7 +65,7 @@ const STALE_CLEAR_SEARCH_VERSION = 9999
 
 const givenClosed = Story.given(init({ id: 'test' }))
 
-const givenOpen = flow(
+const givenOpen = Story.steps(
   givenClosed,
   Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
   acknowledgeFocusItems,
@@ -73,7 +73,7 @@ const givenOpen = flow(
 
 const givenClosedAnimated = Story.given(init({ id: 'test', isAnimated: true }))
 
-const givenOpenAnimated = flow(
+const givenOpenAnimated = Story.steps(
   givenClosedAnimated,
   Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
   acknowledgeFocusItems,
@@ -444,7 +444,7 @@ describe('Menu', () => {
     })
 
     describe('ReleasedPointerOnItems', () => {
-      const givenOpenAndOrigin = flow(
+      const givenOpenAndOrigin = Story.steps(
         givenClosed,
         Story.message(
           Message.PressedPointerOnButton({
@@ -1364,7 +1364,7 @@ describe('Menu', () => {
   describe('modal commands', () => {
     const givenClosedModal = Story.given(init({ id: 'test', isModal: true }))
 
-    const givenOpenModal = flow(
+    const givenOpenModal = Story.steps(
       givenClosedModal,
       Story.message(Message.Opened({ maybeActiveItemIndex: Option.some(0) })),
       Story.Command.resolveAll(

--- a/packages/ui/src/popover/story.test.ts
+++ b/packages/ui/src/popover/story.test.ts
@@ -1,4 +1,4 @@
-import { Option, flow } from 'effect'
+import { Option } from 'effect'
 import * as Story from 'foldkit/story'
 import { expect } from 'vitest'
 
@@ -24,11 +24,14 @@ const animationEndMessage = Message.GotAnimationMessage({
 
 const givenClosed = Story.given(init({ id: 'test' }))
 
-const givenOpen = flow(givenClosed, Story.message(Message.RequestedOpen()))
+const givenOpen = Story.steps(
+  givenClosed,
+  Story.message(Message.RequestedOpen()),
+)
 
 const givenClosedAnimated = Story.given(init({ id: 'test', isAnimated: true }))
 
-const givenOpenAnimated = flow(
+const givenOpenAnimated = Story.steps(
   givenClosedAnimated,
   Story.message(Message.RequestedOpen()),
   Story.Command.resolveAll(
@@ -573,7 +576,7 @@ describe('Popover', () => {
   describe('modal commands', () => {
     const givenClosedModal = Story.given(init({ id: 'test', isModal: true }))
 
-    const givenOpenModal = flow(
+    const givenOpenModal = Story.steps(
       givenClosedModal,
       Story.message(Message.RequestedOpen()),
       Story.Command.resolveAll(

--- a/packages/ui/src/tooltip/story.test.ts
+++ b/packages/ui/src/tooltip/story.test.ts
@@ -1,4 +1,4 @@
-import { Duration, Option, flow } from 'effect'
+import { Duration, Option } from 'effect'
 import * as Story from 'foldkit/story'
 import { expect } from 'vitest'
 
@@ -22,7 +22,7 @@ const resolveShowAsStale = Story.Command.resolve(
 
 const givenHidden = Story.given(init({ id: 'test' }))
 
-const givenHoveredOpen = flow(
+const givenHoveredOpen = Story.steps(
   givenHidden,
   Story.message(Message.EnteredTrigger()),
   Story.Command.resolve(
@@ -31,7 +31,7 @@ const givenHoveredOpen = flow(
   ),
 )
 
-const givenFocusedOpen = flow(
+const givenFocusedOpen = Story.steps(
   givenHidden,
   Story.message(Message.FocusedTrigger()),
 )

--- a/packages/website/src/page/testingStory.md
+++ b/packages/website/src/page/testingStory.md
@@ -10,7 +10,7 @@ The entire test is one `story` call. Start from a Model, send a Message, resolve
 
 Import the steps you need from `foldkit/story`.
 
-- Top-level steps start the test, send Messages, and inspect results: `story`, `given`, `message`, `model`, `expectOutMessage`, and `expectNoOutMessage`.
+- Top-level steps start the test, group reusable setup, send Messages, and inspect results: `story`, `steps`, `given`, `message`, `model`, `expectOutMessage`, and `expectNoOutMessage`.
 - The `Command` namespace handles pending Commands: `resolve`, `resolveAll`, `resolveAllExact`, `expectHas`, `expectExact`, and `expectNone`.
 
 Use named imports when the file contains only Story tests. If a file contains both Story and Scene tests, import the namespaces from `foldkit` so `Story.given` and `Scene.given` stay distinct.
@@ -54,6 +54,16 @@ Use `resolveAllExact` when the resolver list is also a claim about which Command
 :::Info{label="Unresolved Commands"}
 `message` throws if there are pending Commands from a previous step. Resolve all Commands before sending the next Message. `story` throws at the end if any Commands remain unresolved. Every Command your update function produces must be accounted for.
 :::
+
+## Reusable Step Groups
+
+Use `steps` when several stories share the same setup or Message sequence. The group preserves the Model, Message, and OutMessage constraints of every step inside it, so the update passed to `story` still rejects a group built for a different program.
+
+::Snippet{name="testingReusableSteps" label="reusable Story steps"}
+
+A group can contain any step accepted by `story`, including `given`, `message`, Model assertions, Command steps, OutMessage assertions, and another `steps` group. `story` runs the group in declaration order at the position where it appears.
+
+Do not use Effect's `flow` to group Story steps. Message and OutMessage steps are typed data, not functions, and `steps` is the boundary that preserves their types. This does not replace `flow` for ordinary function composition elsewhere in an application.
 
 ## Testing Side Effects
 

--- a/packages/website/src/snippet/index.ts
+++ b/packages/website/src/snippet/index.ts
@@ -314,6 +314,8 @@ export { default as fieldValidationSchemaRaw } from './fieldValidationSchema.ts?
 export { default as fieldValidationSchemaHighlighted } from './fieldValidationSchema.ts?highlighted'
 export { default as testingApiRaw } from './testingApi.ts?raw'
 export { default as testingApiHighlighted } from './testingApi.ts?highlighted'
+export { default as testingReusableStepsRaw } from './testingReusableSteps.ts?raw'
+export { default as testingReusableStepsHighlighted } from './testingReusableSteps.ts?highlighted'
 export { default as sceneApiRaw } from './sceneApi.ts?raw'
 export { default as sceneApiHighlighted } from './sceneApi.ts?highlighted'
 export { default as sceneLocatorsRaw } from './sceneLocators.ts?raw'

--- a/packages/website/src/snippet/testingApi.ts
+++ b/packages/website/src/snippet/testingApi.ts
@@ -5,6 +5,7 @@ import {
   given,
   message,
   model,
+  steps,
   story,
 } from 'foldkit/story'
 
@@ -13,6 +14,9 @@ given(model)
 
 // Send a Message. Commands stay pending.
 message(ClickedSubmit())
+
+// Group a reusable sequence without erasing its step types.
+steps(given(initialModel), message(ClickedSubmit()))
 
 // Resolve one Command with its result. Pass a Definition to match by name,
 // or a Command instance to match by name AND args.

--- a/packages/website/src/snippet/testingReusableSteps.ts
+++ b/packages/website/src/snippet/testingReusableSteps.ts
@@ -1,0 +1,26 @@
+import { given, message, model, steps, story } from 'foldkit/story'
+import { expect, test } from 'vitest'
+
+const givenIncremented = steps(given({ count: 0 }), message(ClickedIncrement()))
+
+test('increments again', () => {
+  story(
+    update,
+    givenIncremented,
+    message(ClickedIncrement()),
+    model(model => {
+      expect(model.count).toBe(2)
+    }),
+  )
+})
+
+test('decrements from the shared setup', () => {
+  story(
+    update,
+    givenIncremented,
+    message(ClickedDecrement()),
+    model(model => {
+      expect(model.count).toBe(0)
+    }),
+  )
+})


### PR DESCRIPTION
Carry Message and OutMessage values through typed, tagged test steps so the tested update remains the source of their types.

Add `Story.steps` for reusable grouped setup and migrate Foldkit UI consumers away from callable Message-step composition.

Closes #1272