### PR TITLE
feat(foldkit)!: add explicit Machine ignore

### DIFF
--- a/.changeset/machine-explicit-ignore.md
+++ b/.changeset/machine-explicit-ignore.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+Add `Machine.ignore()` for explicitly declaring that a guard list should ignore its Message when every preceding `when` guard declines. `Machine.step` reports this outcome as `ExplicitlyIgnored`, and static analysis reports later Edges as `ShadowedByIgnore`.
+
+This adds an `Ignore` variant to `Machine.GuardedEdge` and variants to `Machine.IgnoredReason` and `Machine.DeadTransitionReason`. Update exhaustive matches over those unions to handle `Ignore`, `ExplicitlyIgnored`, and `ShadowedByIgnore`.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.18.16",
+  "version": "0.18.17",
   "description": "Skills for building Foldkit apps \u2014 app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -21,6 +21,7 @@ import {
   type TransitionTable,
   define,
   fold,
+  ignore,
   otherwise,
   to,
   when,
@@ -447,6 +448,32 @@ const booleanGuardMachine = define({
   },
 })
 
+const explicitIgnoreMachine = define({
+  state: ConnectionState,
+  message: ConnectionMessage,
+})({
+  initial: ConnectionState.Disconnected(),
+  states: {
+    Connecting: {
+      on: {
+        SocketErrored: [
+          when(
+            state => state.attemptCount < MAX_CONNECT_ATTEMPTS,
+            'Reconnecting',
+            ({ state }) => ({
+              model: ConnectionState.Reconnecting({
+                attemptCount: state.attemptCount,
+                delayMillis: backoffDelayMillis(state.attemptCount),
+              }),
+            }),
+          ),
+          ignore(),
+        ],
+      },
+    },
+  },
+})
+
 const RemoteDataContext = Schema.Struct({
   shouldSucceed: Schema.Boolean,
   data: Schema.String,
@@ -708,6 +735,41 @@ const shadowedGuardMachine = define({
             () => ({ model: RemoteData.Ok({ data: 'unreachable' }) }),
           ),
         ],
+      },
+    },
+  },
+})
+
+const shadowedByIgnoreMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: [
+          ignore(),
+          when(
+            () => true,
+            'Loading',
+            () => ({ model: RemoteData.Loading() }),
+          ),
+        ],
+      },
+    },
+  },
+})
+
+const ignoreOnlyMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: RemoteData.Idle(),
+  states: {
+    Idle: {
+      on: {
+        ClickedFetch: [ignore()],
       },
     },
   },
@@ -1406,6 +1468,58 @@ describe('guard lists', () => {
     )
     expect(declinedSocketError).toEqual({ model: atLimit })
   })
