### PR TITLE
fix: skip cloud session setup on local SessionStart

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/cloud-session-setup.sh"
+            "command": "if [ \"${CLAUDE_CODE_REMOTE:-}\" = true ]; then bash scripts/cloud-session-setup.sh; fi",
+            "timeout": 300
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ A gate you just wrote is not evidence until you have watched it fail. Break the 
 
 ## Workspace Setup Errors Are Not Pre-Existing
 
-If `pnpm typecheck`, `pnpm lint`, `pnpm build`, or the pre-push hook surfaces errors like `Cannot find module 'foldkit'`, `Cannot find module 'foldkit/html'`, or unexpected `Property X does not exist` against an Effect API, the workspace itself is out of sync. These are not pre-existing branch failures. Run `bash scripts/cloud-session-setup.sh` to reconcile. The SessionStart hook runs this automatically, so it's only relevant if dependencies drift mid-session.
+If `pnpm typecheck`, `pnpm lint`, `pnpm build`, or the pre-push hook surfaces errors like `Cannot find module 'foldkit'`, `Cannot find module 'foldkit/html'`, or unexpected `Property X does not exist` against an Effect API, the workspace itself is out of sync. These are not pre-existing branch failures. Run `bash scripts/cloud-session-setup.sh` to reconcile. The SessionStart hook runs this automatically in Claude Code cloud sessions. Locally it is a no-op, because the install and rebuild race with `pnpm dev:libs`.
 
 ## GitHub CLI Authentication
 

--- a/scripts/cloud-session-setup.sh
+++ b/scripts/cloud-session-setup.sh
@@ -18,8 +18,18 @@
 # Reconciling node_modules to the lockfile, building the prerequisite packages,
 # and removing known stale leftovers eliminates all three classes of phantom
 # problem before the agent runs any checks.
+#
+# SessionStart in .claude/settings.json only invokes this when
+# CLAUDE_CODE_REMOTE=true. Grok and local Claude Code also fire SessionStart, and
+# the install plus dist rebuild races with `pnpm dev:libs`. Run the script
+# directly to reconcile a local workspace.
 
 set -euo pipefail
+
+if [[ -n "${GROK_HOOK_EVENT:-}" && "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
+  echo "[setup] skipping SessionStart outside a Claude Code cloud session"
+  exit 0
+fi
 
 cd "$(git rev-parse --show-toplevel)"
 
@@ -67,13 +77,16 @@ is_dist_stale() {
   local dir="$1"
   [[ -d "$dir/dist" && -d "$dir/src" && -r "$dir/src" ]] || return 0
 
-  local oldest_built
-  oldest_built=$(find "$dir/dist" -type f -printf '%T@ %p\n' 2>/dev/null |
-    sort -n | head -1 | cut -d' ' -f2-)
+  local oldest_built="" file
+  while IFS= read -r -d '' file; do
+    if [[ -z "$oldest_built" || "$file" -ot "$oldest_built" ]]; then
+      oldest_built=$file
+    fi
+  done < <(find "$dir/dist" -type f -print0)
   [[ -n "$oldest_built" ]] || return 0
 
   local newer_source scan_status
-  newer_source=$(find "$dir/src" -type f -newer "$oldest_built" -print -quit 2>/dev/null)
+  newer_source=$(find "$dir/src" -type f -newer "$oldest_built" -print -quit)
   scan_status=$?
 
   [[ $scan_status -ne 0 || -n "$newer_source" ]]


### PR DESCRIPTION
Grok and local Claude Code both fire the Claude SessionStart hook, which ran `pnpm install` and rebuilt library dist/ on every launch. On macOS, `find -printf` is unsupported, so every dist/ looked stale and the rebuild raced with `pnpm dev:libs`, flooding the watch terminal and crashing the app.

Gate SessionStart on CLAUDE_CODE_REMOTE=true, skip the same path when Grok invokes the script, and find the oldest dist file with portable bash so a manual local run no longer rebuilds fresh output.