### PR TITLE
test(scripts): keep the developer git config out of fixture repositories

### DIFF
--- a/scripts/check-website-release-inputs.test.mjs
+++ b/scripts/check-website-release-inputs.test.mjs
@@ -6,6 +6,8 @@ import { dirname, join, resolve } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
+import { gitTestEnvironment } from './lib/test-git.mjs'
+
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const SCRIPT_PATH = resolve(
   REPO_ROOT,
@@ -30,7 +32,11 @@ const SHARED_PACKAGE_INPUTS = [
 ]
 
 const run = (cwd, command, args) => {
-  const result = spawnSync(command, args, { cwd, encoding: 'utf8' })
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: gitTestEnvironment,
+  })
   assert.equal(
     result.status,
     0,
@@ -41,16 +47,7 @@ const run = (cwd, command, args) => {
 
 const commit = (repo, message) => {
   run(repo, 'git', ['add', '.'])
-  run(repo, 'git', [
-    '-c',
-    'user.name=Foldkit Test',
-    '-c',
-    'user.email=foldkit@example.com',
-    'commit',
-    '-q',
-    '-m',
-    message,
-  ])
+  run(repo, 'git', ['commit', '-q', '-m', message])
 }
 
 const write = (repo, path, contents) => {
@@ -101,6 +98,7 @@ const check = repo =>
   spawnSync(process.execPath, [SCRIPT_PATH], {
     cwd: repo,
     encoding: 'utf8',
+    env: gitTestEnvironment,
   })
 
 test('rejects changed package source omitted from the exact release commit', () => {

--- a/scripts/lib/changed-files.test.mjs
+++ b/scripts/lib/changed-files.test.mjs
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { test } from 'node:test'
 
 import { resolveChangedFiles } from './changed-files.mjs'
+import { gitTestEnvironment } from './test-git.mjs'
 
 const ZERO_SHA = '0'.repeat(40)
 const MISSING_SHA_A = 'deadbeef'.repeat(5)
@@ -75,21 +76,10 @@ test('a real revision range resolves the files it touched', () => {
 })
 
 const git = (repositoryDir, ...args) => {
-  const result = spawnSync(
-    'git',
-    [
-      '-C',
-      repositoryDir,
-      '-c',
-      'user.email=test@example.com',
-      '-c',
-      'user.name=Test',
-      '-c',
-      'commit.gpgsign=false',
-      ...args,
-    ],
-    { encoding: 'utf8' },
-  )
+  const result = spawnSync('git', ['-C', repositoryDir, ...args], {
+    encoding: 'utf8',
+    env: gitTestEnvironment,
+  })
 
   assert.equal(result.status, 0, `git ${args.join(' ')}: ${result.stderr}`)
 

--- a/scripts/lib/test-git.mjs
+++ b/scripts/lib/test-git.mjs
@@ -1,0 +1,16 @@
+// NOTE: Tests that drive git in a temporary repository run it with the
+// developer's own configuration kept out. A global `tag.gpgsign` turns the
+// plain `git tag` a release test makes into a signed annotated tag and git
+// refuses it for want of a message; a global `commit.gpgsign` asks a key to
+// sign every fixture commit. Neither has anything to do with what the tests
+// check, and the pre-push hook running them failed on any machine with such
+// a setting. The identity is supplied here too, since the global one is gone.
+export const gitTestEnvironment = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_NOSYSTEM: '1',
+  GIT_AUTHOR_NAME: 'Foldkit Test',
+  GIT_AUTHOR_EMAIL: 'foldkit@example.com',
+  GIT_COMMITTER_NAME: 'Foldkit Test',
+  GIT_COMMITTER_EMAIL: 'foldkit@example.com',
+}

--- a/scripts/plan-website-deploy.test.mjs
+++ b/scripts/plan-website-deploy.test.mjs
@@ -6,6 +6,8 @@ import { dirname, join, resolve } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
+import { gitTestEnvironment } from './lib/test-git.mjs'
+
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const SCRIPT_PATH = resolve(REPO_ROOT, 'scripts/plan-website-deploy.mjs')
 const PACKAGES = [
@@ -27,7 +29,11 @@ const SHARED_PACKAGE_INPUTS = [
 ]
 
 const run = (cwd, command, args) => {
-  const result = spawnSync(command, args, { cwd, encoding: 'utf8' })
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: gitTestEnvironment,
+  })
   assert.equal(
     result.status,
     0,
@@ -38,16 +44,7 @@ const run = (cwd, command, args) => {
 
 const commit = (repo, message) => {
   run(repo, 'git', ['add', '.'])
-  run(repo, 'git', [
-    '-c',
-    'user.name=Foldkit Test',
-    '-c',
-    'user.email=foldkit@example.com',
-    'commit',
-    '-q',
-    '-m',
-    message,
-  ])
+  run(repo, 'git', ['commit', '-q', '-m', message])
 }
 
 const write = (repo, path, contents) => {
@@ -86,12 +83,14 @@ const plan = repo =>
   spawnSync(process.execPath, [SCRIPT_PATH], {
     cwd: repo,
     encoding: 'utf8',
+    env: gitTestEnvironment,
   })
 
 const planTarget = (repo, target) =>
   spawnSync(process.execPath, [SCRIPT_PATH, target], {
     cwd: repo,
     encoding: 'utf8',
+    env: gitTestEnvironment,
   })
 
 const planReleaseTarget = (repo, target) =>
@@ -101,6 +100,7 @@ const planReleaseTarget = (repo, target) =>
     {
       cwd: repo,
       encoding: 'utf8',
+      env: gitTestEnvironment,
     },
   )
 


### PR DESCRIPTION
The release tests drive git inside temporary repositories, and they ran it with whatever the developer has configured globally. A global `tag.gpgsign` turns the plain `git tag` a release fixture makes into a signed annotated tag, which git refuses for want of a message, and a global `commit.gpgsign` asks a key to sign every fixture commit. Neither has anything to do with what the tests check, and the pre-push hook that runs them failed on any machine with such a setting. One test already passed `commit.gpgsign=false` by hand.

A shared `gitTestEnvironment` in `scripts/lib` runs git with `GIT_CONFIG_GLOBAL` pointed at `/dev/null` and `GIT_CONFIG_NOSYSTEM` set, and supplies the fixture identity through the author and committer variables since the global one is gone. The three tests that spawn git use it for their own git calls and for the scripts under test, which run git of their own in the same repository.
