### PR TITLE
style(website): soften the landing background glyphs

### DIFF
--- a/packages/website/src/page/home/content.ts
+++ b/packages/website/src/page/home/content.ts
@@ -52,7 +52,7 @@ const glyph = (symbol: string, offsetY?: string): Html =>
           ih.span([
             ih.Class(
               clsx(
-                'inline-block -translate-x-1/4 text-accent-200/18 dark:text-accent-400/4 font-mono text-[18rem] md:text-[27rem] font-extrabold leading-none -z-10 relative whitespace-nowrap',
+                'inline-block -translate-x-1/4 text-accent-200/14 dark:text-accent-400/4 font-mono text-[18rem] md:text-[27rem] font-extrabold leading-none -z-10 relative whitespace-nowrap',
                 offsetY,
               ),
             ),


### PR DESCRIPTION
The oversized glyphs behind the landing sections sat close enough to the surrounding copy to compete with it in light mode. Drop the light mode fill from 18% to 14% so the copy reads cleanly over them while the glyphs stay visible. Dark mode was already faint enough at 4% and is unchanged.