### PR TITLE
docs(website): drop the false routing default claim

### DIFF
--- a/packages/website/src/page/core/runtime.md
+++ b/packages/website/src/page/core/runtime.md
@@ -15,7 +15,7 @@ The Runtime API makes two independent choices:
 
 ### Without routing
 
-Without a `routing` config, the program doesn't manage the URL bar. This is the default for most programs.
+Without a `routing` config, the program doesn't manage the URL bar.
 
 ::Snippet{name="runMakeApplication" label="makeApplication without routing example"}
 


### PR DESCRIPTION
The Runtime page claimed that a program without a routing config is the default for most programs. The website, the typing game, and most of the larger examples pass a routing config, so the claim was false. Remove the sentence.