### PR TITLE
fix(release): wait 15 minutes for npm to expose a published version

### DIFF
--- a/scripts/lib/coherent-release.mjs
+++ b/scripts/lib/coherent-release.mjs
@@ -23,7 +23,7 @@ export const REGISTRY = 'https://registry.npmjs.org'
 export const uploadTag = (channel, commit) =>
   `foldkit-${channel}-upload-${commit.slice(0, 12)}`
 
-const REGISTRY_ATTEMPTS = 30
+const REGISTRY_ATTEMPTS = 90
 const REGISTRY_DELAY_MILLISECONDS = 10_000
 const REGISTRY_REQUEST_TIMEOUT_MILLISECONDS = 30_000
 const FULL_GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/


### PR DESCRIPTION
The Release workflow's canary job failed four times on main between Aug 27 and Sep 4, each time in `waitForArtifact` with "registry did not expose <package>@<version> after publication". In every run `npm publish` had succeeded and npm answered "Your package is being processed and may take a few minutes to become available", but the script polled 30 times at 10 second intervals, about five minutes, and gave up. All four versions are on the registry now, at five to six minutes after publication by the registry's own timestamps.

Raise `REGISTRY_ATTEMPTS` from 30 to 90, which at the unchanged 10 second interval gives each wait about 15 minutes. The constant is the shared default for both registry waits, so the tagged-snapshot check after a promotion gets the same budget.