### PR TITLE
feat(website): offer search on the landing page

### DIFF
--- a/packages/website/e2e/smoke.spec.ts
+++ b/packages/website/e2e/smoke.spec.ts
@@ -84,3 +84,35 @@ test('selects an item from the combobox', async ({ page }) => {
   await page.getByRole('option', { name: 'Oxford' }).click()
   await expect(combobox).toHaveValue('Oxford')
 })
+
+test('opens search from the landing page', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'networkidle' })
+  await expect(page.locator('[data-foldkit-build]')).toHaveCount(0)
+
+  const dialog = page.locator('#search-dialog')
+
+  await page.getByRole('button', { name: 'Search documentation' }).click()
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByRole('combobox')).toBeFocused()
+
+  await page.keyboard.press('Escape')
+  await expect(dialog).toBeHidden()
+
+  await page.keyboard.press('ControlOrMeta+k')
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByRole('combobox')).toBeFocused()
+})
+
+test('opens search from the landing page below the wide trigger', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 768, height: 900 })
+  await page.goto('/', { waitUntil: 'networkidle' })
+  await expect(page.locator('[data-foldkit-build]')).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Search documentation' }).click()
+
+  const dialog = page.locator('#search-dialog')
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByRole('combobox')).toBeFocused()
+})

--- a/packages/website/src/layout/docs.ts
+++ b/packages/website/src/layout/docs.ts
@@ -52,35 +52,23 @@ import {
 } from '../page'
 import * as Prose from '../prose'
 import { type DocsRoute, homeRouter } from '../route'
-import * as Search from '../search'
 import * as SnippetCopy from '../snippetCopy'
 import { type TableOfContentsEntry } from '../tableOfContentsEntry'
-import { HeaderNav, Sidebar, TableOfContents, ThemeSelector } from '../view'
+import {
+  HeaderNav,
+  Search,
+  Sidebar,
+  TableOfContents,
+  ThemeSelector,
+} from '../view'
 
 const PagefindBody = ih.DataAttribute('pagefind-body', '')
 const PagefindIgnore = ih.DataAttribute('pagefind-ignore', '')
 const LlmIgnore = ih.DataAttribute('llm-ignore', '')
 
-/**
- * The site-wide search dialog Submodel, shared by every shell that renders the
- * docs header, so the wiring cannot drift between the docs and blog views.
- */
-export const searchSubmodelView = (
-  model: Model,
-  h: HtmlBuilder<Message>,
-): Html =>
-  h.submodel({
-    slotId: 'search',
-    model: model.search,
-    view: Search.view,
-    toParentMessage: message => Message.GotSearchMessage({ message }),
-  })
-
-const searchKeyboardWarmupSelector = `#${Search.KEYBOARD_WARMUP_INPUT_ID}`
-
 // DOCS HEADER
 
