### PR TITLE
feat(website): improve docs readability and navigation layout

### DIFF
--- a/packages/website/src/docsNav.ts
+++ b/packages/website/src/docsNav.ts
@@ -147,14 +147,14 @@ export const docsSections: ReadonlyArray<DocsSection> = [
           label: 'Why Foldkit',
         },
         {
-          _tag: 'GettingStarted',
-          href: gettingStartedRouter(),
-          label: 'Getting Started',
-        },
-        {
           _tag: 'Roadmap',
           href: roadmapRouter(),
           label: 'Roadmap',
+        },
+        {
+          _tag: 'GettingStarted',
+          href: gettingStartedRouter(),
+          label: 'Getting Started',
         },
       ],
     ],

--- a/packages/website/src/layout/docs.ts
+++ b/packages/website/src/layout/docs.ts
@@ -71,70 +71,79 @@ export const headerView = (model: Model, h: HtmlBuilder<Message>) =>
   h.header(
     [
       h.Class(
-        'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream dark:bg-gray-900 border-b border-gray-300 dark:border-gray-800 px-6 flex items-center justify-between transform-gpu',
+        'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream dark:bg-gray-900 border-b border-gray-300 dark:border-gray-800 transform-gpu',
       ),
     ],
     [
       h.div(
-        [h.Class('flex items-center gap-2')],
+        [h.Class('docs-shell h-full px-6 flex items-center justify-between')],
         [
-          h.a(
-            [h.Href(homeRouter()), h.Class('flex items-center gap-2')],
-            [
-              h.img([
-                h.Src('/logo.svg'),
-                h.Alt('Foldkit'),
-                h.Width('801'),
-                h.Height('200'),
-                h.Class('h-6 md:h-8 w-auto dark:invert'),
-              ]),
-              Shared.betaTag,
-            ],
-          ),
-        ],
-      ),
-      h.div(
-        [h.Class('flex items-center gap-3 md:gap-8')],
-        [
-          HeaderNav.view(model.route, 'hidden md:flex items-center gap-6', h),
-          Search.triggerView('hidden md:flex', h),
-          ThemeSelector.view(model.maybeThemePreference, h),
           h.div(
-            [h.Class('hidden md:flex items-center gap-3 md:gap-4')],
+            [h.Class('flex items-center gap-2')],
             [
-              Shared.iconLink(
-                Link.github,
-                'GitHub',
-                Icon.github('w-5 h-5 md:w-6 md:h-6'),
-              ),
-              Shared.iconLink(
-                Link.discord,
-                'Discord',
-                Icon.discord('w-5 h-5 md:w-6 md:h-6'),
-              ),
-              Shared.iconLink(
-                Link.xSocial,
-                'X',
-                Icon.xSocial('w-5 h-5 md:w-6 md:h-6'),
-              ),
-              Shared.iconLink(
-                Link.npm,
-                'npm',
-                Icon.npm('w-6 h-6 md:w-8 md:h-8'),
+              h.a(
+                [h.Href(homeRouter()), h.Class('flex items-center gap-2')],
+                [
+                  h.img([
+                    h.Src('/logo.svg'),
+                    h.Alt('Foldkit'),
+                    h.Width('801'),
+                    h.Height('200'),
+                    h.Class('h-6 md:h-8 w-auto dark:invert'),
+                  ]),
+                  Shared.betaTag,
+                ],
               ),
             ],
           ),
-          Search.compactTriggerView('md:hidden', h),
-          h.button(
+          h.div(
+            [h.Class('flex items-center gap-3 md:gap-8')],
             [
-              h.Class(
-                'md:hidden p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-700 dark:text-gray-300 cursor-pointer',
+              HeaderNav.view(
+                model.route,
+                'hidden md:flex items-center gap-6',
+                h,
               ),
-              h.AriaExpanded(model.mobileMenuDialog.isOpen),
-              h.AriaLabel('Toggle menu'),
-              h.OnClick(Message.ClickedOpenMobileMenu()),
+              Search.triggerView('hidden md:flex', h),
+              ThemeSelector.view(model.maybeThemePreference, h),
+              h.div(
+                [h.Class('hidden md:flex items-center gap-3 md:gap-4')],
+                [
+                  Shared.iconLink(
+                    Link.github,
+                    'GitHub',
+                    Icon.github('w-5 h-5 md:w-6 md:h-6'),
+                  ),
+                  Shared.iconLink(
+                    Link.discord,
+                    'Discord',
+                    Icon.discord('w-5 h-5 md:w-6 md:h-6'),
+                  ),
+                  Shared.iconLink(
+                    Link.xSocial,
+                    'X',
+                    Icon.xSocial('w-5 h-5 md:w-6 md:h-6'),
+                  ),
+                  Shared.iconLink(
+                    Link.npm,
+                    'npm',
+                    Icon.npm('w-6 h-6 md:w-8 md:h-8'),
+                  ),
+                ],
+              ),
+              Search.compactTriggerView('md:hidden', h),
+              h.button(
+                [
+                  h.Class(
+                    'md:hidden p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-700 dark:text-gray-300 cursor-pointer',
+                  ),
+                  h.AriaExpanded(model.mobileMenuDialog.isOpen),
+                  h.AriaLabel('Toggle menu'),
+                  h.OnClick(Message.ClickedOpenMobileMenu()),
+                ],
+                [Icon.menu('w-6 h-6')],
+              ),
             ],
-            [Icon.menu('w-6 h-6')],
           ),
         ],
       ),
@@ -150,7 +159,7 @@ export const footerView = (
   h.footer(
     [
       h.Class(
-        'px-6 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] md:px-10 mt-6 border-t border-gray-300 dark:border-gray-800',
+        'px-6 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] md:px-8 xl:px-12 mt-6 border-t border-gray-300 dark:border-gray-800',
       ),
     ],
     [
@@ -165,7 +174,7 @@ export const footerView = (
       Shared.emailForm,
       h.hr([
         h.Class(
-          'my-6 -mx-6 md:-mx-10 border-t border-gray-300 dark:border-gray-800',
+          'my-6 -mx-6 md:-mx-8 xl:-mx-12 border-t border-gray-300 dark:border-gray-800',
         ),
       ]),
       h.div(
@@ -1122,7 +1131,7 @@ export const view = (
       headerView(model, h),
       Search.dialogView(model, h),
       h.div(
-        [h.Class('flex flex-1 pt-[var(--header-height)] md:pl-64')],
+        [h.Class('docs-shell flex flex-1 pt-[var(--header-height)] md:pl-64')],
         [
           Sidebar.view(model, h),
           Sidebar.mobileView(model, h),
@@ -1163,10 +1172,9 @@ export const view = (
                     searchWeight(docsRoute._tag),
                   ),
                   h.Class(
-                    clsx(
-                      'flex-1 w-full px-6 py-8 md:px-10 2xl:py-12 mx-auto min-w-0',
-                      isWideContentRoute(docsRoute) ? 'max-w-4xl' : 'max-w-3xl',
-                    ),
+                    clsx('docs-content flex-1', {
+                      'max-w-5xl': isWideContentRoute(docsRoute),
+                    }),
                   ),
                 ],
                 [

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -1,5 +1,4 @@
 import {
-  Array,
   DateTime,
   Effect,
   Layer,
@@ -54,7 +53,6 @@ import {
 } from './route'
 import * as Search from './search'
 import {
-  DEFAULT_OPEN_GROUPS,
   GroupKey,
   SIDEBAR_STORAGE_KEY,
   SidebarGroups,
@@ -189,7 +187,7 @@ const isGroupOpenOnBoot = (
     return true
   }
   return Option.match(maybeSidebarState, {
-    onNone: () => Array.contains(DEFAULT_OPEN_GROUPS, key),
+    onNone: () => false,
     onSome: ({ open }) => open[key] ?? false,
   })
 }

--- a/packages/website/src/markdown/views.ts
+++ b/packages/website/src/markdown/views.ts
@@ -25,7 +25,7 @@ export type DocViewConfig = Readonly<{
   renderHeadingLink: RenderHeadingLink
 }>
 
-const linkClassName = 'link-accent font-normal'
+const linkClassName = 'link-accent'
 
 const blockquoteClassName =
   'border-l-4 border-gray-300 dark:border-gray-700 pl-4 italic text-gray-700 dark:text-gray-300 mb-5 [&>p:last-child]:mb-0'
@@ -76,7 +76,7 @@ const titleAttributes = (
 export const docViews = (config: DocViewConfig): Partial<Markdown.Views> => {
   return {
     Paragraph: (_paragraph, content) =>
-      ih.p([ih.Class('mb-5 leading-relaxed')], content),
+      ih.p([ih.Class('mb-5 leading-7')], content),
 
     Link: (link, content) =>
       ih.a(

--- a/packages/website/src/page/blog/blogIndex.ts
+++ b/packages/website/src/page/blog/blogIndex.ts
@@ -65,7 +65,7 @@ const postEntry = (post: BlogPost, isFirstEntry: boolean): Html =>
         [`${formatPostDate(post.frontmatter.date)} · ${BLOG_AUTHOR}`],
       ),
       ih.p(
-        [ih.Class('text-gray-600 dark:text-gray-300 leading-relaxed')],
+        [ih.Class('text-gray-600 dark:text-gray-300 leading-7')],
         [post.frontmatter.description],
       ),
       ih.a(

--- a/packages/website/src/page/roadmap.md
+++ b/packages/website/src/page/roadmap.md
@@ -2,11 +2,7 @@
 
 ## Current Goal
 
-Foldkit is pre-1.0, and the current goal is a production-ready 1.0. All work in progress is in service of that release.
-
-For 1.0, Foldkit will target browser applications. Future view targets may include terminal and native mobile.
-
-Day-to-day work is tracked in [GitHub issues](https://github.com/foldkit/foldkit/issues).
+Foldkit is pre-1.0, and the current goal is a production-ready 1.0. All work in progress is in service of that release. For 1.0, Foldkit will target browser applications. Future view targets may include terminal and native mobile. Day-to-day work is tracked in [GitHub issues](https://github.com/foldkit/foldkit/issues).
 
 ## The Path to 1.0
 

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -48,7 +48,7 @@ export const renderHeadingLink =
     headingLinkButton(id, text, toMessage, h)
 
 export const link = (href: string, text: string): Html =>
-  ih.a([ih.Href(href), ih.Class('link-accent font-normal')], [text])
+  ih.a([ih.Href(href), ih.Class('link-accent')], [text])
 
 export const pageTitle = (id: string, text: string, className?: string): Html =>
   ih.h1(
@@ -123,7 +123,7 @@ export const headingWithContent = (
 }
 
 export const para = (...content: ReadonlyArray<string | Html>): Html =>
-  ih.p([ih.Class('mb-5 leading-relaxed')], content)
+  ih.p([ih.Class('mb-5 leading-7')], content)
 
 export const subPara = (...content: ReadonlyArray<string | Html>): Html =>
   ih.p(

--- a/packages/website/src/sidebarStorage.ts
+++ b/packages/website/src/sidebarStorage.ts
@@ -27,8 +27,3 @@ export type GroupKey = typeof GroupKey.Type
 
 export const SidebarGroups = Schema.Record(GroupKey, Schema.Boolean)
 export type SidebarGroups = typeof SidebarGroups.Type
-
-export const DEFAULT_OPEN_GROUPS: ReadonlyArray<GroupKey> = [
-  'getStarted',
-  'coreConcepts',
-]

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -74,6 +74,8 @@
 :root {
   --header-height: calc(3.5rem + env(safe-area-inset-top, 0px));
   --mobile-toc-height: 2.75rem;
+  --docs-max-width: 90rem;
+  --docs-content-width: 58rem;
   --code-foreground: #403d4a;
   --code-background: var(--color-gray-100);
 }
@@ -201,6 +203,21 @@ html.dark {
 }
 
 @layer components {
+  .docs-shell {
+    width: 100%;
+    max-width: var(--docs-max-width);
+    margin-inline: auto;
+  }
+
+  .docs-sidebar {
+    left: max(0px, calc((100% - var(--docs-max-width)) / 2));
+  }
+
+  .docs-content {
+    @apply w-full min-w-0 mx-auto px-6 py-8 md:px-8 xl:px-12 2xl:py-12 font-book leading-7;
+    max-width: var(--docs-content-width);
+  }
+
   .landing-section {
     @apply px-6 py-10 md:px-12 md:py-24 lg:px-20;
   }

--- a/packages/website/src/view/blog.ts
+++ b/packages/website/src/view/blog.ts
@@ -85,9 +85,7 @@ export const view = (
                 'pagefind-weight',
                 Docs.searchWeight(blogRoute._tag),
               ),
-              h.Class(
-                'flex-1 w-full px-6 py-8 md:px-10 2xl:py-12 max-w-3xl mx-auto min-w-0',
-              ),
+              h.Class('docs-content flex-1'),
             ],
             [content],
           ),

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -56,18 +56,17 @@ const sidebarGroup = (
   const buttonClassName = clsx(
     'w-full flex items-center justify-between transition',
     'px-4 py-2.5 md:py-2',
-    'text-xs font-semibold uppercase tracking-wider',
-    'text-gray-600 dark:text-gray-400',
-    'bg-gray-200 dark:bg-gray-800',
+    'text-sm font-medium',
+    'text-gray-800 dark:text-gray-200',
     {
       'cursor-default': config.isLocked,
-      'cursor-pointer hover:bg-gray-300/60 dark:hover:bg-gray-700/60 hover:text-gray-700 dark:hover:text-gray-300':
+      'cursor-pointer hover:text-gray-900 dark:hover:text-white':
         !config.isLocked,
     },
   )
 
   return h.li(
-    [],
+    [h.Class('mb-5 last:mb-0')],
     [
       Disclosure.view(
         {
@@ -239,9 +238,8 @@ const computeNavLinks = (
 const blogSectionHeaderClassName = clsx(
   'w-full flex items-center justify-between transition cursor-default',
   'px-4 py-2.5 md:py-2',
-  'text-xs font-semibold uppercase tracking-wider',
-  'text-gray-600 dark:text-gray-400',
-  'bg-gray-200 dark:bg-gray-800',
+  'text-sm font-medium',
+  'text-gray-800 dark:text-gray-200',
 )
 
 const blogSection = (route: Model['route'], h: HtmlBuilder<Message>): Html =>
@@ -278,7 +276,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
     [
       h.AriaLabel('Documentation sidebar'),
       h.Class(
-        'hidden md:flex fixed top-[var(--header-height)] bottom-0 left-0 z-40 w-64 bg-cream dark:bg-gray-900 border-r border-gray-300 dark:border-gray-800 flex-col',
+        'docs-sidebar hidden md:flex fixed top-[var(--header-height)] bottom-0 z-40 w-64 bg-cream dark:bg-gray-900 border-r border-gray-300 dark:border-gray-800 flex-col',
       ),
     ],
     [
@@ -286,7 +284,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
         [
           h.AriaLabel('Documentation'),
           h.Id(DOCS_SIDEBAR_NAV_ID),
-          h.Class('flex-1 overflow-y-auto pb-4'),
+          h.Class('flex-1 overflow-y-auto py-6'),
         ],
         [desktopNavLinks],
       ),
@@ -353,7 +351,7 @@ export const mobileView = (model: Model, h: HtmlBuilder<Message>): Html => {
           [
             h.AriaLabel('Documentation'),
             h.Id(MOBILE_MENU_NAV_ID),
-            h.Class('flex-1 overflow-y-auto'),
+            h.Class('flex-1 overflow-y-auto py-4'),
             h.Tabindex(-1),
             ...initialFocus,
           ],

--- a/packages/website/src/view/tableOfContents.ts
+++ b/packages/website/src/view/tableOfContents.ts
@@ -27,7 +27,7 @@ const tableOfContentsEntryView = (
           h.Href(`#${entry.id}`),
           h.OnClick(Message.ChangedActiveSection({ sectionId: entry.id })),
           h.Class(
-            clsx('transition block', {
+            clsx('transition block wrap-anywhere', {
               'text-accent-600 dark:text-accent-400 underline': isActive,
               'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white':
                 !isActive,
@@ -48,24 +48,22 @@ export const view = (
   h.aside(
     [
       h.Class(
-        'hidden xl:block sticky top-[var(--header-height)] min-w-64 w-fit h-[calc(100vh-var(--header-height))] shrink-0 overflow-y-auto border-l border-gray-300 dark:border-gray-800 p-4',
+        'hidden xl:block sticky top-[var(--header-height)] w-64 h-[calc(100vh-var(--header-height))] shrink-0 overflow-y-auto border-l border-gray-300 dark:border-gray-800 px-4 pt-8 pb-4',
       ),
     ],
     [
       h.h3(
         [
           h.AriaHidden(true),
-          h.Class(
-            'text-xs font-semibold text-gray-900 dark:text-white uppercase tracking-wider mb-2',
-          ),
+          h.Class('text-sm font-medium text-gray-800 dark:text-gray-200 mb-4'),
         ],
-        ['On This Page'],
+        ['On this page'],
       ),
       h.nav(
         [h.AriaLabel('Table of contents')],
         [
           h.ul(
-            [h.Class('space-y-2 text-sm')],
+            [h.Class('space-y-3 text-sm')],
             Array.map(entries, entry =>
               tableOfContentsEntryView(
                 entry,


### PR DESCRIPTION
Center the documentation columns and header within a bounded layout so the sidebars stay close to the article on wide screens. Widen docs and blog prose, increase its line height, and lighten its weight for easier reading. Consolidate the Roadmap goal into a single paragraph.

Replace sidebar group background bars with spaced text labels, soften the table of contents heading, and give section links more space while keeping long titles within their column. Expand only the current section by default while honoring saved choices, and place Roadmap between Why Foldkit and Getting Started. Preserve independent sidebar scrolling and mobile navigation behavior.
