### PR TITLE
fix(foldkit): exclude shadowed Machine Edges from reachability

### DIFF
--- a/.changeset/shadowed-machine-reachability.md
+++ b/.changeset/shadowed-machine-reachability.md
@@ -1,0 +1,5 @@
+---
+'foldkit': patch
+---
+
+Exclude Machine Edges shadowed by an earlier `otherwise` from reachability analysis and report each dead transition once.

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -511,6 +511,69 @@ const shadowedGuardMachine = define({
   },
 })
 
+const shadowedUnderUnreachableSourceMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Error: {
+      on: {
+        ClickedRetry: [
+          otherwise(to('Loading', () => RemoteData.Loading())),
+          when(
+            (_state, message) => Option.some(message),
+            'Ok',
+            () => RemoteData.Ok({ data: 'unreachable' }),
+          ),
+        ],
+      },
+    },
+  },
+})
+
+const DelimiterCollisionState = defineTaggedUnion({
+  'A|B': {},
+  A: {},
+  Target0: {},
+  Target1: {},
+})
+
+const DelimiterCollisionMessage = defineMessageUnion({
+  C: {},
+  'B|C': {},
+})
+
+const delimiterCollisionMachine = define({
+  state: DelimiterCollisionState,
+  message: DelimiterCollisionMessage,
+})({
+  initial: DelimiterCollisionState.A(),
+  states: {
+    'A|B': {
+      on: {
+        C: [otherwise(to('Target0', () => DelimiterCollisionState.Target0()))],
+      },
+    },
+    A: {
+      on: {
+        'B|C': [
+          when(
+            () => false,
+            'Target0',
+            () => DelimiterCollisionState.Target0(),
+          ),
+          when(
+            () => true,
+            'Target1',
+            () => DelimiterCollisionState.Target1(),
+          ),
+        ],
+      },
+    },
+  },
+})
+
 const PlainIdle = Schema.Struct({ _tag: Schema.Literal('PlainIdle') })
 const PlainActive = Schema.Struct({ _tag: Schema.Literal('PlainActive') })
 
@@ -1232,6 +1295,60 @@ describe('type-level guarantees', () => {
           guard: { _tag: 'When', position: 1 },
         },
         reason: 'ShadowedByOtherwise',
+      },
+    ])
+  })
+
+  it('does not walk through guards listed after otherwise', () => {
+    expect(shadowedGuardMachine.reachableFrom('Idle')).toEqual(
+      new Set(['Idle', 'Loading']),
+    )
+    expect(shadowedGuardMachine.unreachableStates()).toEqual(['Error', 'Ok'])
+  })
+
+  it('reports a shadowed edge under an unreachable source once', () => {
+    expect(shadowedUnderUnreachableSourceMachine.deadTransitions()).toEqual([
+      {
+        edge: {
+          from: 'Error',
+          messageTag: 'ClickedRetry',
+          target: 'Loading',
+          guard: { _tag: 'Otherwise', position: 0 },
+        },
+        reason: 'UnreachableSource',
+      },
+      {
+        edge: {
+          from: 'Error',
+          messageTag: 'ClickedRetry',
+          target: 'Ok',
+          guard: { _tag: 'When', position: 1 },
+        },
+        reason: 'ShadowedByOtherwise',
+      },
+    ])
+  })
+
+  it('keeps source and message tags distinct when they contain delimiters', () => {
+    const result = delimiterCollisionMachine.step(
+      DelimiterCollisionState.A(),
+      DelimiterCollisionMessage['B|C'](),
+    )
+
+    expect(result._tag).toBe('Transitioned')
+    expect(result.state).toStrictEqual(DelimiterCollisionState.Target1())
+    expect(delimiterCollisionMachine.reachableFrom('A')).toEqual(
+      new Set(['A', 'Target0', 'Target1']),
+    )
+    expect(delimiterCollisionMachine.deadTransitions()).toEqual([
+      {
+        edge: {
+          from: 'A|B',
+          messageTag: 'C',
+          target: 'Target0',
+          guard: { _tag: 'Otherwise', position: 0 },
+        },
+        reason: 'UnreachableSource',
       },
     ])
   })

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -416,16 +416,22 @@ export type Machine<
     message: Message,
   ) => Update.Return<State, Message, R>
   step: (state: State, message: Message) => TransitionResult<State, Message, R>
