### PR TITLE
feat(foldkit): export Machine StateTransitions type

### DIFF
--- a/.changeset/machine-state-transitions.md
+++ b/.changeset/machine-state-transitions.md
@@ -1,0 +1,5 @@
+---
+'foldkit': minor
+---
+
+Export `Machine.StateTransitions` for typing an extracted state entry while preserving its Edge state and Message narrowing.

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -18,6 +18,7 @@ import * as Update from '../../update/index.js'
 import {
   type EdgeInput,
   type Machine,
+  type StateTransitions,
   type TransitionTable,
   define,
   otherwise,
@@ -1718,6 +1719,40 @@ describe('state tag extraction', () => {
 })
 
 describe('type-level guarantees', () => {
+  it('preserves narrowing in an extracted state entry', () => {
+    const loadingTransitions: StateTransitions<
+      RemoteData,
+      RemoteDataMessage,
+      'Loading'
+    > = {
+      on: {
+        SucceededFetch: to('Ok', ({ state, message }) => {
+          expectTypeOf(state).toEqualTypeOf<typeof RemoteData.Loading.Type>()
+          expectTypeOf(message).toEqualTypeOf<
+            typeof RemoteDataMessage.SucceededFetch.Type
+          >()
+
+          return { model: RemoteData.Ok({ data: message.data }) }
+        }),
+      },
+    }
+
+    const machine = define({
+      state: RemoteData,
+      message: RemoteDataMessage,
+    })({
+      initial: RemoteData.Loading(),
+      states: { Loading: loadingTransitions },
+    })
+
+    const result = machine.transition(
+      RemoteData.Loading(),
+      RemoteDataMessage.SucceededFetch({ data: 'ready' }),
+    )
+
+    expect(result.model).toStrictEqual(RemoteData.Ok({ data: 'ready' }))
+  })
+
   it('narrows state and message to the table position without annotations', () => {
     const socketError = narrowingMachine.transition(
       ConnectionState.Connecting({ attemptCount: 0 }),

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -215,6 +215,20 @@ export type TransitionTable<
   }>
 }>
 
+/** The transition table entry for one source state. Use this alias when
+ * extracting an entry from a Machine's `states` record to preserve the source
+ * state and triggering Message narrowing inside its Edges.
+ *
+ * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
+ */
+export type StateTransitions<
+  State extends Tagged,
+  Message extends Tagged,
+  SourceTag extends TagOf<State>,
+  R = never,
+  Context = NoMachineContext,
+> = NonNullable<TransitionTable<State, Message, R, Context>[SourceTag]>
+
 const makeEdge = <
   State extends Tagged,
   Message extends Tagged,


### PR DESCRIPTION
Export `Machine.StateTransitions` for typing a single extracted state entry while preserving source-state and trigger-Message narrowing in its Edge handlers.

Carry the Machine Command requirements and Context through the alias.

Closes #707.