### PR TITLE
refactor(website): name the page title and inline code sizes

### DIFF
--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -15,7 +15,12 @@ import { type TableOfContentsEntry } from './tableOfContentsEntry'
 export type RenderHeadingLink = (id: string, text: string) => Html
 
 const mergeClassNames = extendTailwindMerge({
-  extend: { theme: { 'font-weight': ['book', 'code'] } },
+  extend: {
+    theme: {
+      'font-weight': ['book', 'code'],
+      text: ['page-title', 'page-title-wide', 'inline-code'],
+    },
+  },
 })
 
 const headingLinkButton = <Message>(
@@ -55,7 +60,7 @@ export const pageTitle = (id: string, text: string, className?: string): Html =>
     [
       ih.Class(
         mergeClassNames(
-          'font-heading font-book text-[2rem] md:text-[2.5rem] leading-tight tracking-tight text-gray-900 dark:text-white mb-6',
+          'font-heading font-book text-page-title md:text-page-title-wide leading-tight tracking-tight text-gray-900 dark:text-white mb-6',
           className,
         ),
       ),
@@ -159,7 +164,7 @@ export const bulletPoint = (label: string, description: string): Html =>
   ih.span([], [ih.strong([], [`${label}:`]), ` ${description}`])
 
 const inlineCodeClassName =
-  'bg-gray-200/60 dark:bg-gray-800 text-[var(--code-foreground)] [a_&]:text-inherit [:is(h1,h2,h3,h4,h5,h6)_&]:text-inherit mx-[0.1em] px-[0.25em] py-[0.05em] rounded-xs text-[0.9375em] font-code wrap-anywhere'
+  'bg-gray-200/60 dark:bg-gray-800 text-[var(--code-foreground)] [a_&]:text-inherit [:is(h1,h2,h3,h4,h5,h6)_&]:text-inherit mx-[0.1em] px-[0.25em] py-[0.05em] rounded-xs text-inline-code font-code wrap-anywhere'
 
 export const inlineCode = (text: string, className?: string): Html =>
   ih.code([ih.Class(mergeClassNames(inlineCodeClassName, className))], [text])

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -69,6 +69,9 @@
   --font-mono: 'Paper Mono', ui-monospace, monospace;
   --font-weight-book: 350;
   --font-weight-code: 425;
+  --text-page-title: 2rem;
+  --text-page-title-wide: 2.5rem;
+  --text-inline-code: 0.9375em;
 }
 
 :root {


### PR DESCRIPTION
The page title and inline code sizes were arbitrary values at their call sites, which hid two decisions that will be tuned against the live site: how large the top of the type scale is, and how much smaller than its surrounding text inline code sits. They become theme tokens, --text-page-title, --text-page-title-wide, and --text-inline-code, so the values read as a set beside the font tokens and change in one place.

The prose class merger learns the three names as font sizes. Without that it would read text-inline-code as a color and drop the code foreground beside it, which is the same failure the weight tokens needed guarding against.

The chip padding stays as em values in the helper. It is local geometry with one consumer, and the helper is its name.