+
+  it('distinguishes an explicit ignore from guard fallthrough', () => {
+    const belowLimitSocketError = explicitIgnoreMachine.transition(
+      ConnectionState.Connecting({ attemptCount: 2 }),
+      ConnectionMessage.SocketErrored({ reason: 'boom' }),
+    )
+    expect(belowLimitSocketError.model).toStrictEqual(
+      ConnectionState.Reconnecting({ attemptCount: 2, delayMillis: 500 }),
+    )
+
+    const atLimit = ConnectionState.Connecting({
+      attemptCount: MAX_CONNECT_ATTEMPTS,
+    })
+
+    const result = explicitIgnoreMachine.step(
+      atLimit,
+      ConnectionMessage.SocketErrored({ reason: 'boom' }),
+    )
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Connecting',
+      messageTag: 'SocketErrored',
+      state: atLimit,
+      reason: 'ExplicitlyIgnored',
+    })
+
+    expect(
+      explicitIgnoreMachine.transition(
+        atLimit,
+        ConnectionMessage.SocketErrored({ reason: 'boom' }),
+      ),
+    ).toEqual({ model: atLimit })
+  })
+
+  it('supports an explicit ignore as the only guard-list entry', () => {
+    const initial = RemoteData.Idle()
+    const message = RemoteDataMessage.ClickedFetch()
+
+    expect(ignoreOnlyMachine.step(initial, message)).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Idle',
+      messageTag: 'ClickedFetch',
+      state: initial,
+      reason: 'ExplicitlyIgnored',
+    })
+    expect(ignoreOnlyMachine.transition(initial, message)).toEqual({
+      model: initial,
+    })
+    expect(ignoreOnlyMachine.edges).toEqual([])
+    expect(ignoreOnlyMachine.reachableFrom('Idle')).toEqual(new Set(['Idle']))
+    expect(ignoreOnlyMachine.deadTransitions()).toEqual([])
+  })
 })
 
 describe('context', () => {
@@ -1872,6 +1986,35 @@ describe('type-level guarantees', () => {
       new Set(['Idle', 'Loading']),
     )
     expect(shadowedGuardMachine.unreachableStates()).toEqual(['Error', 'Ok'])
+  })
+
+  it('reports and excludes Edges listed after an explicit ignore', () => {
+    const result = shadowedByIgnoreMachine.step(
+      RemoteData.Idle(),
+      RemoteDataMessage.ClickedFetch(),
+    )
+
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Idle',
+      messageTag: 'ClickedFetch',
+      state: RemoteData.Idle(),
+      reason: 'ExplicitlyIgnored',
+    })
+    expect(shadowedByIgnoreMachine.reachableFrom('Idle')).toEqual(
+      new Set(['Idle']),
+    )
+    expect(shadowedByIgnoreMachine.deadTransitions()).toEqual([
+      {
+        edge: {
+          from: 'Idle',
+          messageTag: 'ClickedFetch',
+          target: 'Loading',
+          guard: { _tag: 'When', position: 1 },
+        },
+        reason: 'ShadowedByIgnore',
+      },
+    ])
   })
 
   it('reports a shadowed edge under an unreachable source once', () => {

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -156,7 +156,11 @@ export type Otherwise<
   edge: Edge<State, Message, SourceState, TriggerMessage, void, R, Context>
 }>
 
-/** One entry in an ordered guard list: a {@link When} or the {@link Otherwise} fallback. */
+/** An explicit no-transition fallback at the end of a guard list. Construct with {@link ignore}. */
+export type Ignore = Readonly<{ _tag: 'Ignore' }>
+
+/** One entry in an ordered guard list: a {@link When}, the {@link Otherwise}
+ * transition fallback, or the {@link Ignore} no-transition fallback. */
 export type GuardedEdge<
   State extends Tagged,
   Message extends Tagged,
@@ -167,6 +171,7 @@ export type GuardedEdge<
 > =
   | When<State, Message, SourceState, TriggerMessage, unknown, R, Context>
   | Otherwise<State, Message, SourceState, TriggerMessage, R, Context>
+  | Ignore
 
 type OptionValue<MaybeValue> =
   MaybeValue extends Option.Option<infer Value> ? Value : never
@@ -391,6 +396,16 @@ export const otherwise = <
   edge,
 })
 
+/**
+ * Declares that a Message is intentionally ignored when every preceding
+ * {@link when} guard declines. Evaluation stops at this fallback, and
+ * {@link Machine.step} reports `ExplicitlyIgnored`. Edges listed after it are
+ * reported by {@link Machine.deadTransitions} as `ShadowedByIgnore`.
+ *
+ * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
+ */
+export const ignore = (): Ignore => ({ _tag: 'Ignore' })
+
 // RESULT
 
 /** A step that matched an Edge: the next state plus any transition-time Commands. */
@@ -414,14 +429,16 @@ export type Transitioned<
  * alphabet, but no Edge for it exists from the current state, whether the
  * state is absent from the table or its `on` record lacks the tag.
  * `GuardsFellThrough` means an Edge entry exists for this state and Message,
- * but every guard declined and no {@link otherwise} fallback was present.
+ * but every guard declined and no {@link otherwise} or {@link ignore} fallback
+ * was present.
+ * `ExplicitlyIgnored` means evaluation reached an {@link ignore} fallback.
  */
 export type IgnoredReason =
