### PR TITLE
feat(foldkit): share Machine transitions across states

### DIFF
--- a/.changeset/machine-shared-transitions.md
+++ b/.changeset/machine-shared-transitions.md
@@ -1,0 +1,7 @@
+---
+'foldkit': minor
+---
+
+Add `Machine.forStates(...).on(...)` and the Machine definition's `shared` array for declaring one transition map across several source states.
+
+Shared handlers narrow `state` to the selected state variants and `message` to each transition's Message. State-local transitions replace shared defaults for the same state and Message, while overlapping shared declarations throw when the Machine is defined. Shared transitions are expanded into the Machine's ordinary Edge set before runtime dispatch and static analysis.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foldkit-skills",
-  "version": "0.18.17",
+  "version": "0.18.18",
   "description": "Skills for building Foldkit apps \u2014 app generator, message scaffolding, submodel extraction, and architecture auditing",
   "skills": [
     "./skills/foldkit/",

--- a/examples/state-machine/src/main.ts
+++ b/examples/state-machine/src/main.ts
@@ -161,6 +161,22 @@ export const checkoutMachine = Machine.define({
   message: Message,
 })({
   initial: CheckoutState.Cart({ isShippingRequired: true }),
+  shared: [
+    Machine.forStates(['Cart', 'Shipping', 'Payment', 'Review']).on({
+      ClickedCancel: to('Cancelled', ({ state }) => ({
+        model: CheckoutState.Cancelled({
+          isShippingRequired: state.isShippingRequired,
+        }),
+      })),
+    }),
+    Machine.forStates(['Confirmed', 'Cancelled']).on({
+      ClickedStartOver: to('Cart', ({ state }) => ({
+        model: CheckoutState.Cart({
+          isShippingRequired: state.isShippingRequired,
+        }),
+      })),
+    }),
+  ],
   states: {
     Cart: {
       on: {
@@ -188,11 +204,6 @@ export const checkoutMachine = Machine.define({
             })),
           ),
         ],
-        ClickedCancel: to('Cancelled', ({ state }) => ({
-          model: CheckoutState.Cancelled({
-            isShippingRequired: state.isShippingRequired,
-          }),
-        })),
       },
     },
     Shipping: {
@@ -205,11 +216,6 @@ export const checkoutMachine = Machine.define({
         })),
         ClickedBack: to('Cart', ({ state }) => ({
           model: CheckoutState.Cart({
-            isShippingRequired: state.isShippingRequired,
-          }),
-        })),
-        ClickedCancel: to('Cancelled', ({ state }) => ({
-          model: CheckoutState.Cancelled({
             isShippingRequired: state.isShippingRequired,
           }),
         })),
@@ -249,11 +255,6 @@ export const checkoutMachine = Machine.define({
             })),
           ),
         ],
-        ClickedCancel: to('Cancelled', ({ state }) => ({
-          model: CheckoutState.Cancelled({
-            isShippingRequired: state.isShippingRequired,
-          }),
-        })),
       },
     },
     Review: {
@@ -308,11 +309,6 @@ export const checkoutMachine = Machine.define({
             isShippingRequired: state.isShippingRequired,
           }),
         })),
