### PR TITLE
fix(website): center the hero install command copy button

### DIFF
--- a/packages/website/src/component/codeBlock.ts
+++ b/packages/website/src/component/codeBlock.ts
@@ -1,4 +1,5 @@
 import { clsx } from 'clsx'
+import { Option } from 'effect'
 import { Html, inertHtml as ih } from 'foldkit/html'
 
 const PagefindIgnore = ih.DataAttribute('pagefind-ignore', '')
@@ -12,16 +13,29 @@ export type RenderCopyButton = (
   }>,
 ) => Html
 
+const DEFAULT_COPY_BUTTON_POSITION_CLASS = 'top-2 right-2'
+
+type ViewOptions = Readonly<{
+  className?: string
+  maybeLanguage?: Option.Option<string>
+  copyButtonPositionClass?: string
+}>
+
 export const view = (
   id: string,
   code: string,
   ariaLabel: string,
   renderCopyButton: RenderCopyButton,
-  className?: string,
-  language?: string,
+  {
+    className,
+    maybeLanguage = Option.none(),
+    copyButtonPositionClass = DEFAULT_COPY_BUTTON_POSITION_CLASS,
+  }: ViewOptions = {},
 ) => {
-  const languageAttribute =
-    language === undefined ? [] : [ih.DataAttribute('language', language)]
+  const languageAttribute = Option.match(maybeLanguage, {
+    onNone: () => [],
+    onSome: language => [ih.DataAttribute('language', language)],
+  })
 
   const content = ih.pre(
     [
@@ -47,7 +61,7 @@ export const view = (
         id,
         text: code,
         ariaLabel,
-        positionClass: 'top-2 right-2',
+        positionClass: copyButtonPositionClass,
       }),
     ],
   )
@@ -69,7 +83,7 @@ export const highlightedView = (
         id,
         text: rawCode,
         ariaLabel,
-        positionClass: 'top-2 right-2',
+        positionClass: DEFAULT_COPY_BUTTON_POSITION_CLASS,
       }),
     ],
   )

--- a/packages/website/src/markdown/views.ts
+++ b/packages/website/src/markdown/views.ts
@@ -158,8 +158,7 @@ export const docViews = (config: DocViewConfig): Partial<Markdown.Views> => {
             value,
             'Copy code to clipboard',
             config.renderCopyButton,
-            'mb-8',
-            Option.getOrUndefined(maybeLanguage),
+            { className: 'mb-8', maybeLanguage },
           ),
 
     List: (list, items) => {

--- a/packages/website/src/page/home/content.ts
+++ b/packages/website/src/page/home/content.ts
@@ -226,7 +226,10 @@ const heroSection = (
                 INSTALL_COMMAND,
                 'Copy install command',
                 renderCopyButton,
-                'max-w-fit [&_pre]:text-xs [&_pre]:md:text-sm',
+                {
+                  className: 'max-w-fit [&_pre]:text-xs [&_pre]:md:text-sm',
+                  copyButtonPositionClass: 'top-1/2 -translate-y-1/2 right-2',
+                },
               ),
             ],
           ),


### PR DESCRIPTION
The copy button in the home page install command box was pinned eight pixels from the top of the box. The box is only as tall as one line of text plus padding, so the button ended up nine pixels from the top and three from the bottom on mobile. It read as misaligned.

`CodeBlock.view` now takes its optional arguments as an options record, with a new `copyButtonPositionClass` that defaults to the existing top-right placement used by multi-line blocks. The hero passes a vertically centered position for its single-line command. `language` is now `maybeLanguage: Option<string>`, so the markdown renderer passes its own `maybeLanguage` straight through.

The alternative was a hero-only override through an arbitrary descendant variant on the wrapper class, like the existing `[&_pre]:text-xs`. That would have worked, but it fights the `top-2` the copy button already carries and hides the placement decision in a selector. A named option keeps it explicit and leaves every multi-line block exactly where it was.