-  'OutOfAlphabet' | 'NotApplicable' | 'GuardsFellThrough'
+  'OutOfAlphabet' | 'NotApplicable' | 'GuardsFellThrough' | 'ExplicitlyIgnored'
 
 /**
  * A step that matched no Edge: the state is unchanged and the Message is
- * observable as ignored. `reason` distinguishes the three causes, described
+ * observable as ignored. `reason` distinguishes the four causes, described
  * on {@link IgnoredReason}.
  */
 export type Ignored<State extends Tagged, Message extends Tagged> = Readonly<{
@@ -465,9 +482,11 @@ export type EdgeSummary<
  * Why an Edge cannot fire in a walk of the declared Edge set:
  * `UnreachableSource` means no path from the walk roots reaches the Edge's
  * source state, and `ShadowedByOtherwise` means an earlier `otherwise` in the
- * Edge's guard list always fires first.
+ * Edge's guard list always fires first. `ShadowedByIgnore` means an earlier
+ * {@link ignore} stops evaluation first.
  */
-export type DeadTransitionReason = 'UnreachableSource' | 'ShadowedByOtherwise'
+export type DeadTransitionReason =
+  'UnreachableSource' | 'ShadowedByOtherwise' | 'ShadowedByIgnore'
 
 /** An Edge that cannot fire in a walk of the declared Edge set, with the reason. */
 export type DeadTransition<
@@ -512,20 +531,20 @@ export type Machine<
   ) => TransitionResult<State, Message, R>
   /**
    * The state tags a walk of the statically selectable declared Edges visits
-   * starting from `tag`. Edges listed after an `otherwise` are excluded because
-   * the runtime can never select them.
+   * starting from `tag`. Edges listed after an `otherwise` or {@link ignore}
+   * are excluded because the runtime can never select them.
    */
   reachableFrom: (tag: TagOf<State>) => ReadonlySet<TagOf<State>>
   /**
    * The state tags a walk of the statically selectable declared Edges never
    * visits, starting from the initial state's tag plus `extraRoots`. Edges
-   * listed after an `otherwise` are excluded because the runtime can never
-   * select them. The walk sees only declared Edges, so state changes made
-   * outside `transition` and `step` are invisible to it, and it always starts
-   * at `initial`. Entry points other than `initial`, such as restored
-   * persistence, deep links, or SSR hydration, must be passed as `extraRoots`,
-   * or the states they enter are reported unreachable even though the running
-   * program visits them.
+   * listed after an `otherwise` or {@link ignore} are excluded because the
+   * runtime can never select them. The walk sees only declared Edges, so state
+   * changes made outside `transition` and `step` are invisible to it, and it
+   * always starts at `initial`. Entry points other than `initial`, such as
+   * restored persistence, deep links, or SSR hydration, must be passed as
+   * `extraRoots`, or the states they enter are reported unreachable even
+   * though the running program visits them.
    */
   unreachableStates: (
     extraRoots?: ReadonlyArray<TagOf<State>>,
@@ -534,12 +553,12 @@ export type Machine<
    * The Edges that cannot fire in a walk of the declared Edge set starting
    * from the initial state's tag plus `extraRoots`, each with its
    * {@link DeadTransitionReason}. Each Edge appears at most once;
-   * `ShadowedByOtherwise` takes precedence when its source is also
-   * unreachable. The same assumptions as `unreachableStates` apply: the walk
-   * cannot see state changes made outside `transition` and `step`, and entry
-   * points other than `initial` must be passed as `extraRoots`, or their
-   * outgoing Edges are reported as `UnreachableSource` even though the running
-   * program fires them.
+   * `ShadowedByOtherwise` and `ShadowedByIgnore` take precedence when a source
+   * is also unreachable. The same assumptions as `unreachableStates` apply:
+   * the walk cannot see state changes made outside `transition` and `step`,
+   * and entry points other than `initial` must be passed as `extraRoots`, or
+   * their outgoing Edges are reported as `UnreachableSource` even though the
+   * running program fires them.
    */
   deadTransitions: (
     extraRoots?: ReadonlyArray<TagOf<State>>,
@@ -725,11 +744,26 @@ type LooseGuardedEdge<State extends Tagged, Message extends Tagged, R> =
       _tag: 'Otherwise'
       edge: LooseEdge<State, Message, R>
     }>
+  | Ignore
 
 type SelectedEdge<State extends Tagged, Message extends Tagged, R> = Readonly<{
+  _tag: 'SelectedEdge'
   edge: LooseEdge<State, Message, R>
   guardValue: unknown
 }>
+
+type GuardListIgnoredReason = Extract<
+  IgnoredReason,
+  'GuardsFellThrough' | 'ExplicitlyIgnored'
+>
+
+type IgnoredEdge = Readonly<{
+  _tag: 'IgnoredEdge'
+  reason: GuardListIgnoredReason
+}>
+
+type EdgeSelection<State extends Tagged, Message extends Tagged, R> =
+  SelectedEdge<State, Message, R> | IgnoredEdge
 
 type LooseTable<State extends Tagged, Message extends Tagged, R> = Readonly<
   Record<
@@ -927,16 +961,32 @@ function defineImplementation<
         | ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
     ): ReadonlyArray<EdgeSummary<State, Message>> =>
       isGuardList(edgeOrGuardedEdges)
