### PR TITLE
feat(website): pin the docs TOC and tighten nav padding

### DIFF
--- a/packages/website/src/layout/docs.ts
+++ b/packages/website/src/layout/docs.ts
@@ -1134,7 +1134,13 @@ export const view = (
       headerView(model, h),
       Search.dialogView(model, h),
       h.div(
-        [h.Class('docs-shell flex flex-1 pt-[var(--header-height)] md:pl-64')],
+        [
+          h.Class(
+            clsx('docs-shell flex flex-1 pt-[var(--header-height)] md:pl-64', {
+              'xl:pr-64': Option.isSome(currentPageTableOfContents),
+            }),
+          ),
+        ],
         [
           Sidebar.view(model, h),
           Sidebar.mobileView(model, h),

--- a/packages/website/src/markdown/docPage.ts
+++ b/packages/website/src/markdown/docPage.ts
@@ -11,8 +11,6 @@ import { type Slots } from './slots'
 import { type HeadingIds, collectHeadings } from './tableOfContents'
 import { docViews } from './views'
 
-// DOC PAGE
-
 const renderDocument = (
   document: Markdown.MarkdownDocument,
   pageId: string,

--- a/packages/website/src/styles.css
+++ b/packages/website/src/styles.css
@@ -216,6 +216,10 @@ html.dark {
     left: max(0px, calc((100% - var(--docs-max-width)) / 2));
   }
 
+  .docs-toc {
+    right: max(0px, calc((100% - var(--docs-max-width)) / 2));
+  }
+
   .docs-content {
     @apply w-full min-w-0 mx-auto px-6 py-8 md:px-8 xl:px-12 2xl:py-12 font-book leading-7;
     max-width: var(--docs-content-width);

--- a/packages/website/src/view/sidebar.ts
+++ b/packages/website/src/view/sidebar.ts
@@ -150,7 +150,7 @@ const navLink = (
   )
 
 const getStartedClass = (isActive: boolean) =>
-  clsx('block px-4 py-2.5 md:py-2 transition text-sm font-medium', {
+  clsx('block px-4 py-2.5 md:py-0 transition text-sm font-medium', {
     'text-accent-700 dark:text-accent-400 underline underline-offset-2':
       isActive,
     'text-gray-800 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white':
@@ -316,7 +316,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Html => {
         [
           h.AriaLabel('Documentation'),
           h.Id(DOCS_SIDEBAR_NAV_ID),
-          h.Class('flex-1 overflow-y-auto py-6'),
+          h.Class('flex-1 overflow-y-auto py-5'),
         ],
         [desktopNavLinks],
       ),
@@ -383,7 +383,7 @@ export const mobileView = (model: Model, h: HtmlBuilder<Message>): Html => {
           [
             h.AriaLabel('Documentation'),
             h.Id(MOBILE_MENU_NAV_ID),
-            h.Class('flex-1 overflow-y-auto py-4'),
+            h.Class('flex-1 overflow-y-auto py-2'),
             h.Tabindex(-1),
             ...initialFocus,
           ],

--- a/packages/website/src/view/tableOfContents.ts
+++ b/packages/website/src/view/tableOfContents.ts
@@ -48,14 +48,14 @@ export const view = (
   h.aside(
     [
       h.Class(
-        'hidden xl:block sticky top-[var(--header-height)] w-64 h-[calc(100vh-var(--header-height))] shrink-0 overflow-y-auto border-l border-gray-200 dark:border-gray-800 px-4 pt-8 pb-4',
+        'docs-toc hidden xl:block fixed top-[var(--header-height)] bottom-0 z-30 w-64 overflow-y-auto overscroll-none bg-cream dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800 px-4 pt-4 pb-4',
       ),
     ],
     [
       h.h3(
         [
           h.AriaHidden(true),
-          h.Class('text-sm font-medium text-gray-800 dark:text-gray-200 mb-4'),
+          h.Class('text-sm text-gray-800 dark:text-gray-200 mb-4'),
         ],
         ['On this page'],
       ),


### PR DESCRIPTION
The docs sidebar is already fixed to the viewport. The table of contents was sticky, so it stayed in the column's flow and did not pin to the right of the centered docs shell the way the sidebar pins to the left.

Make the TOC fixed, give it the same max-width pinning, and reserve xl:pr-64 on the shell when a page has a TOC so content does not slide underneath. Tighten the sidebar and TOC top padding so the two columns line up, and reduce the mobile menu padding.