### PR TITLE
refactor(foldkit)!: return update records from Machine Edges

### DIFF
--- a/.changeset/machine-edge-update-records.md
+++ b/.changeset/machine-edge-update-records.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Machine Edge handlers now return one `Update.Return`-shaped record with `model` and optional `commands` fields. This replaces the separate Model builder and Commands callback arguments on `to` and `when`, keeps transition outputs consistent with Foldkit update functions, and lets one derivation feed both the next state and its Commands. Migrate by returning `{ model, commands }` from the existing handler and removing the separate Commands callback.

--- a/examples/state-machine/src/main.ts
+++ b/examples/state-machine/src/main.ts
@@ -164,170 +164,184 @@ export const checkoutMachine = Machine.define({
   states: {
     Cart: {
       on: {
-        SelectedEdition: to('Cart', ({ state, message }) =>
-          evo(state, { isShippingRequired: () => message.isShippingRequired }),
-        ),
+        SelectedEdition: to('Cart', ({ state, message }) => ({
+          model: evo(state, {
+            isShippingRequired: () => message.isShippingRequired,
+          }),
+        })),
         ClickedContinue: [
           when(
             state => state.isShippingRequired,
             'Shipping',
-            ({ state }) =>
-              CheckoutState.Shipping({
+            ({ state }) => ({
+              model: CheckoutState.Shipping({
                 isShippingRequired: state.isShippingRequired,
               }),
+            }),
           ),
           otherwise(
-            to('Payment', ({ state }) =>
-              CheckoutState.Payment({
+            to('Payment', ({ state }) => ({
+              model: CheckoutState.Payment({
                 isPaymentMethodSelected: false,
                 isShippingRequired: state.isShippingRequired,
               }),
-            ),
+            })),
           ),
         ],
-        ClickedCancel: to('Cancelled', ({ state }) =>
-          CheckoutState.Cancelled({
+        ClickedCancel: to('Cancelled', ({ state }) => ({
+          model: CheckoutState.Cancelled({
             isShippingRequired: state.isShippingRequired,
           }),
-        ),
+        })),
       },
     },
     Shipping: {
       on: {
-        ClickedContinue: to('Payment', ({ state }) =>
-          CheckoutState.Payment({
+        ClickedContinue: to('Payment', ({ state }) => ({
+          model: CheckoutState.Payment({
             isPaymentMethodSelected: false,
             isShippingRequired: state.isShippingRequired,
           }),
-        ),
-        ClickedBack: to('Cart', ({ state }) =>
-          CheckoutState.Cart({ isShippingRequired: state.isShippingRequired }),
-        ),
-        ClickedCancel: to('Cancelled', ({ state }) =>
-          CheckoutState.Cancelled({
+        })),
+        ClickedBack: to('Cart', ({ state }) => ({
+          model: CheckoutState.Cart({
             isShippingRequired: state.isShippingRequired,
           }),
-        ),
+        })),
+        ClickedCancel: to('Cancelled', ({ state }) => ({
+          model: CheckoutState.Cancelled({
+            isShippingRequired: state.isShippingRequired,
+          }),
+        })),
       },
     },
     Payment: {
       on: {
-        ToggledPaymentMethod: to('Payment', ({ state, message }) =>
-          evo(state, { isPaymentMethodSelected: () => message.isSelected }),
-        ),
-        ClickedContinue: to('Review', ({ state }) =>
-          CheckoutState.Review({
+        ToggledPaymentMethod: to('Payment', ({ state, message }) => ({
+          model: evo(state, {
+            isPaymentMethodSelected: () => message.isSelected,
+          }),
+        })),
+        ClickedContinue: to('Review', ({ state }) => ({
+          model: CheckoutState.Review({
             isPaymentMethodSelected: state.isPaymentMethodSelected,
             isShippingRequired: state.isShippingRequired,
             isTermsAccepted: false,
             promo: Promo.NoPromo(),
             promoCodeInput: '',
           }),
-        ),
+        })),
         ClickedBack: [
           when(
             state => state.isShippingRequired,
             'Shipping',
-            ({ state }) =>
-              CheckoutState.Shipping({
+            ({ state }) => ({
+              model: CheckoutState.Shipping({
                 isShippingRequired: state.isShippingRequired,
               }),
+            }),
           ),
           otherwise(
-            to('Cart', ({ state }) =>
-              CheckoutState.Cart({
+            to('Cart', ({ state }) => ({
+              model: CheckoutState.Cart({
                 isShippingRequired: state.isShippingRequired,
               }),
-            ),
+            })),
           ),
         ],
-        ClickedCancel: to('Cancelled', ({ state }) =>
-          CheckoutState.Cancelled({
+        ClickedCancel: to('Cancelled', ({ state }) => ({
+          model: CheckoutState.Cancelled({
             isShippingRequired: state.isShippingRequired,
           }),
-        ),
+        })),
       },
     },
     Review: {
       on: {
-        ToggledPaymentMethod: to('Review', ({ state, message }) =>
-          evo(state, { isPaymentMethodSelected: () => message.isSelected }),
-        ),
-        ToggledTermsAccepted: to('Review', ({ state, message }) =>
-          evo(state, { isTermsAccepted: () => message.isAccepted }),
-        ),
-        UpdatedPromoCode: to('Review', ({ state, message }) =>
-          evo(state, {
+        ToggledPaymentMethod: to('Review', ({ state, message }) => ({
+          model: evo(state, {
+            isPaymentMethodSelected: () => message.isSelected,
+          }),
+        })),
+        ToggledTermsAccepted: to('Review', ({ state, message }) => ({
+          model: evo(state, { isTermsAccepted: () => message.isAccepted }),
+        })),
+        UpdatedPromoCode: to('Review', ({ state, message }) => ({
+          model: evo(state, {
             promoCodeInput: () => message.value,
             promo: currentPromo =>
               currentPromo._tag === 'RejectedPromo'
                 ? Promo.NoPromo()
                 : currentPromo,
           }),
-        ),
+        })),
         SubmittedPromoCode: [
           when(
             reviewToMaybeDiscount,
             'Review',
-            ({ state, guardValue: discount }) =>
-              evo(state, { promo: () => Promo.AppliedPromo({ discount }) }),
+            ({ state, guardValue: discount }) => ({
+              model: evo(state, {
+                promo: () => Promo.AppliedPromo({ discount }),
+              }),
+            }),
           ),
           otherwise(
-            to('Review', ({ state }) =>
-              evo(state, { promo: () => Promo.RejectedPromo() }),
-            ),
+            to('Review', ({ state }) => ({
+              model: evo(state, { promo: () => Promo.RejectedPromo() }),
+            })),
           ),
         ],
         ClickedPlaceOrder: [
-          when(
-            isReviewReady,
-            'Placing',
-            ({ state }) =>
-              CheckoutState.Placing({
-                isShippingRequired: state.isShippingRequired,
-                maybeDiscount: promoToMaybeDiscount(state.promo),
-              }),
-            ({ state }) => [
+          when(isReviewReady, 'Placing', ({ state }) => ({
+            model: CheckoutState.Placing({
+              isShippingRequired: state.isShippingRequired,
+              maybeDiscount: promoToMaybeDiscount(state.promo),
+            }),
+            commands: [
               PlaceOrder({ isShippingRequired: state.isShippingRequired }),
             ],
-          ),
+          })),
         ],
-        ClickedBack: to('Payment', ({ state }) =>
-          CheckoutState.Payment({
+        ClickedBack: to('Payment', ({ state }) => ({
+          model: CheckoutState.Payment({
             isPaymentMethodSelected: state.isPaymentMethodSelected,
             isShippingRequired: state.isShippingRequired,
           }),
-        ),
-        ClickedCancel: to('Cancelled', ({ state }) =>
-          CheckoutState.Cancelled({
+        })),
+        ClickedCancel: to('Cancelled', ({ state }) => ({
+          model: CheckoutState.Cancelled({
             isShippingRequired: state.isShippingRequired,
           }),
-        ),
+        })),
       },
     },
     Placing: {
       on: {
-        SucceededPlaceOrder: to('Confirmed', ({ state, message }) =>
-          CheckoutState.Confirmed({
+        SucceededPlaceOrder: to('Confirmed', ({ state, message }) => ({
+          model: CheckoutState.Confirmed({
             isShippingRequired: state.isShippingRequired,
             maybeDiscount: state.maybeDiscount,
             orderId: message.orderId,
           }),
-        ),
+        })),
       },
     },
     Confirmed: {
       on: {
-        ClickedStartOver: to('Cart', ({ state }) =>
-          CheckoutState.Cart({ isShippingRequired: state.isShippingRequired }),
-        ),
+        ClickedStartOver: to('Cart', ({ state }) => ({
+          model: CheckoutState.Cart({
+            isShippingRequired: state.isShippingRequired,
+          }),
+        })),
       },
     },
     Cancelled: {
       on: {
-        ClickedStartOver: to('Cart', ({ state }) =>
-          CheckoutState.Cart({ isShippingRequired: state.isShippingRequired }),
-        ),
+        ClickedStartOver: to('Cart', ({ state }) => ({
+          model: CheckoutState.Cart({
+            isShippingRequired: state.isShippingRequired,
+          }),
+        })),
       },
     },
   },

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -43,27 +43,27 @@ const remoteDataMachine = define({
   states: {
     Idle: {
       on: {
-        ClickedFetch: to('Loading', () => RemoteData.Loading()),
+        ClickedFetch: to('Loading', () => ({ model: RemoteData.Loading() })),
       },
     },
     Loading: {
       on: {
-        SucceededFetch: to('Ok', ({ message }) =>
-          RemoteData.Ok({ data: message.data }),
-        ),
-        FailedFetch: to('Error', ({ message }) =>
-          RemoteData.Error({ error: message.error }),
-        ),
+        SucceededFetch: to('Ok', ({ message }) => ({
+          model: RemoteData.Ok({ data: message.data }),
+        })),
+        FailedFetch: to('Error', ({ message }) => ({
+          model: RemoteData.Error({ error: message.error }),
+        })),
       },
     },
     Error: {
       on: {
-        ClickedRetry: to('Loading', () => RemoteData.Loading()),
+        ClickedRetry: to('Loading', () => ({ model: RemoteData.Loading() })),
       },
     },
     Ok: {
       on: {
-        ClickedFetch: to('Loading', () => RemoteData.Loading()),
+        ClickedFetch: to('Loading', () => ({ model: RemoteData.Loading() })),
       },
     },
   },
@@ -136,79 +136,82 @@ const connectionMachine = define({
   states: {
     Disconnected: {
       on: {
-        ClickedConnect: to('Connecting', () =>
-          ConnectionState.Connecting({ attemptCount: 1 }),
-        ),
+        ClickedConnect: to('Connecting', () => ({
+          model: ConnectionState.Connecting({ attemptCount: 1 }),
+        })),
       },
     },
     Connecting: {
       on: {
-        SocketOpened: to(
-          'Connected',
-          ({ message }) =>
-            ConnectionState.Connected({ sessionId: message.sessionId }),
-          ({ message }) => [
+        SocketOpened: to('Connected', ({ message }) => ({
+          model: ConnectionState.Connected({
+            sessionId: message.sessionId,
+          }),
+          commands: [
             LogTransition({
               description: `Opened session ${message.sessionId}`,
             }),
           ],
-        ),
+        })),
         SocketErrored: [
           when(
             connectingToMaybeBackoff,
             'Reconnecting',
-            ({ state, guardValue }) =>
-              ConnectionState.Reconnecting({
+            ({ state, guardValue }) => ({
+              model: ConnectionState.Reconnecting({
                 attemptCount: state.attemptCount,
                 delayMillis: guardValue.delayMillis,
               }),
+            }),
           ),
           otherwise(
-            to('Failed', ({ state, message }) =>
-              ConnectionState.Failed({
+            to('Failed', ({ state, message }) => ({
+              model: ConnectionState.Failed({
                 attemptCount: state.attemptCount,
                 reason: message.reason,
               }),
-            ),
+            })),
           ),
         ],
       },
     },
     Connected: {
       on: {
-        SocketClosed: to('Reconnecting', () =>
-          ConnectionState.Reconnecting({
+        SocketClosed: to('Reconnecting', () => ({
+          model: ConnectionState.Reconnecting({
             attemptCount: 1,
             delayMillis: backoffDelayMillis(1),
           }),
-        ),
-        ClickedDisconnect: to('Disconnected', () =>
-          ConnectionState.Disconnected(),
-        ),
+        })),
+        ClickedDisconnect: to('Disconnected', () => ({
+          model: ConnectionState.Disconnected(),
+        })),
       },
     },
     Reconnecting: {
       on: {
-        TimedOutBackoff: to('Connecting', ({ state }) =>
-          ConnectionState.Connecting({ attemptCount: state.attemptCount + 1 }),
-        ),
-        ClickedDisconnect: to('Disconnected', () =>
-          ConnectionState.Disconnected(),
-        ),
+        TimedOutBackoff: to('Connecting', ({ state }) => ({
+          model: ConnectionState.Connecting({
+            attemptCount: state.attemptCount + 1,
+          }),
+        })),
+        ClickedDisconnect: to('Disconnected', () => ({
+          model: ConnectionState.Disconnected(),
+        })),
       },
     },
     Failed: {
       on: {
-        ClickedConnect: to('Connecting', () =>
-          ConnectionState.Connecting({ attemptCount: 1 }),
-        ),
+        ClickedConnect: to('Connecting', () => ({
+          model: ConnectionState.Connecting({ attemptCount: 1 }),
+        })),
       },
     },
     Suspended: {
       on: {
-        ClickedConnect: to('Connecting', () =>
-          ConnectionState.Connecting({ attemptCount: 1 }),
-        ),
+        ClickedConnect: to('Connecting', () => ({
+          model: ConnectionState.Connecting({ attemptCount: 1 }),
+        })),
       },
     },
   },
@@ -222,19 +225,19 @@ const extraRootsMachine = define({
   states: {
     Disconnected: {
       on: {
-        ClickedConnect: to('Connecting', () =>
-          ConnectionState.Connecting({ attemptCount: 1 }),
-        ),
+        ClickedConnect: to('Connecting', () => ({
+          model: ConnectionState.Connecting({ attemptCount: 1 }),
+        })),
       },
     },
     Suspended: {
       on: {
-        SocketErrored: to('Failed', ({ message }) =>
-          ConnectionState.Failed({
+        SocketErrored: to('Failed', ({ message }) => ({
+          model: ConnectionState.Failed({
             attemptCount: MAX_CONNECT_ATTEMPTS,
             reason: message.reason,
           }),
-        ),
+        })),
       },
     },
   },
@@ -364,10 +367,12 @@ const narrowingMachine = define({
               const sourceTag: 'Connecting' = guardValue.sourceTag
               const messageTag: 'SocketErrored' = guardValue.messageTag
 
-              return ConnectionState.Failed({
-                attemptCount: state.attemptCount,
-                reason: `${sourceTag} ${messageTag} ${message.reason}`,
-              })
+              return {
+                model: ConnectionState.Failed({
+                  attemptCount: state.attemptCount,
+                  reason: `${sourceTag} ${messageTag} ${message.reason}`,
+                }),
+              }
             },
           ),
         ],
@@ -388,11 +393,12 @@ const guardValueMachine = define({
           when(
             connectingToMaybeNextAttempt,
             'Reconnecting',
-            ({ state, guardValue }) =>
-              ConnectionState.Reconnecting({
+            ({ state, guardValue }) => ({
+              model: ConnectionState.Reconnecting({
                 attemptCount: guardValue.nextAttemptCount,
                 delayMillis: backoffDelayMillis(state.attemptCount),
               }),
+            }),
           ),
         ],
       },
@@ -412,19 +418,20 @@ const booleanGuardMachine = define({
           when(
             state => state.attemptCount < MAX_CONNECT_ATTEMPTS,
             'Reconnecting',
-            ({ state }) =>
-              ConnectionState.Reconnecting({
+            ({ state }) => ({
+              model: ConnectionState.Reconnecting({
                 attemptCount: state.attemptCount,
                 delayMillis: backoffDelayMillis(state.attemptCount),
               }),
+            }),
           ),
           otherwise(
-            to('Failed', ({ state, message }) =>
-              ConnectionState.Failed({
+            to('Failed', ({ state, message }) => ({
+              model: ConnectionState.Failed({
                 attemptCount: state.attemptCount,
                 reason: message.reason,
               }),
-            ),
+            })),
           ),
         ],
       },
@@ -440,8 +447,8 @@ const wrongVariantMachine = define({
   states: {
     Idle: {
       on: {
-        // @ts-expect-error the build function must return the RemoteData.Loading variant named by the target tag
-        ClickedFetch: to('Loading', () => RemoteData.Idle()),
+        // @ts-expect-error the handler's model must be the RemoteData.Loading variant named by the target tag
+        ClickedFetch: to('Loading', () => ({ model: RemoteData.Idle() })),
       },
     },
   },
@@ -456,7 +463,7 @@ const wrongTargetTagMachine = define({
     Idle: {
       on: {
         // @ts-expect-error 'Loadingg' is not a state tag
-        ClickedFetch: to('Loadingg', () => RemoteData.Loading()),
+        ClickedFetch: to('Loadingg', () => ({ model: RemoteData.Loading() })),
       },
     },
   },
@@ -484,7 +491,7 @@ const unknownMessageTagMachine = define({
     Idle: {
       on: {
         // @ts-expect-error 'ClickedFetchh' is not a Message tag
-        ClickedFetchh: to('Loading', () => RemoteData.Loading()),
+        ClickedFetchh: to('Loading', () => ({ model: RemoteData.Loading() })),
       },
     },
   },
@@ -499,11 +506,11 @@ const shadowedGuardMachine = define({
     Idle: {
       on: {
         ClickedFetch: [
-          otherwise(to('Loading', () => RemoteData.Loading())),
+          otherwise(to('Loading', () => ({ model: RemoteData.Loading() }))),
           when(
             (_state, message) => Option.some(message),
             'Ok',
-            () => RemoteData.Ok({ data: 'unreachable' }),
+            () => ({ model: RemoteData.Ok({ data: 'unreachable' }) }),
           ),
         ],
       },
@@ -520,11 +527,11 @@ const shadowedUnderUnreachableSourceMachine = define({
     Error: {
       on: {
         ClickedRetry: [
-          otherwise(to('Loading', () => RemoteData.Loading())),
+          otherwise(to('Loading', () => ({ model: RemoteData.Loading() }))),
           when(
             (_state, message) => Option.some(message),
             'Ok',
-            () => RemoteData.Ok({ data: 'unreachable' }),
+            () => ({ model: RemoteData.Ok({ data: 'unreachable' }) }),
           ),
         ],
       },
@@ -552,7 +559,13 @@ const delimiterCollisionMachine = define({
   states: {
     'A|B': {
       on: {
-        C: [otherwise(to('Target0', () => DelimiterCollisionState.Target0()))],
+        C: [
+          otherwise(
+            to('Target0', () => ({
+              model: DelimiterCollisionState.Target0(),
+            })),
+          ),
+        ],
       },
     },
     A: {
@@ -561,12 +574,12 @@ const delimiterCollisionMachine = define({
           when(
             () => false,
             'Target0',
-            () => DelimiterCollisionState.Target0(),
+            () => ({ model: DelimiterCollisionState.Target0() }),
           ),
           when(
             () => true,
             'Target1',
-            () => DelimiterCollisionState.Target1(),
+            () => ({ model: DelimiterCollisionState.Target1() }),
           ),
         ],
       },
@@ -588,7 +601,9 @@ const plainTagMachine = define({
   states: {
     PlainIdle: {
       on: {
-        ClickedFetch: to('PlainActive', () => ({ _tag: 'PlainActive' })),
+        ClickedFetch: to('PlainActive', () => ({
+          model: { _tag: 'PlainActive' },
+        })),
       },
     },
   },
@@ -613,19 +628,23 @@ const nestedUnionMachine = define({
   states: {
     NestedIdle: {
       on: {
-        ClickedFetch: to('NestedLoading', () => NestedState.NestedLoading()),
+        ClickedFetch: to('NestedLoading', () => ({
+          model: NestedState.NestedLoading(),
+        })),
       },
     },
     NestedLoading: {
       on: {
-        SucceededFetch: to('NestedOk', ({ message }) =>
-          NestedState.NestedOk({ data: message.data }),
-        ),
+        SucceededFetch: to('NestedOk', ({ message }) => ({
+          model: NestedState.NestedOk({ data: message.data }),
+        })),
       },
     },
     NestedOk: {
       on: {
-        ClickedRetry: to('NestedIdle', () => NestedState.NestedIdle()),
+        ClickedRetry: to('NestedIdle', () => ({
+          model: NestedState.NestedIdle(),
+        })),
       },
     },
   },
@@ -692,11 +711,10 @@ const inferredRequirementsMachine = define({
   states: {
     Idle: {
       on: {
-        ClickedSubmit: to(
-          'Presigning',
-          () => SubmitState.Presigning(),
-          () => [Presign()],
-        ),
+        ClickedSubmit: to('Presigning', () => ({
+          model: SubmitState.Presigning(),
+          commands: [Presign()],
+        })),
       },
     },
   },
@@ -714,10 +732,12 @@ const inferredGuardRequirementsMachine = define({
           when(
             () => true,
             'Presigning',
-            () => SubmitState.Presigning(),
-            () => [Presign()],
+            () => ({
+              model: SubmitState.Presigning(),
+              commands: [Presign()],
+            }),
           ),
-          otherwise(to('Idle', () => SubmitState.Idle())),
+          otherwise(to('Idle', () => ({ model: SubmitState.Idle() }))),
         ],
       },
     },
@@ -736,14 +756,13 @@ const inferredOtherwiseRequirementsMachine = define({
           when(
             () => false,
             'Submitted',
-            () => SubmitState.Submitted(),
+            () => ({ model: SubmitState.Submitted() }),
           ),
           otherwise(
-            to(
-              'Presigning',
-              () => SubmitState.Presigning(),
-              () => [Presign()],
-            ),
+            to('Presigning', () => ({
+              model: SubmitState.Presigning(),
+              commands: [Presign()],
+            })),
           ),
         ],
       },
@@ -759,11 +778,10 @@ const explicitRequirementsMachine = define({
   states: {
     Idle: {
       on: {
-        ClickedSubmit: to(
-          'Presigning',
-          () => SubmitState.Presigning(),
-          () => [Presign()],
-        ),
+        ClickedSubmit: to('Presigning', () => ({
+          model: SubmitState.Presigning(),
+          commands: [Presign()],
+        })),
       },
     },
     Presigning: {
@@ -772,16 +790,20 @@ const explicitRequirementsMachine = define({
           when(
             () => true,
             'Persisting',
-            () => SubmitState.Persisting(),
-            () => [Persist()],
+            () => ({
+              model: SubmitState.Persisting(),
+              commands: [Persist()],
+            }),
           ),
-          otherwise(to('Idle', () => SubmitState.Idle())),
+          otherwise(to('Idle', () => ({ model: SubmitState.Idle() }))),
         ],
       },
     },
     Persisting: {
       on: {
-        SucceededPersist: to('Submitted', () => SubmitState.Submitted()),
+        SucceededPersist: to('Submitted', () => ({
+          model: SubmitState.Submitted(),
+        })),
       },
     },
   },

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -29,10 +29,10 @@ export type Variant<Union extends Tagged, Tag extends TagOf<Union>> = Extract<
 // EDGE
 
 /**
- * The single argument an Edge's `build` and `commands` callbacks receive:
- * the source state, the triggering Message, and the guard value produced by
- * the Edge's {@link when} guard (`void` on unguarded and boolean-guarded
- * Edges). Destructure the fields you need.
+ * The single argument an Edge handler receives: the source state, the
+ * triggering Message, and the guard value produced by the Edge's {@link when}
+ * guard (`void` on unguarded and boolean-guarded Edges). Destructure the fields
+ * you need.
  */
 export type EdgeInput<
   SourceState extends Tagged,
@@ -46,11 +46,10 @@ export type EdgeInput<
 
 /**
  * A single transition edge. The target state tag is a literal value, so the
- * edge set of a Machine is enumerable data. `build` constructs the target
- * variant from its {@link EdgeInput}. `maybeCommands` holds transition-time
- * effects, dispatched as ordinary Commands.
+ * edge set of a Machine is enumerable data. `handler` returns the target
+ * variant and any transition-time Commands as an `Update.Return` record.
  *
- * The correlation between `target` and `build`'s return variant is enforced
+ * The correlation between `target` and `handler`'s Model variant is enforced
  * by {@link to}'s signature, not by this type. Keeping this type free of the
  * target tag is what lets TypeScript infer the source state and trigger
  * Message from the transition table position.
@@ -67,12 +66,9 @@ export type Edge<
 > = Readonly<{
   _tag: 'Edge'
   target: TagOf<State>
-  build: (input: EdgeInput<SourceState, TriggerMessage, unknown>) => State
-  maybeCommands: Option.Option<
-    (
-      input: EdgeInput<SourceState, TriggerMessage, unknown>,
-    ) => ReadonlyArray<Command<Message, never, R>>
-  >
+  handler: (
+    input: EdgeInput<SourceState, TriggerMessage, unknown>,
+  ) => Update.Return<State, Message, R>
   readonly '~foldkit/EdgeGuardValue'?: GuardValue
 }>
 
@@ -168,12 +164,9 @@ const makeEdge = <
   R = never,
 >(
   target: TargetTag,
-  build: (
+  handler: (
     input: NoInfer<EdgeInput<SourceState, TriggerMessage, GuardValue>>,
-  ) => NoInfer<Variant<State, TargetTag>>,
-  commands?: (
-    input: NoInfer<EdgeInput<SourceState, TriggerMessage, GuardValue>>,
-  ) => NoInfer<ReadonlyArray<Command<Message, never, R>>>,
+  ) => Update.Return<NoInfer<Variant<State, TargetTag>>, NoInfer<Message>, R>,
 ): Edge<State, Message, SourceState, TriggerMessage, GuardValue, R> => {
   const narrowGuardValue = (
     input: EdgeInput<SourceState, TriggerMessage, unknown>,
@@ -185,23 +178,20 @@ const makeEdge = <
   return {
     _tag: 'Edge',
     target,
-    build: input => build(narrowGuardValue(input)),
-    maybeCommands:
-      commands === undefined
-        ? Option.none()
-        : Option.some(input => commands(narrowGuardValue(input))),
+    handler: input => handler(narrowGuardValue(input)),
   }
 }
 
 /**
  * Declares a transition Edge to the state variant named by `target`. The
- * `build` callback receives an {@link EdgeInput} whose state and Message are
- * narrowed to the variants the Edge sits under in the transition table, and
- * must return the target variant. Optional `commands` attach transition-time
- * effects.
+ * `handler` receives an {@link EdgeInput} whose state and Message are narrowed
+ * to the variants the Edge sits under in the transition table, and returns an
+ * `Update.Return` record whose `model` is the target variant and whose optional
+ * `commands` are transition-time effects.
  *
- * The `commands` callback may return Commands whose Effects need services. The
- * requirements they carry flow into the Machine's `R` through {@link define}.
+ * The handler's `commands` field may contain Commands whose Effects need
+ * services. The requirements they carry flow into the Machine's `R` through
+ * {@link define}.
  *
  * Only meaningful inside a {@link TransitionTable}: the source and trigger
  * types flow in from the table position contextually.
@@ -217,20 +207,17 @@ export const to = <
   R = never,
 >(
   target: TargetTag,
-  build: (
+  handler: (
     input: NoInfer<EdgeInput<SourceState, TriggerMessage>>,
-  ) => NoInfer<Variant<State, TargetTag>>,
-  commands?: (
-    input: NoInfer<EdgeInput<SourceState, TriggerMessage>>,
-  ) => ReadonlyArray<Command<NoInfer<Message>, never, R>>,
+  ) => Update.Return<NoInfer<Variant<State, TargetTag>>, NoInfer<Message>, R>,
 ): Edge<State, Message, SourceState, TriggerMessage, void, R> =>
-  makeEdge(target, build, commands)
+  makeEdge(target, handler)
 
 /**
  * Guards an Edge. Guard lists run in order, and the first guard that passes
  * fires its Edge. A guard either resolves the state and Message to an
  * `Option` (returning `Option.some` passes, and the wrapped value flows into
- * the Edge's build and commands callbacks as `guardValue`) or returns a
+ * the Edge's handler as `guardValue`) or returns a
  * plain boolean when there is nothing to extract (returning `true` passes,
  * and `guardValue` is `void`).
  *
@@ -253,16 +240,11 @@ export const when = <
     message: NoInfer<TriggerMessage>,
   ) => GuardResult,
   target: TargetTag,
-  build: (
+  handler: (
     input: NoInfer<
       EdgeInput<SourceState, TriggerMessage, GuardValueOf<GuardResult>>
     >,
-  ) => NoInfer<Variant<State, TargetTag>>,
-  commands?: (
-    input: NoInfer<
-      EdgeInput<SourceState, TriggerMessage, GuardValueOf<GuardResult>>
-    >,
-  ) => ReadonlyArray<Command<NoInfer<Message>, never, R>>,
+  ) => Update.Return<NoInfer<Variant<State, TargetTag>>, NoInfer<Message>, R>,
 ): When<
   State,
   Message,
@@ -281,13 +263,13 @@ export const when = <
       return result
     }
   },
-  edge: makeEdge(target, build, commands),
+  edge: makeEdge(target, handler),
 })
 
 /**
- * The unconditional fallback at the end of a guard list. Its edge may carry
- * Commands whose Effects need services, threading their requirements into the
- * Machine's `R` the same way {@link to} and {@link when} do.
+ * The unconditional fallback at the end of a guard list. Its Edge handler may
+ * return Commands whose Effects need services, threading their requirements
+ * into the Machine's `R` the same way {@link to} and {@link when} do.
  *
  * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
  */
@@ -569,10 +551,10 @@ const flattenUnionMembers = (
  * narrowing collapses.
  *
  * The Machine is not a runtime: `transition` has the same shape as a Foldkit
- * `update` branch and returns `[nextState, commands]`, so the machine state
- * lives in the Model and the Foldkit runtime never learns the Machine
- * exists. Messages that match no Edge leave the state unchanged; use `step`
- * when the `Ignored` outcome should be observable.
+ * `update` branch and returns an `Update.Return`, so the machine state lives in
+ * the Model and the Foldkit runtime never learns the Machine exists. Messages
+ * that match no Edge leave the state unchanged; use `step` when the `Ignored`
+ * outcome should be observable.
  *
  * Because every Edge names a literal target tag, the Edge set is plain data:
  * `reachableFrom`, `unreachableStates`, `deadTransitions`, and `toMermaid`
@@ -591,7 +573,10 @@ const flattenUnionMembers = (
  *   states: {
  *     Idle: {
  *       on: {
- *         ClickedSubmit: to('Uploading', () => Uploading(), () => [Presign()]),
+ *         ClickedSubmit: to('Uploading', () => ({
+ *           model: Uploading(),
+ *           commands: [Presign()],
+ *         })),
  *       },
  *     },
  *   },
@@ -726,26 +711,22 @@ export const define =
       state: State,
       message: Message,
       selectedEdge: SelectedEdge<State, Message, R>,
-    ): Transitioned<State, Message, R> => ({
-      _tag: 'Transitioned',
-      from: state._tag,
-      target: selectedEdge.edge.target,
-      messageTag: message._tag,
-      state: selectedEdge.edge.build({
+    ): Transitioned<State, Message, R> => {
+      const edgeUpdate = selectedEdge.edge.handler({
         state,
         message,
         guardValue: selectedEdge.guardValue,
-      }),
-      commands: Option.match(selectedEdge.edge.maybeCommands, {
-        onNone: () => [],
-        onSome: buildCommands =>
-          buildCommands({
-            state,
-            message,
-            guardValue: selectedEdge.guardValue,
-          }),
-      }),
-    })
+      })
+
+      return {
+        _tag: 'Transitioned',
+        from: state._tag,
+        target: selectedEdge.edge.target,
+        messageTag: message._tag,
+        state: edgeUpdate.model,
+        commands: edgeUpdate.commands ?? [],
+      }
+    }
 
     const makeIgnored = (
       state: State,

--- a/scripts/fixtures/packed-ssr-consumer/src/inferred-machine-edge.ts
+++ b/scripts/fixtures/packed-ssr-consumer/src/inferred-machine-edge.ts
@@ -16,7 +16,7 @@ export const startEdge = to<
   IdleState,
   MachineMessage,
   'Running'
->('Running', () => MachineState.Running())
+>('Running', () => ({ model: MachineState.Running() }))
 
 export const guardedStartEdge = when<
   MachineState,
@@ -28,5 +28,5 @@ export const guardedStartEdge = when<
 >(
   state => Option.some(state._tag.length),
   'Running',
-  () => MachineState.Running(),
+  () => ({ model: MachineState.Running() }),
 )


### PR DESCRIPTION
Machine Edge builders split the next state and Commands across positional callbacks. That duplicated input-derived work and diverged from Foldkit’s standard update shape.

Have `to` and `when` accept one handler that returns `{ model, commands? }`. Preserve target-variant, guard-value, and Command requirement inference, then migrate the example and packed consumer fixture.