-        ? Array.map(edgeOrGuardedEdges, (guardedEdge, position) =>
-            guardedEdge._tag === 'When'
-              ? makeEdgeSummary(from, messageTag, guardedEdge.edge.target, {
-                  _tag: 'When',
-                  position,
-                })
-              : makeEdgeSummary(from, messageTag, guardedEdge.edge.target, {
-                  _tag: 'Otherwise',
-                  position,
-                }),
+        ? Array.flatMap(edgeOrGuardedEdges, (guardedEdge, position) =>
+            Match.value(guardedEdge).pipe(
+              Match.withReturnType<
+                ReadonlyArray<EdgeSummary<State, Message>>
+              >(),
+              Match.tagsExhaustive({
+                When: guardedWhen => [
+                  makeEdgeSummary(from, messageTag, guardedWhen.edge.target, {
+                    _tag: 'When',
+                    position,
+                  }),
+                ],
+                Otherwise: guardedOtherwise => [
+                  makeEdgeSummary(
+                    from,
+                    messageTag,
+                    guardedOtherwise.edge.target,
+                    {
+                      _tag: 'Otherwise',
+                      position,
+                    },
+                  ),
+                ],
+                Ignore: () => [],
+              }),
+            ),
           )
         : [
             makeEdgeSummary(from, messageTag, edgeOrGuardedEdges.target, {
@@ -983,33 +1033,45 @@ function defineImplementation<
       state: State,
       message: Message,
       context?: Context,
-    ): Option.Option<SelectedEdge<State, Message, R>> =>
+    ): EdgeSelection<State, Message, R> =>
       Array.matchLeft(guardedEdges, {
-        onEmpty: () => Option.none(),
-        onNonEmpty: (guardedEdge, rest) => {
-          if (guardedEdge._tag === 'When') {
-            const maybeGuardValue = runGuard(
-              guardedEdge,
-              state,
-              message,
-              context,
-            )
+        onEmpty: () => ({
+          _tag: 'IgnoredEdge',
+          reason: 'GuardsFellThrough',
+        }),
+        onNonEmpty: (guardedEdge, rest) =>
+          Match.value(guardedEdge).pipe(
+            Match.withReturnType<EdgeSelection<State, Message, R>>(),
+            Match.tagsExhaustive({
+              When: guardedWhen => {
+                const maybeGuardValue = runGuard(
+                  guardedWhen,
+                  state,
+                  message,
+                  context,
+                )
 
-            if (Option.isSome(maybeGuardValue)) {
-              return Option.some({
-                edge: guardedEdge.edge,
-                guardValue: maybeGuardValue.value,
-              })
-            } else {
-              return selectFromGuardList(rest, state, message, context)
-            }
-          } else {
-            return Option.some({
-              edge: guardedEdge.edge,
-              guardValue: undefined,
-            })
-          }
-        },
+                if (Option.isSome(maybeGuardValue)) {
+                  return {
+                    _tag: 'SelectedEdge',
+                    edge: guardedWhen.edge,
+                    guardValue: maybeGuardValue.value,
+                  }
+                } else {
+                  return selectFromGuardList(rest, state, message, context)
+                }
+              },
+              Otherwise: guardedOtherwise => ({
+                _tag: 'SelectedEdge',
+                edge: guardedOtherwise.edge,
+                guardValue: undefined,
+              }),
+              Ignore: () => ({
+                _tag: 'IgnoredEdge',
+                reason: 'ExplicitlyIgnored',
+              }),
+            }),
+          ),
       })
 
     const chooseEdge = (
@@ -1019,10 +1081,14 @@ function defineImplementation<
       state: State,
       message: Message,
       context?: Context,
-    ): Option.Option<SelectedEdge<State, Message, R>> =>
+    ): EdgeSelection<State, Message, R> =>
       isGuardList(edgeOrGuardedEdges)
         ? selectFromGuardList(edgeOrGuardedEdges, state, message, context)
-        : Option.some({ edge: edgeOrGuardedEdges, guardValue: undefined })
+        : {
+            _tag: 'SelectedEdge',
+            edge: edgeOrGuardedEdges,
+            guardValue: undefined,
+          }
 
     const makeRuntimeEdgeInput = (
       state: State,
@@ -1093,15 +1159,24 @@ function defineImplementation<
                 ? 'NotApplicable'
                 : 'OutOfAlphabet',
             ),
-          onSome: edgeOrGuardedEdges =>
-            Option.match(
-              chooseEdge(edgeOrGuardedEdges, state, message, context),
-              {
-                onNone: () => makeIgnored(state, message, 'GuardsFellThrough'),
-                onSome: selectedEdge =>
+          onSome: edgeOrGuardedEdges => {
+            const selection = chooseEdge(
+              edgeOrGuardedEdges,
+              state,
+              message,
+              context,
+            )
+
+            return Match.value(selection).pipe(
+              Match.withReturnType<TransitionResult<State, Message, R>>(),
+              Match.tagsExhaustive({
+                SelectedEdge: selectedEdge =>
                   makeTransitioned(state, message, selectedEdge, context),
-              },
-            ),
+                IgnoredEdge: ignoredEdge =>
+                  makeIgnored(state, message, ignoredEdge.reason),
+              }),
+            )
+          },
         }),
       )
     }
