### PR TITLE
docs(website): shorten Core sidebar heading

### DIFF
--- a/packages/website/src/docsNav.ts
+++ b/packages/website/src/docsNav.ts
@@ -162,7 +162,7 @@ export const docsSections: ReadonlyArray<DocsSection> = [
   },
   {
     key: 'coreConcepts',
-    label: 'Core Concepts',
+    label: 'Core',
     pageGroups: [
       [
         {


### PR DESCRIPTION
The Core docs section includes both concepts and concrete framework APIs. Shorten its sidebar heading to “Core” while keeping the internal storage key and content metadata unchanged.