-        ClickedCancel: to('Cancelled', ({ state }) => ({
-          model: CheckoutState.Cancelled({
-            isShippingRequired: state.isShippingRequired,
-          }),
-        })),
       },
     },
     Placing: {
@@ -322,24 +318,6 @@ export const checkoutMachine = Machine.define({
             isShippingRequired: state.isShippingRequired,
             maybeDiscount: state.maybeDiscount,
             orderId: message.orderId,
-          }),
-        })),
-      },
-    },
-    Confirmed: {
-      on: {
-        ClickedStartOver: to('Cart', ({ state }) => ({
-          model: CheckoutState.Cart({
-            isShippingRequired: state.isShippingRequired,
-          }),
-        })),
-      },
-    },
-    Cancelled: {
-      on: {
-        ClickedStartOver: to('Cart', ({ state }) => ({
-          model: CheckoutState.Cart({
-            isShippingRequired: state.isShippingRequired,
           }),
         })),
       },

--- a/packages/foldkit/src/experimental/machine/machine.test.ts
+++ b/packages/foldkit/src/experimental/machine/machine.test.ts
@@ -22,6 +22,7 @@ import {
   type TransitionTable,
   define,
   fold,
+  forStates,
   ignore,
   otherwise,
   to,
@@ -75,6 +76,49 @@ const remoteDataMachine = define({
     Ok: {
       on: {
         ClickedFetch: to('Loading', () => ({ model: RemoteData.Loading() })),
+      },
+    },
+  },
+})
+
+const sharedRemoteDataMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: RemoteData.Idle(),
+  shared: [
+    forStates(['Idle', 'Idle', 'Error']).on({
+      ClickedFetch: to('Loading', ({ state, message }) => {
+        expectTypeOf(state).toEqualTypeOf<
+          typeof RemoteData.Idle.Type | typeof RemoteData.Error.Type
+        >()
+        expectTypeOf(message).toEqualTypeOf<
+          typeof RemoteDataMessage.ClickedFetch.Type
+        >()
+
+        return { model: RemoteData.Loading() }
+      }),
+    }),
+  ],
+  states: {},
+})
+
+const locallyOverriddenSharedRemoteDataMachine = define({
+  state: RemoteData,
+  message: RemoteDataMessage,
+})({
+  initial: RemoteData.Idle(),
+  shared: [
+    forStates(['Idle', 'Error']).on({
+      ClickedFetch: to('Loading', () => ({ model: RemoteData.Loading() })),
+    }),
+  ],
+  states: {
+    Error: {
+      on: {
+        ClickedFetch: to('Ok', ({ state }) => ({
+          model: RemoteData.Ok({ data: state.error }),
+        })),
       },
     },
   },
@@ -984,6 +1028,50 @@ const inferredRequirementsMachine = define({
   },
 })
 
+const inferredSharedRequirementsMachine = define({
+  state: SubmitState,
+  message: SubmitMessage,
+})({
+  initial: SubmitState.Idle(),
+  shared: [
+    forStates(['Idle', 'Submitted']).on({
+      ClickedSubmit: to('Presigning', () => ({
+        model: SubmitState.Presigning(),
+        commands: [Presign()],
+      })),
+    }),
+  ],
+  states: {},
+})
+
+const inferredSharedContextualRequirementsMachine = define({
+  state: SubmitState,
+  message: SubmitMessage,
+  context: SubmitContext,
+})({
+  initial: SubmitState.Idle(),
+  shared: [
+    forStates(['Idle', 'Submitted']).on({
+      ClickedSubmit: [
+        when(
+          (_state, _message, context) => context.shouldSubmit,
+          'Presigning',
+          ({ context }) => {
+            expectTypeOf(context).toEqualTypeOf<SubmitContext>()
+
+            return {
+              model: SubmitState.Presigning(),
+              commands: [Presign()],
+            }
+          },
+        ),
+        otherwise(to('Idle', () => ({ model: SubmitState.Idle() }))),
+      ],
+    }),
+  ],
+  states: {},
+})
+
 const inferredContextualRequirementsMachine = define({
   state: SubmitState,
   message: SubmitMessage,
@@ -1253,6 +1341,95 @@ describe('remote data machine', () => {
         '  Ok --> Loading: ClickedFetch',
       ].join('\n'),
     )
+  })
+})
+
+describe('shared transitions', () => {
+  it('expands one transition across every selected source state', () => {
+    const idleFetch = sharedRemoteDataMachine.transition(
+      RemoteData.Idle(),
+      RemoteDataMessage.ClickedFetch(),
+    )
+    expect(idleFetch.model).toStrictEqual(RemoteData.Loading())
+
+    const errorFetch = sharedRemoteDataMachine.transition(
+      RemoteData.Error({ error: 'offline' }),
+      RemoteDataMessage.ClickedFetch(),
+    )
+    expect(errorFetch.model).toStrictEqual(RemoteData.Loading())
+
+    expect(sharedRemoteDataMachine.edges).toEqual([
+      {
+        from: 'Idle',
+        messageTag: 'ClickedFetch',
+        target: 'Loading',
+        guard: { _tag: 'Unguarded' },
+      },
+      {
+        from: 'Error',
+        messageTag: 'ClickedFetch',
+        target: 'Loading',
+        guard: { _tag: 'Unguarded' },
+      },
+    ])
+    expect(sharedRemoteDataMachine.reachableFrom('Error')).toEqual(
+      new Set(['Error', 'Loading']),
+    )
+    expect(sharedRemoteDataMachine.toMermaid()).toContain(
+      '  Error --> Loading: ClickedFetch',
+    )
+  })
+
+  it('lets a state-local transition replace its shared default', () => {
+    const idleFetch = locallyOverriddenSharedRemoteDataMachine.transition(
+      RemoteData.Idle(),
+      RemoteDataMessage.ClickedFetch(),
+    )
+    expect(idleFetch.model).toStrictEqual(RemoteData.Loading())
+
+    const errorFetch = locallyOverriddenSharedRemoteDataMachine.transition(
+      RemoteData.Error({ error: 'offline' }),
+      RemoteDataMessage.ClickedFetch(),
+    )
+    expect(errorFetch.model).toStrictEqual(RemoteData.Ok({ data: 'offline' }))
+  })
+
+  it('rejects overlapping shared transitions for the same state and Message', () => {
+    expect(() =>
+      define({ state: RemoteData, message: RemoteDataMessage })({
+        initial: RemoteData.Idle(),
+        shared: [
+          forStates(['Idle']).on({
+            ClickedFetch: to('Loading', () => ({
+              model: RemoteData.Loading(),
+            })),
+          }),
+          forStates(['Idle']).on({
+            ClickedFetch: to('Loading', () => ({
+              model: RemoteData.Loading(),
+            })),
+          }),
+        ],
+        states: {},
+      }),
+    ).toThrow(
+      'Machine.define: shared transitions overlap for state "Idle" and Message "ClickedFetch"',
+    )
+  })
+
+  it('includes shared Messages in the Machine alphabet', () => {
+    const result = sharedRemoteDataMachine.step(
+      RemoteData.Loading(),
+      RemoteDataMessage.ClickedFetch(),
+    )
+
+    expect(result).toEqual({
+      _tag: 'Ignored',
+      stateTag: 'Loading',
+      messageTag: 'ClickedFetch',
+      state: RemoteData.Loading(),
+      reason: 'NotApplicable',
+    })
   })
 })
 