@@ -1113,22 +1188,59 @@ function defineImplementation<
     ): Update.Return<State, Message, R> => {
       const result = step(state, message, ...contextArguments)
 
-      if (result._tag === 'Transitioned') {
-        return { model: result.state, commands: result.commands }
-      } else {
-        return { model: result.state }
-      }
+      return Match.value(result).pipe(
+        Match.withReturnType<Update.Return<State, Message, R>>(),
+        Match.tagsExhaustive({
+          Transitioned: transitioned => ({
+            model: transitioned.state,
+            commands: transitioned.commands,
+          }),
+          Ignored: ignored => ({ model: ignored.state }),
+        }),
+      )
     }
+
+    const makeDeadTransition = (
+      edge: EdgeSummary<State, Message>,
+      reason: DeadTransitionReason,
+    ): DeadTransition<State, Message> => ({ edge, reason })
 
     type EdgeGroup = ReadonlyArray<EdgeSummary<State, Message>>
     type PositionedEdgeGuard = Exclude<
       EdgeGuard,
       Readonly<{ _tag: 'Unguarded' }>
     >
+    type LooseGuardListFallback = Exclude<
+      LooseGuardedEdge<State, Message, R>,
+      Readonly<{ _tag: 'When' }>
+    >
+    type ShadowingReason = Extract<
+      DeadTransitionReason,
+      'ShadowedByOtherwise' | 'ShadowedByIgnore'
+    >
+    type GuardListFallback = Readonly<{
+      position: number
+      reason: ShadowingReason
+    }>
 
     const isPositionedEdgeGuard = (
       guard: EdgeGuard,
     ): guard is PositionedEdgeGuard => guard._tag !== 'Unguarded'
