### PR TITLE
docs(website): reword the 0.157.0 post description

### DIFF
--- a/packages/website/src/page/blog/post/foldkit-0-157-0.md
+++ b/packages/website/src/page/blog/post/foldkit-0-157-0.md
@@ -1,6 +1,6 @@
 ---
 title: Foldkit 0.156.0 and 0.157.0
-description: Foldkit 0.156.0 and 0.157.0 add two recommended lint rules, improve refined union matching, and update Story, Scene, Mount, Foldkit UI, and Vite.
+description: Two new recommended @foldkit/oxlint-plugin rules, less boilerplate when matching refined unions, plus updates to Story, Scene, Mount, @foldkit/ui, and Foldkit's Vite plugin.
 date: 2026-09-02
 coverImage: /blog/foldkit-0-157-0/cover.webp
 coverImageAlt: The number 157 in large cyan type layered over the number 156 in coral on a light gray background.


### PR DESCRIPTION
The description was written with phrasing the post itself ended up not using. It now leads with the two new recommended `@foldkit/oxlint-plugin` rules and names the packages the post covers. The version numbers are gone, since the title above already carries them on the blog index.