-  /** The state tags a walk of the declared Edge set visits starting from `tag`. */
+  /**
+   * The state tags a walk of the statically selectable declared Edges visits
+   * starting from `tag`. Edges listed after an `otherwise` are excluded because
+   * the runtime can never select them.
+   */
   reachableFrom: (tag: TagOf<State>) => ReadonlySet<TagOf<State>>
   /**
-   * The state tags a walk of the declared Edge set never visits, starting
-   * from the initial state's tag plus `extraRoots`. The walk sees only the
-   * declared Edges, so state changes made outside `transition` and `step`
-   * are invisible to it, and it always starts at `initial`. Entry points
-   * other than `initial`, such as restored persistence, deep links, or SSR
-   * hydration, must be passed as `extraRoots`, or the states they enter are
-   * reported unreachable even though the running program visits them.
+   * The state tags a walk of the statically selectable declared Edges never
+   * visits, starting from the initial state's tag plus `extraRoots`. Edges
+   * listed after an `otherwise` are excluded because the runtime can never
+   * select them. The walk sees only declared Edges, so state changes made
+   * outside `transition` and `step` are invisible to it, and it always starts
+   * at `initial`. Entry points other than `initial`, such as restored
+   * persistence, deep links, or SSR hydration, must be passed as `extraRoots`,
+   * or the states they enter are reported unreachable even though the running
+   * program visits them.
    */
   unreachableStates: (
     extraRoots?: ReadonlyArray<TagOf<State>>,
@@ -433,11 +439,13 @@ export type Machine<
   /**
    * The Edges that cannot fire in a walk of the declared Edge set starting
    * from the initial state's tag plus `extraRoots`, each with its
-   * {@link DeadTransitionReason}. The same assumptions as
-   * `unreachableStates` apply: the walk cannot see state changes made
-   * outside `transition` and `step`, and entry points other than `initial`
-   * must be passed as `extraRoots`, or their outgoing Edges are reported as
-   * `UnreachableSource` even though the running program fires them.
+   * {@link DeadTransitionReason}. Each Edge appears at most once;
+   * `ShadowedByOtherwise` takes precedence when its source is also
+   * unreachable. The same assumptions as `unreachableStates` apply: the walk
+   * cannot see state changes made outside `transition` and `step`, and entry
+   * points other than `initial` must be passed as `extraRoots`, or their
+   * outgoing Edges are reported as `UnreachableSource` even though the running
+   * program fires them.
    */
   deadTransitions: (
     extraRoots?: ReadonlyArray<TagOf<State>>,
@@ -789,9 +797,83 @@ export const define =
       }
     }
 
+    type EdgeGroup = ReadonlyArray<EdgeSummary<State, Message>>
+    type PositionedEdgeGuard = Exclude<
+      EdgeGuard,
+      Readonly<{ _tag: 'Unguarded' }>
+    >
+
+    const isPositionedEdgeGuard = (
+      guard: EdgeGuard,
+    ): guard is PositionedEdgeGuard => guard._tag !== 'Unguarded'
+
+    const maybeGuardPosition = (
+      edgeSummary: EdgeSummary<State, Message>,
+    ): Option.Option<number> =>
+      pipe(
+        edgeSummary.guard,
+        Option.liftPredicate(isPositionedEdgeGuard),
+        Option.map(guard => guard.position),
+      )
+
+    const groupEdgesByMessageTag = (
+      edgesFromState: EdgeGroup,
+    ): ReadonlyArray<EdgeGroup> =>
+      pipe(
+        edgesFromState,
+        Array.groupBy<EdgeSummary<State, Message>, string>(
+          edgeSummary => edgeSummary.messageTag,
+        ),
+        Record.values,
+      )
+
+    const edgesAfterGuardPosition = (
+      edgeGroup: EdgeGroup,
+      guardPosition: number,
+    ): EdgeGroup =>
+      Array.filter(edgeGroup, edgeSummary =>
+        pipe(
+          maybeGuardPosition(edgeSummary),
+          Option.exists(position => position > guardPosition),
+        ),
+      )
+
+    const shadowedEdgesInGroup = (edgeGroup: EdgeGroup): EdgeGroup =>
+      pipe(
+        edgeGroup,
+        Array.findFirst(edgeSummary => edgeSummary.guard._tag === 'Otherwise'),
+        Option.flatMap(maybeGuardPosition),
+        Option.match({
+          onNone: () => [],
+          onSome: otherwisePosition =>
+            edgesAfterGuardPosition(edgeGroup, otherwisePosition),
+        }),
+      )
+
+    const edgeGroups = pipe(
+      edges,
+      Array.groupBy<EdgeSummary<State, Message>, string>(
+        edgeSummary => edgeSummary.from,
+      ),
+      Record.values,
+      Array.flatMap(groupEdgesByMessageTag),
+    )
+
+    const shadowedEdges: ReadonlyArray<EdgeSummary<State, Message>> = pipe(
+      edgeGroups,
+      Array.flatMap(shadowedEdgesInGroup),
+    )
+
+    const shadowedEdgeSet = HashSet.fromIterable(shadowedEdges)
+
+    const selectableEdges = Array.filter(
+      edges,
+      edgeSummary => !HashSet.has(shadowedEdgeSet, edgeSummary),
+    )
+
     const targetsFrom = (tag: TagOf<State>): ReadonlyArray<TagOf<State>> =>
       pipe(
-        edges,
+        selectableEdges,
         Array.filter(edgeSummary => edgeSummary.from === tag),
         Array.map(edgeSummary => edgeSummary.target),
       )
