### PR TITLE
fix(website): keep long content within narrow viewports

### DIFF
--- a/packages/website/src/page/apiReference/view.ts
+++ b/packages/website/src/page/apiReference/view.ts
@@ -74,12 +74,12 @@ const functionView = (
         ],
         [
           h.div(
-            [h.Class('flex items-center gap-2')],
+            [h.Class('flex flex-wrap items-center gap-2')],
             [
               h.h3(
                 [
                   h.Class(
-                    'text-base font-mono font-code text-gray-900 dark:text-white scroll-mt-6',
+                    'text-base font-mono font-code text-gray-900 dark:text-white scroll-mt-6 wrap-anywhere',
                   ),
                   h.Id(id),
                 ],
@@ -375,12 +375,12 @@ const typeView = (
         ],
         [
           h.div(
-            [h.Class('flex items-center gap-2')],
+            [h.Class('flex flex-wrap items-center gap-2')],
             [
               h.h3(
                 [
                   h.Class(
-                    'text-base font-mono font-code text-gray-900 dark:text-white scroll-mt-6',
+                    'text-base font-mono font-code text-gray-900 dark:text-white scroll-mt-6 wrap-anywhere',
                   ),
                   h.Id(id),
                 ],
@@ -448,12 +448,12 @@ const interfaceView = (
         ],
         [
           h.div(
-            [h.Class('flex items-center gap-2')],
+            [h.Class('flex flex-wrap items-center gap-2')],
             [
               h.h3(
                 [
                   h.Class(
-                    'text-base font-mono font-code text-gray-900 dark:text-white scroll-mt-6',
+                    'text-base font-mono font-code text-gray-900 dark:text-white scroll-mt-6 wrap-anywhere',
                   ),
                   h.Id(id),
                 ],
@@ -521,12 +521,12 @@ const variableView = (
         ],
         [
           h.div(
-            [h.Class('flex items-center gap-2')],
+            [h.Class('flex flex-wrap items-center gap-2')],
             [
               h.h3(
                 [
                   h.Class(
-                    'text-base font-mono font-code text-gray-900 dark:text-white scroll-mt-6',
+                    'text-base font-mono font-code text-gray-900 dark:text-white scroll-mt-6 wrap-anywhere',
                   ),
                   h.Id(id),
                 ],

--- a/packages/website/src/page/ui/demo/radioGroup.ts
+++ b/packages/website/src/page/ui/demo/radioGroup.ts
@@ -28,7 +28,7 @@ const verticalGroupClassName = 'flex flex-col gap-3 w-full'
 const verticalOptionClassName =
   'relative flex cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 data-[checked]:border-accent-600 dark:data-[checked]:border-accent-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 outline-none focus-visible:ring-2 focus-visible:ring-accent-600 dark:focus-visible:ring-accent-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900'
 
-const horizontalGroupClassName = 'flex flex-row gap-3 w-full'
+const horizontalGroupClassName = 'flex flex-col sm:flex-row gap-3 w-full'
 
 const horizontalOptionClassName =
   'relative flex flex-col flex-1 cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 data-[checked]:border-accent-600 dark:data-[checked]:border-accent-500 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 outline-none focus-visible:ring-2 focus-visible:ring-accent-600 dark:focus-visible:ring-accent-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900'

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -152,7 +152,7 @@ export const bulletPoint = (label: string, description: string): Html =>
   ih.span([], [ih.strong([], [`${label}:`]), ` ${description}`])
 
 const inlineCodeClassName =
-  'bg-gray-200/70 dark:bg-gray-800 px-1 py-px rounded text-sm border border-gray-300/50 dark:border-gray-700/50'
+  'bg-gray-200/70 dark:bg-gray-800 px-1 py-px rounded text-sm border border-gray-300/50 dark:border-gray-700/50 wrap-anywhere'
 
 export const inlineCode = (text: string, className?: string): Html =>
   ih.code([ih.Class(twMerge(inlineCodeClassName, className))], [text])


### PR DESCRIPTION
Three layouts pushed the document wider than a phone screen, so the browser zoomed the whole page out and the text column stopped filling the viewport. The AI overview page was the reported case. A scan of every page on the site at a 390px viewport found two more.

Inline code in prose never wrapped, so a long path such as the FOLDKIT.md template URL on the AI overview page ran past the right edge. The inline code style now allows a break anywhere inside the token. `overflow-wrap: anywhere` only breaks a token when no other soft wrap fits, so ordinary inline code renders unchanged on desktop.

API reference headings put a monospace symbol name, its kind badge, and the source link in one row that could not wrap. The row now wraps, and a long name can break. `break-words` would not have fixed this case, because the heading is a flex item and only `anywhere` participates in min-content sizing.

The horizontal RadioGroup demo laid its three plan cards side by side at every width. It now stacks them below the small breakpoint, matching the ui-showcase example.