### PR TITLE
fix(ui): keep an anchored panel in place under a fixed header

### DIFF
--- a/.changeset/anchor-focus-prevent-scroll.md
+++ b/.changeset/anchor-focus-prevent-scroll.md
@@ -1,0 +1,9 @@
+---
+'@foldkit/ui': patch
+---
+
+Keep an anchored panel in place when its button sits in a fixed header. Two things went wrong for a panel opened from a `position: fixed` header, for example a Menu, Listbox, or Popover, both visible in the website's theme picker on phones and tablets.
+
+Opening the panel scrolled the page. The reveal focused the freshly positioned panel with a plain `.focus()`, and on a page whose `scroll-padding-top` is larger than the panel's offset from the top of the viewport, the browser scrolled the document to push the panel below that padding. The reveal now focuses with `preventScroll: true`, since Floating UI has already placed the panel in view.
+
+Scrolling with the panel open made it jump. The panel was positioned with Floating UI's absolute strategy in document coordinates, so every scroll moved it with the page until the scroll listener put it back under the button. A portaled panel whose button has a `position: fixed` ancestor is now positioned with the fixed strategy and stays under the button as the page scrolls.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <h3 align="center">The frontend framework for correctness.</h3>
 
 <p align="center">
-  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/get-started/why-foldkit"><strong>Why Foldkit</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/get-started/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqGm"><strong>Discord</strong></a>
+  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/introduction/why-foldkit"><strong>Why Foldkit</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/get-started/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqGm"><strong>Discord</strong></a>
 </p>
 
 ---

--- a/packages/foldkit/README.md
+++ b/packages/foldkit/README.md
@@ -13,7 +13,7 @@
 <h3 align="center">The frontend framework for correctness.</h3>
 
 <p align="center">
-  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/get-started/why-foldkit"><strong>Why Foldkit</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/get-started/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqGm"><strong>Discord</strong></a>
+  <a href="https://foldkit.dev"><strong>Documentation</strong></a> · <a href="https://foldkit.dev/introduction/why-foldkit"><strong>Why Foldkit</strong></a> · <a href="https://foldkit.dev/example-apps"><strong>Examples</strong></a> · <a href="https://foldkit.dev/get-started/getting-started"><strong>Getting Started</strong></a> · <a href="https://discord.gg/kav8VNxqGm"><strong>Discord</strong></a>
 </p>
 
 ---

--- a/packages/ui/src/anchor/anchor.focusAfterPosition.test.ts
+++ b/packages/ui/src/anchor/anchor.focusAfterPosition.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ComputePositionConfig,
+  Placement as FloatingPlacement,
+} from '@floating-ui/dom'
+
+import { anchorSetup } from './index.js'
+
+type MockComputePositionReturn = {
+  x: number
+  y: number
+  placement: FloatingPlacement
+}
+
+const BUTTON_ID = 'btn'
+
+const computePositionMock =
+  vi.fn<
+    (
+      reference: Element,
+      floating: Element,
+      options: Partial<ComputePositionConfig>,
+    ) => Promise<MockComputePositionReturn>
+  >()
+
+vi.mock('@floating-ui/dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('@floating-ui/dom')>()
+  return {
+    ...actual,
+    computePosition: (
+      reference: Element,
+      floating: Element,
+      options: Partial<ComputePositionConfig>,
+    ) => computePositionMock(reference, floating, options),
+    autoUpdate: (
+      _reference: unknown,
+      _floating: unknown,
+      update: () => void,
+    ) => {
+      update()
+      return () => {}
+    },
+  }
+})
+
+describe('anchorSetup focusAfterPosition', () => {
+  afterEach(() => {
+    computePositionMock.mockReset()
+    vi.unstubAllGlobals()
+    document.body.replaceChildren()
+  })
+
+  it('focuses the panel with preventScroll once the first position resolves', async () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    })
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: 'bottom-start',
+    })
+
+    const button = document.createElement('button')
+    button.id = BUTTON_ID
+    const element = document.createElement('div')
+    element.tabIndex = 0
+    element.style.visibility = 'hidden'
+    document.body.append(button, element)
+    const focusSpy = vi.spyOn(element, 'focus')
+
+    const cleanup = anchorSetup(element, {
+      buttonId: BUTTON_ID,
+      anchor: { portal: false },
+      focusAfterPosition: true,
+    })
+
+    await vi.waitFor(() => {
+      expect(focusSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+    expect(element.style.visibility).toBe('')
+
+    cleanup()
+  })
+})

--- a/packages/ui/src/anchor/anchor.strategy.test.ts
+++ b/packages/ui/src/anchor/anchor.strategy.test.ts
@@ -1,0 +1,116 @@
+import { Array, Option, pipe } from 'effect'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ComputePositionConfig,
+  Placement as FloatingPlacement,
+  Strategy,
+} from '@floating-ui/dom'
+
+import { type AnchorConfig, anchorSetup } from './index.js'
+
+type MockComputePositionReturn = {
+  x: number
+  y: number
+  placement: FloatingPlacement
+}
+
+const BUTTON_ID = 'btn'
+
+const computePositionMock =
+  vi.fn<
+    (
+      reference: Element,
+      floating: Element,
+      options: Partial<ComputePositionConfig>,
+    ) => Promise<MockComputePositionReturn>
+  >()
+
+vi.mock('@floating-ui/dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('@floating-ui/dom')>()
+  return {
+    ...actual,
+    computePosition: (
+      reference: Element,
+      floating: Element,
+      options: Partial<ComputePositionConfig>,
+    ) => computePositionMock(reference, floating, options),
+    autoUpdate: (
+      _reference: unknown,
+      _floating: unknown,
+      update: () => void,
+    ) => {
+      update()
+      return () => {}
+    },
+  }
+})
+
+describe('anchorSetup strategy', () => {
+  afterEach(() => {
+    computePositionMock.mockReset()
+    document.body.replaceChildren()
+  })
+
+  const strategyOfCall = (callIndex: number): Strategy | undefined =>
+    pipe(
+      Array.get(computePositionMock.mock.calls, callIndex),
+      Option.map(([, , options]) => options.strategy),
+      Option.getOrThrowWith(
+        () =>
+          new Error(`Expected a computePosition call at index ${callIndex}`),
+      ),
+    )
+
+  const mountAnchor = (
+    anchor: AnchorConfig,
+    containerPosition: string,
+  ): Readonly<{ element: HTMLElement; cleanup: () => void }> => {
+    computePositionMock.mockResolvedValue({
+      x: 10,
+      y: 20,
+      placement: 'bottom-start',
+    })
+    const container = document.createElement('header')
+    container.style.position = containerPosition
+    const nav = document.createElement('nav')
+    const wrapper = document.createElement('div')
+    const button = document.createElement('button')
+    button.id = BUTTON_ID
+    wrapper.append(button)
+    nav.append(wrapper)
+    container.append(nav)
+    const element = document.createElement('div')
+    element.style.position = 'absolute'
+    document.body.append(container, element)
+    const cleanup = anchorSetup(element, { buttonId: BUTTON_ID, anchor })
+    return { element, cleanup }
+  }
+
+  it('positions a portaled panel with the fixed strategy when the button sits inside a fixed container', () => {
+    const { element, cleanup } = mountAnchor({}, 'fixed')
+
+    expect(strategyOfCall(0)).toBe('fixed')
+    expect(element.style.position).toBe('fixed')
+
+    cleanup()
+  })
+
+  it('keeps the absolute strategy when no ancestor of the button is fixed', () => {
+    const { element, cleanup } = mountAnchor({}, 'sticky')
+
+    expect(strategyOfCall(0)).toBe('absolute')
+    expect(element.style.position).toBe('absolute')
+
+    cleanup()
+  })
+
+  it('keeps the absolute strategy for a panel that is not portaled', () => {
+    const { element, cleanup } = mountAnchor({ portal: false }, 'fixed')
+
+    expect(strategyOfCall(0)).toBe('absolute')
+    expect(element.style.position).toBe('absolute')
+
+    cleanup()
+  })
+})

