### PR TITLE
feat(website): set headings and emphasis in Favorit Medium

### DIFF
--- a/.github/workflows/deploy-website-build.yml
+++ b/.github/workflows/deploy-website-build.yml
@@ -26,6 +26,8 @@ on:
         required: true
       website_light_font:
         required: true
+      website_medium_font:
+        required: true
 
 permissions:
   contents: read
@@ -79,6 +81,7 @@ jobs:
         env:
           ABC_FAVORIT_BOOK_WOFF2_BASE64: ${{ secrets.website_book_font }}
           ABC_FAVORIT_LIGHT_WOFF2_BASE64: ${{ secrets.website_light_font }}
+          ABC_FAVORIT_MEDIUM_WOFF2_BASE64: ${{ secrets.website_medium_font }}
 
       - name: Resolve GitHub star count
         id: github-stars

--- a/.github/workflows/deploy-website-canary.yml
+++ b/.github/workflows/deploy-website-canary.yml
@@ -18,6 +18,8 @@ on:
         required: true
       ABC_FAVORIT_LIGHT_WOFF2_BASE64:
         required: true
+      ABC_FAVORIT_MEDIUM_WOFF2_BASE64:
+        required: true
 
 concurrency:
   group: deploy-website-canary
@@ -39,3 +41,4 @@ jobs:
       vercel_project_id: ${{ secrets.VERCEL_WEBSITE_CANARY_PROJECT_ID }}
       website_book_font: ${{ secrets.ABC_FAVORIT_BOOK_WOFF2_BASE64 }}
       website_light_font: ${{ secrets.ABC_FAVORIT_LIGHT_WOFF2_BASE64 }}
