### PR TITLE
docs(website): explain Button attribute overrides and live regions

### DIFF
--- a/packages/website/src/page/ui/buttonPage.md
+++ b/packages/website/src/page/ui/buttonPage.md
@@ -54,7 +54,7 @@ Button sets `aria-disabled="true"` when disabled instead of the native `disabled
 Add your own attributes after the `button` bundle. A later attribute wins, so `h.Type('submit')` after the bundle replaces the default. A button that changes its own text, such as one cycling through values on a tap, announces each change by carrying a live region: spread `h.AriaLive('polite')` and `h.AriaAtomic(true)` after the bundle. Button adds no ARIA beyond what it manages, so this is the intended way.
 
 ```ts
-h.button([...button, h.AriaLive("polite"), h.AriaAtomic(true)], [label]);
+h.button([...button, h.AriaLive('polite'), h.AriaAtomic(true)], [label])
 ```
 
 ## API Reference

--- a/packages/website/src/page/ui/buttonPage.md
+++ b/packages/website/src/page/ui/buttonPage.md
@@ -51,6 +51,12 @@ Button sets `aria-disabled="true"` when disabled instead of the native `disabled
 
 `tabindex="0"` is always set to ensure focusability. The `type` attribute defaults to `"button"` to prevent accidental form submissions.
 
+Add your own attributes after the `button` bundle. A later attribute wins, so `h.Type('submit')` after the bundle replaces the default. A button that changes its own text, such as one cycling through values on a tap, announces each change by carrying a live region: spread `h.AriaLive('polite')` and `h.AriaAtomic(true)` after the bundle. Button adds no ARIA beyond what it manages, so this is the intended way.
+
+```ts
+h.button([...button, h.AriaLive("polite"), h.AriaAtomic(true)], [label]);
+```
+
 ## API Reference
 
 ### ViewConfig {#view-config}

--- a/packages/website/src/page/ui/buttonPage.md
+++ b/packages/website/src/page/ui/buttonPage.md
@@ -51,7 +51,7 @@ Button sets `aria-disabled="true"` when disabled instead of the native `disabled
 
 `tabindex="0"` is always set to ensure focusability. The `type` attribute defaults to `"button"` to prevent accidental form submissions.
 
-Add your own attributes after the `button` bundle. A later attribute wins, so `h.Type('submit')` after the bundle replaces the default. A button that changes its own text, such as one cycling through values on a tap, announces each change by carrying a live region: spread `h.AriaLive('polite')` and `h.AriaAtomic(true)` after the bundle. Button adds no ARIA beyond what it manages, so this is the intended way.
+Add your own attributes after the `button` bundle. A later attribute wins, so `h.Type('submit')` after the bundle replaces the default. A button that changes its own text, such as one cycling through values on a tap, announces each change by carrying a live region: spread `h.AriaLive('polite')` and `h.AriaAtomic(true)` after the bundle. Button does not add `aria-live` or `aria-atomic` for you.
 
 ```ts
 h.button([...button, h.AriaLive('polite'), h.AriaAtomic(true)], [label])


### PR DESCRIPTION
Clarify that attributes spread after Button's `button` bundle override matching bundle attributes, so consumers can supply their own values.

Show how a Button whose visible label changes can carry `aria-live` and `aria-atomic` itself to announce each update.