@@ -832,62 +914,25 @@ export const define =
       reason: DeadTransitionReason,
     ): DeadTransition<State, Message> => ({ edge, reason })
 
-    const guardPosition = (
-      edgeSummary: EdgeSummary<State, Message>,
-    ): Option.Option<number> =>
-      edgeSummary.guard._tag === 'Unguarded'
-        ? Option.none()
-        : Option.some(edgeSummary.guard.position)
-
-    const shadowedEdges = (): ReadonlyArray<DeadTransition<State, Message>> =>
-      pipe(
-        edges,
-        Array.groupBy<EdgeSummary<State, Message>, string>(
-          edgeSummary => `${edgeSummary.from}|${edgeSummary.messageTag}`,
-        ),
-        Record.values,
-        Array.flatMap(group => {
-          const maybeOtherwisePosition = pipe(
-            group,
-            Array.findFirst(
-              edgeSummary => edgeSummary.guard._tag === 'Otherwise',
-            ),
-            Option.flatMap(guardPosition),
-          )
-
-          return Option.match(maybeOtherwisePosition, {
-            onNone: () => [],
-            onSome: otherwisePosition =>
-              pipe(
-                group,
-                Array.filter(edgeSummary =>
-                  Option.match(guardPosition(edgeSummary), {
-                    onNone: () => false,
-                    onSome: position => position > otherwisePosition,
-                  }),
-                ),
-                Array.map(edgeSummary =>
-                  makeDeadTransition(edgeSummary, 'ShadowedByOtherwise'),
-                ),
-              ),
-          })
-        }),
-      )
-
     const deadTransitions = (
       extraRoots: ReadonlyArray<TagOf<State>> = [],
     ): ReadonlyArray<DeadTransition<State, Message>> => {
       const reachable = reachableFromRoots([initialTag, ...extraRoots])
 
       const unreachableSourceEdges = pipe(
-        edges,
+        selectableEdges,
         Array.filter(edgeSummary => !reachable.has(edgeSummary.from)),
         Array.map(edgeSummary =>
           makeDeadTransition(edgeSummary, 'UnreachableSource'),
         ),
       )
 
-      return [...unreachableSourceEdges, ...shadowedEdges()]
+      return Array.flatten([
+        unreachableSourceEdges,
+        Array.map(shadowedEdges, edgeSummary =>
+          makeDeadTransition(edgeSummary, 'ShadowedByOtherwise'),
+        ),
+      ])
     }
 
     const toMermaid = (): string => {


### PR DESCRIPTION
Machine reachability walked every declared Edge even when an earlier `otherwise` made the Edge impossible to select. This could hide unreachable states and cause `deadTransitions()` to report one Edge twice.

Group Edges structurally by source and Message tag, derive shadowed Edges once, exclude them from graph traversal, and give `ShadowedByOtherwise` precedence when causes overlap.

Closes #1282