+
+    const isGuardListFallback = (
+      guardedEdge: LooseGuardedEdge<State, Message, R>,
+    ): guardedEdge is LooseGuardListFallback => guardedEdge._tag !== 'When'
+
+    const fallbackToShadowingReason = (
+      fallback: LooseGuardListFallback,
+    ): ShadowingReason =>
+      Match.value(fallback).pipe(
+        Match.withReturnType<ShadowingReason>(),
+        Match.tagsExhaustive({
+          Otherwise: () => 'ShadowedByOtherwise',
+          Ignore: () => 'ShadowedByIgnore',
+        }),
+      )
 
     const maybeGuardPosition = (
       edgeSummary: EdgeSummary<State, Message>,
@@ -1161,15 +1273,54 @@ function defineImplementation<
         ),
       )
 
-    const shadowedEdgesInGroup = (edgeGroup: EdgeGroup): EdgeGroup =>
+    const guardListAt = (
+      from: TagOf<State>,
+      messageTag: TagOf<Message>,
+    ): Option.Option<ReadonlyArray<LooseGuardedEdge<State, Message, R>>> =>
+      pipe(
+        Record.get(looseStates, from),
+        Option.flatMap(stateEntry => Record.get(stateEntry.on, messageTag)),
+        Option.flatMap(Option.liftPredicate(isGuardList)),
+      )
+
+    const firstGuardListFallback = (
+      guardedEdges: ReadonlyArray<LooseGuardedEdge<State, Message, R>>,
+    ): Option.Option<GuardListFallback> =>
+      pipe(
+        guardedEdges,
+        Array.findFirstWithIndex(isGuardListFallback),
+        Option.map(([fallback, position]) => ({
+          position,
+          reason: fallbackToShadowingReason(fallback),
+        })),
+      )
+
+    const firstFallbackInEdgeGroup = (
+      edgeGroup: EdgeGroup,
+    ): Option.Option<GuardListFallback> =>
       pipe(
         edgeGroup,
-        Array.findFirst(edgeSummary => edgeSummary.guard._tag === 'Otherwise'),
-        Option.flatMap(maybeGuardPosition),
+        Array.head,
+        Option.flatMap(edgeSummary =>
+          guardListAt(edgeSummary.from, edgeSummary.messageTag),
+        ),
+        Option.flatMap(firstGuardListFallback),
+      )
+
+    const shadowedTransitionsInGroup = (
+      edgeGroup: EdgeGroup,
+    ): ReadonlyArray<DeadTransition<State, Message>> =>
+      pipe(
+        firstFallbackInEdgeGroup(edgeGroup),
         Option.match({
           onNone: () => [],
-          onSome: otherwisePosition =>
-            edgesAfterGuardPosition(edgeGroup, otherwisePosition),
+          onSome: fallback =>
+            pipe(
+              edgesAfterGuardPosition(edgeGroup, fallback.position),
+              Array.map(edgeSummary =>
+                makeDeadTransition(edgeSummary, fallback.reason),
+              ),
+            ),
         }),
       )
 
@@ -1182,12 +1333,14 @@ function defineImplementation<
       Array.flatMap(groupEdgesByMessageTag),
     )
 
-    const shadowedEdges: ReadonlyArray<EdgeSummary<State, Message>> = pipe(
-      edgeGroups,
-      Array.flatMap(shadowedEdgesInGroup),
-    )
+    const shadowedTransitions: ReadonlyArray<DeadTransition<State, Message>> =
+      pipe(edgeGroups, Array.flatMap(shadowedTransitionsInGroup))
 
