### PR TITLE
feat(foldkit): add Machine context

### DIFF
--- a/.changeset/machine-read-context.md
+++ b/.changeset/machine-read-context.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+Add opt-in, Schema-typed read-only context to experimental Machines. Declare `context` in the first `Machine.define` stage to require it as the third argument to `transition` and `step`, expose it as the third guard parameter, and include it in `EdgeInput`.
+
+Context-free Machines retain their existing two-argument call signatures and Edge input shape. Use context for per-dispatch reads from data outside the Machine state; keep state-owned snapshots in the state and continue using Messages for values that should be observable facts.

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -15,7 +15,15 @@ import { defineMessageUnion, defineTaggedUnion } from '../../schema/index.js'
 import { evo } from '../../struct/index.js'
 import * as Subscription from '../../subscription/public.js'
 import * as Update from '../../update/index.js'
-import { define, otherwise, to, when } from './machine.js'
+import {
+  type EdgeInput,
+  type Machine,
+  type TransitionTable,
+  define,
+  otherwise,
+  to,
+  when,
+} from './machine.js'
 
 // REMOTE DATA
 
@@ -439,6 +447,179 @@ const booleanGuardMachine = define({
   },
 })
 
+const RemoteDataContext = Schema.Struct({
+  shouldSucceed: Schema.Boolean,
+  data: Schema.String,
+  errorPrefix: Schema.String,
+})
+type RemoteDataContext = typeof RemoteDataContext.Type
+
+const contextualRemoteDataMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+  context: RemoteDataContext,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: [
+          when(
+            (state, message, context) => {
+              expectTypeOf(state).toEqualTypeOf<typeof RemoteData.Idle.Type>()
+              expectTypeOf(message).toEqualTypeOf<
+                typeof RemoteDataMessage.ClickedFetch.Type
+              >()
+              expectTypeOf(context).toEqualTypeOf<RemoteDataContext>()
+
+              if (context.shouldSucceed) {
+                return Option.some(
+                  `${state._tag}:${message._tag}:${context.data}`,
+                )
+              } else {
+                return Option.none()
+              }
+            },
+            'Ok',
+            ({ state, message, guardValue, context }) => {
+              expectTypeOf(state).toEqualTypeOf<typeof RemoteData.Idle.Type>()
+              expectTypeOf(message).toEqualTypeOf<
+                typeof RemoteDataMessage.ClickedFetch.Type
+              >()
+              expectTypeOf(guardValue).toEqualTypeOf<string>()
+              expectTypeOf(context).toEqualTypeOf<RemoteDataContext>()
+
+              return {
+                model: RemoteData.Ok({
+                  data: `${guardValue}:${context.data}`,
+                }),
+              }
+            },
+          ),
+          otherwise(
+            to('Error', ({ context }) => ({
+              model: RemoteData.Error({
+                error: `${context.errorPrefix}: unavailable`,
+              }),
+            })),
+          ),
+        ],
+      },
+    },
+    Error: {
+      on: {
+        ClickedRetry: to('Ok', input => ({
+          model: RemoteData.Ok({
+            data: `${globalThis.String(Object.hasOwn(input, 'context'))}:${input.context.data}`,
+          }),
+        })),
+      },
+    },
+  },
+})
+
+const contextFreeInputShapeMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: to('Ok', input => {
+          if (false) {
+            // @ts-expect-error context-free Edge inputs have no context field
+            expectTypeOf(input.context).toBeNever()
+          }
+
+          return {
+            model: RemoteData.Ok({
+              data: globalThis.String(Object.hasOwn(input, 'context')),
+            }),
+          }
+        }),
+      },
+    },
+  },
+})
+
+const contextFreeGuardArityMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: [
+          when(
+            (...guardArguments) => guardArguments.length === 2,
+            'Loading',
+            () => ({ model: RemoteData.Loading() }),
+          ),
+        ],
+      },
+    },
+  },
+})
+
+const voidContextMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+  context: Schema.Void,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: to('Loading', ({ context }) => {
+          expectTypeOf(context).toEqualTypeOf<void>()
+
+          return { model: RemoteData.Loading() }
+        }),
+      },
+    },
+  },
+})
+
+const anyContextMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+  context: Schema.Any,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: to('Loading', ({ context }) => {
+          expectTypeOf(context).toBeAny()
+
+          return { model: RemoteData.Loading() }
+        }),
+      },
+    },
+  },
+})
+
+const neverContextMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+  context: Schema.Never,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: to('Loading', ({ context }) => {
+          expectTypeOf(context).toBeNever()
+
+          return { model: RemoteData.Loading() }
+        }),
+      },
+    },
+  },
+})
+
 const wrongVariantMachine = define({
   state: RemoteData,
   message: RemoteDataMessage,
@@ -703,6 +884,9 @@ const Persist = Command.define('Persist', {
   }),
 })
 
