### PR TITLE
feat(website): improve docs legibility

### DIFF
--- a/packages/website/scripts/demoCodePlugin.ts
+++ b/packages/website/scripts/demoCodePlugin.ts
@@ -72,7 +72,6 @@ const demoCodeToHtml = async (
   const importLines = importsCode.trimEnd().split('\n')
   const bodyLines = bodyCode.trimEnd().split('\n')
   const lines = [...importLines, '', ...bodyLines]
-  const lineDigits = String(bodyLines.length).length
   const tokens = phaseTokensByLine(bodyLines, phaseRegions)
 
   const html = await codeToHtml(lines.join('\n'), {
@@ -85,7 +84,7 @@ const demoCodeToHtml = async (
     })),
   })
 
-  return html.replace('<pre ', `<pre data-line-digits="${lineDigits}" `)
+  return html
 }
 
 const demoCodePlugin = (

--- a/packages/website/src/component/codeBlock.ts
+++ b/packages/website/src/component/codeBlock.ts
@@ -76,7 +76,7 @@ export const highlightedView = (
   className?: string,
 ) =>
   ih.div(
-    [PagefindIgnore, ih.Class(clsx('relative min-w-0 mt-8', className))],
+    [PagefindIgnore, ih.Class(clsx('relative min-w-0 mt-6', className))],
     [
       content,
       renderCopyButton({

--- a/packages/website/src/layout/docs.ts
+++ b/packages/website/src/layout/docs.ts
@@ -50,7 +50,7 @@ import {
   Ui,
 } from '../page'
 import * as Prose from '../prose'
-import { type DocsRoute, homeRouter } from '../route'
+import { AppRoute, type DocsRoute, homeRouter } from '../route'
 import * as SnippetCopy from '../snippetCopy'
 import { type TableOfContentsEntry } from '../tableOfContentsEntry'
 import {
@@ -71,7 +71,7 @@ export const headerView = (model: Model, h: HtmlBuilder<Message>) =>
   h.header(
     [
       h.Class(
-        'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream dark:bg-gray-900 border-b border-gray-300 dark:border-gray-800 px-4 md:px-6 flex items-center justify-between transform-gpu',
+        'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream dark:bg-gray-900 border-b border-gray-300 dark:border-gray-800 px-6 flex items-center justify-between transform-gpu',
       ),
     ],
     [
@@ -150,7 +150,7 @@ export const footerView = (
   h.footer(
     [
       h.Class(
-        'px-4 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] md:px-6 mt-6 border-t border-gray-300 dark:border-gray-800',
+        'px-6 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] md:px-10 mt-6 border-t border-gray-300 dark:border-gray-800',
       ),
     ],
     [
@@ -165,7 +165,7 @@ export const footerView = (
       Shared.emailForm,
       h.hr([
         h.Class(
-          'my-6 -mx-4 md:-mx-6 border-t border-gray-300 dark:border-gray-800',
+          'my-6 -mx-6 md:-mx-10 border-t border-gray-300 dark:border-gray-800',
         ),
       ]),
       h.div(
@@ -299,6 +299,10 @@ export const searchWeight = (tag: string): string =>
     Match.whenOr('Examples', 'ExampleDetail', 'TypingTerminal', () => '2'),
     Match.orElse(() => '4'),
   )
+
+// CONTENT WIDTH
+
+const isWideContentRoute = AppRoute.isAnyOf(['Examples', 'ExampleDetail'])
 
 // CONTENT ROUTING
 
@@ -1154,7 +1158,10 @@ export const view = (
                     searchWeight(docsRoute._tag),
                   ),
                   h.Class(
-                    'flex-1 w-full px-4 py-6 md:px-6 2xl:py-10 max-w-4xl mx-auto min-w-0',
+                    clsx(
+                      'flex-1 w-full px-6 py-8 md:px-10 2xl:py-12 mx-auto min-w-0',
+                      isWideContentRoute(docsRoute) ? 'max-w-4xl' : 'max-w-3xl',
+                    ),
                   ),
                 ],
                 [

--- a/packages/website/src/layout/marketing.ts
+++ b/packages/website/src/layout/marketing.ts
@@ -14,7 +14,7 @@ const headerView = (model: Model, h: HtmlBuilder<Message>) =>
   h.header(
     [
       h.Class(
-        'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream/80 dark:bg-gray-900/80 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800 px-4 md:px-6 flex items-center justify-between',
+        'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream/80 dark:bg-gray-900/80 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800 px-6 flex items-center justify-between',
       ),
     ],
     [

--- a/packages/website/src/markdown/islands.ts
+++ b/packages/website/src/markdown/islands.ts
@@ -56,7 +56,7 @@ export const docIslands = (
               ? 'Copy snippet to clipboard'
               : `Copy ${label} to clipboard`,
             slots.renderCopyButton,
-            className ?? 'mb-8',
+            className ?? 'mb-6',
           ),
       }),
 

--- a/packages/website/src/markdown/views.ts
+++ b/packages/website/src/markdown/views.ts
@@ -28,9 +28,9 @@ export type DocViewConfig = Readonly<{
 const linkClassName = 'link-accent font-normal'
 
 const blockquoteClassName =
-  'border-l-4 border-gray-300 dark:border-gray-700 pl-4 italic text-gray-700 dark:text-gray-300 mb-4 [&>p:last-child]:mb-0'
+  'border-l-4 border-gray-300 dark:border-gray-700 pl-4 italic text-gray-700 dark:text-gray-300 mb-5 [&>p:last-child]:mb-0'
 
-const listClassName = 'mb-8 space-y-2 [&>li>p:last-child]:mb-0'
+const listClassName = 'mb-6 space-y-2 [&>li>p:last-child]:mb-0'
 
 const diagramLanguage = 'diagram'
 
@@ -76,7 +76,7 @@ const titleAttributes = (
 export const docViews = (config: DocViewConfig): Partial<Markdown.Views> => {
   return {
     Paragraph: (_paragraph, content) =>
-      ih.p([ih.Class('mb-4 leading-relaxed')], content),
+      ih.p([ih.Class('mb-5 leading-relaxed')], content),
 
     Link: (link, content) =>
       ih.a(
@@ -158,7 +158,7 @@ export const docViews = (config: DocViewConfig): Partial<Markdown.Views> => {
             value,
             'Copy code to clipboard',
             config.renderCopyButton,
-            { className: 'mb-8', maybeLanguage },
+            { className: 'mb-6', maybeLanguage },
           ),
 
     List: (list, items) => {

--- a/packages/website/src/page/blog/blogPost.ts
+++ b/packages/website/src/page/blog/blogPost.ts
@@ -54,7 +54,7 @@ export const view = (
       ih.header(
         [ih.Class('mb-8')],
         [
-          Prose.pageTitle(post.slug, post.frontmatter.title),
+          Prose.pageTitle(post.slug, post.frontmatter.title, 'mb-3'),
           ih.p(
             [ih.Class('text-gray-500 dark:text-gray-400')],
             [`${formatPostDate(post.frontmatter.date)} · ${BLOG_AUTHOR}`],

--- a/packages/website/src/page/core/submodelPage/view.ts
+++ b/packages/website/src/page/core/submodelPage/view.ts
@@ -56,7 +56,7 @@ const mapMessagesUnderHoodDemo = (
                   [...attributes.panel, h.Class('docs-disclosure-panel')],
                   [
                     h.div(
-                      [h.Class('-mt-8')],
+                      [h.Class('-mt-6')],
                       [
                         CodeBlock.highlightedView(
                           'core-submodel-map-messages-under-hood',

--- a/packages/website/src/page/home/content.ts
+++ b/packages/website/src/page/home/content.ts
@@ -730,7 +730,7 @@ const testingSection = (renderCopyButton: CodeBlock.RenderCopyButton): Html =>
             Snippet.landingStoryTestRaw,
             'Copy Story test example to clipboard',
             renderCopyButton,
-            '',
+            'mt-8',
           ),
           CodeBlock.highlightedView(
             'home-scene-test',
@@ -741,7 +741,7 @@ const testingSection = (renderCopyButton: CodeBlock.RenderCopyButton): Html =>
             Snippet.landingSceneTestRaw,
             'Copy Scene test example to clipboard',
             renderCopyButton,
-            '',
+            'mt-8',
           ),
         ],
       ),

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -46,11 +46,14 @@ export const renderHeadingLink =
 export const link = (href: string, text: string): Html =>
   ih.a([ih.Href(href), ih.Class('link-accent font-normal')], [text])
 
-export const pageTitle = (id: string, text: string): Html =>
+export const pageTitle = (id: string, text: string, className?: string): Html =>
   ih.h1(
     [
       ih.Class(
-        'text-3xl md:text-[2.5rem] leading-normal font-normal text-gray-900 dark:text-white mb-4',
+        twMerge(
+          'text-[2rem] md:text-[2.5rem] leading-tight tracking-tight font-normal text-gray-900 dark:text-white mb-6',
+          className,
+        ),
       ),
       ih.Id(id),
       ih.DataAttribute('pagefind-meta', 'section'),
@@ -61,33 +64,33 @@ export const pageTitle = (id: string, text: string): Html =>
 const sectionHeadingConfig = {
   h2: {
     textClassName:
-      'text-2xl md:text-3xl font-normal text-gray-900 dark:text-white scroll-mt-6',
+      'text-2xl md:text-3xl leading-snug tracking-tight font-normal text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 mt-8 mb-4 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-12 mb-4 [h1+&]:mt-8 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h3: {
     textClassName:
-      'text-xl font-normal text-gray-900 dark:text-white scroll-mt-6',
+      'text-xl md:text-2xl leading-snug tracking-tight font-normal text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 mt-6 mb-2 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-10 mb-3 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h4: {
     textClassName:
       'text-base font-mono font-normal text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-8 mb-3 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h5: {
     textClassName:
       'text-sm font-mono font-normal text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-6 mb-2 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h6: {
     textClassName:
       'text-sm font-mono font-normal text-gray-500 dark:text-gray-400 scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-6 mb-2 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
 }
 
@@ -116,11 +119,11 @@ export const headingWithContent = (
 }
 
 export const para = (...content: ReadonlyArray<string | Html>): Html =>
-  ih.p([ih.Class('mb-4 leading-relaxed')], content)
+  ih.p([ih.Class('mb-5 leading-relaxed')], content)
 
 export const subPara = (...content: ReadonlyArray<string | Html>): Html =>
   ih.p(
-    [ih.Class('mb-4 text-sm leading-6 text-gray-800 dark:text-gray-400')],
+    [ih.Class('mb-5 text-sm leading-6 text-gray-800 dark:text-gray-400')],
     content,
   )
 
@@ -144,7 +147,7 @@ export const headingsFor = (renderHeadingLink: RenderHeadingLink) => ({
 
 export const bullets = (...items: ReadonlyArray<string | Html>): Html =>
   ih.ul(
-    [ih.Class('list-disc mb-8 space-y-2')],
+    [ih.Class('list-disc mb-6 space-y-2')],
     Array.map(items, item => ih.li([], [item])),
   )
 
@@ -152,7 +155,7 @@ export const bulletPoint = (label: string, description: string): Html =>
   ih.span([], [ih.strong([], [`${label}:`]), ` ${description}`])
 
 const inlineCodeClassName =
-  'bg-gray-200/70 dark:bg-gray-800 px-1 py-px rounded text-sm border border-gray-300/50 dark:border-gray-700/50 wrap-anywhere'
+  'bg-gray-200/60 dark:bg-gray-800 text-[var(--code-foreground)] [a_&]:text-inherit [:is(h1,h2,h3,h4,h5,h6)_&]:text-inherit mx-[0.1em] px-[0.25em] py-[0.05em] rounded-xs text-[0.9375em] font-code wrap-anywhere'
 
 export const inlineCode = (text: string, className?: string): Html =>
   ih.code([ih.Class(twMerge(inlineCodeClassName, className))], [text])
@@ -286,7 +289,7 @@ export const diagram = (content: string): Html =>
   ih.pre(
     [
       ih.Class(
-        'code-surface mb-4 mx-auto w-fit max-w-full text-sm p-4 overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700/50',
+        'code-surface mb-6 mx-auto w-fit max-w-full text-sm p-4 overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700/50',
       ),
     ],
     [content],
@@ -301,7 +304,7 @@ export const ctaLinks = (blocks: ReadonlyArray<Html>): Html =>
   ih.div(
     [
       ih.Class(
-        'mb-8 flex flex-wrap gap-x-6 gap-y-2 [&>p]:m-0 [&_a]:font-medium',
+        'mb-6 flex flex-wrap gap-x-6 gap-y-2 [&>p]:m-0 [&_a]:font-medium',
       ),
     ],
     blocks,

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -104,11 +104,11 @@ html.dark {
   }
 
   body {
-    @apply text-base leading-relaxed font-light tracking-[0.01em] text-gray-800 dark:text-gray-200;
+    @apply text-base leading-relaxed font-normal text-gray-900 dark:text-gray-200;
   }
 
   strong {
-    font-weight: 350;
+    font-weight: 600;
   }
 
   :is(h1, h2, h3, h4).font-mono {
@@ -127,8 +127,16 @@ html.dark {
     @apply font-mono font-normal text-accent-500 dark:text-accent-400 text-sm;
   }
 
+  .list-decimal {
+    padding-left: 1.75rem;
+  }
+
+  .list-decimal li::marker {
+    @apply text-gray-500 dark:text-gray-400;
+  }
+
   pre {
-    @apply pr-14 pl-2.75 py-4 rounded-lg overflow-x-auto border border-gray-200 dark:border-gray-700/50 font-code text-sm;
+    @apply pr-14 pl-4 py-4 rounded-lg overflow-x-auto border border-gray-200 dark:border-gray-700/50 font-code text-sm;
   }
 
   .dark .shiki {
@@ -146,27 +154,6 @@ html.dark {
 
   pre code .line {
     @apply leading-6;
-  }
-
-  pre code .line[data-line]::before {
-    content: attr(data-line);
-    @apply inline-block mr-4 text-right text-gray-500 select-none border-r border-gray-300 pr-4;
-  }
-
-  .dark pre code .line[data-line]::before {
-    border-color: #332f3b;
-  }
-
-  pre[data-line-digits='1'] code .line[data-line]::before {
-    @apply w-8;
-  }
-
-  pre[data-line-digits='2'] code .line[data-line]::before {
-    @apply w-10;
-  }
-
-  pre[data-line-digits='3'] code .line[data-line]::before {
-    @apply w-12;
   }
 
   .code-embed {
@@ -383,11 +370,6 @@ html.dark {
     border-radius: 0;
     border: none;
     overflow: visible;
-  }
-
-  .demo-code-panel pre code .line[data-line]::before,
-  .note-demo-code-panel pre code .line[data-line]::before {
-    @apply hidden;
   }
 
   .demo-code-panel pre {

--- a/packages/website/src/view/blog.ts
+++ b/packages/website/src/view/blog.ts
@@ -86,7 +86,7 @@ export const view = (
                 Docs.searchWeight(blogRoute._tag),
               ),
               h.Class(
-                'flex-1 w-full px-4 py-6 md:px-6 2xl:py-10 max-w-3xl mx-auto min-w-0',
+                'flex-1 w-full px-6 py-8 md:px-10 2xl:py-12 max-w-3xl mx-auto min-w-0',
               ),
             ],
             [content],

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -319,7 +319,7 @@ export const mobileView = (model: Model, h: HtmlBuilder<Message>): Html => {
         h.div(
           [
             h.Class(
-              'flex justify-between items-center h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] px-4 border-b border-gray-300 dark:border-gray-800 shrink-0',
+              'flex justify-between items-center h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] px-6 border-b border-gray-300 dark:border-gray-800 shrink-0',
             ),
           ],
           [

--- a/packages/website/src/view/tableOfContents.ts
+++ b/packages/website/src/view/tableOfContents.ts
@@ -122,7 +122,7 @@ export const mobileView = (
       h.summary(
         [
           h.Class(
-            'flex items-center justify-between px-4 py-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden group-open:border-b group-open:border-gray-300 dark:group-open:border-gray-800',
+            'flex items-center justify-between px-6 py-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden group-open:border-b group-open:border-gray-300 dark:group-open:border-gray-800',
           ),
         ],
         [
@@ -181,10 +181,10 @@ export const mobileView = (
                       ),
                       h.Class(
                         clsx(
-                          'transition flex items-center justify-between py-3 px-4',
+                          'transition flex items-center justify-between py-3 px-6',
                           {
-                            'pl-8': level === 'h3',
-                            'pl-12': level === 'h4',
+                            'pl-10': level === 'h3',
+                            'pl-14': level === 'h4',
                             'text-accent-600 dark:text-accent-400': isActive,
                             'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white':
                               !isActive,

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -77,28 +77,11 @@ const highlightCodePlugin = (): Plugin => ({
     const rawCode = await readFile(filePath, 'utf-8')
     const code = rawCode.trimEnd()
 
-    const lines = code.split('\n')
-    const lineCount = lines.length
-    const lineDigits = String(lineCount).length
-
     const lang = highlightLanguage(filePath)
 
-    const html = await codeToHtml(code, {
-      lang,
-      themes: shikiThemes,
-      decorations: lines.map((line, i) => ({
-        start: { line: i, character: 0 },
-        end: { line: i, character: line.length },
-        properties: { 'data-line': i + 1 },
-      })),
-    })
+    const html = await codeToHtml(code, { lang, themes: shikiThemes })
 
-    const htmlWithDigits = html.replace(
-      '<pre ',
-      `<pre data-line-digits="${lineDigits}" `,
-    )
-
-    return `export default ${JSON.stringify(htmlWithDigits)}`
+    return `export default ${JSON.stringify(html)}`
   },
 })
 
@@ -143,22 +126,11 @@ const cssSnippetsPlugin = (): Plugin => {
           const filePath = join(snippetDirectory, fileName)
           this.addWatchFile(filePath)
           const raw = (await readFile(filePath, 'utf-8')).trimEnd()
-          const lines = raw.split('\n')
 
-          const html = await codeToHtml(raw, {
+          const highlighted = await codeToHtml(raw, {
             lang: 'css',
             themes: shikiThemes,
-            decorations: lines.map((line, index) => ({
-              start: { line: index, character: 0 },
-              end: { line: index, character: line.length },
-              properties: { 'data-line': index + 1 },
-            })),
           })
-
-          const highlighted = html.replace(
-            '<pre ',
-            `<pre data-line-digits="${String(lines.length).length}" `,
-          )
 
           return [fileName.replace(/\.css$/, ''), { raw, highlighted }] as const
         }),
@@ -747,29 +719,13 @@ const highlightExampleFile = async (
 ) => {
   const rawCode = await readFile(filePath, 'utf-8')
   const code = rawCode.trimEnd()
-  const lines = code.split('\n')
-  const lineCount = lines.length
-  const lineDigits = String(lineCount).length
   const lang = langFromExtension(filePath)
 
-  const html = await codeToHtml(code, {
-    lang,
-    themes: shikiThemes,
-    decorations: lines.map((line, i) => ({
-      start: { line: i, character: 0 },
-      end: { line: i, character: line.length },
-      properties: { 'data-line': i + 1 },
-    })),
-  })
-
-  const htmlWithDigits = html.replace(
-    '<pre ',
-    `<pre data-line-digits="${lineDigits}" `,
-  )
+  const html = await codeToHtml(code, { lang, themes: shikiThemes })
 
   return {
     path: relative(baseDirectory, filePath),
-    highlightedHtml: htmlWithDigits,
+    highlightedHtml: html,
     rawCode: code,
   }
 }


### PR DESCRIPTION
Prose reads thin and loose next to comparable docs sites. Body copy now uses the Book weight at the darkest gray with default tracking, and strong text asks for a bolder weight instead of matching the headings.

Headings get tight tracking, a larger h3 step, and more room above than below so each section groups with its own content. Ordered lists gain the padding their markers need, which stops the numbers hanging off the left edge on narrow screens. Inline code drops its border, takes the code block foreground color, and scales with the surrounding text.

Code blocks drop their line numbers. No page refers to a line by number, the gutter cost three rem of width on every snippet, and the demo panels and API reference already rendered without one. The build-time highlighters stop emitting the per-line attributes that only fed the gutter; the landing demo keeps its data-line hook for phase highlighting.

Docs and blog pages use a 48rem column, keeping the wide column for the example pages, and the content, header, footer, mobile drawer, and mobile table of contents share wider outer padding. Paragraph, list, code block, diagram, and callout spacing now step evenly instead of alternating between 1rem and 2rem. The landing page keeps its code block spacing.