-    const shadowedEdgeSet = HashSet.fromIterable(shadowedEdges)
+    const shadowedEdgeSet = pipe(
+      shadowedTransitions,
+      Array.map(shadowedTransition => shadowedTransition.edge),
+      HashSet.fromIterable,
+    )
 
     const selectableEdges = Array.filter(
       edges,
@@ -1232,11 +1385,6 @@ function defineImplementation<
       return Array.filter(stateTags, stateTag => !reachable.has(stateTag))
     }
 
-    const makeDeadTransition = (
-      edge: EdgeSummary<State, Message>,
-      reason: DeadTransitionReason,
-    ): DeadTransition<State, Message> => ({ edge, reason })
-
     const deadTransitions = (
       extraRoots: ReadonlyArray<TagOf<State>> = [],
     ): ReadonlyArray<DeadTransition<State, Message>> => {
@@ -1250,12 +1398,7 @@ function defineImplementation<
         ),
       )
 
-      return Array.flatten([
-        unreachableSourceEdges,
-        Array.map(shadowedEdges, edgeSummary =>
-          makeDeadTransition(edgeSummary, 'ShadowedByOtherwise'),
-        ),
-      ])
+      return Array.flatten([unreachableSourceEdges, shadowedTransitions])
     }
 
     const toMermaid = (): string => {

--- a/skills/generate-program/blindSpots.md
+++ b/skills/generate-program/blindSpots.md
@@ -22,11 +22,13 @@ Skip, reset, cancel, undo. Trace what each does to counters and derived state. D
 
 For every discriminated-union state: can the code transition INTO every state? OUT of every state? Are there dead states (created, never entered)? States that should be reachable but aren't?
 
-When the answer takes real tracing, that is the signal to reach for `Machine` (`foldkit/experimental`, with `to` / `when` / `otherwise` from `foldkit/experimental/machine`). Writing the transitions as a table makes the edge set enumerable data instead of control flow spread across update handlers, and the Machine then answers this blind spot by computation rather than by reading:
+When the answer takes real tracing, that is the signal to reach for `Machine` (`foldkit/experimental`, with `to` / `when` / `otherwise` / `ignore` from `foldkit/experimental/machine`). Writing the transitions as a table makes the edge set enumerable data instead of control flow spread across update handlers, and the Machine then answers this blind spot by computation rather than by reading:
 
 - `unreachableStates(extraRoots?)` returns the state tags the declared Edge set does not reach from `initial` plus any extra roots.
-- `deadTransitions(extraRoots?)` reports Edges whose source that same walk does not reach, tagged `UnreachableSource`, plus Edges shadowed by an earlier `otherwise`, tagged `ShadowedByOtherwise`.
+- `deadTransitions(extraRoots?)` reports Edges whose source that same walk does not reach, tagged `UnreachableSource`, plus Edges shadowed by an earlier `otherwise` or `ignore()`, tagged `ShadowedByOtherwise` or `ShadowedByIgnore`.
 - `reachableFrom(tag)` gives the closure from any state, and `toMermaid()` renders the diagram for review.
+
+Use `ignore()` as the final entry in an ordered guard list when the Message should intentionally produce no transition after every preceding `when` guard declines. `step()` then reports `ExplicitlyIgnored`, which keeps that deliberate outcome distinct from an accidental guard fallthrough.
 
 The walk cannot see state changes made outside `transition` and `step`. Pass every restored, deep-linked, hydrated, or otherwise externally entered state as an extra root before treating `UnreachableSource` findings as application defects.
 


### PR DESCRIPTION
Add `Machine.ignore()` as an explicit no-transition fallback for ordered guard lists without introducing the parallel `decide` / `go` transition form considered in #1071. The reported Machine tables do not show enough repeated multi-arm derivation to justify a second transition language.

When reached, `step` reports `ExplicitlyIgnored`. Edges declared after the fallback are excluded from reachability and reported as `ShadowedByIgnore`.

This expands `Machine.GuardedEdge`, `Machine.IgnoredReason`, and `Machine.DeadTransitionReason`. Update exhaustive matches over those unions for `Ignore`, `ExplicitlyIgnored`, and `ShadowedByIgnore`.

Refresh the shipped program-generation guidance for the new fallback and analysis result.

Closes #1071.