### PR TITLE
docs(website): clarify architecture and Subscription diagrams

### DIFF
--- a/packages/website/src/page/core/architecture.md
+++ b/packages/website/src/page/core/architecture.md
@@ -18,15 +18,15 @@ Every Foldkit app repeats the same cycle:
 The complete cycle looks like this:
 
 ```diagram
-+------> update -> Commands -----------+
++-----> update --> Commands -----------+
 |         |                            |
 |         v                            |
-|       Model -> Subscriptions --------+
+|       Model ---> Subscriptions ------+
 |         |                            |
-|         +-> ManagedResources --------+
+|         +------> ManagedResources ---+
 |         |                            |
 |         v                            |
-|       view -> Mounts ----------------+
+|       view ----> Mounts -------------+
 |         |                            |
 |         v                            |
 |       Browser -> events -------------+

--- a/packages/website/src/page/patterns/subscriptionOrganization.md
+++ b/packages/website/src/page/patterns/subscriptionOrganization.md
@@ -11,26 +11,29 @@ This mirrors the other halves of the boundary. `Update.foldChild` lifts child up
 Each level declares local entries with `Subscription.make` and lifts child records with `Subscription.lift`. By the time a Stream reaches the root, it emits root Messages that the Runtime can dispatch through update. This diagram follows one leaf record through those lifts:
 
 ```diagram
-page/settings/themeMenu/
-  subscription.ts
-  Subscription.make
-  Stream<ThemeMenu.Message>
-               |
-       Subscription.lift
- wraps with GotThemeMenuMessage
-               v
-page/settings/
-  subscription.ts
-  Stream<Settings.Message>
-               |
-       Subscription.lift
-   wraps with GotSettingsMessage
-               v
-subscription.ts (root)
-  Stream<Message>
-               |
-               v
-            Runtime
++-------------------------------+
+| ThemeMenu                     |
+| Stream<ThemeMenu.Message>     |
++-------------------------------+
+  |
+  | Subscription.lift
+  | wraps with GotThemeMenuMessage
+  v
++-------------------------------+
+| Settings                      |
+| Stream<Settings.Message>      |
++-------------------------------+
+  |
+  | Subscription.lift
+  | wraps with GotSettingsMessage
+  v
++-------------------------------+
+| Root                          |
+| Stream<Message>               |
++-------------------------------+
+  |
+  v
+Runtime
 ```
 
 ## The Composition Verbs {#composition-verbs}


### PR DESCRIPTION
Align the architecture loop into two columns and group Subscription streams by composition level so each lift and Message wrapper is easier to follow.
