### PR TITLE
feat(foldkit): add Machine fold helper

### DIFF
--- a/.changeset/machine-fold.md
+++ b/.changeset/machine-fold.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+Add `Machine.fold`, a dual helper that folds a Machine state field into its enclosing Model.
+
+The helper supports both data-first update calls and data-last `Update.Step` composition. Contextual Machines read their required context from the enclosing Model for each transition.

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -7,7 +7,7 @@ import {
   Schema,
   Stream,
 } from 'effect'
-import { describe, expect, expectTypeOf, it } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 import * as Command from '../../command/public.js'
 import * as ManagedResource from '../../managedResource/public.js'
@@ -20,6 +20,7 @@ import {
   type Machine,
   type TransitionTable,
   define,
+  fold,
   otherwise,
   to,
   when,
@@ -261,12 +262,11 @@ type AppModel = typeof AppModel.Type
 
 type AppUpdateReturn = Update.Return<AppModel, ConnectionMessage>
 
-const foldConnection = Update.foldChild({
-  update: connectionMachine.transition,
+const foldConnection = fold({
+  machine: connectionMachine,
   read: (model: AppModel) => Option.some(model.connection),
   write: (model, nextConnection) =>
     evo(model, { connection: () => nextConnection }),
-  toParentMessage: (message: ConnectionMessage) => message,
 })
 
 const update = (model: AppModel, message: ConnectionMessage) =>
@@ -516,6 +516,20 @@ const contextualRemoteDataMachine = define({
       },
     },
   },
+})
+
+const ContextualAppModel = Schema.Struct({
+  remoteData: RemoteData,
+  remoteDataContext: RemoteDataContext,
+})
+type ContextualAppModel = typeof ContextualAppModel.Type
+
+const foldContextualRemoteData = fold({
+  machine: contextualRemoteDataMachine,
+  read: (model: ContextualAppModel) => Option.some(model.remoteData),
+  write: (model, nextRemoteData) =>
+    evo(model, { remoteData: () => nextRemoteData }),
+  context: model => model.remoteDataContext,
 })
 
 const contextFreeInputShapeMachine = define({
@@ -858,6 +872,9 @@ const SubmitState = defineTaggedUnion({
   Submitted: {},
 })
 type SubmitState = typeof SubmitState.Type
+
+const SubmitAppModel = Schema.Struct({ submit: SubmitState })
+type SubmitAppModel = typeof SubmitAppModel.Type
 
 const SubmitMessage = defineMessageUnion({
   ClickedSubmit: {},
@@ -1429,6 +1446,93 @@ describe('context', () => {
     )
   })
 
+  it('reads context from the enclosing Model when folding', () => {
+    const model: ContextualAppModel = {
+      remoteData: RemoteData.Idle(),
+      remoteDataContext: succeeds,
+    }
+
+    const result = foldContextualRemoteData(
+      model,
+      RemoteDataMessage.ClickedFetch(),
+    )
+
+    expect(result.model.remoteData).toStrictEqual(
+      RemoteData.Ok({ data: 'Idle:ClickedFetch:payload:payload' }),
+    )
+    expect(result.model.remoteDataContext).toBe(model.remoteDataContext)
+  })
+
+  it('calls contextual transitions with the current context argument', () => {
+    const transition = vi.fn(contextualRemoteDataMachine.transition)
+    const machine: Machine<
+      RemoteData,
+      RemoteDataMessage,
+      never,
+      RemoteDataContext
+    > = { ...contextualRemoteDataMachine, transition }
+    const foldRemoteData = fold({
+      machine,
+      read: (model: ContextualAppModel) => Option.some(model.remoteData),
+      write: (model, nextRemoteData) =>
+        evo(model, { remoteData: () => nextRemoteData }),
+      context: model => model.remoteDataContext,
+    })
+    const model: ContextualAppModel = {
+      remoteData: RemoteData.Idle(),
+      remoteDataContext: succeeds,
+    }
+    const message = RemoteDataMessage.ClickedFetch()
+
+    foldRemoteData(model, message)
+
+    expect(transition).toHaveBeenCalledWith(model.remoteData, message, succeeds)
+  })
+
+  it('reads context from the current Model in data-last composition', () => {
+    const model: ContextualAppModel = {
+      remoteData: RemoteData.Idle(),
+      remoteDataContext: fails,
+    }
+
+    const result = Update.combine(model, [
+      stepModel => ({
+        model: evo(stepModel, {
+          remoteDataContext: () => succeeds,
+        }),
+      }),
+      foldContextualRemoteData(RemoteDataMessage.ClickedFetch()),
+    ])
+
+    expect(result.model.remoteData).toStrictEqual(
+      RemoteData.Ok({ data: 'Idle:ClickedFetch:payload:payload' }),
+    )
+  })
+
+  it('does not read context when the Machine state is absent', () => {
+    const model: ContextualAppModel = {
+      remoteData: RemoteData.Idle(),
+      remoteDataContext: succeeds,
+    }
+    const foldMissingRemoteData = fold({
+      machine: contextualRemoteDataMachine,
+      read: (_model: ContextualAppModel) => Option.none(),
+      write: (_model, _nextRemoteData) => {
+        throw new Error('write should not run')
+      },
+      context: () => {
+        throw new Error('context should not be read')
+      },
+    })
+
+    const result = foldMissingRemoteData(
+      model,
+      RemoteDataMessage.ClickedFetch(),
+    )
+
+    expect(result).toEqual({ model })
+  })
+
   it('adds context to unguarded Edge inputs only when declared', () => {
     const contextualResult = contextualRemoteDataMachine.transition(
       RemoteData.Error({ error: 'offline' }),
@@ -1837,6 +1941,151 @@ describe('integration', () => {
     expect(releaseUpdate.commands ?? []).toEqual([])
   })
 
+  it('folds data-last as a composable Step', () => {
+    const model: AppModel = {
+      connection: ConnectionState.Disconnected(),
+      isDebugPanelOpen: false,
+    }
+
+    const connect = foldConnection(ConnectionMessage.ClickedConnect())
+    const connectionUpdate = connect(model)
+
+    expectTypeOf(foldConnection).toEqualTypeOf<
+      Update.Fold<AppModel, ConnectionMessage, ConnectionMessage>
+    >()
+    expect(connectionUpdate.model.connection).toStrictEqual(
+      ConnectionState.Connecting({ attemptCount: 1 }),
+    )
+    expect(connectionUpdate.commands).toEqual([])
+  })
+
+  it('calls context-free transitions with two arguments', () => {
+    const transition = vi.fn(connectionMachine.transition)
+    const machine: Machine<ConnectionState, ConnectionMessage> = {
+      ...connectionMachine,
+      transition,
+    }
+    const foldConnectionWithSpy = fold({
+      machine,
+      read: (model: AppModel) => Option.some(model.connection),
+      write: (model, nextConnection) =>
+        evo(model, { connection: () => nextConnection }),
+    })
+    const model: AppModel = {
+      connection: ConnectionState.Disconnected(),
+      isDebugPanelOpen: false,
+    }
+    const message = ConnectionMessage.ClickedConnect()
+
+    foldConnectionWithSpy(model, message)
+
+    expect(transition).toHaveBeenCalledWith(model.connection, message)
+  })
+
+  it('returns the enclosing Model untouched when the Machine state is absent', () => {
+    const model: AppModel = {
+      connection: ConnectionState.Disconnected(),
+      isDebugPanelOpen: false,
+    }
+    const foldMissingConnection = fold({
+      machine: connectionMachine,
+      read: (_model: AppModel) => Option.none(),
+      write: (_model, _nextConnection) => {
+        throw new Error('write should not run')
+      },
+    })
+
+    const connectionUpdate = foldMissingConnection(
+      model,
+      ConnectionMessage.ClickedConnect(),
+    )
+
+    expect(connectionUpdate).toEqual({ model })
+  })
+
+  it('preserves Machine Commands without mapping them', () => {
+    const commands: Update.Commands<ConnectionMessage> = [
+      LogTransition({ description: 'Opened session session-1' }),
+    ]
+    const machine: Machine<ConnectionState, ConnectionMessage> = {
+      ...connectionMachine,
+      transition: state => ({ model: state, commands }),
+    }
+    const foldCommands = fold({
+      machine,
+      read: (model: AppModel) => Option.some(model.connection),
+      write: (model, nextConnection) =>
+        evo(model, { connection: () => nextConnection }),
+    })
+    const model: AppModel = {
+      connection: ConnectionState.Connecting({ attemptCount: 1 }),
+      isDebugPanelOpen: false,
+    }
+
+    const connectionUpdate = foldCommands(
+      model,
+      ConnectionMessage.SocketOpened({ sessionId: 'session-1' }),
+    )
+
+    expect(connectionUpdate.commands).toBe(commands)
+  })
+
+  it('omits Commands when the Machine ignores the Message', () => {
+    const model: AppModel = {
+      connection: ConnectionState.Disconnected(),
+      isDebugPanelOpen: false,
+    }
+
+    const connectionUpdate = foldConnection(
+      model,
+      ConnectionMessage.SocketOpened({ sessionId: 'session-1' }),
+    )
+
+    expect(connectionUpdate.model.connection).toBe(model.connection)
+    expect(Object.hasOwn(connectionUpdate, 'commands')).toBe(false)
+  })
+
+  it('requires context exactly when the Machine declares it', () => {
+    if (false) {
+      // @ts-expect-error a contextual Machine fold requires a context reader
+      fold({
+        machine: contextualRemoteDataMachine,
+        read: (model: ContextualAppModel) => Option.some(model.remoteData),
+        write: (model, nextRemoteData) =>
+          evo(model, { remoteData: () => nextRemoteData }),
+      })
+
+      fold({
+        machine: remoteDataMachine,
+        read: (model: ContextualAppModel) => Option.some(model.remoteData),
+        write: (model, nextRemoteData) =>
+          evo(model, { remoteData: () => nextRemoteData }),
+        // @ts-expect-error a context-free Machine fold rejects a context reader
+        context: model => model.remoteDataContext,
+      })
+
+      fold({
+        machine: contextualRemoteDataMachine,
+        read: (model: ContextualAppModel) => Option.some(model.remoteData),
+        write: (model, nextRemoteData) =>
+          evo(model, { remoteData: () => nextRemoteData }),
+        // @ts-expect-error the context reader must return RemoteDataContext
+        context: () => ({ shouldSucceed: true }),
+      })
+
+      fold({
+        machine: voidContextMachine,
+        read: (model: ContextualAppModel) => Option.some(model.remoteData),
+        write: (model, nextRemoteData) =>
+          evo(model, { remoteData: () => nextRemoteData }),
+        // @ts-expect-error Schema.Void context readers must return undefined
+        context: () => 'not void',
+      })
+    }
+
+    expect(true).toBe(true)
+  })
+
   it('wires the gating sketch records', () => {
     expect(Object.keys(managedResources)).toEqual(['socket'])
     expect(Object.keys(subscriptions)).toEqual(['backoffTimer'])
@@ -1844,6 +2093,23 @@ describe('integration', () => {
 })
 
 describe('edge command requirements', () => {
+  it('threads Machine requirements through its fold', () => {
+    const foldSubmit = fold({
+      machine: inferredRequirementsMachine,
+      read: (model: SubmitAppModel) => Option.some(model.submit),
+      write: (model, nextSubmit) => evo(model, { submit: () => nextSubmit }),
+    })
+    const submitClick = foldSubmit(
+      { submit: SubmitState.Idle() },
+      SubmitMessage.ClickedSubmit(),
+    )
+
+    expectTypeOf(submitClick).toEqualTypeOf<
+      Update.Return<SubmitAppModel, SubmitMessage, UploadsClient>
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
+  })
+
   it('threads a requirement inferred from a single edge command into R', () => {
     const submitClick = inferredRequirementsMachine.transition(
       SubmitState.Idle(),

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -1,5 +1,6 @@
 import {
   Array,
+  Function,
   HashSet,
   Match,
   Option,
@@ -494,10 +495,10 @@ export type Machine<
   edges: ReadonlyArray<EdgeSummary<State, Message>>
   /** Runs one Message through the Machine as a Foldkit update. The returned
    * `Update.Return<State, Message, R>` stores the next Machine state in
-   * `model` and any transition-time Commands in `commands`, so a context-free
-   * `transition` can be passed directly to `Update.foldChild`. Use a closure
-   * around a contextual `transition`. Use `step` when code needs to distinguish
-   * a `Transitioned` result from an `Ignored` result or inspect Edge metadata.
+   * `model` and any transition-time Commands in `commands`. Use {@link fold}
+   * to read and write the Machine state inside an enclosing Model. Use `step`
+   * when code needs to distinguish a `Transitioned` result from an `Ignored`
+   * result or inspect Edge metadata.
    */
   transition: (
     state: State,
@@ -545,6 +546,113 @@ export type Machine<
   ) => ReadonlyArray<DeadTransition<State, Message>>
   toMermaid: () => string
 }>
+
+type FoldContextField<ParentModel, Context> =
+  HasMachineContext<Context> extends true
+    ? Readonly<{
+        context: (
+          model: NoInfer<ParentModel>,
+        ) => NoInfer<MachineContextArgument<Context>>
+      }>
+    : Readonly<{ context?: never }>
+
+/** The capabilities needed to fold a Machine state field into its enclosing
+ * Model. `read` returns an `Option` because the field may be absent in the
+ * current Model variant; `write` replaces it after a transition. A contextual
+ * Machine also requires `context`, which reads the current context from the
+ * enclosing Model for each transition. */
+export type FoldConfig<
+  ParentModel,
+  State extends Tagged,
+  Message extends Tagged,
+  R = never,
+  Context = NoMachineContext,
+> = Readonly<{
+  machine: Machine<State, Message, R, Context>
+  read: (model: ParentModel) => Option.Option<State>
+  write: (model: ParentModel, nextState: State) => ParentModel
+}> &
+  FoldContextField<ParentModel, Context>
+
+type AnyFoldConfig = Readonly<{
+  machine: any
+  read: (model: any) => Option.Option<any>
+  write: (model: any, nextState: any) => any
+  context?: (model: any) => any
+}>
+
+const transitionFoldedMachine = (
+  config: AnyFoldConfig,
+  model: any,
+  state: any,
+  message: any,
+): Update.Return<any, any, any> => {
+  const readContext = config.context
+
+  if (readContext !== undefined) {
+    return config.machine.transition(state, message, readContext(model))
+  } else {
+    return config.machine.transition(state, message)
+  }
+}
+
+/** Folds a Machine state field into an enclosing Model. Any transition-time
+ * Commands pass through unchanged.
+ *
+ * When `read` returns `None`, the fold returns the original Model without
+ * running a transition. For a contextual Machine, `context` is read only when
+ * the Machine state is present and is supplied to that transition.
+ *
+ * ```ts
+ * const foldUpload = Machine.fold({
+ *   machine: uploadMachine,
+ *   read: (model: Model) => Option.some(model.upload),
+ *   write: (model, nextUpload) =>
+ *     evo(model, { upload: () => nextUpload }),
+ *   context: model => model.uploadQueues,
+ * })
+ *
+ * // Data-first in update
+ * foldUpload(model, message)
+ *
+ * // Data-last in a composed update
+ * Update.combine(model, [foldUpload(message), recordUploadAttempt])
+ * ```
+ *
+ * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
+ */
+export const fold: {
+  <
+    ParentModel,
+    State extends Tagged,
+    Message extends Tagged,
+    R = never,
+    Context = NoMachineContext,
+  >(
+    config: FoldConfig<ParentModel, State, Message, R, Context>,
+  ): Update.Fold<ParentModel, Message, Message, R>
+} = (config: AnyFoldConfig) =>
+  Function.dual(2, (model: any, message: any) => {
+    const maybeState = config.read(model)
+
+    if (Option.isNone(maybeState)) {
+      return { model }
+    }
+
+    const transition = transitionFoldedMachine(
+      config,
+      model,
+      maybeState.value,
+      message,
+    )
+    const nextModel = config.write(model, transition.model)
+
+    if (transition.commands === undefined) {
+      return { model: nextModel }
+    } else {
+      return { model: nextModel, commands: transition.commands }
+    }
+  })
 
 /**
  * The Schemas a Machine is defined over: the state union and the Message
@@ -693,11 +801,9 @@ const flattenUnionMembers = (
  *
  * The Machine is not a runtime: `transition` returns an `Update.Return`, so the
  * Machine state lives in the Model and the Foldkit runtime never learns the
- * Machine exists. A context-free `transition` has the same shape as a Foldkit
- * `update` branch and can be passed directly to `Update.foldChild`. A
- * contextual Machine needs a closure that reads its context from the parent
- * Model. Messages that match no Edge leave the state unchanged; use `step`
- * when the `Ignored` outcome should be observable.
+ * Machine exists. Use {@link fold} to read and write a Machine state field in
+ * an enclosing Model. Messages that match no Edge leave the state unchanged;
+ * use `step` when the `Ignored` outcome should be observable.
  *
  * Declare a `context` Schema when transitions need a read-only view of data
  * outside the Machine state. The context is passed to guards and Edge handlers


### PR DESCRIPTION
Add `Machine.fold` for folding a Machine state field into its enclosing Model in either data-first form or as an `Update.Step`.

Read contextual data from the current parent Model for each transition and pass Machine Commands through unchanged.

Closes #1192.