+      website_medium_font: ${{ secrets.ABC_FAVORIT_MEDIUM_WOFF2_BASE64 }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -100,3 +100,4 @@ jobs:
       vercel_project_id: ${{ secrets.VERCEL_WEBSITE_PROJECT_ID }}
       website_book_font: ${{ secrets.ABC_FAVORIT_BOOK_WOFF2_BASE64 }}
       website_light_font: ${{ secrets.ABC_FAVORIT_LIGHT_WOFF2_BASE64 }}
+      website_medium_font: ${{ secrets.ABC_FAVORIT_MEDIUM_WOFF2_BASE64 }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage
 packages/website/src/generated/
 packages/website/public/fonts/ABCFavorit-Book.woff2
 packages/website/public/fonts/ABCFavorit-Light.woff2
+packages/website/public/fonts/ABCFavorit-Medium.woff2
 packages/oxlint-plugin-foldkit/recommended.json
 packages/oxlint-plugin-foldkit/all.json
 .playwright-mcp/

--- a/packages/website/FONTS.md
+++ b/packages/website/FONTS.md
@@ -9,6 +9,7 @@ match production:
 
 - `ABCFavorit-Book.woff2`
 - `ABCFavorit-Light.woff2`
+- `ABCFavorit-Medium.woff2`
 
 Production restores the files from encrypted GitHub Actions secrets by running
 `scripts/restore-website-fonts.sh` before building the website.

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -51,7 +51,7 @@ export const pageTitle = (id: string, text: string, className?: string): Html =>
     [
       ih.Class(
         twMerge(
-          'text-[2rem] md:text-[2.5rem] leading-tight tracking-tight font-normal text-gray-900 dark:text-white mb-6',
+          'text-[1.75rem] md:text-4xl leading-tight tracking-tight font-medium text-gray-900 dark:text-white mb-6',
           className,
         ),
       ),
@@ -64,13 +64,13 @@ export const pageTitle = (id: string, text: string, className?: string): Html =>
 const sectionHeadingConfig = {
   h2: {
     textClassName:
-      'text-2xl md:text-3xl leading-snug tracking-tight font-normal text-gray-900 dark:text-white scroll-mt-6',
+      'text-[1.375rem] md:text-2xl leading-snug tracking-tight font-medium text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
       'group flex items-center gap-1 md:hover-capable:gap-0 mt-12 mb-4 [h1+&]:mt-8 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h3: {
     textClassName:
-      'text-xl md:text-2xl leading-snug tracking-tight font-normal text-gray-900 dark:text-white scroll-mt-6',
+      'text-lg md:text-xl leading-snug tracking-tight font-medium text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
       'group flex items-center gap-1 md:hover-capable:gap-0 mt-10 mb-3 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -19,6 +19,13 @@
 }
 
 @font-face {
+  font-family: 'ABC Favorit';
+  src: url('/fonts/ABCFavorit-Medium.woff2') format('woff2');
+  font-weight: 500;
+  font-display: swap;
+}
+
+@font-face {
   font-family: 'JetBrains Mono';
   src: url('/fonts/JetBrainsMono-Variable.woff2') format('woff2');
   font-weight: 300 600;
@@ -95,6 +102,7 @@ html.dark {
   html {
     @apply bg-cream dark:bg-gray-900;
     color-scheme: light;
+    font-synthesis-weight: none;
     scroll-padding-top: calc(var(--header-height) + var(--mobile-toc-height));
   }
 
@@ -108,7 +116,7 @@ html.dark {
   }
 
   strong {
-    font-weight: 600;
+    font-weight: 500;
   }
 
   :is(h1, h2, h3, h4).font-mono {

--- a/scripts/deploy-website-workflow.test.mjs
+++ b/scripts/deploy-website-workflow.test.mjs
@@ -777,7 +777,16 @@ test('production and canary call the shared deployment with separate projects', 
       workflow,
       /website_light_font: \$\{\{ secrets\.ABC_FAVORIT_LIGHT_WOFF2_BASE64 \}\}/,
     )
+    assert.match(
+      workflow,
+      /website_medium_font: \$\{\{ secrets\.ABC_FAVORIT_MEDIUM_WOFF2_BASE64 \}\}/,
+    )
   }
+  assert.match(buildWorkflow, /website_medium_font:\n\s+required: true/)
+  assert.match(
+    buildWorkflow,
+    /ABC_FAVORIT_MEDIUM_WOFF2_BASE64: \$\{\{ secrets\.website_medium_font \}\}/,
+  )
 })
 
 test('the canary hostname moves only after its staged deployment passes smoke tests', () => {

--- a/scripts/restore-website-fonts.sh
+++ b/scripts/restore-website-fonts.sh
@@ -30,3 +30,6 @@ restore_font \
 restore_font \
   "${ABC_FAVORIT_LIGHT_WOFF2_BASE64:-}" \
   "$fonts_directory/ABCFavorit-Light.woff2"
+restore_font \
+  "${ABC_FAVORIT_MEDIUM_WOFF2_BASE64:-}" \
+  "$fonts_directory/ABCFavorit-Medium.woff2"


### PR DESCRIPTION
Stacked on #1318. Draft until the `ABC_FAVORIT_MEDIUM_WOFF2_BASE64` repository secret exists, then retarget to `main` once #1318 merges.

The site licenses only the Light and Book cuts of ABC Favorit, which sit one small step apart. Headings have carried their hierarchy through size alone, and every bold label on the site (callout titles, table headers, sidebar section labels, `strong` text, the 404 title) has been synthesized by the browser from Book. A Medium (500) cut gives all of them a real face. This is the change that gets the docs the heading contrast Base UI has with its bold cut.

**Type.** Headings move to weight 500 and come down a step in size, since weight now does the work size was doing: the page title is 2.25rem on desktop instead of 2.5rem, h2 is `text-2xl` instead of `text-3xl`, h3 is `text-xl` instead of `text-2xl`. Mobile h2 sits at 22px so it steps clearly above the 18px h3. `strong` asks for 500 instead of 600. `font-synthesis-weight: none` on the root turns off browser weight synthesis, so any remaining `font-semibold` or `font-bold` request in the sans resolves to Medium rather than a smeared copy of it, while the code font keeps its real heavier weights. No class names change.

**Delivery.** The Medium file joins the two existing licensed files: ignored in git, restored by `scripts/restore-website-fonts.sh` from the new secret, and threaded through the production and canary deploy workflows as `website_medium_font`. The workflow test asserts the secret at every hop and was mutation-checked against removing the required declaration and the restore step's env line.

**Before merging**

1. License the Medium cut and drop `ABCFavorit-Medium.woff2` beside the other two locally to preview.
2. Add the `ABC_FAVORIT_MEDIUM_WOFF2_BASE64` secret (base64 of the woff2, same as Book and Light). Without it, the next production and canary deploys fail at the "Restore licensed website fonts" step after the build has already run.
3. Check the heading sizes on the live preview. They were chosen for a Medium face I could not render here. If the h2 wants to be a size larger, it is one class in `prose.ts`.

Verified with `tsc`, prettier, `bash -n` on the restore script, the workflow test, and the pre-push suite. The sandbox has no Favorit files, so the rendered checks cover heading sizes and margins only, not the weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7ychiXXo88y58Y5aQHuvQ