+const SubmitContext = Schema.Struct({ shouldSubmit: Schema.Boolean })
+type SubmitContext = typeof SubmitContext.Type
+
 const inferredRequirementsMachine = define({
   state: SubmitState,
   message: SubmitMessage,
@@ -715,6 +899,35 @@ const inferredRequirementsMachine = define({
           model: SubmitState.Presigning(),
           commands: [Presign()],
         })),
+      },
+    },
+  },
+})
+
+const inferredContextualRequirementsMachine = define({
+  state: SubmitState,
+  message: SubmitMessage,
+  context: SubmitContext,
+})({
+  initial: SubmitState.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedSubmit: [
+          when(
+            (_state, _message, context) => context.shouldSubmit,
+            'Presigning',
+            ({ context }) => {
+              expectTypeOf(context).toEqualTypeOf<SubmitContext>()
+
+              return {
+                model: SubmitState.Presigning(),
+                commands: [Presign()],
+              }
+            },
+          ),
+          otherwise(to('Idle', () => ({ model: SubmitState.Idle() }))),
+        ],
       },
     },
   },
@@ -803,6 +1016,32 @@ const explicitRequirementsMachine = define({
       on: {
         SucceededPersist: to('Submitted', () => ({
           model: SubmitState.Submitted(),
+        })),
+      },
+    },
+  },
+})
+
+const explicitContextualRequirementsMachine = define({
+  state: SubmitState,
+  message: SubmitMessage,
+  context: SubmitContext,
+})<UploadsClient | SaveClient>({
+  initial: SubmitState.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedSubmit: to('Presigning', () => ({
+          model: SubmitState.Presigning(),
+          commands: [Presign()],
+        })),
+      },
+    },
+    Presigning: {
+      on: {
+        SucceededPresign: to('Persisting', () => ({
+          model: SubmitState.Persisting(),
+          commands: [Persist()],
         })),
       },
     },
@@ -1152,6 +1391,209 @@ describe('guard lists', () => {
   })
 })
 