-export const docsHeaderView = (model: Model, h: HtmlBuilder<Message>) =>
+export const headerView = (model: Model, h: HtmlBuilder<Message>) =>
   h.header(
     [
       h.Class(
@@ -110,30 +98,7 @@ export const docsHeaderView = (model: Model, h: HtmlBuilder<Message>) =>
         [h.Class('flex items-center gap-3 md:gap-8')],
         [
           HeaderNav.view(model.route, 'hidden md:flex items-center gap-6', h),
-          h.button(
-            [
-              h.Class(
-                'hidden md:flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/50 dark:bg-gray-800/50 text-gray-500 dark:text-gray-400 text-sm hover:border-gray-400 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-300 transition cursor-pointer',
-              ),
-              h.AriaLabel('Search documentation'),
-              h.OnClick(Message.ClickedOpenSearch(), {
-                focusSelector: searchKeyboardWarmupSelector,
-              }),
-            ],
-            [
-              Icon.magnifyingGlass('w-4 h-4'),
-              h.span([h.Class('mr-4')], ['Search...']),
-              h.span(
-                [
-                  h.AriaHidden(true),
-                  h.Class(
-                    'text-xs text-gray-400 dark:text-gray-500 border border-gray-300 dark:border-gray-700 rounded px-1.5 py-px font-mono',
-                  ),
-                ],
-                ['⌘K'],
-              ),
-            ],
-          ),
+          Search.triggerView('hidden md:flex', h),
           ThemeSelector.view(model.maybeThemePreference, h),
           h.div(
             [h.Class('hidden md:flex items-center gap-3 md:gap-4')],
@@ -160,18 +125,7 @@ export const docsHeaderView = (model: Model, h: HtmlBuilder<Message>) =>
               ),
             ],
           ),
-          h.button(
-            [
-              h.Class(
-                'md:hidden p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-700 dark:text-gray-300 cursor-pointer',
-              ),
-              h.AriaLabel('Search documentation'),
-              h.OnClick(Message.ClickedOpenSearch(), {
-                focusSelector: searchKeyboardWarmupSelector,
-              }),
-            ],
-            [Icon.magnifyingGlass('w-5 h-5')],
-          ),
+          Search.compactTriggerView('md:hidden', h),
           h.button(
             [
               h.Class(
@@ -190,7 +144,7 @@ export const docsHeaderView = (model: Model, h: HtmlBuilder<Message>) =>
 
 // DOCS FOOTER
 
-export const docsFooterView = (
+export const footerView = (
   currentYear: number,
   h: HtmlBuilder<Message>,
 ): Html =>
@@ -403,11 +357,11 @@ type DocPageView = (
 type ProseDocPageView = (renderHeadingLink: Prose.RenderHeadingLink) => Html
 
 const renderDocContent = (
-  view: DocPageView,
+  pageView: DocPageView,
   snippetCopy: SnippetCopy.Model,
   h: HtmlBuilder<Message>,
 ): Html =>
-  view(
+  pageView(
     SnippetCopy.renderer(
       snippetCopy,
       message => Message.GotSnippetCopyMessage({ message }),
@@ -417,10 +371,12 @@ const renderDocContent = (
   )
 
 const renderProseContent = (
-  view: ProseDocPageView,
+  pageView: ProseDocPageView,
   h: HtmlBuilder<Message>,
 ): Html =>
-  view(Prose.renderHeadingLink(hash => Message.ClickedCopyLink({ hash }), h))
+  pageView(
+    Prose.renderHeadingLink(hash => Message.ClickedCopyLink({ hash }), h),
+  )
 
 const memoizedDocContent = createLazy()
 const memoizedProseContent = createLazy()
@@ -440,7 +396,7 @@ const lazyApiReferenceSkeleton = createLazy()
 
 // VIEW
 
-export const docsView = (
+export const view = (
   model: Model,
   docsRoute: DocsRoute,
   h: HtmlBuilder<Message>,
@@ -1161,8 +1117,8 @@ export const docsView = (
     [h.Class('flex flex-col min-h-screen')],
     [
       Shared.skipNavLink,
-      docsHeaderView(model, h),
-      searchSubmodelView(model, h),
+      headerView(model, h),
+      Search.dialogView(model, h),
       h.div(
         [h.Class('flex flex-1 pt-[var(--header-height)] md:pl-64')],
         [
@@ -1216,7 +1172,7 @@ export const docsView = (
                   ),
                 ],
               ),
-              h.div([PagefindIgnore], [docsFooterView(model.currentYear, h)]),
+              h.div([PagefindIgnore], [footerView(model.currentYear, h)]),
             ],
           ),
           Option.match(currentPageTableOfContents, {

--- a/packages/website/src/layout/index.ts
+++ b/packages/website/src/layout/index.ts
@@ -1,0 +1,2 @@
+export * as Docs from './docs'
+export * as Marketing from './marketing'

--- a/packages/website/src/layout/marketing.ts
+++ b/packages/website/src/layout/marketing.ts
@@ -6,7 +6,7 @@ import { Link } from '../link'
 import { Message } from '../message'
 import { type Model } from '../model'
 import { gettingStartedRouter, homeRouter } from '../route'
-import { HeaderNav, Sidebar, ThemeSelector } from '../view'
+import { HeaderNav, Search, Sidebar, ThemeSelector } from '../view'
 
 const PagefindBody = ih.DataAttribute('pagefind-body', '')
 
@@ -39,10 +39,12 @@ const headerView = (model: Model, h: HtmlBuilder<Message>) =>
             'hidden sm:flex items-center gap-6 mr-4',
             h,
           ),
+          Search.triggerView('hidden lg:flex', h),
           h.div(
             [h.Class('hidden md:flex')],
             [ThemeSelector.view(model.maybeThemePreference, h)],
           ),
+          Search.compactTriggerView('hidden sm:inline-flex lg:hidden', h),
           h.a(
             [
               h.Href(gettingStartedRouter()),
@@ -111,6 +113,7 @@ export const view = (
     [
       Shared.skipNavLink,
       headerView(model, h),
+      Search.dialogView(model, h),
       Sidebar.mobileView(model, h),
       h.main(
         [

--- a/packages/website/src/route.test.ts
+++ b/packages/website/src/route.test.ts
@@ -114,14 +114,14 @@ describe('section predicates', () => {
       route: Route.AppRoute.Home(),
       isDocsSection: false,
       isBlog: false,
-      isSearch: false,
+      isSearch: true,
     },
     {
       name: 'Newsletter',
       route: Route.AppRoute.Newsletter(),
       isDocsSection: false,
       isBlog: false,
-      isSearch: false,
+      isSearch: true,
     },
     {
       name: 'Playground',

--- a/packages/website/src/route.ts
+++ b/packages/website/src/route.ts
@@ -223,10 +223,12 @@ export const isPlaygroundRoute = AppRoute.isAnyOf(['Playground'])
 
 export const isBlogRoute = AppRoute.isAnyOf(['Blog', 'BlogPost'])
 
+const isMarketingRoute = AppRoute.isAnyOf(['Home', 'Newsletter'])
+
 const isDocsUnionRoute = Schema.is(DocsRoute)
 
 export const isSearchRoute = (route: AppRoute): boolean =>
-  isDocsUnionRoute(route) || isBlogRoute(route)
+  isDocsUnionRoute(route) || isBlogRoute(route) || isMarketingRoute(route)
 
 /**
  * Whether a route belongs to the documentation section, which is what the

--- a/packages/website/src/subscription/searchShortcut.ts
+++ b/packages/website/src/subscription/searchShortcut.ts
@@ -7,12 +7,12 @@ import { isSearchRoute } from '../route'
 
 export const subscriptions = Subscription.make<Model, Message>()(entry => ({
   searchShortcut: entry(
-    { isDocsPage: Schema.Boolean },
+    { isSearchAvailable: Schema.Boolean },
     {
       modelToDependencies: model => ({
-        isDocsPage: isSearchRoute(model.route),
+        isSearchAvailable: isSearchRoute(model.route),
       }),
-      dependenciesToStream: ({ isDocsPage }) =>
+      dependenciesToStream: ({ isSearchAvailable }) =>
         Stream.when(
           Subscription.fromEventFilterMap<
             KeyboardEvent,
@@ -28,7 +28,7 @@ export const subscriptions = Subscription.make<Model, Message>()(entry => ({
               return Option.none()
             },
           }),
-          Effect.sync(() => isDocsPage),
+          Effect.sync(() => isSearchAvailable),
         ),
     },
   ),

--- a/packages/website/src/view/application.ts
+++ b/packages/website/src/view/application.ts
@@ -3,8 +3,7 @@ import { type Document, type HtmlBuilder } from 'foldkit/html'
 
 import { Shared } from '../component'
 import { Deployment } from '../deployment'
-import { docsView } from '../layout/docs'
-import * as Marketing from '../layout/marketing'
+import { Docs, Marketing } from '../layout'
 import { Message } from '../message'
 import { type Model } from '../model'
 import { Home, Newsletter, Playground } from '../page'
@@ -81,7 +80,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
           }),
       }),
     ),
-    Match.orElse(route => docsView(model, route, h)),
+    Match.orElse(route => Docs.view(model, route, h)),
   )
 
   return {

--- a/packages/website/src/view/blog.ts
+++ b/packages/website/src/view/blog.ts
@@ -7,18 +7,14 @@ import {
 } from 'foldkit/html'
 
 import { Shared } from '../component'
-import {
-  docsFooterView,
-  docsHeaderView,
-  searchSubmodelView,
-  searchWeight,
-} from '../layout/docs'
+import { Docs } from '../layout'
 import { Message } from '../message'
 import { type Model } from '../model'
 import { Blog, NotFound } from '../page'
 import * as Prose from '../prose'
 import { type BlogPostRoute, type BlogRoute, homeRouter } from '../route'
 import * as SnippetCopy from '../snippetCopy'
+import * as Search from './search'
 import * as Sidebar from './sidebar'
 
 const PagefindBody = ih.DataAttribute('pagefind-body', '')
@@ -70,8 +66,8 @@ export const view = (
     [h.Class('flex flex-col min-h-screen')],
     [
       Shared.skipNavLink,
-      docsHeaderView(model, h),
-      searchSubmodelView(model, h),
+      Docs.headerView(model, h),
+      Search.dialogView(model, h),
       Sidebar.mobileView(model, h),
       h.main(
         [
@@ -85,14 +81,17 @@ export const view = (
             contentKey,
             [
               PagefindBody,
-              h.DataAttribute('pagefind-weight', searchWeight(blogRoute._tag)),
+              h.DataAttribute(
+                'pagefind-weight',
+                Docs.searchWeight(blogRoute._tag),
+              ),
               h.Class(
                 'flex-1 w-full px-4 py-6 md:px-6 2xl:py-10 max-w-3xl mx-auto min-w-0',
               ),
             ],
             [content],
           ),
-          h.div([PagefindIgnore], [docsFooterView(model.currentYear, h)]),
+          h.div([PagefindIgnore], [Docs.footerView(model.currentYear, h)]),
         ],
       ),
     ],

--- a/packages/website/src/view/index.ts
+++ b/packages/website/src/view/index.ts
@@ -1,4 +1,5 @@
 export * as HeaderNav from './headerNav'
+export * as Search from './search'
 export * as Sidebar from './sidebar'
 export * as TableOfContents from './tableOfContents'
 export * as ThemeSelector from './themeSelector'

--- a/packages/website/src/view/search.ts
+++ b/packages/website/src/view/search.ts
@@ -1,0 +1,67 @@
+import { clsx } from 'clsx'
+import { Html, type HtmlBuilder } from 'foldkit/html'
+
+import { Icon } from '../icon'
+import { Message } from '../message'
+import { type Model } from '../model'
+import * as Search from '../search'
+
+const keyboardWarmupSelector = `#${Search.KEYBOARD_WARMUP_INPUT_ID}`
+
+const onClickOpenSearch = (h: HtmlBuilder<Message>) =>
+  h.OnClick(Message.ClickedOpenSearch(), {
+    focusSelector: keyboardWarmupSelector,
+  })
+
+export const dialogView = (model: Model, h: HtmlBuilder<Message>): Html =>
+  h.submodel({
+    slotId: 'search',
+    model: model.search,
+    view: Search.view,
+    toParentMessage: message => Message.GotSearchMessage({ message }),
+  })
+
+export const triggerView = (className: string, h: HtmlBuilder<Message>): Html =>
+  h.button(
+    [
+      h.Class(
+        clsx(
+          'items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/50 dark:bg-gray-800/50 text-gray-500 dark:text-gray-400 text-sm hover:border-gray-400 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-300 transition cursor-pointer',
+          className,
+        ),
+      ),
+      h.AriaLabel('Search documentation'),
+      onClickOpenSearch(h),
+    ],
+    [
+      Icon.magnifyingGlass('w-4 h-4'),
+      h.span([h.Class('mr-4')], ['Search...']),
+      h.span(
+        [
+          h.AriaHidden(true),
+          h.Class(
+            'text-xs text-gray-400 dark:text-gray-500 border border-gray-300 dark:border-gray-700 rounded px-1.5 py-px font-mono',
+          ),
+        ],
+        ['⌘K'],
+      ),
+    ],
+  )
+
+export const compactTriggerView = (
+  className: string,
+  h: HtmlBuilder<Message>,
+): Html =>
+  h.button(
+    [
+      h.Class(
+        clsx(
+          'items-center p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-700 dark:text-gray-300 cursor-pointer',
+          className,
+        ),
+      ),
+      h.AriaLabel('Search documentation'),
+      onClickOpenSearch(h),
+    ],
+    [Icon.magnifyingGlass('w-5 h-5')],
+  )


### PR DESCRIPTION
The search dialog was reachable only from the docs and blog shells. The landing page and the newsletter page render the marketing shell, which had no search trigger and never mounted the dialog, so a visitor who landed on the site's front door had to navigate into the docs before they could search.

The marketing shell now mounts the search dialog Submodel and renders a trigger in its header, and `isSearchRoute` covers the marketing routes so the `⌘K` shortcut fires there too.

The two triggers move out of the docs layout into `view/search.ts`, where all three shells share them, along with the dialog slot. The docs header had both buttons written inline, including the `focusSelector` that warms up the iOS keyboard, and copying that into the marketing header would have been a second place to keep it right.

Each header says at which widths it shows each trigger, because they have different room. The docs header carries no call to action, so it keeps the wide trigger from `md` and the icon below that. The marketing header also carries `Get started`, which wraps to two lines inside the fixed header height once a fourth control joins the row: it takes the icon from `sm` and the wide trigger from `lg`. Below `sm` the landing page has no search trigger. Fitting one there means either dropping `Get started`, the only way into the docs above the fold on a phone, or moving search into the mobile menu.

The blog and application views reach the layouts through a `layout` barrel, as `Docs` and `Marketing`, the way `view` already exposes its modules. The docs layout's exports drop their `docs` prefix to read as `Docs.view`, `Docs.headerView`, and `Docs.footerView`.

The search shortcut subscription's dependency is now `isSearchAvailable`. It was named `isDocsPage`, which stopped describing the routes it gates when the blog joined them.