--- a/packages/ui/src/anchor/anchor.ts
+++ b/packages/ui/src/anchor/anchor.ts
@@ -108,6 +108,11 @@ export const portalToContainingRoot = (element: Element): (() => void) => {
   }
 }
 
+const isInsideFixedContainer = (element: Element | null): boolean =>
+  element !== null &&
+  (getComputedStyle(element).position === 'fixed' ||
+    isInsideFixedContainer(element.parentElement))
+
 const toSide = (placement: FloatingPlacement): string =>
   pipe(placement, String.split('-'), Array.headNonEmpty)
 
@@ -171,9 +176,17 @@ const setOrResetLength = (
  *  components like Popover where Tab should navigate naturally within the
  *  panel. When `focusAfterPosition` is true, the element is focused after the
  *  first position computation clears visibility, deferred via
- *  requestAnimationFrame so the element is painted before focus fires.
+ *  requestAnimationFrame so the element is painted before focus fires. That
+ *  focus passes `preventScroll`. Floating UI has already placed the element
+ *  in view, so a scroll-on-focus can only move the page under it, which
+ *  happens when the element's top edge lands within the document's
+ *  `scroll-padding-top`.
  *  `focusSelector` optionally targets a descendant (e.g. a calendar grid
  *  inside a popover panel) instead of the panel itself.
+ *  A portaled element whose button sits inside a `position: fixed` ancestor
+ *  is positioned with Floating UI's fixed strategy, so it stays under the
+ *  button while the page scrolls instead of moving with the document until
+ *  `autoUpdate` repositions it.
  *  The side the element currently sits on is written to `data-placement`, so
  *  CSS can react to it. When `isPlacementLocked` is true, the element keeps the
  *  side that the first positioning picks, `flip` is removed from every later
@@ -203,9 +216,16 @@ export const anchorSetup = (
   // NOTE: inside a shadow root the panel's offsetParent resolves to the
   // light-DOM host element, so Floating UI's absolute strategy mis-measures
   // its position. The fixed strategy is viewport-relative and sidesteps the
-  // offsetParent entirely. Light-DOM apps keep the absolute strategy.
-  const strategy = inShadow ? 'fixed' : 'absolute'
-  if (inShadow) {
+  // offsetParent entirely. A portaled panel whose button sits inside a
+  // `position: fixed` ancestor needs the fixed strategy too: absolute
+  // coordinates move with the document on every scroll while the button
+  // stays put, so the panel visibly lags until `autoUpdate` catches up. A
+  // `sticky` ancestor is left alone, since it is viewport-anchored only past
+  // its threshold and neither strategy is right across the whole scroll
+  // range. Other light-DOM apps keep the absolute strategy.
+  const isAnchoredToFixedContainer = isPortal && isInsideFixedContainer(button)
+  const strategy = inShadow || isAnchoredToFixedContainer ? 'fixed' : 'absolute'
+  if (strategy === 'fixed') {
     element.style.position = 'fixed'
   }
 
@@ -354,7 +374,7 @@ export const anchorSetup = (
                   ? owner.querySelector(config.focusSelector)
                   : element
                 if (target instanceof HTMLElement) {
-                  target.focus()
+                  target.focus({ preventScroll: true })
                 }
               })
             }

--- a/packages/website/src/component/shared.ts
+++ b/packages/website/src/component/shared.ts
@@ -37,7 +37,7 @@ export const canaryBanner = (commit: string): Html => {
 export const betaTag: Html = ih.span(
   [
     ih.Class(
-      'hidden sm:inline-block -rotate-6 rounded bg-accent-700 dark:bg-accent-500 px-1.5 py-0.5 text-[10px] font-extrabold uppercase leading-none tracking-wider text-white dark:text-accent-900 select-none',
+      'hidden sm:inline-block -rotate-6 rounded-xs bg-accent-700 dark:bg-accent-500 px-1 py-0.5 text-[10px] font-semibold uppercase leading-none tracking-wider text-white dark:text-accent-900 select-none',
     ),
     ih.AriaLabel('Beta'),
   ],
@@ -49,12 +49,18 @@ export const iconLink = (link: string, ariaLabel: string, icon: Html): Html =>
     [
       ih.Href(link),
       ih.Class(
-        'text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition',
+        'text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition',
       ),
       ih.AriaLabel(ariaLabel),
     ],
     [icon],
   )
+
+export const headerGroupDivider = (className: string): Html =>
+  ih.span([
+    ih.AriaHidden(true),
+    ih.Class(clsx('h-4 w-px shrink-0 bg-gray-200 dark:bg-gray-800', className)),
+  ])
 
 const STAR_COUNT_MIN_WIDTH = 'min-w-[3ch]'
 
@@ -174,7 +180,11 @@ export const emailSignupContent: Html = ih.div(
       ['Stay in the update loop.'],
     ),
     ih.p(
-      [ih.Class('text-lg text-gray-600 dark:text-gray-300 mb-8 max-w-xl')],
+      [
+        ih.Class(
+          'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 mb-8 max-w-xl',
+        ),
+      ],
       ['New releases, patterns, and the occasional deep dive.'],
     ),
     emailForm,

--- a/packages/website/src/docsNav.test.ts
+++ b/packages/website/src/docsNav.test.ts
@@ -5,7 +5,10 @@ import { findActiveSectionKey } from './docsNav'
 
 describe('findActiveSectionKey', () => {
   test.each([
-    ['Manifesto', 'getStarted'],
+    ['Blog', 'blog'],
+    ['BlogPost', 'blog'],
+    ['Manifesto', 'introduction'],
+    ['Roadmap', 'introduction'],
     ['CoreModel', 'coreConcepts'],
     ['ComingFromReact', 'comparisons'],
     ['ReactComparison', 'comparisons'],
@@ -43,6 +46,12 @@ describe('findActiveSectionKey', () => {
   test('a route in no section resolves to none', () => {
     expect(
       Option.getOrNull(findActiveSectionKey('Home', Option.none())),
+    ).toBeNull()
+  })
+
+  test('the top-level Get Started page is not in a section', () => {
+    expect(
+      Option.getOrNull(findActiveSectionKey('GettingStarted', Option.none())),
     ).toBeNull()
   })
 })

--- a/packages/website/src/docsNav.ts
+++ b/packages/website/src/docsNav.ts
@@ -135,10 +135,16 @@ export type DocsSection = Readonly<{
   pageGroups: ReadonlyArray<ReadonlyArray<NavPage>>
 }>
 
+export const getStartedPage: NavPage = {
+  _tag: 'GettingStarted',
+  href: gettingStartedRouter(),
+  label: 'Get Started',
+}
+
 export const docsSections: ReadonlyArray<DocsSection> = [
   {
-    key: 'getStarted',
-    label: 'Get Started',
+    key: 'introduction',
+    label: 'Introduction',
     pageGroups: [
       [
         {
@@ -150,11 +156,6 @@ export const docsSections: ReadonlyArray<DocsSection> = [
           _tag: 'Roadmap',
           href: roadmapRouter(),
           label: 'Roadmap',
-        },
-        {
-          _tag: 'GettingStarted',
-          href: gettingStartedRouter(),
-          label: 'Getting Started',
         },
       ],
     ],
@@ -697,10 +698,10 @@ export const docsSections: ReadonlyArray<DocsSection> = [
 
 // FLAT PAGE LIST
 
-export const allPages: ReadonlyArray<NavPage> = Array.flatMap(
-  docsSections,
-  ({ pageGroups }) => Array.flatten(pageGroups),
-)
+export const allPages: ReadonlyArray<NavPage> = [
+  getStartedPage,
+  ...Array.flatMap(docsSections, ({ pageGroups }) => Array.flatten(pageGroups)),
+]
 
 // NEXT / PREV LOOKUP
 
@@ -729,10 +730,14 @@ export const findActiveSectionKey = (
   routeTag: string,
   maybeExampleSlug: Option.Option<string>,
 ): Option.Option<GroupKey> => {
-  // NOTE: ApiModule pages aren't in docsSections; their apiReference group is
+  // NOTE: ApiModule and Blog pages aren't in docsSections. Their groups are
   // rendered separately, so map them explicitly.
   if (routeTag === 'ApiModule') {
     return Option.some('apiReference')
+  }
+
+  if (routeTag === 'Blog' || routeTag === 'BlogPost') {
+    return Option.some('blog')
   }
   return pipe(
     docsSections,

--- a/packages/website/src/layout/docs.ts
+++ b/packages/website/src/layout/docs.ts
@@ -71,7 +71,7 @@ export const headerView = (model: Model, h: HtmlBuilder<Message>) =>
   h.header(
     [
       h.Class(
-        'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream dark:bg-gray-900 border-b border-gray-300 dark:border-gray-800 transform-gpu',
+        'fixed top-0 inset-x-0 z-50 h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] bg-cream dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 transform-gpu',
       ),
     ],
     [
@@ -83,7 +83,7 @@ export const headerView = (model: Model, h: HtmlBuilder<Message>) =>
         ],
         [
           h.div(
-            [h.Class('flex items-center gap-2')],
+            [h.Class('flex items-center gap-12')],
             [
               h.a(
                 [h.Href(homeRouter()), h.Class('flex items-center gap-2')],
@@ -98,52 +98,47 @@ export const headerView = (model: Model, h: HtmlBuilder<Message>) =>
                   Shared.betaTag,
                 ],
               ),
-            ],
-          ),
-          h.div(
-            [h.Class('flex items-center gap-3 md:gap-8')],
-            [
               HeaderNav.view(
                 model.route,
                 'hidden md:flex items-center gap-6',
                 h,
               ),
+            ],
+          ),
+          h.div(
+            [h.Class('flex items-center gap-1')],
+            [
               Search.triggerView('hidden md:flex', h),
+              Shared.headerGroupDivider('hidden md:block mx-3'),
+              h.div(
+                [h.Class('hidden md:flex items-center gap-3')],
+                [
+                  Shared.iconLink(
+                    Link.github,
+                    'GitHub',
+                    Icon.github('w-5 h-5'),
+                  ),
+                  Shared.iconLink(
+                    Link.discord,
+                    'Discord',
+                    Icon.discord('w-5 h-5'),
+                  ),
+                  Shared.iconLink(Link.xSocial, 'X', Icon.xSocial('w-5 h-5')),
+                  Shared.iconLink(Link.npm, 'npm', Icon.npm('w-6 h-6')),
+                ],
+              ),
+              Shared.headerGroupDivider('hidden md:block mx-3'),
+              Search.compactTriggerView('inline-flex md:hidden', h),
               ThemeSelector.view(
                 model.themeMenu,
                 model.maybeThemePreference,
                 h,
               ),
-              h.div(
-                [h.Class('hidden md:flex items-center gap-3 md:gap-4')],
-                [
-                  Shared.iconLink(
-                    Link.github,
-                    'GitHub',
-                    Icon.github('w-5 h-5 md:w-6 md:h-6'),
-                  ),
-                  Shared.iconLink(
-                    Link.discord,
-                    'Discord',
-                    Icon.discord('w-5 h-5 md:w-6 md:h-6'),
-                  ),
-                  Shared.iconLink(
-                    Link.xSocial,
-                    'X',
-                    Icon.xSocial('w-5 h-5 md:w-6 md:h-6'),
-                  ),
-                  Shared.iconLink(
-                    Link.npm,
-                    'npm',
-                    Icon.npm('w-6 h-6 md:w-8 md:h-8'),
-                  ),
-                ],
-              ),
-              Search.compactTriggerView('md:hidden', h),
+              Shared.headerGroupDivider('mx-2 md:hidden'),
               h.button(
                 [
                   h.Class(
-                    'md:hidden -mr-2 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-700 dark:text-gray-300 cursor-pointer',
+                    'md:hidden -mr-2 inline-flex size-8 items-center justify-center rounded-md text-gray-500 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-400',
                   ),
                   h.AriaExpanded(model.mobileMenuDialog.isOpen),
                   h.AriaLabel('Toggle menu'),
@@ -167,7 +162,7 @@ export const footerView = (
   h.footer(
     [
       h.Class(
-        'px-6 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] md:px-8 xl:px-12 mt-6 border-t border-gray-300 dark:border-gray-800',
+        'px-6 pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] md:px-8 xl:px-12 mt-6 border-t border-gray-200 dark:border-gray-800',
       ),
     ],
     [
@@ -182,7 +177,7 @@ export const footerView = (
       Shared.emailForm,
       h.hr([
         h.Class(
-          'my-6 -mx-6 md:-mx-8 xl:-mx-12 border-t border-gray-300 dark:border-gray-800',
+          'my-6 -mx-6 md:-mx-8 xl:-mx-12 border-t border-gray-200 dark:border-gray-800',
         ),
       ]),
       h.div(
@@ -269,7 +264,7 @@ const pageNavigationView = (tag: string, h: HtmlBuilder<Message>) => {
     [
       h.AriaLabel('Page navigation'),
       h.Class(
-        'flex items-stretch justify-between gap-4 mt-12 pt-6 border-t border-gray-300 dark:border-gray-800',
+        'flex items-stretch justify-between gap-4 mt-12 pt-6 border-t border-gray-200 dark:border-gray-800',
       ),
     ],
     [

--- a/packages/website/src/layout/marketing.ts
+++ b/packages/website/src/layout/marketing.ts
@@ -18,28 +18,30 @@ const headerView = (model: Model, h: HtmlBuilder<Message>) =>
       ),
     ],
     [
-      h.a(
-        [h.Href(homeRouter()), h.Class('flex items-center gap-2')],
+      h.div(
+        [h.Class('flex items-center gap-8 md:gap-12')],
         [
-          h.img([
-            h.Src('/logo.svg'),
-            h.Alt('Foldkit'),
-            h.Width('801'),
-            h.Height('200'),
-            h.Class('h-6 md:h-8 w-auto dark:invert'),
-          ]),
-          Shared.betaTag,
+          h.a(
+            [h.Href(homeRouter()), h.Class('flex items-center gap-2')],
+            [
+              h.img([
+                h.Src('/logo.svg'),
+                h.Alt('Foldkit'),
+                h.Width('801'),
+                h.Height('200'),
+                h.Class('h-6 md:h-8 w-auto dark:invert'),
+              ]),
+              Shared.betaTag,
+            ],
+          ),
+          HeaderNav.view(model.route, 'hidden sm:flex items-center gap-6', h),
         ],
       ),
       h.div(
-        [h.Class('flex items-center gap-3')],
+        [h.Class('flex items-center gap-2')],
         [
-          HeaderNav.view(
-            model.route,
-            'hidden sm:flex items-center gap-6 mr-4',
-            h,
-          ),
           Search.triggerView('hidden lg:flex', h),
+          Search.compactTriggerView('hidden sm:inline-flex lg:hidden', h),
           h.div(
             [h.Class('hidden md:flex')],
             [
@@ -50,7 +52,7 @@ const headerView = (model: Model, h: HtmlBuilder<Message>) =>
               ),
             ],
           ),
-          Search.compactTriggerView('hidden sm:inline-flex lg:hidden', h),
+          Shared.headerGroupDivider('hidden sm:block mx-3'),
           h.a(
             [
               h.Href(gettingStartedRouter()),
@@ -63,7 +65,7 @@ const headerView = (model: Model, h: HtmlBuilder<Message>) =>
           h.button(
             [
               h.Class(
-                'sm:hidden -mr-2 p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-700 dark:text-gray-300 cursor-pointer',
+                'sm:hidden -mr-2 inline-flex size-8 items-center justify-center rounded-md text-gray-500 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-400',
               ),
               h.AriaExpanded(model.mobileMenuDialog.isOpen),
               h.AriaLabel('Toggle menu'),
@@ -80,7 +82,7 @@ const footerView = (currentYear: number): Html =>
   ih.footer(
     [
       ih.Class(
-        'px-6 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom,0px))] md:px-12 lg:px-20 border-t border-gray-300 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-400',
+        'px-6 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom,0px))] md:px-12 lg:px-20 border-t border-gray-200 dark:border-gray-800 text-sm text-gray-500 dark:text-gray-400',
       ),
     ],
     [

--- a/packages/website/src/markdown/views.ts
+++ b/packages/website/src/markdown/views.ts
@@ -35,17 +35,17 @@ const listClassName = 'mb-6 space-y-2 [&>li>p:last-child]:mb-0'
 const diagramLanguage = 'diagram'
 
 const tableWrapperClassName =
-  'overflow-x-auto overscroll-x-none mb-6 border border-gray-300 dark:border-gray-700 rounded-lg overflow-hidden'
+  'overflow-x-auto overscroll-x-none mb-6 border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden'
 const tableClassName = 'w-full min-w-[40rem]'
 const tableHeadClassName =
-  'bg-cream dark:bg-gray-900 border-b border-gray-300 dark:border-gray-700'
+  'bg-cream dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800'
 const tableBodyClassName = 'bg-cream dark:bg-gray-900'
 const tableRowClassName =
-  'border-b border-gray-300 dark:border-gray-700 last:border-b-0'
+  'border-b border-gray-200 dark:border-gray-800 last:border-b-0'
 const tableHeaderCellClassName =
-  'px-4 py-3 text-left text-base font-semibold text-gray-900 dark:text-white border-r border-gray-300 dark:border-gray-700 last:border-r-0'
+  'px-4 py-3 text-left text-base font-semibold text-gray-900 dark:text-white border-r border-gray-200 dark:border-gray-800 last:border-r-0'
 const tableCellClassName =
-  'px-4 py-3 text-base min-w-[12rem] text-gray-800 dark:text-gray-200 border-r border-gray-300 dark:border-gray-700 last:border-r-0'
+  'px-4 py-3 text-base min-w-[12rem] text-gray-800 dark:text-gray-200 border-r border-gray-200 dark:border-gray-800 last:border-r-0'
 
 const alignmentAttributes = (
   alignment: Alignment,
@@ -180,7 +180,7 @@ export const docViews = (config: DocViewConfig): Partial<Markdown.Views> => {
       ih.blockquote([ih.Class(blockquoteClassName)], blocks),
 
     ThematicBreak: () =>
-      ih.hr([ih.Class('my-8 border-gray-300 dark:border-gray-800')]),
+      ih.hr([ih.Class('my-8 border-gray-200 dark:border-gray-800')]),
 
     Image: ({ url, alt, maybeTitle }) =>
       ih.img([

--- a/packages/website/src/page/about.md
+++ b/packages/website/src/page/about.md
@@ -20,7 +20,7 @@ Releases go out through Changesets. Every user-visible change to a published pac
 
 ## Project Status
 
-Foldkit is pre-1.0. The architecture is settled and the core API is stable in practice, but minor releases can still change public surface. The [roadmap](/roadmap) lists the work that gates 1.0, which features are experimental today, and which architectural decisions will not change.
+Foldkit is pre-1.0. The architecture is settled and the core API is stable in practice, but minor releases can still change public surface. The [roadmap](/introduction/roadmap) lists the work that gates 1.0, which features are experimental today, and which architectural decisions will not change.
 
 ## This Site
 
@@ -31,5 +31,5 @@ The site is also built to be read by agents. Every page is available as Markdown
 ## Where to Go Next
 
 - [Getting Started](/get-started/getting-started) creates a project and walks through the generated structure.
-- [Why Foldkit](/get-started/why-foldkit) explains why Foldkit exists and the principles behind its design.
+- [Why Foldkit](/introduction/why-foldkit) explains why Foldkit exists and the principles behind its design.
 - [Contact](/contact) lists the ways to reach the project.

--- a/packages/website/src/page/blog/post/foldkit-0-157-0.md
+++ b/packages/website/src/page/blog/post/foldkit-0-157-0.md
@@ -67,7 +67,7 @@ Other changes:
 - `Machine.unreachableStates` and `Machine.deadTransitions` can now account for states entered through persistence or deep links.
 - Dialog now falls back to the first focusable element—or the dialog itself—when its requested focus target is missing or cannot receive focus.
 - DevTools overlay dependencies are now preloaded, so Vite does not reload on first use.
-- The former Manifesto page is now [Why Foldkit](/get-started/why-foldkit).
+- The former Manifesto page is now [Why Foldkit](/introduction/why-foldkit).
 
 Thank you to [@rjdellecese](https://github.com/rjdellecese) for proposing the Effect module naming convention and Mount view-state API, and to [@artile](https://github.com/artile) for reporting the Dialog focus issue. Thank you also to [@armancharan](https://github.com/armancharan) for adding `vitest.config.ts` typechecking across the repo and [@filipfalcon](https://github.com/filipfalcon) for the Vite preload fix!
 

--- a/packages/website/src/page/demoView.ts
+++ b/packages/website/src/page/demoView.ts
@@ -22,7 +22,7 @@ export const modelStateField = (name: string, value: string): Html =>
 
 export const modelState = (fields: ReadonlyArray<Html>): Html =>
   ih.div(
-    [ih.Class('pt-3 border-t border-gray-300 dark:border-gray-800')],
+    [ih.Class('pt-3 border-t border-gray-200 dark:border-gray-800')],
     [
       sectionLabel('Model State'),
       ih.div(

--- a/packages/website/src/page/gettingStarted.md
+++ b/packages/website/src/page/gettingStarted.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Get Started
 
 Built on Effect. Architected like Elm. Written in TypeScript. Let’s get your first application running.
 

--- a/packages/website/src/page/home/content.ts
+++ b/packages/website/src/page/home/content.ts
@@ -191,7 +191,7 @@ const heroSection = (
           h.p(
             [
               h.Class(
-                'mt-6 text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl leading-relaxed',
+                'mt-6 text-base md:text-lg font-light text-gray-500 dark:text-gray-400 max-w-3xl leading-relaxed',
               ),
             ],
             [
@@ -241,7 +241,7 @@ const poweredByItem = (text: string): Html =>
         [Icon.check('w-5 h-5')],
       ),
       ih.span(
-        [ih.Class('font-normal text-gray-600 dark:text-gray-300')],
+        [ih.Class('font-light text-gray-500 dark:text-gray-400')],
         [text],
       ),
     ],
@@ -272,7 +272,7 @@ const poweredBySection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'mt-4 text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-6 max-w-3xl',
+                'mt-4 text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-6 max-w-3xl',
               ),
             ],
             [
@@ -283,7 +283,7 @@ const poweredBySection = (): Html =>
             [
               ih.Role('list'),
               ih.Class(
-                'flex flex-col gap-2 text-lg text-gray-600 dark:text-gray-300 list-none',
+                'flex flex-col gap-2 text-base md:text-lg font-light text-gray-500 dark:text-gray-400 list-none',
               ),
             ],
             [
@@ -339,7 +339,7 @@ const promiseSection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-10 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-10 max-w-3xl',
               ),
             ],
             [
@@ -391,7 +391,7 @@ const demoSection = (demoTabsView: Html): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-10 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-10 max-w-3xl',
               ),
             ],
             [
@@ -470,7 +470,7 @@ const includedSection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-10 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-10 max-w-3xl',
               ),
             ],
             [
@@ -663,7 +663,7 @@ const examplesSection: Html = ih.section(
         ih.p(
           [
             ih.Class(
-              'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-10 max-w-3xl',
+              'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-10 max-w-3xl',
             ),
           ],
           [
@@ -718,7 +718,7 @@ const testingSection = (renderCopyButton: CodeBlock.RenderCopyButton): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-10 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-10 max-w-3xl',
               ),
             ],
             [
@@ -782,7 +782,7 @@ const devToolsSection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-4 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-4 max-w-3xl',
               ),
             ],
             [
@@ -792,7 +792,7 @@ const devToolsSection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-4 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-4 max-w-3xl',
               ),
             ],
             [
@@ -802,7 +802,7 @@ const devToolsSection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-10 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-10 max-w-3xl',
               ),
             ],
             [
@@ -860,7 +860,7 @@ const fitSection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-4 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-4 max-w-3xl',
               ),
             ],
             [
@@ -878,7 +878,7 @@ const fitSection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-10 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-10 max-w-3xl',
               ),
             ],
             [
@@ -1053,7 +1053,7 @@ const trustSection = (): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 leading-relaxed mb-10 max-w-3xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 leading-relaxed mb-10 max-w-3xl',
               ),
             ],
             [
@@ -1225,7 +1225,7 @@ const aiSection = (aiHeadingToggleCount: number): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 mb-4 max-w-2xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 mb-4 max-w-2xl',
               ),
             ],
             [
@@ -1235,7 +1235,7 @@ const aiSection = (aiHeadingToggleCount: number): Html =>
           ih.p(
             [
               ih.Class(
-                'text-lg text-gray-600 dark:text-gray-300 mb-8 max-w-2xl',
+                'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 mb-8 max-w-2xl',
               ),
             ],
             [
@@ -1280,7 +1280,7 @@ const finalCtaSection = (
                   ih.p(
                     [
                       ih.Class(
-                        'text-lg text-gray-600 dark:text-gray-300 mb-8 max-w-xl',
+                        'text-base md:text-lg font-light text-gray-500 dark:text-gray-400 mb-8 max-w-xl',
                       ),
                     ],
                     [

--- a/packages/website/src/page/home/home.ts
+++ b/packages/website/src/page/home/home.ts
@@ -71,9 +71,9 @@ const lazyNotePlayerDemo = createLazy()
 
 const VIEWPORT_PADDING = 16
 
-// NOTE: mirrors the md+ CSS --header-height (4.5rem); the variable's
+// NOTE: mirrors the md+ CSS --header-height (4rem); the variable's
 // env(safe-area-inset-top) term is not readable from static config.
-const MD_HEADER_HEIGHT = 72
+const MD_HEADER_HEIGHT = 64
 
 const HEADER_CLEARANCE = MD_HEADER_HEIGHT + VIEWPORT_PADDING
 

--- a/packages/website/src/prose.ts
+++ b/packages/website/src/prose.ts
@@ -75,31 +75,31 @@ const sectionHeadingConfig = {
     textClassName:
       'font-heading font-book text-2xl md:text-3xl leading-snug tracking-tight text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 mt-12 mb-4 [h1+&]:mt-8 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-16 mb-4 [h1+&]:mt-12 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h3: {
     textClassName:
       'font-heading font-book text-xl md:text-2xl leading-snug tracking-tight text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 mt-10 mb-3 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-12 mb-3 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h4: {
     textClassName:
       'text-base font-mono font-normal text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 mt-8 mb-3 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-10 mb-3 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h5: {
     textClassName:
       'text-sm font-mono font-normal text-gray-900 dark:text-white scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 mt-6 mb-2 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-8 mb-2 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
   h6: {
     textClassName:
       'text-sm font-mono font-normal text-gray-500 dark:text-gray-400 scroll-mt-6',
     wrapperClassName:
-      'group flex items-center gap-1 md:hover-capable:gap-0 mt-6 mb-2 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
+      'group flex items-center gap-1 md:hover-capable:gap-0 mt-8 mb-2 md:hover-capable:flex-row-reverse md:hover-capable:justify-end md:hover-capable:-ml-[1.5rem]',
   },
 }
 
@@ -176,7 +176,7 @@ export const infoCallout = (
   ih.div(
     [
       ih.Class(
-        'border border-gray-300 dark:border-gray-700 bg-gray-200/40 dark:bg-gray-800/40 py-3.5 px-5 mb-6 rounded-lg',
+        'border border-gray-200 dark:border-gray-800 bg-gray-200/40 dark:bg-gray-800/40 py-3.5 px-5 mb-6 rounded-lg',
       ),
     ],
     [
@@ -235,7 +235,11 @@ const calloutBlocks = (
   }>,
 ): Html =>
   ih.div(
-    [ih.Class(`border ${config.borderClassName} py-3.5 px-5 mb-6 rounded-lg`)],
+    [
+      ih.Class(
+        `border ${config.borderClassName} py-3.5 px-5 mt-8 mb-6 rounded-lg`,
+      ),
+    ],
     [
       ih.p(
         [
@@ -266,7 +270,7 @@ export const infoCalloutBlocks = (
 ): Html =>
   calloutBlocks({
     borderClassName:
-      'border-gray-300 dark:border-gray-700 bg-gray-200/40 dark:bg-gray-800/40',
+      'border-gray-200 dark:border-gray-800 bg-gray-200/40 dark:bg-gray-800/40',
     labelClassName: 'text-gray-800 dark:text-gray-200',
     icon: Icon.informationCircle('w-5 h-5 shrink-0'),
     label,

--- a/packages/website/src/route.test.ts
+++ b/packages/website/src/route.test.ts
@@ -46,10 +46,6 @@ describe('route table', () => {
       expect(parsed._tag).toBe(expectedTag(name))
     },
   )
-
-  test('builds the Why Foldkit page at its renamed URL', () => {
-    expect(Route.manifestoRouter()).toBe('/get-started/why-foldkit')
-  })
 })
 
 describe('blog routes', () => {

--- a/packages/website/src/route.ts
+++ b/packages/website/src/route.ts
@@ -254,6 +254,7 @@ const section =
     pipe(literal(sectionSlug), slash(literal(pageSlug)), mapTo(route))
 
 const getStarted = section('get-started')
+const introduction = section('introduction')
 const faq = section('faq')
 const react = section('react')
 const elm = section('elm')
@@ -267,13 +268,16 @@ const ai = section('ai')
 
 export const homeRouter = pipe(root, mapTo(AppRoute.Home))
 
-export const manifestoRouter = getStarted('why-foldkit', AppRoute.Manifesto)
+export const manifestoRouter = introduction('why-foldkit', AppRoute.Manifesto)
 export const gettingStartedRouter = getStarted(
   'getting-started',
   AppRoute.GettingStarted,
 )
 
-export const roadmapRouter = staticPage('roadmap', AppRoute.Roadmap)
+export const roadmapRouter = introduction('roadmap', AppRoute.Roadmap)
+
+const manifestoFromGetStarted = getStarted('why-foldkit', AppRoute.Manifesto)
+const roadmapFromRoot = staticPage('roadmap', AppRoute.Roadmap)
 
 export const performanceRouter = faq('performance', AppRoute.Performance)
 
@@ -481,7 +485,12 @@ export const aiMcpRouter = ai('mcp', AppRoute.AiMcp)
 
 // PARSER
 
-const getStartedParser = oneOf(manifestoRouter, gettingStartedRouter)
+const introductionParser = oneOf(
+  manifestoRouter,
+  roadmapRouter,
+  manifestoFromGetStarted,
+  roadmapFromRoot,
+)
 
 const faqParser = performanceRouter
 
@@ -599,8 +608,8 @@ const siteParser = oneOf(
 )
 
 const docsParser = oneOf(
-  getStartedParser,
-  roadmapRouter,
+  gettingStartedRouter,
+  introductionParser,
   faqParser,
   reactParser,
   elmParser,

--- a/packages/website/src/search/view.ts
+++ b/packages/website/src/search/view.ts
@@ -52,7 +52,7 @@ const searchInputView = (model: Model, h: HtmlBuilder<Message>): Html => {
   return h.div(
     [
       h.Class(
-        'flex items-center gap-3 px-4 py-3 border-b border-gray-300 dark:border-gray-700',
+        'flex items-center gap-3 px-4 py-3 border-b border-gray-200 dark:border-gray-800',
       ),
     ],
     [

--- a/packages/website/src/sidebarStorage.ts
+++ b/packages/website/src/sidebarStorage.ts
@@ -10,7 +10,8 @@ export type SidebarState = typeof SidebarState.Type
 export const SidebarStateJsonString = Schema.fromJsonString(SidebarState)
 
 export const GroupKey = Schema.Literals([
-  'getStarted',
+  'blog',
+  'introduction',
   'coreConcepts',
   'comparisons',
   'faq',

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -69,8 +69,8 @@
   --font-mono: 'Paper Mono', ui-monospace, monospace;
   --font-weight-book: 350;
   --font-weight-code: 425;
-  --text-page-title: 2rem;
-  --text-page-title-wide: 2.5rem;
+  --text-page-title: 2.5rem;
+  --text-page-title-wide: 3rem;
   --text-inline-code: 0.9375em;
 }
 
@@ -90,7 +90,7 @@ html.dark {
 
 @media (min-width: theme(--breakpoint-md)) {
   :root {
-    --header-height: calc(4.5rem + env(safe-area-inset-top, 0px));
+    --header-height: calc(4rem + env(safe-area-inset-top, 0px));
   }
 }
 
@@ -121,7 +121,7 @@ html.dark {
   }
 
   strong {
-    font-weight: 600;
+    font-weight: 500;
   }
 
   :is(h1, h2, h3, h4).font-mono {
@@ -255,11 +255,11 @@ html.dark {
   }
 
   .docs-disclosure-button {
-    @apply w-full flex items-center justify-between px-4 py-3 text-left text-base font-normal cursor-pointer transition border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-white hover:bg-gray-200/50 dark:hover:bg-gray-800 rounded-lg data-[open]:rounded-b-none select-none;
+    @apply w-full flex items-center justify-between px-4 py-3 text-left text-base font-normal cursor-pointer transition border border-gray-200 dark:border-gray-800 text-gray-900 dark:text-white hover:bg-gray-200/50 dark:hover:bg-gray-800 rounded-lg data-[open]:rounded-b-none select-none;
   }
 
   .docs-disclosure-panel {
-    @apply px-4 py-3 border-x border-b border-gray-300 dark:border-gray-700 rounded-b-lg text-gray-800 dark:text-gray-200;
+    @apply px-4 py-3 border-x border-b border-gray-200 dark:border-gray-800 rounded-b-lg text-gray-800 dark:text-gray-200;
   }
 
   .cta-primary,

--- a/packages/website/src/view/headerNav.ts
+++ b/packages/website/src/view/headerNav.ts
@@ -12,8 +12,6 @@ import {
   isDocsSectionRoute,
 } from '../route'
 
-// HEADER NAV
-
 const HeaderSection = Schema.Literals(['Docs', 'Blog'])
 type HeaderSection = typeof HeaderSection.Type
 
@@ -34,14 +32,8 @@ const sectionToHref = (section: HeaderSection): string =>
   )
 
 const linkClassName =
-  'text-sm text-gray-700 dark:text-gray-300 underline decoration-2 underline-offset-4 decoration-transparent transition hover:text-gray-900 dark:hover:text-white hover:decoration-gray-300 dark:hover:decoration-gray-600 data-[current]:text-accent-700 data-[current]:dark:text-accent-400 data-[current]:decoration-accent-600 data-[current]:dark:decoration-accent-400 data-[current]:hover:text-accent-700 data-[current]:hover:decoration-accent-600 data-[current]:dark:hover:text-accent-400 data-[current]:dark:hover:decoration-accent-400'
+  'text-sm font-normal text-gray-500 dark:text-gray-400 transition hover:text-gray-700 dark:hover:text-gray-300 data-[current]:font-medium data-[current]:text-accent-700 data-[current]:dark:text-accent-400 data-[current]:hover:text-accent-700 data-[current]:dark:hover:text-accent-400'
 
-/**
- * The site's primary section links, shared by the landing and docs headers.
- * The current section is derived from the route, so `Docs` stays highlighted
- * anywhere inside the documentation and `Blog` across the index and posts.
- * `className` lays the `nav` element out in its host header.
- */
 export const view = (
   route: AppRoute,
   className: string,

--- a/packages/website/src/view/search.ts
+++ b/packages/website/src/view/search.ts
@@ -26,7 +26,7 @@ export const triggerView = (className: string, h: HtmlBuilder<Message>): Html =>
     [
       h.Class(
         clsx(
-          'items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/50 dark:bg-gray-800/50 text-gray-500 dark:text-gray-400 text-sm hover:border-gray-400 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-300 transition cursor-pointer',
+          'items-center gap-1 h-8 px-2 rounded-md text-gray-500 dark:text-gray-400 text-sm hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-300 transition cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-400',
           className,
         ),
       ),
@@ -35,15 +35,14 @@ export const triggerView = (className: string, h: HtmlBuilder<Message>): Html =>
     ],
     [
       Icon.magnifyingGlass('w-4 h-4'),
-      h.span([h.Class('mr-4')], ['Search...']),
       h.span(
         [
           h.AriaHidden(true),
           h.Class(
-            'text-xs text-gray-400 dark:text-gray-500 border border-gray-300 dark:border-gray-700 rounded px-1.5 py-px font-mono',
+            'text-xs text-gray-500 dark:text-gray-400 rounded font-mono space-x-0.5',
           ),
         ],
-        ['⌘K'],
+        [h.span([], ['⌘']), h.span([], ['K'])],
       ),
     ],
   )
@@ -56,7 +55,7 @@ export const compactTriggerView = (
     [
       h.Class(
         clsx(
-          'items-center p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-700 dark:text-gray-300 cursor-pointer',
+          'size-8 items-center justify-center rounded-md text-gray-500 transition hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800 cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:focus-visible:outline-accent-400',
           className,
         ),
       ),

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -12,6 +12,7 @@ import {
   type NavPage,
   docsSections,
   findActiveSectionKey,
+  getStartedPage,
   isNavPageActive,
 } from '../docsNav'
 import { Icon } from '../icon'
@@ -28,7 +29,8 @@ import {
 import { type GroupKey, type SidebarGroups } from '../sidebarStorage'
 
 const GROUP_ID: Record<GroupKey, string> = {
-  getStarted: 'get-started-group',
+  blog: 'blog-group',
+  introduction: 'introduction-group',
   coreConcepts: 'core-concepts-group',
   comparisons: 'comparisons-group',
   faq: 'faq-group',
@@ -43,14 +45,14 @@ const GROUP_ID: Record<GroupKey, string> = {
 }
 
 const sidebarGroup = (
-  config: {
-    readonly id: string
-    readonly label: string
-    readonly isOpen: boolean
-    readonly onToggle: (isOpen: boolean) => Message
-    readonly children: Html
-    readonly isLocked: boolean
-  },
+  config: Readonly<{
+    id: string
+    label: string
+    isOpen: boolean
+    onToggle: (isOpen: boolean) => Message
+    children: Html
+    isLocked: boolean
+  }>,
   h: HtmlBuilder<Message>,
 ): Html => {
   const buttonClassName = clsx(
@@ -66,7 +68,7 @@ const sidebarGroup = (
   )
 
   return h.li(
-    [h.Class('mb-5 last:mb-0')],
+    [h.Class('mb-2.5 last:mb-0')],
     [
       Disclosure.view(
         {
@@ -147,6 +149,43 @@ const navLink = (
     ],
   )
 
+const getStartedClass = (isActive: boolean) =>
+  clsx('block px-4 py-2.5 md:py-2 transition text-sm font-medium', {
+    'text-accent-700 dark:text-accent-400 underline underline-offset-2':
+      isActive,
+    'text-gray-800 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white':
+      !isActive,
+  })
+
+const getStartedNavItem = (
+  route: Model['route'],
+  maybeExampleSlug: Option.Option<string>,
+  h: HtmlBuilder<Message>,
+): Html => {
+  const isActive = isNavPageActive(
+    route._tag,
+    maybeExampleSlug,
+    getStartedPage._tag,
+  )
+
+  return h.li(
+    [h.Class('mb-2.5')],
+    [
+      h.a(
+        [
+          h.Href(getStartedPage.href),
+          h.Class(getStartedClass(isActive)),
+          ...(isActive ? [h.AriaCurrent('page')] : []),
+        ],
+        [getStartedPage.label],
+      ),
+    ],
+  )
+}
+
+const DESKTOP_ID_PREFIX = 'desktop'
+const MOBILE_ID_PREFIX = 'mobile'
+
 const computeNavLinks = (
   idPrefix: string,
   route: Model['route'],
@@ -171,7 +210,7 @@ const computeNavLinks = (
 
   const pageGroupList = (pages: ReadonlyArray<NavPage>): Html =>
     h.ul(
-      [h.Class('space-y-0.5')],
+      [h.Class('space-y-1')],
       Array.map(pages, page =>
         navLink(
           page.href,
@@ -185,6 +224,26 @@ const computeNavLinks = (
   return h.ul(
     [h.Class('space-y-0.5')],
     [
+      getStartedNavItem(route, maybeExampleSlug, h),
+      ...(idPrefix === MOBILE_ID_PREFIX
+        ? [
+            sidebarGroup(
+              {
+                id: `${idPrefix}-${GROUP_ID.blog}`,
+                label: 'Blog',
+                isOpen: sidebarGroups.blog,
+                onToggle: isOpen =>
+                  Message.ToggledSidebarGroup({ key: 'blog', isOpen }),
+                isLocked: isLocked('blog'),
+                children: h.ul(
+                  [h.Class('space-y-0.5')],
+                  [navLink(blogRouter(), isBlogRoute(route), 'Posts', h)],
+                ),
+              },
+              h,
+            ),
+          ]
+        : []),
       ...Array.map(docsSections, section => {
         return sidebarGroup(
           {
@@ -198,7 +257,7 @@ const computeNavLinks = (
               [h.Class('divide-y divide-gray-200 dark:divide-gray-800')],
               Array.map(section.pageGroups, group =>
                 h.div(
-                  [h.Class('py-2 first:pt-0 last:pb-0')],
+                  [h.Class('py-3 first:pt-0 last:pb-0')],
                   [pageGroupList(group)],
                 ),
               ),
@@ -216,7 +275,7 @@ const computeNavLinks = (
             Message.ToggledSidebarGroup({ key: 'apiReference', isOpen }),
           isLocked: isLocked('apiReference'),
           children: h.ul(
-            [h.Class('space-y-0.5')],
+            [h.Class('space-y-1')],
             Array.map(apiModuleIndex, ({ slug, name }) =>
               navLink(
                 apiModuleRouter({
@@ -235,33 +294,6 @@ const computeNavLinks = (
   )
 }
 
-const blogSectionHeaderClassName = clsx(
-  'w-full flex items-center justify-between transition cursor-default',
-  'px-4 py-2.5 md:py-2',
-  'text-sm font-medium',
-  'text-gray-800 dark:text-gray-200',
-)
-
-const blogSection = (route: Model['route'], h: HtmlBuilder<Message>): Html =>
-  h.div(
-    [],
-    [
-      h.div([h.Class(blogSectionHeaderClassName)], ['Blog']),
-      h.div(
-        [h.Class('px-4 py-2')],
-        [
-          h.ul(
-            [h.Class('space-y-0.5')],
-            [navLink(blogRouter(), isBlogRoute(route), 'Posts', h)],
-          ),
-        ],
-      ),
-    ],
-  )
-
-const DESKTOP_ID_PREFIX = 'desktop'
-const MOBILE_ID_PREFIX = 'mobile'
-
 const lazyNavLinks = createKeyedLazy()
 
 export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
@@ -276,7 +308,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
     [
       h.AriaLabel('Documentation sidebar'),
       h.Class(
-        'docs-sidebar hidden md:flex fixed top-[var(--header-height)] bottom-0 z-40 w-64 bg-cream dark:bg-gray-900 border-r border-gray-300 dark:border-gray-800 flex-col',
+        'docs-sidebar hidden md:flex fixed top-[var(--header-height)] bottom-0 z-40 w-64 bg-cream dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 flex-col',
       ),
     ],
     [
@@ -317,7 +349,7 @@ export const mobileView = (model: Model, h: HtmlBuilder<Message>): Html => {
         h.div(
           [
             h.Class(
-              'flex justify-between items-center h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] px-4 md:px-6 border-b border-gray-300 dark:border-gray-800 shrink-0',
+              'flex justify-between items-center h-[var(--header-height)] pt-[env(safe-area-inset-top,0px)] px-4 md:px-6 border-b border-gray-200 dark:border-gray-800 shrink-0',
             ),
           ],
           [
@@ -355,12 +387,12 @@ export const mobileView = (model: Model, h: HtmlBuilder<Message>): Html => {
             h.Tabindex(-1),
             ...initialFocus,
           ],
-          [blogSection(model.route, h), mobileNavLinks],
+          [mobileNavLinks],
         ),
         h.div(
           [
             h.Class(
-              'p-4 border-t border-gray-300 dark:border-gray-800 shrink-0',
+              'p-4 border-t border-gray-200 dark:border-gray-800 shrink-0',
             ),
           ],
           [

--- a/packages/website/src/view/tableOfContents.ts
+++ b/packages/website/src/view/tableOfContents.ts
@@ -48,7 +48,7 @@ export const view = (
   h.aside(
     [
       h.Class(
-        'hidden xl:block sticky top-[var(--header-height)] w-64 h-[calc(100vh-var(--header-height))] shrink-0 overflow-y-auto border-l border-gray-300 dark:border-gray-800 px-4 pt-8 pb-4',
+        'hidden xl:block sticky top-[var(--header-height)] w-64 h-[calc(100vh-var(--header-height))] shrink-0 overflow-y-auto border-l border-gray-200 dark:border-gray-800 px-4 pt-8 pb-4',
       ),
     ],
     [
@@ -113,14 +113,14 @@ export const mobileView = (
         Message.ToggledMobileTableOfContents({ isOpen: open }),
       ),
       h.Class(
-        'group xl:hidden fixed top-[var(--header-height)] left-0 right-0 md:left-64 z-40 bg-cream dark:bg-gray-900 border-b border-gray-300 dark:border-gray-800',
+        'group xl:hidden fixed top-[var(--header-height)] left-0 right-0 md:left-64 z-40 bg-cream dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800',
       ),
     ],
     [
       h.summary(
         [
           h.Class(
-            'flex items-center justify-between px-4 md:px-6 py-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden group-open:border-b group-open:border-gray-300 dark:group-open:border-gray-800',
+            'flex items-center justify-between px-4 md:px-6 py-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden group-open:border-b group-open:border-gray-200 dark:group-open:border-gray-800',
           ),
         ],
         [
@@ -158,7 +158,7 @@ export const mobileView = (
         ],
         [
           h.ul(
-            [h.Class('text-sm divide-y divide-gray-300 dark:divide-gray-800')],
+            [h.Class('text-sm divide-y divide-gray-200 dark:divide-gray-800')],
             Array.map(entries, ({ level, id, text }) => {
               const isActive = Option.match(maybeActiveSectionId, {
                 onNone: () => false,

--- a/packages/website/src/view/themeSelector.ts
+++ b/packages/website/src/view/themeSelector.ts
@@ -12,9 +12,9 @@ import { Icon } from '../icon'
 import { Message, type ThemePreference } from '../message'
 
 const THEME_PREFERENCES: ReadonlyArray<ThemePreference> = [
+  'Dark',
   'Light',
   'System',
-  'Dark',
 ]
 
 const THEME_MENU_ANCHOR: Menu.AnchorConfig = {
@@ -22,8 +22,6 @@ const THEME_MENU_ANCHOR: Menu.AnchorConfig = {
   gap: 8,
   padding: 8,
 }
-
-const triggerIconClassName = 'w-6 h-6'
 
 export const ThemeMenu = Menu.create<ThemePreference>()
 
@@ -58,7 +56,7 @@ export const view = (
 
         return {
           className:
-            'w-full cursor-pointer rounded-md px-3 py-2 text-left text-sm text-gray-700 transition hover:bg-gray-100 data-[active]:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800 dark:data-[active]:bg-gray-800',
+            'w-full cursor-pointer rounded-md px-3 py-3 md:py-2 text-left text-sm text-gray-700 transition hover:bg-gray-100 data-[active]:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800 dark:data-[active]:bg-gray-800',
           content: ih.div(
             [ih.Class('flex w-full items-center gap-3')],
             [
@@ -76,15 +74,15 @@ export const view = (
           ),
         }
       },
-      buttonContent: preferenceIcon(activePreference, triggerIconClassName),
+      buttonContent: preferenceIcon(activePreference, 'w-5 h-5'),
       buttonAttributes: childAttributes([
         ih.Class(
-          'inline-flex size-10 cursor-pointer items-center justify-center rounded-md text-gray-700 transition hover:bg-gray-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:text-gray-300 dark:hover:bg-gray-800 dark:focus-visible:outline-accent-400',
+          'inline-flex size-8 cursor-pointer items-center justify-center rounded-md text-gray-500 transition hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:focus-visible:outline-accent-400',
         ),
       ]),
       itemsAttributes: childAttributes([
         ih.Class(
-          'z-[70] min-w-40 rounded-lg border border-gray-200 bg-cream p-2 shadow-lg dark:border-gray-700 dark:bg-gray-900',
+          'z-[70] min-w-40 rounded-md border border-gray-200 bg-cream p-2 shadow-lg dark:border-gray-700 dark:bg-gray-900',
         ),
       ]),
       backdropAttributes: childAttributes([ih.Class('fixed inset-0 z-[60]')]),

--- a/scripts/deploy-website-workflow.test.mjs
+++ b/scripts/deploy-website-workflow.test.mjs
@@ -669,14 +669,14 @@ test('the old manifesto paths redirect to Why Foldkit', () => {
     const result = resolveRequest(productionConfig, pathname)
     assert.equal(result.kind, 'redirect', pathname)
     assert.equal(result.status, 308, pathname)
-    assert.equal(result.location, '/get-started/why-foldkit', pathname)
+    assert.equal(result.location, '/introduction/why-foldkit', pathname)
   }
 
   for (const pathname of ['/manifesto.md', '/get-started/manifesto.md']) {
     const result = resolveRequest(productionConfig, pathname)
     assert.equal(result.kind, 'redirect', pathname)
     assert.equal(result.status, 308, pathname)
-    assert.equal(result.location, '/get-started/why-foldkit.md', pathname)
+    assert.equal(result.location, '/introduction/why-foldkit.md', pathname)
   }
 })
 

--- a/scripts/website-vercel-config.mjs
+++ b/scripts/website-vercel-config.mjs
@@ -175,7 +175,7 @@ export const websiteVercelConfig = channel => {
       {
         src: '^/$',
         headers: {
-          Link: '</sitemap.xml>; rel="sitemap", </get-started/why-foldkit>; rel="about", </get-started/getting-started>; rel="help", </example-apps>; rel="related", </ai/overview>; rel="describedby", </openapi.json>; rel="service-desc"',
+          Link: '</sitemap.xml>; rel="sitemap", </introduction/why-foldkit>; rel="about", </get-started/getting-started>; rel="help", </example-apps>; rel="related", </ai/overview>; rel="describedby", </openapi.json>; rel="service-desc"',
         },
         continue: true,
       },
@@ -254,22 +254,42 @@ export const websiteVercelConfig = channel => {
       {
         src: '^/manifesto/?$',
         status: 308,
-        headers: { Location: '/get-started/why-foldkit' },
+        headers: { Location: '/introduction/why-foldkit' },
       },
       {
         src: '^/manifesto\\.md$',
         status: 308,
-        headers: { Location: '/get-started/why-foldkit.md' },
+        headers: { Location: '/introduction/why-foldkit.md' },
       },
       {
         src: '^/get-started/manifesto/?$',
         status: 308,
-        headers: { Location: '/get-started/why-foldkit' },
+        headers: { Location: '/introduction/why-foldkit' },
       },
       {
         src: '^/get-started/manifesto\\.md$',
         status: 308,
-        headers: { Location: '/get-started/why-foldkit.md' },
+        headers: { Location: '/introduction/why-foldkit.md' },
+      },
+      {
+        src: '^/get-started/why-foldkit/?$',
+        status: 308,
+        headers: { Location: '/introduction/why-foldkit' },
+      },
+      {
+        src: '^/get-started/why-foldkit\\.md$',
+        status: 308,
+        headers: { Location: '/introduction/why-foldkit.md' },
+      },
+      {
+        src: '^/roadmap/?$',
+        status: 308,
+        headers: { Location: '/introduction/roadmap' },
+      },
+      {
+        src: '^/roadmap\\.md$',
+        status: 308,
+        headers: { Location: '/introduction/roadmap.md' },
       },
       {
         src: '^/getting-started$',
@@ -284,12 +304,12 @@ export const websiteVercelConfig = channel => {
       {
         src: '^/(?:faq/)?why-no-jsx/?$',
         status: 308,
-        headers: { Location: '/get-started/why-foldkit' },
+        headers: { Location: '/introduction/why-foldkit' },
       },
       {
         src: '^/(?:faq/)?why-no-jsx\\.md$',
         status: 308,
-        headers: { Location: '/get-started/why-foldkit.md' },
+        headers: { Location: '/introduction/why-foldkit.md' },
       },
       {
         src: '^/what-about-ssr$',


### PR DESCRIPTION
Two things went wrong for a panel opened from a `position: fixed` header, for example a Menu, Listbox, or Popover, both visible in the website's theme picker on phones and tablets.

Opening the panel scrolled the page. The reveal in `anchorSetup` focused the freshly positioned panel with a plain `.focus()`. On a page whose `scroll-padding-top` is larger than the panel's offset from the top of the viewport, the browser scrolled the document to push the panel below that padding. The website's docs header and mobile table of contents add up to more padding than the gap under the button. The reveal now focuses with `preventScroll: true`, since Floating UI has already placed the panel in view and a scroll-on-focus can only move the page under it.

Scrolling with the panel open made it jump. The panel was positioned with Floating UI's absolute strategy in document coordinates, so every scroll moved it with the page until `autoUpdate` put it back under the button. A portaled panel whose button has a `position: fixed` ancestor is now positioned with the fixed strategy, the same one shadow-root hosts already use, and stays under the button as the page scrolls.

Tests pin the `preventScroll` option on the reveal focus and the strategy choice for fixed, non-fixed, and non-portaled cases.