+describe('context', () => {
+  const succeeds: RemoteDataContext = {
+    shouldSucceed: true,
+    data: 'payload',
+    errorPrefix: 'fetch',
+  }
+
+  const fails: RemoteDataContext = {
+    shouldSucceed: false,
+    data: 'payload',
+    errorPrefix: 'fetch',
+  }
+
+  it('passes context through guards and into the selected Edge handler', () => {
+    const result = contextualRemoteDataMachine.step(
+      RemoteData.Idle(),
+      RemoteDataMessage.ClickedFetch(),
+      succeeds,
+    )
+
+    expect(result._tag).toBe('Transitioned')
+    expect(result.state).toStrictEqual(
+      RemoteData.Ok({ data: 'Idle:ClickedFetch:payload:payload' }),
+    )
+  })
+
+  it('passes context through an otherwise fallback', () => {
+    const result = contextualRemoteDataMachine.transition(
+      RemoteData.Idle(),
+      RemoteDataMessage.ClickedFetch(),
+      fails,
+    )
+
+    expect(result.model).toStrictEqual(
+      RemoteData.Error({ error: 'fetch: unavailable' }),
+    )
+  })
+
+  it('adds context to unguarded Edge inputs only when declared', () => {
+    const contextualResult = contextualRemoteDataMachine.transition(
+      RemoteData.Error({ error: 'offline' }),
+      RemoteDataMessage.ClickedRetry(),
+      succeeds,
+    )
+    expect(contextualResult.model).toStrictEqual(
+      RemoteData.Ok({ data: 'true:payload' }),
+    )
+
+    const contextFreeResult = contextFreeInputShapeMachine.transition(
+      RemoteData.Idle(),
+      RemoteDataMessage.ClickedFetch(),
+    )
+    expect(contextFreeResult.model).toStrictEqual(
+      RemoteData.Ok({ data: 'false' }),
+    )
+  })
+
+  it('keeps context-free guard invocation at two arguments', () => {
+    const result = contextFreeGuardArityMachine.transition(
+      RemoteData.Idle(),
+      RemoteDataMessage.ClickedFetch(),
+    )
+
+    expect(result.model).toStrictEqual(RemoteData.Loading())
+  })
+
+  it('preserves the runtime arity of context-free Machine functions', () => {
+    expect(remoteDataMachine.transition).toHaveLength(2)
+    expect(remoteDataMachine.step).toHaveLength(2)
+  })
+
+  it('still requires context when the Message is ignored', () => {
+    const result = contextualRemoteDataMachine.step(
+      RemoteData.Ok({ data: 'settled' }),
+      RemoteDataMessage.ClickedRetry(),
+      succeeds,
+    )
+
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Ok',
+      messageTag: 'ClickedRetry',
+      state: RemoteData.Ok({ data: 'settled' }),
+      reason: 'NotApplicable',
+    })
+  })
+
+  it('makes context arity part of the Machine type', () => {
+    if (false) {
+      // @ts-expect-error contextual transition requires its third argument
+      contextualRemoteDataMachine.transition(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+      )
+
+      // @ts-expect-error contextual step requires its third argument
+      contextualRemoteDataMachine.step(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+      )
+
+      contextualRemoteDataMachine.transition(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+        // @ts-expect-error contextual transition requires RemoteDataContext
+        { shouldSucceed: true },
+      )
+
+      remoteDataMachine.transition(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+        // @ts-expect-error context-free transition accepts exactly two arguments
+        succeeds,
+      )
+
+      // @ts-expect-error a declared void context still requires a third argument
+      voidContextMachine.transition(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+      )
+
+      // @ts-expect-error a declared any context still requires a third argument
+      anyContextMachine.transition(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+      )
+      anyContextMachine.transition(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+        { arbitrary: true },
+      )
+
+      // @ts-expect-error a declared never context still requires a third argument
+      neverContextMachine.transition(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+      )
+      neverContextMachine.transition(
+        RemoteData.Idle(),
+        RemoteDataMessage.ClickedFetch(),
+        // @ts-expect-error no value satisfies a never context
+        undefined,
+      )
+
+      define({ state: RemoteData, message: RemoteDataMessage })({
+        initial: RemoteData.Idle(),
+        states: {
+          Idle: {
+            on: {
+              ClickedFetch: [
+                when(
+                  // @ts-expect-error context-free guards accept exactly two arguments
+                  (_state, _message, _context) => true,
+                  'Loading',
+                  () => ({ model: RemoteData.Loading() }),
+                ),
+              ],
+            },
+          },
+        },
+      })
+    }
+
+    const voidContextResult = voidContextMachine.transition(
+      RemoteData.Idle(),
+      RemoteDataMessage.ClickedFetch(),
+      undefined,
+    )
+    expect(voidContextResult.model).toStrictEqual(RemoteData.Loading())
+
+    expect(true).toBe(true)
+  })
+
+  it('preserves existing public generic positions', () => {
+    type IdleState = typeof RemoteData.Idle.Type
+    type ClickedFetchMessage = typeof RemoteDataMessage.ClickedFetch.Type
+    type ExpectedInput = Readonly<{
+      state: IdleState
+      message: ClickedFetchMessage
+      guardValue: string
+    }>
+
+    expectTypeOf<
+      EdgeInput<IdleState, ClickedFetchMessage, string>
+    >().toEqualTypeOf<ExpectedInput>()
+
+    const machine: Machine<RemoteData, RemoteDataMessage, never> =
+      remoteDataMachine
+    expect(machine.initial).toStrictEqual(RemoteData.Idle())
+
+    const table: TransitionTable<RemoteData, RemoteDataMessage, never> = {
+      Idle: {
+        on: {
+          ClickedFetch: to('Loading', () => ({
+            model: RemoteData.Loading(),
+          })),
+        },
+      },
+    }
+    expect(Object.keys(table)).toEqual(['Idle'])
+  })
+})
+
 describe('ignored reasons', () => {
   it('reports a message that appears in no state entry as OutOfAlphabet', () => {
     const result = connectionMachine.step(
@@ -1450,6 +1892,20 @@ describe('edge command requirements', () => {
     ])
   })
 
+  it('infers requirements independently from a declared context', () => {
+    const submitClick = inferredContextualRequirementsMachine.transition(
+      SubmitState.Idle(),
+      SubmitMessage.ClickedSubmit(),
+      { shouldSubmit: true },
+    )
+
+    expectTypeOf(submitClick.commands).toEqualTypeOf<
+      | ReadonlyArray<Command.Command<SubmitMessage, never, UploadsClient>>
+      | undefined
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
+  })
+
   it('threads a requirement inferred from an otherwise fallback command', () => {
     const submitClick = inferredOtherwiseRequirementsMachine.transition(
       SubmitState.Idle(),
@@ -1547,5 +2003,21 @@ describe('edge command requirements', () => {
     expect(persistMessages).toEqual([
       SubmitMessage.SucceededPersist({ id: PERSISTED_ID }),
     ])
+  })
+
+  it('keeps R as the contextual definition stage generic', () => {
+    const submitClick = explicitContextualRequirementsMachine.transition(
+      SubmitState.Idle(),
+      SubmitMessage.ClickedSubmit(),
+      { shouldSubmit: true },
+    )
+
+    expectTypeOf(submitClick.commands).toEqualTypeOf<
+      | ReadonlyArray<
+          Command.Command<SubmitMessage, never, UploadsClient | SaveClient>
+        >
+      | undefined
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
   })
 })

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -26,23 +26,65 @@ export type Variant<Union extends Tagged, Tag extends TagOf<Union>> = Extract<
   Readonly<{ _tag: Tag }>
 >
 
+declare const NoMachineContextTypeId: unique symbol
+type NoMachineContext = typeof NoMachineContextTypeId
+
+type IsAny<Value> = 0 extends 1 & Value ? true : false
+type IsNever<Value> = [Value] extends [never] ? true : false
+
+type HasMachineContext<Context> =
+  IsAny<Context> extends true
+    ? true
+    : [Context] extends [never]
+      ? true
+      : [Context] extends [NoMachineContext]
+        ? false
+        : true
+
+type ContextArguments<Context> =
+  HasMachineContext<Context> extends true ? [context: Context] : []
+
+type MachineContextArgument<Context> =
+  IsAny<Context> extends true
+    ? Context
+    : IsNever<Context> extends true
+      ? Context
+      : undefined extends Context
+        ? Exclude<Context, void | undefined> | undefined
+        : Context
+
+type MachineContextArguments<Context> =
+  HasMachineContext<Context> extends true
+    ? [context: MachineContextArgument<Context>]
+    : []
+
 // EDGE
 
 /**
  * The single argument an Edge handler receives: the source state, the
- * triggering Message, and the guard value produced by the Edge's {@link when}
- * guard (`void` on unguarded and boolean-guarded Edges). Destructure the fields
- * you need.
+ * triggering Message, the guard value produced by the Edge's {@link when}
+ * guard (`void` on unguarded and boolean-guarded Edges), and the read-only
+ * context declared for the Machine when one exists. Destructure the fields you
+ * need.
  */
 export type EdgeInput<
   SourceState extends Tagged,
   TriggerMessage extends Tagged,
   GuardValue = void,
-> = Readonly<{
-  state: SourceState
-  message: TriggerMessage
-  guardValue: GuardValue
-}>
+  Context = NoMachineContext,
+> =
+  HasMachineContext<Context> extends true
+    ? Readonly<{
+        state: SourceState
+        message: TriggerMessage
+        guardValue: GuardValue
+        context: Context
+      }>
+    : Readonly<{
+        state: SourceState
+        message: TriggerMessage
+        guardValue: GuardValue
+      }>
 
 /**
  * A single transition edge. The target state tag is a literal value, so the
@@ -63,11 +105,12 @@ export type Edge<
   TriggerMessage extends Message,
   GuardValue = void,
   R = never,
+  Context = NoMachineContext,
 > = Readonly<{
   _tag: 'Edge'
   target: TagOf<State>
   handler: (
-    input: EdgeInput<SourceState, TriggerMessage, unknown>,
+    input: EdgeInput<SourceState, TriggerMessage, unknown, Context>,
   ) => Update.Return<State, Message, R>
   readonly '~foldkit/EdgeGuardValue'?: GuardValue
 }>
@@ -80,10 +123,23 @@ export type When<
   TriggerMessage extends Message,
   GuardValue = unknown,
   R = never,
+  Context = NoMachineContext,
 > = Readonly<{
   _tag: 'When'
-  guard: (state: SourceState, message: TriggerMessage) => Option.Option<unknown>
-  edge: Edge<State, Message, SourceState, TriggerMessage, GuardValue, R>
+  guard: (
+    state: SourceState,
+    message: TriggerMessage,
+    ...context: ContextArguments<Context>
+  ) => Option.Option<unknown>
+  edge: Edge<
+    State,
+    Message,
+    SourceState,
+    TriggerMessage,
+    GuardValue,
+    R,
+    Context
+  >
 }>
 
 /** The unconditional fallback Edge at the end of a guard list. Construct with {@link otherwise}. */
@@ -93,9 +149,10 @@ export type Otherwise<
   SourceState extends State,
   TriggerMessage extends Message,
   R = never,
+  Context = NoMachineContext,
 > = Readonly<{
   _tag: 'Otherwise'
-  edge: Edge<State, Message, SourceState, TriggerMessage, void, R>
+  edge: Edge<State, Message, SourceState, TriggerMessage, void, R, Context>
 }>
 
 /** One entry in an ordered guard list: a {@link When} or the {@link Otherwise} fallback. */
@@ -105,9 +162,10 @@ export type GuardedEdge<
   SourceState extends State,
   TriggerMessage extends Message,
   R = never,
+  Context = NoMachineContext,
 > =
-  | When<State, Message, SourceState, TriggerMessage, unknown, R>
-  | Otherwise<State, Message, SourceState, TriggerMessage, R>
+  | When<State, Message, SourceState, TriggerMessage, unknown, R, Context>
+  | Otherwise<State, Message, SourceState, TriggerMessage, R, Context>
 
 type OptionValue<MaybeValue> =
   MaybeValue extends Option.Option<infer Value> ? Value : never
@@ -129,6 +187,7 @@ export type TransitionTable<
   State extends Tagged,
   Message extends Tagged,
   R = never,
+  Context = NoMachineContext,
 > = Readonly<{
   [SourceTag in TagOf<State>]?: Readonly<{
     on: Readonly<{
@@ -139,7 +198,8 @@ export type TransitionTable<
             Variant<State, SourceTag>,
             Variant<Message, MessageTag>,
             void,
-            R
+            R,
+            Context
           >
         | ReadonlyArray<
             GuardedEdge<
@@ -147,7 +207,8 @@ export type TransitionTable<
               Message,
               Variant<State, SourceTag>,
               Variant<Message, MessageTag>,
-              R
+              R,
+              Context
             >
           >
     }>
@@ -162,17 +223,26 @@ const makeEdge = <
   const TargetTag extends TagOf<State>,
   GuardValue = void,
   R = never,
+  Context = NoMachineContext,
 >(
   target: TargetTag,
   handler: (
-    input: NoInfer<EdgeInput<SourceState, TriggerMessage, GuardValue>>,
+    input: NoInfer<EdgeInput<SourceState, TriggerMessage, GuardValue, Context>>,
   ) => Update.Return<NoInfer<Variant<State, TargetTag>>, NoInfer<Message>, R>,
-): Edge<State, Message, SourceState, TriggerMessage, GuardValue, R> => {
+): Edge<
+  State,
+  Message,
+  SourceState,
+  TriggerMessage,
+  GuardValue,
+  R,
+  Context
+> => {
   const narrowGuardValue = (
-    input: EdgeInput<SourceState, TriggerMessage, unknown>,
-  ): EdgeInput<SourceState, TriggerMessage, GuardValue> => {
+    input: EdgeInput<SourceState, TriggerMessage, unknown, Context>,
+  ): EdgeInput<SourceState, TriggerMessage, GuardValue, Context> => {
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-    return input as EdgeInput<SourceState, TriggerMessage, GuardValue>
+    return input as EdgeInput<SourceState, TriggerMessage, GuardValue, Context>
   }
 
   return {
@@ -187,7 +257,8 @@ const makeEdge = <
  * `handler` receives an {@link EdgeInput} whose state and Message are narrowed
  * to the variants the Edge sits under in the transition table, and returns an
  * `Update.Return` record whose `model` is the target variant and whose optional
- * `commands` are transition-time effects.
+ * `commands` are transition-time effects. When the Machine declares a context,
+ * the input also contains that context for the current transition.
  *
  * The handler's `commands` field may contain Commands whose Effects need
  * services. The requirements they carry flow into the Machine's `R` through
@@ -205,13 +276,23 @@ export const to = <
   TriggerMessage extends Message,
   const TargetTag extends TagOf<State>,
   R = never,
+  Context = NoMachineContext,
 >(
   target: TargetTag,
   handler: (
-    input: NoInfer<EdgeInput<SourceState, TriggerMessage>>,
+    input: NoInfer<EdgeInput<SourceState, TriggerMessage, void, Context>>,
   ) => Update.Return<NoInfer<Variant<State, TargetTag>>, NoInfer<Message>, R>,
-): Edge<State, Message, SourceState, TriggerMessage, void, R> =>
-  makeEdge(target, handler)
+): Edge<State, Message, SourceState, TriggerMessage, void, R, Context> =>
+  makeEdge<
+    State,
+    Message,
+    SourceState,
+    TriggerMessage,
+    TargetTag,
+    void,
+    R,
+    Context
+  >(target, handler)
 
 /**
  * Guards an Edge. Guard lists run in order, and the first guard that passes
@@ -221,8 +302,10 @@ export const to = <
  * plain boolean when there is nothing to extract (returning `true` passes,
  * and `guardValue` is `void`).
  *
- * The state and Message parameters are `NoInfer` so they resolve from the
- * guard list's table position alone.
+ * When the Machine declares a context, the guard receives it as a third
+ * parameter and its Edge handler receives it in {@link EdgeInput}. The state,
+ * Message, and context parameters are `NoInfer` so they resolve from the guard
+ * list's table position alone.
  *
  * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
  */
@@ -234,15 +317,17 @@ export const when = <
   GuardResult extends Option.Option<unknown> | boolean,
   const TargetTag extends TagOf<State>,
   R = never,
+  Context = NoMachineContext,
 >(
   guard: (
     state: NoInfer<SourceState>,
     message: NoInfer<TriggerMessage>,
+    ...context: ContextArguments<NoInfer<Context>>
   ) => GuardResult,
   target: TargetTag,
   handler: (
     input: NoInfer<
-      EdgeInput<SourceState, TriggerMessage, GuardValueOf<GuardResult>>
+      EdgeInput<SourceState, TriggerMessage, GuardValueOf<GuardResult>, Context>
     >,
   ) => Update.Return<NoInfer<Variant<State, TargetTag>>, NoInfer<Message>, R>,
 ): When<
@@ -251,20 +336,38 @@ export const when = <
   SourceState,
   TriggerMessage,
   GuardValueOf<GuardResult>,
-  R
-> => ({
-  _tag: 'When',
-  guard: (state, message) => {
-    const result = guard(state, message)
+  R,
+  Context
+> => {
+  const normalizeGuard = (
+    state: SourceState,
+    message: TriggerMessage,
+    ...context: ContextArguments<Context>
+  ): Option.Option<unknown> => {
+    const result = guard(state, message, ...context)
 
     if (Predicate.isBoolean(result)) {
       return result ? Option.some(undefined) : Option.none()
     } else {
       return result
     }
-  },
-  edge: makeEdge(target, handler),
-})
+  }
+
+  return {
+    _tag: 'When',
+    guard: normalizeGuard,
+    edge: makeEdge<
+      State,
+      Message,
+      SourceState,
+      TriggerMessage,
+      TargetTag,
+      GuardValueOf<GuardResult>,
+      R,
+      Context
+    >(target, handler),
+  }
+}
 
 /**
  * The unconditional fallback at the end of a guard list. Its Edge handler may
@@ -279,9 +382,10 @@ export const otherwise = <
   SourceState extends State,
   TriggerMessage extends Message,
   R = never,
+  Context = NoMachineContext,
 >(
-  edge: Edge<State, Message, SourceState, TriggerMessage, void, R>,
-): Otherwise<State, Message, SourceState, TriggerMessage, R> => ({
+  edge: Edge<State, Message, SourceState, TriggerMessage, void, R, Context>,
+): Otherwise<State, Message, SourceState, TriggerMessage, R, Context> => ({
   _tag: 'Otherwise',
   edge,
 })
@@ -383,21 +487,28 @@ export type Machine<
   State extends Tagged,
   Message extends Tagged,
   R = never,
+  Context = NoMachineContext,
 > = Readonly<{
   initial: State
   stateTags: ReadonlyArray<TagOf<State>>
   edges: ReadonlyArray<EdgeSummary<State, Message>>
   /** Runs one Message through the Machine as a Foldkit update. The returned
    * `Update.Return<State, Message, R>` stores the next Machine state in
-   * `model` and any transition-time Commands in `commands`, so `transition`
-   * can be passed directly to `Update.foldChild`. Use `step` when code needs
-   * to distinguish a `Transitioned` result from an `Ignored` result or
-   * inspect Edge metadata. */
+   * `model` and any transition-time Commands in `commands`, so a context-free
+   * `transition` can be passed directly to `Update.foldChild`. Use a closure
+   * around a contextual `transition`. Use `step` when code needs to distinguish
+   * a `Transitioned` result from an `Ignored` result or inspect Edge metadata.
+   */
   transition: (
     state: State,
     message: Message,
+    ...context: MachineContextArguments<Context>
   ) => Update.Return<State, Message, R>
-  step: (state: State, message: Message) => TransitionResult<State, Message, R>
+  step: (
+    state: State,
+    message: Message,
+    ...context: MachineContextArguments<Context>
+  ) => TransitionResult<State, Message, R>
   /**
    * The state tags a walk of the statically selectable declared Edges visits
    * starting from `tag`. Edges listed after an `otherwise` are excluded because
@@ -440,7 +551,7 @@ export type Machine<
  * union. Passed to `define`'s first stage so the type parameters are
  * fully resolved before the transition table is checked.
  */
-export type MachineSchemas<
+type MachineSchemaFields<
   State extends Tagged,
   Message extends Tagged,
 > = Readonly<{
@@ -448,6 +559,20 @@ export type MachineSchemas<
     Readonly<{ Type: State; members: ReadonlyArray<Schema.Top> }>
   message: Schema.Top & Readonly<{ Type: Message }>
 }>
+
+/**
+ * The Schemas a Machine is defined over, including an optional read-only
+ * context Schema. A declared context is required by the Machine's guards,
+ * Edge handlers, `transition`, and `step`.
+ */
+export type MachineSchemas<
+  State extends Tagged,
+  Message extends Tagged,
+  ContextSchema extends Schema.Top | undefined = undefined,
+> = MachineSchemaFields<State, Message> &
+  ([ContextSchema] extends [Schema.Top]
+    ? Readonly<{ context: ContextSchema }>
+    : Readonly<{ context?: never }>)
 
 /** The Machine definition: the initial state and the transition table.
  *
@@ -457,25 +582,41 @@ export type MachineDefinition<
   State extends Tagged,
   Message extends Tagged,
   R = never,
+  Context = NoMachineContext,
 > = Readonly<{
   initial: State
-  states: TransitionTable<State, Message, R>
+  states: TransitionTable<State, Message, R, Context>
 }>
 
-type LooseEdge<State extends Tagged, Message extends Tagged, R> = Edge<
-  State,
-  Message,
-  State,
-  Message,
-  unknown,
-  R
->
+type RuntimeEdgeInput<State extends Tagged, Message extends Tagged> = Readonly<{
+  state: State
+  message: Message
+  guardValue: unknown
+  context?: unknown
+}>
 
-type LooseGuardedEdge<
-  State extends Tagged,
-  Message extends Tagged,
-  R,
-> = GuardedEdge<State, Message, State, Message, R>
+type LooseEdge<State extends Tagged, Message extends Tagged, R> = Readonly<{
+  _tag: 'Edge'
+  target: TagOf<State>
+  handler: (
+    input: RuntimeEdgeInput<State, Message>,
+  ) => Update.Return<State, Message, R>
+}>
+
+type LooseGuardedEdge<State extends Tagged, Message extends Tagged, R> =
+  | Readonly<{
+      _tag: 'When'
+      guard: (
+        state: State,
+        message: Message,
+        context?: unknown,
+      ) => Option.Option<unknown>
+      edge: LooseEdge<State, Message, R>
+    }>
+  | Readonly<{
+      _tag: 'Otherwise'
+      edge: LooseEdge<State, Message, R>
+    }>
 
 type SelectedEdge<State extends Tagged, Message extends Tagged, R> = Readonly<{
   edge: LooseEdge<State, Message, R>
@@ -550,11 +691,20 @@ const flattenUnionMembers = (
  * table while the type parameters are still being inferred, and the
  * narrowing collapses.
  *
- * The Machine is not a runtime: `transition` has the same shape as a Foldkit
- * `update` branch and returns an `Update.Return`, so the machine state lives in
- * the Model and the Foldkit runtime never learns the Machine exists. Messages
- * that match no Edge leave the state unchanged; use `step` when the `Ignored`
- * outcome should be observable.
+ * The Machine is not a runtime: `transition` returns an `Update.Return`, so the
+ * Machine state lives in the Model and the Foldkit runtime never learns the
+ * Machine exists. A context-free `transition` has the same shape as a Foldkit
+ * `update` branch and can be passed directly to `Update.foldChild`. A
+ * contextual Machine needs a closure that reads its context from the parent
+ * Model. Messages that match no Edge leave the state unchanged; use `step`
+ * when the `Ignored` outcome should be observable.
+ *
+ * Declare a `context` Schema when transitions need a read-only view of data
+ * outside the Machine state. The context is passed to guards and Edge handlers
+ * on each call; it is not decoded, stored, or included in static analysis. Data
+ * that the state owns for its lifetime belongs in the state as a snapshot.
+ * Values that should be visible as facts in Story tests and DevTools should
+ * still enter through Messages.
  *
  * Because every Edge names a literal target tag, the Edge set is plain data:
  * `reachableFrom`, `unreachableStates`, `deadTransitions`, and `toMermaid`
@@ -566,33 +716,70 @@ const flattenUnionMembers = (
  * distinct services `R` cannot be inferred to their union, so supply it on the
  * second call: `define(schemas)<UploadsClient | SaveClient>({ ... })`.
  *
- * @example An edge Command that needs a service
+ * @example Read external Model data through context
  * ```ts
- * const machine = define({ state: DialogState, message: DialogMessage })({
+ * const machine = define({
+ *   state: DialogState,
+ *   message: DialogMessage,
+ *   context: UploadQueues,
+ * })({
  *   initial: Idle(),
  *   states: {
  *     Idle: {
  *       on: {
- *         ClickedSubmit: to('Uploading', () => ({
- *           model: Uploading(),
- *           commands: [Presign()],
- *         })),
+ *         ClickedSubmit: [
+ *           when(
+ *             (_state, message, queues) => queues.has(message.fileId),
+ *             'Uploading',
+ *             ({ message, context: queues }) => ({
+ *               model: Uploading({ fileId: message.fileId }),
+ *               commands: [UploadFromQueue({ queues, fileId: message.fileId })],
+ *             }),
+ *           ),
+ *         ],
  *       },
  *     },
  *   },
  * })
- * // Commands on the return from machine.transition(...) require UploadsClient.
+ * machine.transition(model.dialog, message, model.uploadQueues)
  * ```
  *
  * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
  */
-export const define =
-  <State extends Tagged, Message extends Tagged>(
-    schemas: MachineSchemas<State, Message>,
-  ) =>
-  <R = never>(
-    definition: MachineDefinition<State, Message, R>,
-  ): Machine<State, Message, R> => {
+export function define<
+  State extends Tagged,
+  Message extends Tagged,
+  ContextSchema extends Schema.Top,
+>(
+  schemas: MachineSchemas<State, Message, ContextSchema>,
+): <R = never>(
+  definition: MachineDefinition<State, Message, R, ContextSchema['Type']>,
+) => Machine<State, Message, R, ContextSchema['Type']>
+export function define<State extends Tagged, Message extends Tagged>(
+  schemas: MachineSchemas<State, Message>,
+): <R = never>(
+  definition: MachineDefinition<State, Message, R>,
+) => Machine<State, Message, R>
+export function define(
+  schemas: MachineSchemaFields<Tagged, Tagged> &
+    Readonly<{ context?: Schema.Top }>,
+): unknown {
+  return defineImplementation(schemas)
+}
+
+function defineImplementation<
+  State extends Tagged,
+  Message extends Tagged,
+  Context = NoMachineContext,
+>(
+  schemas: MachineSchemaFields<State, Message> &
+    Readonly<{ context?: Schema.Top }>,
+): <R = never>(
+  definition: MachineDefinition<State, Message, R, Context>,
+) => Machine<State, Message, R, Context> {
+  return <R = never>(
+    definition: MachineDefinition<State, Message, R, Context>,
+  ): Machine<State, Message, R, Context> => {
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
     const looseStates = definition.states as unknown as LooseTable<
       State,
@@ -600,6 +787,7 @@ export const define =
       R
     >
 
+    const hasContext = Predicate.hasProperty(schemas, 'context')
     const initialTag = definition.initial._tag
 
     const stateTags = pipe(
@@ -668,16 +856,38 @@ export const define =
       HashSet.fromIterable,
     )
 
+    const runGuard = (
+      guardedEdge: Extract<
+        LooseGuardedEdge<State, Message, R>,
+        Readonly<{ _tag: 'When' }>
+      >,
+      state: State,
+      message: Message,
+      context?: Context,
+    ): Option.Option<unknown> => {
+      if (hasContext) {
+        return guardedEdge.guard(state, message, context)
+      } else {
+        return guardedEdge.guard(state, message)
+      }
+    }
+
     const selectFromGuardList = (
       guardedEdges: ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
       state: State,
       message: Message,
+      context?: Context,
     ): Option.Option<SelectedEdge<State, Message, R>> =>
       Array.matchLeft(guardedEdges, {
         onEmpty: () => Option.none(),
         onNonEmpty: (guardedEdge, rest) => {
           if (guardedEdge._tag === 'When') {
-            const maybeGuardValue = guardedEdge.guard(state, message)
+            const maybeGuardValue = runGuard(
+              guardedEdge,
+              state,
+              message,
+              context,
+            )
 
             if (Option.isSome(maybeGuardValue)) {
               return Option.some({
@@ -685,7 +895,7 @@ export const define =
                 guardValue: maybeGuardValue.value,
               })
             } else {
-              return selectFromGuardList(rest, state, message)
+              return selectFromGuardList(rest, state, message, context)
             }
           } else {
             return Option.some({
@@ -702,21 +912,39 @@ export const define =
         | ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
       state: State,
       message: Message,
+      context?: Context,
     ): Option.Option<SelectedEdge<State, Message, R>> =>
       isGuardList(edgeOrGuardedEdges)
-        ? selectFromGuardList(edgeOrGuardedEdges, state, message)
+        ? selectFromGuardList(edgeOrGuardedEdges, state, message, context)
         : Option.some({ edge: edgeOrGuardedEdges, guardValue: undefined })
+
+    const makeRuntimeEdgeInput = (
+      state: State,
+      message: Message,
+      guardValue: unknown,
+      context?: Context,
+    ): RuntimeEdgeInput<State, Message> => {
+      if (hasContext) {
+        return { state, message, guardValue, context }
+      } else {
+        return { state, message, guardValue }
+      }
+    }
 
     const makeTransitioned = (
       state: State,
       message: Message,
       selectedEdge: SelectedEdge<State, Message, R>,
+      context?: Context,
     ): Transitioned<State, Message, R> => {
-      const edgeUpdate = selectedEdge.edge.handler({
+      const edgeInput = makeRuntimeEdgeInput(
         state,
         message,
-        guardValue: selectedEdge.guardValue,
-      })
+        selectedEdge.guardValue,
+        context,
+      )
+
+      const edgeUpdate = selectedEdge.edge.handler(edgeInput)
 
       return {
         _tag: 'Transitioned',
@@ -743,8 +971,11 @@ export const define =
     const step = (
       state: State,
       message: Message,
-    ): TransitionResult<State, Message, R> =>
-      pipe(
+      ...contextArguments: [context?: Context]
+    ): TransitionResult<State, Message, R> => {
+      const context = pipe(contextArguments, Array.head, Option.getOrUndefined)
+
+      return pipe(
         Record.get(looseStates, state._tag),
         Option.flatMap(stateEntry => Record.get(stateEntry.on, message._tag)),
         Option.match({
@@ -757,19 +988,24 @@ export const define =
                 : 'OutOfAlphabet',
             ),
           onSome: edgeOrGuardedEdges =>
-            Option.match(chooseEdge(edgeOrGuardedEdges, state, message), {
-              onNone: () => makeIgnored(state, message, 'GuardsFellThrough'),
-              onSome: selectedEdge =>
-                makeTransitioned(state, message, selectedEdge),
-            }),
+            Option.match(
+              chooseEdge(edgeOrGuardedEdges, state, message, context),
+              {
+                onNone: () => makeIgnored(state, message, 'GuardsFellThrough'),
+                onSome: selectedEdge =>
+                  makeTransitioned(state, message, selectedEdge, context),
+              },
+            ),
         }),
       )
+    }
 
     const transition = (
       state: State,
       message: Message,
+      ...contextArguments: [context?: Context]
     ): Update.Return<State, Message, R> => {
-      const result = step(state, message)
+      const result = step(state, message, ...contextArguments)
 
       if (result._tag === 'Transitioned') {
         return { model: result.state, commands: result.commands }
@@ -957,3 +1193,4 @@ export const define =
       toMermaid,
     }
   }
+}

--- a/scripts/fixtures/packed-ssr-consumer/src/inferred-machine-edge.ts
+++ b/scripts/fixtures/packed-ssr-consumer/src/inferred-machine-edge.ts
@@ -1,9 +1,12 @@
-import { Option } from 'effect'
-import { to, when } from 'foldkit/experimental/machine'
+import { Option, Schema } from 'effect'
+import { define, to, when } from 'foldkit/experimental/machine'
 import { defineMessageUnion } from 'foldkit/message'
 import { defineTaggedUnion } from 'foldkit/schema'
 
-const MachineState = defineTaggedUnion({ Idle: {}, Running: {} })
+const MachineState = defineTaggedUnion({
+  Idle: {},
+  Running: { label: Schema.String },
+})
 type MachineState = typeof MachineState.Type
 type IdleState = typeof MachineState.Idle.Type
 
@@ -16,7 +19,7 @@ export const startEdge = to<
   IdleState,
   MachineMessage,
   'Running'
->('Running', () => ({ model: MachineState.Running() }))
+>('Running', () => ({ model: MachineState.Running({ label: 'direct' }) }))
 
 export const guardedStartEdge = when<
   MachineState,
@@ -28,5 +31,33 @@ export const guardedStartEdge = when<
 >(
   state => Option.some(state._tag.length),
   'Running',
-  () => ({ model: MachineState.Running() }),
+  () => ({ model: MachineState.Running({ label: 'guarded' }) }),
 )
+
+const MachineContext = Schema.Struct({
+  canStart: Schema.Boolean,
+  label: Schema.String,
+})
+
+export const contextualMachine = define({
+  state: MachineState,
+  message: MachineMessage,
+  context: MachineContext,
+})({
+  initial: MachineState.Idle(),
+  states: {
+    Idle: {
+      on: {
+        Started: [
+          when(
+            (_state, _message, context) => context.canStart,
+            'Running',
+            ({ context }) => ({
+              model: MachineState.Running({ label: context.label }),
+            }),
+          ),
+        ],
+      },
+    },
+  },
+})


### PR DESCRIPTION
Allow a Machine to declare a Schema-typed context in `define`’s first stage. Thread each supplied context through guards and Edge handlers while preserving the exact two-argument API and input shape of context-free Machines.

Keep context separate from state-owned snapshots and observable Message facts.

Closes #851