@@ -1937,6 +2114,46 @@ describe('state tag extraction', () => {
 })
 
 describe('type-level guarantees', () => {
+  it('rejects invalid shared transition declarations', () => {
+    if (false) {
+      // @ts-expect-error a shared transition must select at least one source state
+      forStates([])
+
+      define({ state: RemoteData, message: RemoteDataMessage })({
+        initial: RemoteData.Idle(),
+        shared: [
+          // @ts-expect-error Missing is not a RemoteData state tag
+          forStates(['Idle', 'Missing']).on({}),
+        ],
+        states: {},
+      })
+
+      define({ state: RemoteData, message: RemoteDataMessage })({
+        initial: RemoteData.Idle(),
+        shared: [
+          forStates(['Idle'])
+            // @ts-expect-error UnknownMessage is not a RemoteData Message tag
+            .on({
+              ClickedFetch: [ignore()],
+              UnknownMessage: [ignore()],
+            }),
+        ],
+        states: {},
+      })
+
+      define({ state: RemoteData, message: RemoteDataMessage })({
+        initial: RemoteData.Idle(),
+        shared: [
+          // @ts-expect-error shared fragments must be built with forStates
+          { _tag: 'ForStates', sourceTags: ['Idle'], on: {} },
+        ],
+        states: {},
+      })
+    }
+
+    expect(true).toBe(true)
+  })
+
   it('preserves narrowing in an extracted state entry', () => {
     const loadingTransitions: StateTransitions<
       RemoteData,
@@ -2310,6 +2527,34 @@ describe('edge command requirements', () => {
     expect(messages).toEqual([
       SubmitMessage.SucceededPresign({ url: PRESIGNED_URL }),
     ])
+  })
+
+  it('threads a requirement inferred from a shared edge command into R', () => {
+    const submitClick = inferredSharedRequirementsMachine.transition(
+      SubmitState.Idle(),
+      SubmitMessage.ClickedSubmit(),
+    )
+    expect(submitClick.model).toStrictEqual(SubmitState.Presigning())
+
+    expectTypeOf(submitClick.commands).toEqualTypeOf<
+      | ReadonlyArray<Command.Command<SubmitMessage, never, UploadsClient>>
+      | undefined
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
+  })
+
+  it('infers shared guard context independently from edge requirements', () => {
+    const submitClick = inferredSharedContextualRequirementsMachine.transition(
+      SubmitState.Idle(),
+      SubmitMessage.ClickedSubmit(),
+      { shouldSubmit: true },
+    )
+
+    expectTypeOf(submitClick.commands).toEqualTypeOf<
+      | ReadonlyArray<Command.Command<SubmitMessage, never, UploadsClient>>
+      | undefined
+    >()
+    expect(submitClick.commands ?? []).toHaveLength(1)
   })
 
   it('threads a requirement inferred from a guard-list edge command', () => {

--- a/packages/foldkit/src/experimental/machine/machine.ts
+++ b/packages/foldkit/src/experimental/machine/machine.ts
@@ -1,6 +1,7 @@
 import {
   Array,
   Function,
+  HashMap,
   HashSet,
   Match,
   Option,
@@ -95,7 +96,7 @@ export type EdgeInput<
  * The correlation between `target` and `handler`'s Model variant is enforced
  * by {@link to}'s signature, not by this type. Keeping this type free of the
  * target tag is what lets TypeScript infer the source state and trigger
- * Message from the transition table position.
+ * Message from the transition-map position.
  *
  * Construct with {@link to}.
  */
@@ -221,6 +222,139 @@ export type TransitionTable<
   }>
 }>
 
+const ForStatesTypeId: unique symbol = Symbol('foldkit/Machine/ForStates')
+declare const ForStatesVarianceTypeId: unique symbol
+
+type ForStatesFragment<
+  State extends Tagged,
+  Message extends Tagged,
+  R,
+  Context,
+  SourceTags extends ReadonlyArray<string> = ReadonlyArray<TagOf<State>>,
+> = Readonly<{
+  _tag: 'ForStates'
+  [ForStatesTypeId]: typeof ForStatesTypeId
+  sourceTags: SourceTags
+  on: unknown
+  readonly [ForStatesVarianceTypeId]?: Readonly<{
+    state: State
+    message: Message
+    requirements: R
+    context: Context
+  }>
+}>
+
+type SharedTransitionMap<
+  State extends Tagged,
+  Message extends Tagged,
+  SourceState extends State,
+  R,
+  Context,
+> = Readonly<{
+  [MessageTag in TagOf<Message>]?:
+    | Edge<
+        State,
+        Message,
+        SourceState,
+        Variant<Message, MessageTag>,
+        void,
+        R,
+        Context
+      >
+    | ReadonlyArray<
+        GuardedEdge<
+          State,
+          Message,
+          SourceState,
+          Variant<Message, MessageTag>,
+          R,
+          Context
+        >
+      >
+}>
+
+type RequirementsOfGuarded<Value> =
+  Value extends When<any, any, any, any, any, infer R, any>
+    ? R
+    : Value extends Otherwise<any, any, any, any, infer R, any>
+      ? R
+      : never
+
+type RequirementsOfTransition<Value> =
+  Value extends Edge<any, any, any, any, any, infer R, any>
+    ? R
+    : Value extends ReadonlyArray<infer GuardedEdge>
+      ? RequirementsOfGuarded<GuardedEdge>
+      : never
+
+type RequirementsOfTransitionMap<Transitions> = RequirementsOfTransition<
+  NonNullable<Transitions[keyof Transitions]>
+>
+
+type ForStatesBuilder<SourceTags extends Array.NonEmptyReadonlyArray<string>> =
+  Readonly<{
+    on: <
+      State extends Tagged,
+      Message extends Tagged,
+      Context,
+      R,
+      const Transitions extends SharedTransitionMap<
+        State,
+        Message,
+        Variant<State, Extract<SourceTags[number], TagOf<State>>>,
+        R,
+        Context
+      >,
+    >(
+      transitions: Exclude<SourceTags[number], TagOf<State>> extends never
+        ? Exclude<keyof Transitions, TagOf<Message>> extends never
+          ? Transitions
+          : never
+        : never,
+    ) => ForStatesFragment<
+      State,
+      Message,
+      RequirementsOfTransitionMap<Transitions>,
+      Context,
+      SourceTags
+    >
+  }>
+
+/** Selects source state tags for a shared transition map. The `on` handler's
+ * `state` is narrowed to the union of the selected variants, and its `message`
+ * is narrowed by the map key.
+ *
+ * Add the resulting fragment to a Machine definition's `shared` array. Shared
+ * transitions are defaults: a state-local transition for the same Message
+ * replaces the shared transition. Defining the same state/Message pair in two
+ * shared fragments throws when the Machine is defined.
+ *
+ * @example
+ * ```ts
+ * shared: [
+ *   forStates(['Editing', 'Reviewing']).on({
+ *     ClickedCancel: to('Cancelled', ({ state }) => ({
+ *       model: CheckoutState.Cancelled({ draftId: state.draftId }),
+ *     })),
+ *   }),
+ * ]
+ * ```
+ *
+ * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
+ */
+export const forStates: <
+  const SourceTags extends Array.NonEmptyReadonlyArray<string>,
+>(
+  sourceTags: SourceTags,
+) => ForStatesBuilder<SourceTags> = sourceTags => ({
+  on: transitions => ({
+    _tag: 'ForStates',
+    [ForStatesTypeId]: ForStatesTypeId,
+    sourceTags,
+    on: transitions,
+  }),
+})
+
 /** The transition table entry for one source state. Use this alias when
  * extracting an entry from a Machine's `states` record to preserve the source
  * state and triggering Message narrowing inside its Edges.
@@ -275,17 +409,19 @@ const makeEdge = <
 /**
  * Declares a transition Edge to the state variant named by `target`. The
  * `handler` receives an {@link EdgeInput} whose state and Message are narrowed
- * to the variants the Edge sits under in the transition table, and returns an
- * `Update.Return` record whose `model` is the target variant and whose optional
- * `commands` are transition-time effects. When the Machine declares a context,
- * the input also contains that context for the current transition.
+ * to the variants the Edge sits under in a state-local or shared transition
+ * map, and returns an `Update.Return` record whose `model` is the target
+ * variant and whose optional `commands` are transition-time effects. When the
+ * Machine declares a context, the input also contains that context for the
+ * current transition.
  *
  * The handler's `commands` field may contain Commands whose Effects need
  * services. The requirements they carry flow into the Machine's `R` through
  * {@link define}.
  *
- * Only meaningful inside a {@link TransitionTable}: the source and trigger
- * types flow in from the table position contextually.
+ * Only meaningful inside a Machine definition's state-local or shared
+ * transition map: the source and trigger types flow in from that position
+ * contextually.
  *
  * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
  */
@@ -325,7 +461,7 @@ export const to = <
  * When the Machine declares a context, the guard receives it as a third
  * parameter and its Edge handler receives it in {@link EdgeInput}. The state,
  * Message, and context parameters are `NoInfer` so they resolve from the guard
- * list's table position alone.
+ * list's transition-map position alone.
  *
  * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
  */
@@ -690,7 +826,7 @@ export const fold: {
 /**
  * The Schemas a Machine is defined over: the state union and the Message
  * union. Passed to `define`'s first stage so the type parameters are
- * fully resolved before the transition table is checked.
+ * fully resolved before the Machine definition is checked.
  */
 type MachineSchemaFields<
   State extends Tagged,
@@ -715,7 +851,9 @@ export type MachineSchemas<
     ? Readonly<{ context: ContextSchema }>
     : Readonly<{ context?: never }>)
 
-/** The Machine definition: the initial state and the transition table.
+/** The Machine definition: the initial state, shared transition defaults, and
+ * the state-local transition table. A state-local transition replaces a
+ * shared transition for the same state and Message.
  *
  * @experimental Ships from `foldkit/experimental/machine`; expect breaking changes while the API settles.
  */
@@ -726,6 +864,7 @@ export type MachineDefinition<
   Context = NoMachineContext,
 > = Readonly<{
   initial: State
+  shared?: ReadonlyArray<ForStatesFragment<State, Message, R, Context>>
   states: TransitionTable<State, Message, R, Context>
 }>
 
@@ -779,20 +918,150 @@ type IgnoredEdge = Readonly<{
 type EdgeSelection<State extends Tagged, Message extends Tagged, R> =
   SelectedEdge<State, Message, R> | IgnoredEdge
 
+type LooseTransition<State extends Tagged, Message extends Tagged, R> =
+  | LooseEdge<State, Message, R>
+  | ReadonlyArray<LooseGuardedEdge<State, Message, R>>
+
+type LooseTransitionMap<
+  State extends Tagged,
+  Message extends Tagged,
+  R,
+> = Readonly<Record<TagOf<Message>, LooseTransition<State, Message, R>>>
+
+type LooseStateTransitions<
+  State extends Tagged,
+  Message extends Tagged,
+  R,
+> = Readonly<{ on: LooseTransitionMap<State, Message, R> }>
+
 type LooseTable<State extends Tagged, Message extends Tagged, R> = Readonly<
-  Record<
-    TagOf<State>,
-    Readonly<{
-      on: Readonly<
-        Record<
-          TagOf<Message>,
-          | LooseEdge<State, Message, R>
-          | ReadonlyArray<LooseGuardedEdge<State, Message, R>>
-        >
-      >
-    }>
-  >
+  Record<TagOf<State>, LooseStateTransitions<State, Message, R>>
 >
+
+type LooseForStatesFragment<
+  State extends Tagged,
+  Message extends Tagged,
+  R,
+> = Readonly<{
+  sourceTags: ReadonlyArray<TagOf<State>>
+  on: LooseTransitionMap<State, Message, R>
+}>
+
+type ExpandedSharedTransitions<
+  State extends Tagged,
+  Message extends Tagged,
+  R,
+> = Readonly<{
+  states: LooseTable<State, Message, R>
+  messageTagsByState: HashMap.HashMap<
+    TagOf<State>,
+    HashSet.HashSet<TagOf<Message>>
+  >
+}>
+
+const emptyLooseRecord = <Key extends string, Value>(): Readonly<
+  Record<Key, Value>
+> => {
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+  return {} as Readonly<Record<Key, Value>>
+}
+
+const addSharedTransition = <State extends Tagged, Message extends Tagged, R>(
+  explicitStates: LooseTable<State, Message, R>,
+  expanded: ExpandedSharedTransitions<State, Message, R>,
+  sourceTag: TagOf<State>,
+  messageTag: TagOf<Message>,
+  transition: LooseTransition<State, Message, R>,
+): ExpandedSharedTransitions<State, Message, R> => {
+  const sharedMessageTags = pipe(
+    HashMap.get(expanded.messageTagsByState, sourceTag),
+    Option.getOrElse(() => HashSet.empty<TagOf<Message>>()),
+  )
+
+  if (HashSet.has(sharedMessageTags, messageTag)) {
+    throw new Error(
+      `Machine.define: shared transitions overlap for state "${sourceTag}" and Message "${messageTag}"`,
+    )
+  }
+
+  const nextMessageTagsByState = pipe(
+    expanded.messageTagsByState,
+    HashMap.set(sourceTag, HashSet.add(sharedMessageTags, messageTag)),
+  )
+  const isStateLocal = pipe(
+    Record.get(explicitStates, sourceTag),
+    Option.exists(stateEntry => Record.has(stateEntry.on, messageTag)),
+  )
+
+  if (isStateLocal) {
+    return {
+      states: expanded.states,
+      messageTagsByState: nextMessageTagsByState,
+    }
+  }
+
+  const stateEntry: LooseStateTransitions<State, Message, R> = pipe(
+    Record.get(expanded.states, sourceTag),
+    Option.getOrElse(() => ({
+      on: emptyLooseRecord<
+        TagOf<Message>,
+        LooseTransition<State, Message, R>
+      >(),
+    })),
+  )
+
+  return {
+    states: pipe(
+      expanded.states,
+      Record.set(sourceTag, {
+        on: Record.set(stateEntry.on, messageTag, transition),
+      }),
+    ),
+    messageTagsByState: nextMessageTagsByState,
+  }
+}
+
+const expandSharedTransitions = <
+  State extends Tagged,
+  Message extends Tagged,
+  R,
+>(
+  explicitStates: LooseTable<State, Message, R>,
+  shared: ReadonlyArray<LooseForStatesFragment<State, Message, R>>,
+): LooseTable<State, Message, R> =>
+  pipe(
+    shared,
+    Array.reduce<
+      ExpandedSharedTransitions<State, Message, R>,
+      LooseForStatesFragment<State, Message, R>
+    >(
+      {
+        states: explicitStates,
+        messageTagsByState: HashMap.empty(),
+      },
+      (expanded, fragment) =>
+        pipe(
+          Array.dedupe(fragment.sourceTags),
+          Array.reduce(expanded, (nextExpanded, sourceTag) =>
+            pipe(
+              Record.toEntries(fragment.on),
+              Array.reduce(
+                nextExpanded,
+                (nextStateExpanded, [messageTag, transition]) =>
+                  addSharedTransition(
+                    explicitStates,
+                    nextStateExpanded,
+                    sourceTag,
+                    messageTag,
+                    transition,
+                  ),
+              ),
+            ),
+          ),
+        ),
+    ),
+    result => result.states,
+  )
 
 const isGuardList = <State extends Tagged, Message extends Tagged, R>(
   edgeOrGuardedEdges:
@@ -838,14 +1107,19 @@ const flattenUnionMembers = (
   })
 
 /**
- * Compiles a declarative transition table into a {@link Machine}.
+ * Compiles a declarative Machine definition into a {@link Machine}.
  *
  * Two stages: the first takes the state and Message union Schemas and fixes
- * the type parameters, the second takes the initial state and the transition
- * table. The split is what lets TypeScript narrow `state` and `message`
- * inside every Edge from its table position: a single-call form checks the
- * table while the type parameters are still being inferred, and the
- * narrowing collapses.
+ * the type parameters, the second takes the initial state, optional shared
+ * transition defaults, and the state-local transition table. The split is
+ * what lets TypeScript narrow `state` and `message` inside every Edge from its
+ * transition-map position: a single-call form checks the definition while the
+ * type parameters are still being inferred, and the narrowing collapses.
+ *
+ * Build shared defaults with {@link forStates}. Each fragment is expanded
+ * into the ordinary state-local table before dispatch and static analysis. A
+ * state-local transition replaces its shared default for that state and
+ * Message; overlapping shared fragments throw when the Machine is defined.
  *
  * The Machine is not a runtime: `transition` returns an `Update.Return`, so the
  * Machine state lives in the Model and the Foldkit runtime never learns the
@@ -935,11 +1209,16 @@ function defineImplementation<
     definition: MachineDefinition<State, Message, R, Context>,
   ): Machine<State, Message, R, Context> => {
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-    const looseStates = definition.states as unknown as LooseTable<
+    const explicitStates = definition.states as unknown as LooseTable<
       State,
       Message,
       R
     >
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
+    const shared = (definition.shared ?? []) as ReadonlyArray<
+      LooseForStatesFragment<State, Message, R>
+    >
+    const looseStates = expandSharedTransitions(explicitStates, shared)
 
     const hasContext = Predicate.hasProperty(schemas, 'context')
     const initialTag = definition.initial._tag

--- a/skills/generate-program/blindSpots.md
+++ b/skills/generate-program/blindSpots.md
@@ -30,6 +30,8 @@ When the answer takes real tracing, that is the signal to reach for `Machine` (`
 
 Use `ignore()` as the final entry in an ordered guard list when the Message should intentionally produce no transition after every preceding `when` guard declines. `step()` then reports `ExplicitlyIgnored`, which keeps that deliberate outcome distinct from an accidental guard fallthrough.
 
+When identical transitions apply from several states, declare the shared default with `Machine.forStates(['First', 'Second']).on({ ... })` in the definition's `shared` array. The handler's `state` is the union of the selected variants, so only fields common to every selected state are available. A transition in a state's own `on` record replaces the shared default for that state and Message; never overlap two shared groups for the same pair.
+
 The walk cannot see state changes made outside `transition` and `step`. Pass every restored, deep-linked, hydrated, or otherwise externally entered state as an extra root before treating `UnreachableSource` findings as application defects.
 
 Recommend it when a flow has several states, guarded transitions, or edges that are easy to get wrong (checkout, onboarding, multi-step approval, connection lifecycles). `repos/foldkit/examples/state-machine/` is the reference. Don't push it on a three-state union that one exhaustive `match` already handles legibly; the table costs more than it saves there. The module is under `experimental/`, so say so when recommending it.


### PR DESCRIPTION
Add `Machine.forStates(...).on(...)` and the Machine definition’s `shared` array for declaring one transition map across several source states. The staged call preserves exact source-state union, Message, context, and Command requirement inference.

Expand shared defaults into the ordinary flat transition table before dispatch and static analysis. State-local transitions replace shared defaults for the same state and Message, while overlapping shared fragments fail at definition time.

Adopt the helper in the checkout Machine example and teach the shipped app-generation guidance when to use it.

Closes #706.